### PR TITLE
Map semicolon's in using statements.

### DIFF
--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpRazorCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpRazorCodeGeneratorTest.cs
@@ -91,10 +91,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                 Directory.CreateDirectory("./tests");
             }
 
-            RunTest(testType, onResults: (results) =>
-            {
-                File.WriteAllText(String.Format("./tests/{0}.cs", testType), results.GeneratedCode);
-            });
+            RunTest(testType);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CSharpCodeBuilderTests.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CSharpCodeBuilderTests.cs
@@ -12,12 +12,12 @@ namespace Microsoft.AspNet.Razor.Test.Generator.CodeTree
         [Fact]
         public void CodeTreeWithUsings()
         {
-            var syntaxTreeNode = Mock.Of<SyntaxTreeNode>();
+            var syntaxTreeNode = new Mock<Span>(new SpanBuilder());
             var language = new CSharpRazorCodeLanguage();
             RazorEngineHost host = new RazorEngineHost(language);
             var context = CodeGeneratorContext.Create(host, "TestClass", "TestNamespace", "Foo.cs", shouldGenerateLinePragmas: false);
-            context.CodeTreeBuilder.AddUsingChunk("FakeNamespace1", syntaxTreeNode);
-            context.CodeTreeBuilder.AddUsingChunk("FakeNamespace2.SubNamespace", syntaxTreeNode);
+            context.CodeTreeBuilder.AddUsingChunk("FakeNamespace1", syntaxTreeNode.Object);
+            context.CodeTreeBuilder.AddUsingChunk("FakeNamespace2.SubNamespace", syntaxTreeNode.Object);
             CodeBuilder codeBuilder = language.CreateBuilder(context);
 
             // Act


### PR DESCRIPTION
This allows for users to write "@using System;" and still have proper intellisense and mapping.  Also removed some legacy code that I came across when running tests.
