### PR TITLE
Revert changes to CSharpDesignTimeHelpersVisitor.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpCodeBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpCodeBuilder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
 
                     new CSharpHelperVisitor(writer, Context).Accept(Tree.Chunks);
                     new CSharpTypeMemberVisitor(writer, Context).Accept(Tree.Chunks);
-                    new CSharpDesignTimeHelpersVisitor(writer, Context).Accept(Tree.Chunks);
+                    new CSharpDesignTimeHelpersVisitor(writer, Context).AcceptTree(Tree);
                   
                     // TODO: resolve variable declarations
 

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpDesignTimeHelpersVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpDesignTimeHelpersVisitor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
             _context = context;
         }
 
-        public override void Accept(System.Collections.Generic.IList<Chunk> chunks)
+        public void AcceptTree(CodeTree tree)
         {
             if (_context.Host.DesignTimeMode)
             {
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
                 {
                     using (_writer.BuildDisableWarningScope())
                     {
-                        Accept(chunks);
+                        Accept(tree.Chunks);
                     }
                 }
             }

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/ChunkVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/ChunkVisitor.cs
@@ -5,7 +5,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
 {
     public abstract class ChunkVisitor : IChunkVisitor
     {
-        public virtual void Accept(IList<Chunk> chunks)
+        public void Accept(IList<Chunk> chunks)
         {
             if (chunks == null)
             {

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CodeTreeOutputValidator.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CodeTreeOutputValidator.cs
@@ -114,7 +114,6 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         private static void ValidateCodeTreeContainsAll(string codeTreeCode, string codeDOMCode, string regex)
         {
             var matches = Regex.Matches(codeDOMCode, regex);
-            Assert.NotEmpty(matches);
 
             for (int i = 0; i < matches.Count; i++)
             {


### PR DESCRIPTION
Without the initial code tree acceptance you end up stack overflowing.  Also removed a validation check that ensures that there's always a base type (not true).
