### PR TITLE
Modify parser to group html begin/end elements.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/HtmlLanguageCharacteristics.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/HtmlLanguageCharacteristics.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNet.Razor.Parser
                 return "<";
             case HtmlSymbolType.Bang:
                 return "!";
-            case HtmlSymbolType.Solidus:
+            case HtmlSymbolType.ForwardSlash:
                 return "/";
             case HtmlSymbolType.QuestionMark:
                 return "?";

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/BlockType.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/BlockType.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         Template,
 
         // Special
-        Comment
+        Comment,
+        Tag
     }
 }

--- a/src/Microsoft.AspNet.Razor/Tokenizer/HtmlTokenizer.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/HtmlTokenizer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.AspNet.Razor.Tokenizer
             case '!':
                 return EndSymbol(HtmlSymbolType.Bang);
             case '/':
-                return EndSymbol(HtmlSymbolType.Solidus);
+                return EndSymbol(HtmlSymbolType.ForwardSlash);
             case '?':
                 return EndSymbol(HtmlSymbolType.QuestionMark);
             case '[':

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/HtmlSymbolType.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/HtmlSymbolType.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
         NewLine, // Newline
         OpenAngle, // <
         Bang, // !
-        Solidus, // /
+        ForwardSlash, // /
         QuestionMark, // ?
         DoubleHyphen, // --
         LeftBracket, // [

--- a/src/Microsoft.AspNet.Razor/Utils/DisposableAction.cs
+++ b/src/Microsoft.AspNet.Razor/Utils/DisposableAction.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNet.Razor.Utils
     internal class DisposableAction : IDisposable
     {
         private Action _action;
+        private bool _invoked;
 
         public DisposableAction(Action action)
         {
@@ -20,16 +21,10 @@ namespace Microsoft.AspNet.Razor.Utils
 
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            // If we were disposed by the finalizer it's because the user didn't use a "using" block, so don't do anything!
-            if (disposing)
+            if (!_invoked)
             {
                 _action();
+                _invoked = true;
             }
         }
     }

--- a/test/Microsoft.AspNet.Razor.Test/Tokenizer/HtmlTokenizerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Tokenizer/HtmlTokenizerTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.Razor.Test.Tokenizer
         [Fact]
         public void Solidus_Is_Recognized()
         {
-            TestSingleToken("/", HtmlSymbolType.Solidus);
+            TestSingleToken("/", HtmlSymbolType.ForwardSlash);
         }
 
         [Fact]


### PR DESCRIPTION
- Added a "Tag" block type.
- Wrapped all begin/end elements in a "Tag" Markup block.
- Attempted to change as little as possible in the parser since it is easily the most fragile part of Razor.
#75

Since this impacted a large amount of the existing tests I've created a separate "test" PR.  I felt that the existing tests did more than enough verification for this "feature" since it's at the core of the Razor parser, let me know if you have a different opinion.

Test PR: https://github.com/aspnet/Razor/pull/87
