### PR TITLE
Fix tests to work with new TagBlock parsing format.

### DIFF
--- a/test/Microsoft.AspNet.Razor.Test/Framework/BlockFactory.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/BlockFactory.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+
+namespace Microsoft.AspNet.Razor.Test.Framework
+{
+    public class BlockFactory
+    {
+        private SpanFactory _factory;
+
+        public BlockFactory(SpanFactory factory)
+        {
+            _factory = factory;
+        }
+
+        public Block MarkupTagBlock(string content)
+        {
+            return MarkupTagBlock(content, AcceptedCharacters.Any);
+        }
+
+        public Block MarkupTagBlock(string content, AcceptedCharacters acceptedCharacters)
+        {
+            return new MarkupTagBlock(
+                _factory.Markup(content).Accepts(acceptedCharacters)
+            );
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
@@ -134,12 +134,27 @@ namespace Microsoft.AspNet.Razor.Test.Framework
         }
     }
 
+    public class MarkupTagBlock : Block
+    {
+        private const BlockType ThisBlockType = BlockType.Tag;
+
+        public MarkupTagBlock(params SyntaxTreeNode[] children)
+            : base(ThisBlockType, children, BlockCodeGenerator.Null)
+        {
+        }
+    }
+
     public class MarkupBlock : Block
     {
         private const BlockType ThisBlockType = BlockType.Markup;
 
+        public MarkupBlock(BlockType blockType, IBlockCodeGenerator codeGenerator, IEnumerable<SyntaxTreeNode> children)
+            : base(blockType, children, codeGenerator)
+        {
+        }
+
         public MarkupBlock(IBlockCodeGenerator codeGenerator, IEnumerable<SyntaxTreeNode> children)
-            : base(ThisBlockType, children, codeGenerator)
+            : this(ThisBlockType, codeGenerator, children)
         {
         }
 

--- a/test/Microsoft.AspNet.Razor.Test/Framework/CsHtmlCodeParserTestBase.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/CsHtmlCodeParserTestBase.cs
@@ -13,6 +13,11 @@ namespace Microsoft.AspNet.Razor.Test.Framework
             get { return CSharpCodeParser.DefaultKeywords; }
         }
 
+        protected override BlockFactory CreateBlockFactory()
+        {
+            return new BlockFactory(Factory ?? CreateSpanFactory());
+        }
+
         protected override SpanFactory CreateSpanFactory()
         {
             return SpanFactory.CreateCsHtml();

--- a/test/Microsoft.AspNet.Razor.Test/Framework/CsHtmlMarkupParserTestBase.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/CsHtmlMarkupParserTestBase.cs
@@ -13,6 +13,11 @@ namespace Microsoft.AspNet.Razor.Test.Framework
             get { return CSharpCodeParser.DefaultKeywords; }
         }
 
+        protected override BlockFactory CreateBlockFactory()
+        {
+            return new BlockFactory(Factory ?? CreateSpanFactory());
+        }
+
         protected override SpanFactory CreateSpanFactory()
         {
             return SpanFactory.CreateCsHtml();

--- a/test/Microsoft.AspNet.Razor.Test/Framework/ParserTestBase.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/ParserTestBase.cs
@@ -21,10 +21,12 @@ namespace Microsoft.AspNet.Razor.Test.Framework
         protected static Block IgnoreOutput = new IgnoreOutputBlock();
 
         public SpanFactory Factory { get; private set; }
+        public BlockFactory BlockFactory { get; private set; }
 
         protected ParserTestBase()
         {
             Factory = CreateSpanFactory();
+            BlockFactory = CreateBlockFactory();
         }
 
         public abstract ParserBase CreateMarkupParser();
@@ -38,6 +40,7 @@ namespace Microsoft.AspNet.Razor.Test.Framework
         }
 
         protected abstract SpanFactory CreateSpanFactory();
+        protected abstract BlockFactory CreateBlockFactory();
 
         protected virtual void ParseBlockTest(string document)
         {

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpRazorCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpRazorCodeGeneratorTest.cs
@@ -432,7 +432,10 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     tabTest: withTabs ? TabTest.Tabs : TabTest.NoTabs,
                     spans: new TestSpan[]
             {
-                new TestSpan(SpanKind.Markup, 0, 16),
+                new TestSpan(SpanKind.Markup, 0, 6),
+                new TestSpan(SpanKind.Markup, 6, 8),
+                new TestSpan(SpanKind.Markup, 8, 14),
+                new TestSpan(SpanKind.Markup, 14, 16),
                 new TestSpan(SpanKind.Transition, 16, 17),
                 new TestSpan(SpanKind.Code, 17, 31),
                 new TestSpan(SpanKind.Markup, 31, 38),

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CSharpPaddingBuilderTests.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CSharpPaddingBuilderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,14 +18,14 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         public void CalculatePaddingForEmptySpanReturnsZero()
         {
             // Arrange
-            RazorEngineHost host = CreateHost(designTime: true);
+            var host = CreateHost(designTime: true);
 
-            Span span = new Span(new SpanBuilder());
+            var span = new Span(new SpanBuilder());
 
             var paddingBuilder = new CSharpPaddingBuilder(host);
 
             // Act
-            int padding = paddingBuilder.CalculatePadding(span, 0);
+            var padding = paddingBuilder.CalculatePadding(span, 0);
 
             // Assert
             Assert.Equal(0, padding);
@@ -35,9 +36,9 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         public void CalculatePaddingForEmptySpanWith4Spaces(bool designTime, bool isIndentingWithTabs, int tabSize)
         {
             // Arrange
-            RazorEngineHost host = CreateHost(designTime, isIndentingWithTabs, tabSize);
+            var host = CreateHost(designTime, isIndentingWithTabs, tabSize);
 
-            Span span = GenerateSpan(@"    @{", SpanKind.Code, 3, "");
+            var span = GenerateSpan(@"    @{", SpanKind.Code, 3, "");
 
             var paddingBuilder = new CSharpPaddingBuilder(host);
 
@@ -53,14 +54,14 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         public void CalculatePaddingForIfSpanWith5Spaces(bool designTime, bool isIndentingWithTabs, int tabSize)
         {
             // Arrange
-            RazorEngineHost host = CreateHost(designTime, isIndentingWithTabs, tabSize);
+            var host = CreateHost(designTime, isIndentingWithTabs, tabSize);
 
-            Span span = GenerateSpan(@"    @if (true)", SpanKind.Code, 2, "if (true)");
+            var span = GenerateSpan(@"    @if (true)", SpanKind.Code, 2, "if (true)");
 
             var paddingBuilder = new CSharpPaddingBuilder(host);
 
             // Act
-            int padding = paddingBuilder.CalculatePadding(span, 1);
+            var padding = paddingBuilder.CalculatePadding(span, 1);
 
             // Assert
             Assert.Equal(4, padding);
@@ -85,22 +86,20 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         public void VerifyPaddingForIfSpanWith4Spaces(bool designTime, bool isIndentingWithTabs, int tabSize, int numTabs, int numSpaces)
         {
             // Arrange
-            RazorEngineHost host = CreateHost(designTime, isIndentingWithTabs, tabSize);
+            var host = CreateHost(designTime, isIndentingWithTabs, tabSize);
 
             // no new lines involved
-            Span spanFlat = GenerateSpan("    @if (true)", SpanKind.Code, 2, "if (true)");
-            Span spanNewlines = GenerateSpan("\t<div>\r\n    @if (true)", SpanKind.Code, 3, "if (true)");
+            var spanFlat = GenerateSpan("    @if (true)", SpanKind.Code, 2, "if (true)");
+            var spanNewlines = GenerateSpan("\t<div>" + Environment.NewLine + "    @if (true)", SpanKind.Code, 5, "if (true)");
 
             var paddingBuilder = new CSharpPaddingBuilder(host);
 
             // Act
-            string paddingFlat = paddingBuilder.BuildStatementPadding(spanFlat);
-
-
-            string paddingNewlines = paddingBuilder.BuildStatementPadding(spanNewlines);
+            var paddingFlat = paddingBuilder.BuildStatementPadding(spanFlat);
+            var paddingNewlines = paddingBuilder.BuildStatementPadding(spanNewlines);
 
             // Assert
-            string code = " if (true)";
+            var code = " if (true)";
             VerifyPadded(numTabs, numSpaces, code, paddingFlat);
             VerifyPadded(numTabs, numSpaces, code, paddingNewlines);
         }
@@ -123,20 +122,20 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         public void VerifyPaddingForIfSpanWithTwoTabs(bool designTime, bool isIndentingWithTabs, int tabSize, int numTabs, int numSpaces)
         {
             // Arrange
-            RazorEngineHost host = CreateHost(designTime, isIndentingWithTabs, tabSize);
+            var host = CreateHost(designTime, isIndentingWithTabs, tabSize);
 
             // no new lines involved
-            Span spanFlat = GenerateSpan("\t\t@if (true)", SpanKind.Code, 2, "if (true)");
-            Span spanNewlines = GenerateSpan("\t<div>\r\n\t\t@if (true)", SpanKind.Code, 3, "if (true)");
+            var spanFlat = GenerateSpan("\t\t@if (true)", SpanKind.Code, 2, "if (true)");
+            var spanNewlines = GenerateSpan("\t<div>" + Environment.NewLine + "\t\t@if (true)", SpanKind.Code, 5, "if (true)");
 
             var paddingBuilder = new CSharpPaddingBuilder(host);
 
             // Act
-            string paddingFlat = paddingBuilder.BuildStatementPadding(spanFlat);
-            string paddingNewlines = paddingBuilder.BuildStatementPadding(spanNewlines);
+            var paddingFlat = paddingBuilder.BuildStatementPadding(spanFlat);
+            var paddingNewlines = paddingBuilder.BuildStatementPadding(spanNewlines);
 
             // Assert
-            string code = " if (true)";
+            var code = " if (true)";
             VerifyPadded(numTabs, numSpaces, code, paddingFlat);
             VerifyPadded(numTabs, numSpaces, code, paddingNewlines);
         }
@@ -158,27 +157,26 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         public void CalculatePaddingForOpenedIf(bool designTime, bool isIndentingWithTabs, int tabSize, int numTabs, int numSpaces)
         {
             // Arrange
-            RazorEngineHost host = CreateHost(designTime, isIndentingWithTabs, tabSize);
+            var host = CreateHost(designTime, isIndentingWithTabs, tabSize);
 
-            string text = "\r\n<html>\r\n<body>\r\n\t\t@if (true) { \r\n</body>\r\n</html>";
+            var text = string.Format("{0}<html>{0}<body>{0}\t\t@if (true) {{ {0}</body>{0}</html>", Environment.NewLine);
 
-            Span span = GenerateSpan(text, SpanKind.Code, 3, "if (true) { \r\n");
+            var code = "if (true) { " + Environment.NewLine;
+            var span = GenerateSpan(text, SpanKind.Code, 7, code);
 
             var paddingBuilder = new CSharpPaddingBuilder(host);
 
             // Act
-            string padding = paddingBuilder.BuildStatementPadding(span);
+            var padding = paddingBuilder.BuildStatementPadding(span);
 
             // Assert
-            string code = " if (true) { \r\n";
-
             VerifyPadded(numTabs, numSpaces, code, padding);
         }
 
         private static void VerifyPadded(int numTabs, int numSpaces, string code, string padding)
         {
-            string padded = padding + code;
-            string expectedPadding = new string('\t', numTabs) + new string(' ', numSpaces);
+            var padded = padding + code;
+            var expectedPadding = new string('\t', numTabs) + new string(' ', numSpaces);
 
             Assert.Equal(expectedPadding, padding);
             Assert.Equal(numTabs + numSpaces + code.Length, padded.Length);
@@ -214,7 +212,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
 
         private static Span GenerateSpan(string text, SpanKind spanKind, int spanIndex, string spanText)
         {
-            Span[] spans = GenerateSpans(text, spanKind, spanIndex, spanText);
+            var spans = GenerateSpans(text, spanKind, spanIndex, spanText);
 
             return spans[spanIndex];
         }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpAutoCompleteTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpAutoCompleteTest.cs
@@ -121,10 +121,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                                    .AsStatement()
                                                    .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString) { AutoCompleteString = "}" }),
                                                new MarkupBlock(
-                                                   Factory.Markup(@"<p></p>")
-                                                       .With(new MarkupCodeGenerator())
-                                                       .Accepts(AcceptedCharacters.None)
-                                                   ),
+                                                   new MarkupTagBlock(
+                                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                                   new MarkupTagBlock(
+                                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None))),
                                                Factory.Span(SpanKind.Code, new CSharpSymbol(Factory.LocationTracker.CurrentLocation, String.Empty, CSharpSymbolType.Unknown))
                                                    .With(new StatementCodeGenerator())
                                                )
@@ -144,7 +144,12 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            .AutoCompleteWith("}", atEndOfSpan: true)
                            .Accepts(AcceptedCharacters.Any),
                     new MarkupBlock(
-                        Factory.Markup("\r\n<p>Foo</p>"))),
+                        Factory.Markup("\r\n"),
+                        new MarkupTagBlock(
+                            Factory.Markup("<p>")),
+                        Factory.Markup("Foo"),
+                        new MarkupTagBlock(
+                            Factory.Markup("</p>")))),
                 new RazorError(RazorResources.FormatParseError_Expected_X("}"),
                                 29, 1, 10));
         }
@@ -161,10 +166,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    .AsStatement()
                                    .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString) { AutoCompleteString = "}" }),
                                new MarkupBlock(
-                                   Factory.Markup(@"<p></p>")
-                                       .With(new MarkupCodeGenerator())
-                                       .Accepts(AcceptedCharacters.None)
-                                   ),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None))),
                                Factory.Span(SpanKind.Code, new CSharpSymbol(Factory.LocationTracker.CurrentLocation, String.Empty, CSharpSymbolType.Unknown))
                                    .With(new StatementCodeGenerator())
                                ),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpBlockTest.cs
@@ -312,7 +312,11 @@ while(true);", BlockType.Statement, SpanKind.Code, acceptedCharacters: AcceptedC
                                Factory.CodeTransition(),
                                Factory.Code("do { var foo = bar;").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Foo</p> ").Accepts(AcceptedCharacters.None)
+                                    Factory.Markup(" "),
+                                    BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                                    Factory.Markup("Foo"),
+                                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("foo++; } while (foo<bar>);").AsStatement().Accepts(AcceptedCharacters.None)
                                ));
@@ -478,7 +482,16 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
         [Fact]
         public void ParseBlockSupportsMarkupWithinTryClause()
         {
-            RunSimpleWrappedMarkupTest("try {", " <p>Foo</p> ", "}");
+            RunSimpleWrappedMarkupTest(
+                prefix: "try {", 
+                markup: " <p>Foo</p> ", 
+                suffix: "}",
+                expectedMarkup: new MarkupBlock(
+                    Factory.Markup(" "),
+                    BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                    Factory.Markup("Foo"),
+                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)));
         }
 
         [Fact]
@@ -490,7 +503,16 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
         [Fact]
         public void ParseBlockSupportsMarkupWithinCatchClause()
         {
-            RunSimpleWrappedMarkupTest("try { var foo = new { } } catch(Foo Bar Baz) {", " <p>Foo</p> ", "}");
+            RunSimpleWrappedMarkupTest(
+                prefix: "try { var foo = new { } } catch(Foo Bar Baz) {", 
+                markup: " <p>Foo</p> ", 
+                suffix: "}",
+                expectedMarkup: new MarkupBlock(
+                    Factory.Markup(" "),
+                    BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                    Factory.Markup("Foo"),
+                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)));
         }
 
         [Fact]
@@ -508,7 +530,16 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
         [Fact]
         public void ParseBlockSupportsMarkupWithinAdditionalCatchClauses()
         {
-            RunSimpleWrappedMarkupTest("try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) {", " <p>Foo</p> ", "}");
+            RunSimpleWrappedMarkupTest(
+                prefix: "try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) {",
+                markup: " <p>Foo</p> ",
+                suffix: "}",
+                expectedMarkup: new MarkupBlock(
+                    Factory.Markup(" "),
+                    BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                    Factory.Markup("Foo"),
+                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)));
         }
 
         [Fact]
@@ -520,7 +551,17 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
         [Fact]
         public void ParseBlockSupportsMarkupWithinFinallyClause()
         {
-            RunSimpleWrappedMarkupTest("try { var foo = new { } } finally {", " <p>Foo</p> ", "}", acceptedCharacters: AcceptedCharacters.None);
+            RunSimpleWrappedMarkupTest(
+                prefix: "try { var foo = new { } } finally {",
+                markup: " <p>Foo</p> ",
+                suffix: "}",
+                expectedMarkup: new MarkupBlock(
+                    Factory.Markup(" "),
+                    BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                    Factory.Markup("Foo"),
+                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)),
+                acceptedCharacters: AcceptedCharacters.None);
         }
 
         [Fact]
@@ -638,38 +679,54 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
                 new StatementBlock(
                     Factory.Code("foreach(var c in db.Categories) {\r\n").AsStatement(),
                     new MarkupBlock(
-                        Factory.Markup("            <div>\r\n                <h1>"),
+                        Factory.Markup("            "),
+                        BlockFactory.MarkupTagBlock("<div>", AcceptedCharacters.None),
+                        Factory.Markup("\r\n                "),
+                        BlockFactory.MarkupTagBlock("<h1>", AcceptedCharacters.None),
+                        Factory.EmptyHtml(),
                         new ExpressionBlock(
                             Factory.CodeTransition(),
                             Factory.Code("c.Name")
                                    .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                    .Accepts(AcceptedCharacters.NonWhiteSpace)),
-                        Factory.Markup("</h1>\r\n                <ul>\r\n"),
+                        BlockFactory.MarkupTagBlock("</h1>", AcceptedCharacters.None),
+                        Factory.Markup("\r\n                "),
+                        BlockFactory.MarkupTagBlock("<ul>", AcceptedCharacters.None),
+                        Factory.Markup("\r\n"),
                         new StatementBlock(
                             Factory.Code(@"                    ").AsStatement(),
                             Factory.CodeTransition(),
                             Factory.Code("foreach(var p in c.Products) {\r\n").AsStatement(),
                             new MarkupBlock(
-                                Factory.Markup("                        <li><a"),
-                                new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href=\"", 193, 5, 30), new LocationTagged<string>("\"", 256, 5, 93)),
-                                    Factory.Markup(" href=\"").With(SpanCodeGenerator.Null),
-                                    new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 200, 5, 37), 200, 5, 37),
-                                        new ExpressionBlock(
-                                            Factory.CodeTransition(),
-                                            Factory.Code("Html.ActionUrl(\"Products\", \"Detail\", new { id = p.Id })")
-                                                   .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                   .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                                    Factory.Markup("\"").With(SpanCodeGenerator.Null)),
-                                Factory.Markup(">"),
+                                Factory.Markup("                        "),
+                                BlockFactory.MarkupTagBlock("<li>", AcceptedCharacters.None),
+                                new MarkupTagBlock(
+                                    Factory.Markup("<a"),
+                                    new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href=\"", 193, 5, 30), new LocationTagged<string>("\"", 256, 5, 93)),
+                                        Factory.Markup(" href=\"").With(SpanCodeGenerator.Null),
+                                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 200, 5, 37), 200, 5, 37),
+                                            new ExpressionBlock(
+                                                Factory.CodeTransition(),
+                                                Factory.Code("Html.ActionUrl(\"Products\", \"Detail\", new { id = p.Id })")
+                                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                                       .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                        Factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                    Factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                Factory.EmptyHtml(),
                                 new ExpressionBlock(
                                     Factory.CodeTransition(),
                                     Factory.Code("p.Name")
                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                            .Accepts(AcceptedCharacters.NonWhiteSpace)),
-                                Factory.Markup("</a></li>\r\n").Accepts(AcceptedCharacters.None)),
+                                BlockFactory.MarkupTagBlock("</a>", AcceptedCharacters.None),
+                                BlockFactory.MarkupTagBlock("</li>", AcceptedCharacters.None),
+                                Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)),
                             Factory.Code("                    }\r\n").AsStatement().Accepts(AcceptedCharacters.None)),
-                        Factory.Markup("                </ul>\r\n            </div>\r\n")
-                               .Accepts(AcceptedCharacters.None)),
+                        Factory.Markup("                "),
+                        BlockFactory.MarkupTagBlock("</ul>", AcceptedCharacters.None),
+                        Factory.Markup("\r\n            "),
+                        BlockFactory.MarkupTagBlock("</div>", AcceptedCharacters.None),
+                        Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)),
                     Factory.Code("        }").AsStatement().Accepts(AcceptedCharacters.None)));
         }
 
@@ -696,14 +753,12 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
                                Factory.Code(postComment).AsStatement().Accepts(acceptedCharacters)));
         }
 
-        private void RunSimpleWrappedMarkupTest(string prefix, string markup, string suffix, AcceptedCharacters acceptedCharacters = AcceptedCharacters.Any)
+        private void RunSimpleWrappedMarkupTest(string prefix, string markup, string suffix, MarkupBlock expectedMarkup, AcceptedCharacters acceptedCharacters = AcceptedCharacters.Any)
         {
             ParseBlockTest(prefix + markup + suffix,
                            new StatementBlock(
                                Factory.Code(prefix).AsStatement(),
-                               new MarkupBlock(
-                                   Factory.Markup(markup).Accepts(AcceptedCharacters.None)
-                                   ),
+                               expectedMarkup,
                                Factory.Code(suffix).AsStatement().Accepts(acceptedCharacters)
                                ));
         }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
@@ -136,7 +136,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            .AutoCompleteWith(null, atEndOfSpan: true)
                            .Accepts(AcceptedCharacters.Any),
                     new MarkupBlock(
-                        Factory.Markup(" <p>F", "{", "o", "}", "o", "</p> ")),
+                        Factory.Markup(" "),
+                        new MarkupTagBlock(
+                            Factory.Markup("<p>")),
+                        Factory.Markup("F", "{", "o", "}", "o"),
+                        new MarkupTagBlock(
+                            Factory.Markup("</p>")),
+                        Factory.Markup(" ")),
                     Factory.MetaCode("}")
                            .Accepts(AcceptedCharacters.None)));
         }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpErrorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpErrorTest.cs
@@ -389,16 +389,21 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new StatementBlock(
                                Factory.Code("if(foo) ").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("<p>Bar</p> ").Accepts(AcceptedCharacters.None)
-                                   ),
+                                    BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                                    Factory.Markup("Bar"),
+                                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)),
                                Factory.Code("else if(bar) ").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("<p>Baz</p> ").Accepts(AcceptedCharacters.None)
-                                   ),
+                                    BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                                    Factory.Markup("Baz"),
+                                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)),
                                Factory.Code("else ").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("<p>Boz</p>").Accepts(AcceptedCharacters.None)
-                                   ),
+                                    BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                                    Factory.Markup("Boz"),
+                                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None)),
                                Factory.EmptyCSharp().AsStatement()
                                ),
                            new RazorError(expectedMessage, 8, 0, 8),
@@ -427,8 +432,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                new MarkupBlock(
                                    Factory.Markup(" "),
                                    Factory.MarkupTransition(),
-                                   Factory.Markup("<p>Bar</p> ").Accepts(AcceptedCharacters.None)
-                                   ),
+                                   BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                                    Factory.Markup("Bar"),
+                                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)),
                                Factory.Code("}").AsStatement()
                                ),
                            new RazorError(
@@ -496,8 +503,11 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new StatementBlock(
                                Factory.Code("if(\r\nelse {").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Foo</p> ").Accepts(AcceptedCharacters.None)
-                                   ),
+                                   Factory.Markup(" "),
+                                    BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                                    Factory.Markup("Foo"),
+                                    BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)),
                                Factory.Code("}").AsStatement().Accepts(AcceptedCharacters.None)
                                ),
                            new RazorError(
@@ -547,13 +557,15 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new StatementBlock(
                                Factory.Code("if(foo) {\r\n    var foo = \"foo bar baz\r\n    ").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("<p>Foo is "),
+                                   BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
+                                   Factory.Markup("Foo is "),
                                    new ExpressionBlock(
                                        Factory.CodeTransition(),
                                        Factory.Code("foo")
                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                            .Accepts(AcceptedCharacters.NonWhiteSpace)),
-                                   Factory.Markup("</p>\r\n").Accepts(AcceptedCharacters.None)),
+                                   BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)),
                                Factory.Code("}").AsStatement()
                                ),
                            new RazorError(
@@ -581,7 +593,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.Code("String.Format(")
                            .AsStatement(),
                     new MarkupBlock(
-                        Factory.Markup("<html></html>").Accepts(AcceptedCharacters.None)),
+                        BlockFactory.MarkupTagBlock("<html>", AcceptedCharacters.None),
+                        BlockFactory.MarkupTagBlock("</html>", AcceptedCharacters.None)),
                     Factory.EmptyCSharp().AsStatement(),
                     Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                 expectedErrors: new[] {

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpHelperTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpHelperTest.cs
@@ -205,7 +205,12 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    .AsStatement()
                                    .AutoCompleteWith("}"),
                             new MarkupBlock(
-                                Factory.Markup("    <p>Foo</p>").Accepts(AcceptedCharacters.None)),
+                                Factory.Markup("    "),
+                                new MarkupTagBlock(
+                                    Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                Factory.Markup("Foo"),
+                                new MarkupTagBlock(
+                                    Factory.Markup("</p>").Accepts(AcceptedCharacters.None))),
                             Factory.EmptyCSharp().AsStatement()))),
                 new RazorError(
                         RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("helper", "}", "{"),
@@ -227,13 +232,18 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         new StatementBlock(
                             Factory.Code("    \r\n").AsStatement(),
                             new MarkupBlock(
-                                Factory.Markup("    <p>"),
+                                Factory.Markup("    "),
+                                new MarkupTagBlock(
+                                    Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                Factory.EmptyHtml(),
                                 new ExpressionBlock(
                                     Factory.CodeTransition(),
                                     Factory.Code("foo")
                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                            .Accepts(AcceptedCharacters.NonWhiteSpace)),
-                                Factory.Markup("</p>\r\n").Accepts(AcceptedCharacters.None)),
+                                new MarkupTagBlock(
+                                    Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)),
                             Factory.EmptyCSharp().AsStatement()),
                         Factory.Code("}").Hidden().Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));
@@ -258,13 +268,18 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         new StatementBlock(
                             Factory.Code("    \r\n").AsStatement(),
                             new MarkupBlock(
-                                Factory.Markup(@"    <p>"),
+                                Factory.Markup(@"    "),
+                                new MarkupTagBlock(
+                                    Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                Factory.EmptyHtml(),
                                 new ExpressionBlock(
                                     Factory.CodeTransition(),
                                     Factory.Code("foo")
                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                            .Accepts(AcceptedCharacters.NonWhiteSpace)),
-                                Factory.Markup("</p>\r\n").Accepts(AcceptedCharacters.None)),
+                                new MarkupTagBlock(
+                                    Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)),
                             Factory.EmptyCSharp().AsStatement()),
                         Factory.Code("}").Hidden().Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpNestedStatementsTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpNestedStatementsTest.cs
@@ -92,9 +92,14 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.Code("while(true) {")
                            .AsStatement(),
                     new MarkupBlock(
-                        Factory.Markup(" <p>Hello</p> ")
-                               .With(new MarkupCodeGenerator())
-                               .Accepts(AcceptedCharacters.None)),
+                        Factory.Markup(" "),
+                        new MarkupTagBlock(
+                            Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                        Factory.Markup("Hello"),
+                        new MarkupTagBlock(
+                            Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                        Factory.Markup(" ").Accepts(AcceptedCharacters.None)
+                        ),
                     Factory.Code("}")
                            .AsStatement()
                            .Accepts(AcceptedCharacters.None)));

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpRazorCommentsTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpRazorCommentsTest.cs
@@ -125,8 +125,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.Code("\r\n").AsStatement(),
                         new MarkupBlock(
                             Factory.Markup("    "),
-                            Factory.MarkupTransition("<text").Accepts(AcceptedCharacters.Any),
-                            Factory.Markup("\r\n    "),
+                            new MarkupTagBlock(
+                                Factory.MarkupTransition("<text").Accepts(AcceptedCharacters.Any)),
+                            Factory.Markup("\r\n    ").Accepts(AcceptedCharacters.None),
                             new CommentBlock(
                                 Factory.MarkupTransition(HtmlSymbolType.RazorCommentTransition)
                                        .Accepts(AcceptedCharacters.None),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSectionTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSectionTest.cs
@@ -79,7 +79,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     new SectionBlock(new SectionCodeGenerator(string.Empty),
                         Factory.CodeTransition(),
                         Factory.MetaCode("section ")),
-                    Factory.Markup("9 { <p>Foo</p> }")),
+                    Factory.Markup("9 { "),
+                    new MarkupTagBlock(
+                        Factory.Markup("<p>")),
+                    Factory.Markup("Foo"),
+                    new MarkupTagBlock(
+                        Factory.Markup("</p>")),
+                     Factory.Markup(" }")),
                 new RazorError(
                         RazorResources.FormatParseError_Unexpected_Character_At_Section_Name_Start(RazorResources.FormatErrorComponent_Character("9")),
                     9, 0, 9));
@@ -94,7 +100,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     new SectionBlock(new SectionCodeGenerator("foo"),
                         Factory.CodeTransition(),
                         Factory.MetaCode("section foo")),
-                    Factory.Markup("-bar { <p>Foo</p> }")),
+                    Factory.Markup("-bar { "),
+                    new MarkupTagBlock(
+                        Factory.Markup("<p>")),
+                    Factory.Markup("Foo"),
+                    new MarkupTagBlock(
+                        Factory.Markup("</p>")),
+                    Factory.Markup(" }")),
                 new RazorError(RazorResources.ParseError_MissingOpenBraceAfterSection, 12, 0, 12));
         }
 
@@ -115,7 +127,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                 Factory.MetaCode("section bar {")
                                        .AutoCompleteWith(null, atEndOfSpan: true),
                                 new MarkupBlock(
-                                    Factory.Markup(" <p>Foo</p> ")),
+                                    Factory.Markup(" "),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>")),
+                                    Factory.Markup("Foo"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>")),
+                                    Factory.Markup(" ")),
                                 Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                             Factory.Markup(" ")),
                         Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
@@ -152,8 +170,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.MetaCode("section foo {")
                                .AutoCompleteWith("}", atEndOfSpan: true),
                         new MarkupBlock(
+                            Factory.Markup(" "),
+                            new MarkupTagBlock(
+                                Factory.Markup("<p>")),
                             // Need to provide the markup span as fragments, since the parser will split the {} into separate symbols.
-                            Factory.Markup(" <p>Foo", "{", "}", "</p>")))),
+                            Factory.Markup("Foo", "{", "}"),
+                            new MarkupTagBlock(
+                                Factory.Markup("</p>"))))),
                 new RazorError(
                     RazorResources.FormatParseError_Expected_X("}"),
                     27, 0, 27));
@@ -190,7 +213,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.MetaCode("section foo      \r\n\r\n\r\n\r\n\r\n\r\n{")
                                .AutoCompleteWith(null, atEndOfSpan: true),
                         new MarkupBlock(
-                            Factory.Markup("\r\n<p>Foo</p>\r\n")),
+                            Factory.Markup("\r\n"),
+                            new MarkupTagBlock(
+                                Factory.Markup("<p>")),
+                            Factory.Markup("Foo"),
+                            new MarkupTagBlock(
+                                Factory.Markup("</p>")),
+                            Factory.Markup("\r\n")),
                         Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));
         }
@@ -206,7 +235,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.MetaCode("section foo {")
                                .AutoCompleteWith(null, atEndOfSpan: true),
                         new MarkupBlock(
-                            Factory.Markup(" <p>Foo</p> ")),
+                            Factory.Markup(" "),
+                            new MarkupTagBlock(
+                                Factory.Markup("<p>")),
+                            Factory.Markup("Foo"),
+                            new MarkupTagBlock(
+                                Factory.Markup("</p>")),
+                            Factory.Markup(" ")),
                         Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));
         }
@@ -222,7 +257,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.MetaCode("section foo{")
                                .AutoCompleteWith(null, atEndOfSpan: true),
                         new MarkupBlock(
-                            Factory.Markup(" <p>Foo</p> ")),
+                            Factory.Markup(" "),
+                            new MarkupTagBlock(
+                                Factory.Markup("<p>")),
+                            Factory.Markup("Foo"),
+                            new MarkupTagBlock(
+                                Factory.Markup("</p>")),
+                            Factory.Markup(" ")),
                         Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));
         }
@@ -238,7 +279,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.MetaCode("section foo {")
                                .AutoCompleteWith(null, atEndOfSpan: true),
                         new MarkupBlock(
-                            Factory.Markup(" <script>(function foo() { return 1; })();</script> ")),
+                            Factory.Markup(" "),
+                            new MarkupTagBlock(
+                                Factory.Markup("<script>")),
+                            Factory.Markup("(function foo() { return 1; })();"),
+                            new MarkupTagBlock(
+                                Factory.Markup("</script>")), 
+                            Factory.Markup(" ")),
                         Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));
         }
@@ -372,7 +419,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.MetaCode("section s {")
                             .AutoCompleteWith(null, atEndOfSpan: true),
                         new MarkupBlock(
-                            Factory.Markup(Environment.NewLine + "<a" + Environment.NewLine + "<!--  > \" '-->")),
+                            Factory.Markup(Environment.NewLine),
+                            new MarkupTagBlock(
+                                Factory.Markup("<a" + Environment.NewLine)),
+                            Factory.Markup("<!--  > \" '-->")),
                         Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));
         }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSpecialBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSpecialBlockTest.cs
@@ -189,8 +189,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new StatementBlock(
                                Factory.Code("if(!false) {\r\n    // Foo\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("\t<p>A real tag!</p>\r\n")
-                                       .Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\t"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("A real tag!"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)),
                                Factory.Code("}").AsStatement()
                                ));
         }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpTemplateTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpTemplateTest.cs
@@ -21,14 +21,17 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             return new TemplateBlock(
                 new MarkupBlock(
                     Factory.MarkupTransition(),
-                    Factory.Markup("<p>Foo #"),
+                    new MarkupTagBlock(
+                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                    Factory.Markup("Foo #"),
                     new ExpressionBlock(
                         Factory.CodeTransition(),
                         Factory.Code("item")
                             .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                             .Accepts(AcceptedCharacters.NonWhiteSpace)
                         ),
-                    Factory.Markup("</p>").Accepts(AcceptedCharacters.None)
+                    new MarkupTagBlock(
+                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None))
                     )
                 );
         }
@@ -40,7 +43,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             return new TemplateBlock(
                 new MarkupBlock(
                     Factory.MarkupTransition(),
-                    Factory.Markup("<p>Foo #"),
+                    new MarkupTagBlock(
+                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                    Factory.Markup("Foo #"),
                     new ExpressionBlock(
                         Factory.CodeTransition(),
                         Factory.Code("Html.Repeat(10, ")
@@ -48,21 +53,25 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         new TemplateBlock(
                             new MarkupBlock(
                                 Factory.MarkupTransition(),
-                                Factory.Markup("<p>"),
+                                new MarkupTagBlock(
+                                    Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                Factory.EmptyHtml(),
                                 new ExpressionBlock(
                                     Factory.CodeTransition(),
                                     Factory.Code("item")
                                         .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                         .Accepts(AcceptedCharacters.NonWhiteSpace)
                                     ),
-                                Factory.Markup("</p>").Accepts(AcceptedCharacters.None)
+                                new MarkupTagBlock(
+                                    Factory.Markup("</p>").Accepts(AcceptedCharacters.None))
                                 )
                             ),
                         Factory.Code(")")
                             .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                             .Accepts(AcceptedCharacters.NonWhiteSpace)
                         ),
-                    Factory.Markup("</p>").Accepts(AcceptedCharacters.None)
+                    new MarkupTagBlock(
+                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None))
                     )
                 );
         }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpToMarkupSwitchTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpToMarkupSwitchTest.cs
@@ -34,7 +34,11 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                new TemplateBlock(
                                    new MarkupBlock(
                                        Factory.MarkupTransition(),
-                                       Factory.Markup("<p>Foo</p>").Accepts(AcceptedCharacters.None)
+                                       new MarkupTagBlock(
+                                            Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                       Factory.Markup("Foo"),
+                                       new MarkupTagBlock(
+                                           Factory.Markup("</p>").Accepts(AcceptedCharacters.None))
                                        )
                                    ),
                                Factory.Code("    )")
@@ -75,7 +79,11 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
                                Factory.Code("\r\n    ").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("<p>Foo</p>").Accepts(AcceptedCharacters.None)
+                                        new MarkupTagBlock(
+                                            Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                       Factory.Markup("Foo"),
+                                       new MarkupTagBlock(
+                                           Factory.Markup("</p>").Accepts(AcceptedCharacters.None))
                                    ),
                                Factory.Code("    \r\n").AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
@@ -93,7 +101,11 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.Code("\r\n    ").AsStatement(),
                                new MarkupBlock(
                                    Factory.MarkupTransition(),
-                                   Factory.Markup("<p>Foo</p>").Accepts(AcceptedCharacters.None)
+                                        new MarkupTagBlock(
+                                            Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                       Factory.Markup("Foo"),
+                                       new MarkupTagBlock(
+                                           Factory.Markup("</p>").Accepts(AcceptedCharacters.None))
                                    ),
                                Factory.Code("    \r\n").AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
@@ -172,13 +184,17 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                        .With(new SingleLineMarkupEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString, AcceptedCharacters.None))
                                    ),
                                new MarkupBlock(
-                                   Factory.Markup("<br/>\r\n")
-                                       .Accepts(AcceptedCharacters.None)
+                                   new MarkupTagBlock(
+                                        Factory.Markup("<br/>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                new MarkupBlock(
-                                   Factory.Markup("<a>Foo</a>\r\n")
-                                       .Accepts(AcceptedCharacters.None)
-                                   ),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<a>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Foo"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</a>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)),
                                new MarkupBlock(
                                    Factory.MarkupTransition(),
                                    Factory.MetaMarkup(":", HtmlSymbolType.Colon),
@@ -204,13 +220,19 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new StatementBlock(
                                Factory.Code("if(foo) {\r\n    var foo = \"After this statement there are 10 spaces\";          \r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("    <p>\r\n        Foo\r\n"),
+                                   Factory.Markup("    "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n        Foo\r\n"),
                                    new ExpressionBlock(
                                        Factory.Code("        ").AsStatement(),
                                        Factory.CodeTransition(),
                                        Factory.Code("bar").AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)
                                        ),
-                                   Factory.Markup("\r\n    </p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("\r\n    "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                new MarkupBlock(
                                    Factory.Markup("    "),
@@ -228,15 +250,33 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new StatementBlock(
                                Factory.Code("if(foo) {").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Bar</p> ").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup(" "),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("Bar"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("} else if(bar) {").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Baz</p> ").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup(" "),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("Baz"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("} else {").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Boz</p> ").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup(" "),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("Boz"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("}").AsStatement().Accepts(AcceptedCharacters.None)
                                ));
@@ -250,15 +290,33 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
                                Factory.Code(" if(foo) {").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Bar</p> ").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup(" "),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("Bar"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("} else if(bar) {").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Baz</p> ").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup(" "),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("Baz"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("} else {").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Boz</p> ").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup(" "),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("Boz"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("} ").AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
@@ -287,22 +345,52 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new StatementBlock(
                                Factory.Code("switch(foo) {\r\n    case 0:\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("        <p>Foo</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("        "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Foo"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("        break;\r\n    case 1:\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("        <p>Bar</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("        "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Bar"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("        return;\r\n    case 2:\r\n        {\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("            <p>Baz</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("            "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Baz"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                new MarkupBlock(
-                                   Factory.Markup("            <p>Boz</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("            "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Boz"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("        }\r\n    default:\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("        <p>Biz</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("        "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Biz"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("}").AsStatement().Accepts(AcceptedCharacters.None)));
         }
@@ -330,22 +418,52 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
                                Factory.Code(" switch(foo) {\r\n    case 0:\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("        <p>Foo</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("        "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Foo"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("        break;\r\n    case 1:\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("        <p>Bar</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("        "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Bar"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("        return;\r\n    case 2:\r\n        {\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("            <p>Baz</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("            "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Baz"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                new MarkupBlock(
-                                   Factory.Markup("            <p>Boz</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("            "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Boz"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("        }\r\n    default:\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("        <p>Biz</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("        "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("Biz"),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("} ").AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)));
@@ -358,7 +476,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new StatementBlock(
                                Factory.Code("for(int i = 0; i < 10; i++) {").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Foo</p> ").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup(" "),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("Foo"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("}").AsStatement().Accepts(AcceptedCharacters.None)
                                ));
@@ -372,7 +496,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
                                Factory.Code(" for(int i = 0; i < 10; i++) {").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup(" <p>Foo</p> ").Accepts(AcceptedCharacters.None)
+                                    Factory.Markup(" "),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("Foo"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("} ").AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)));
@@ -422,9 +552,11 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.Code("if (i > 0) {").AsStatement(),
                                new MarkupBlock(
                                    Factory.Markup(" "),
-                                   Factory.MarkupTransition("<text>").Accepts(AcceptedCharacters.None),
-                                   Factory.Markup(";"),
-                                   Factory.MarkupTransition("</text>").Accepts(AcceptedCharacters.None),
+                                   new MarkupTagBlock(
+                                        Factory.MarkupTransition("<text>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup(";").Accepts(AcceptedCharacters.None),
+                                   new MarkupTagBlock(
+                                        Factory.MarkupTransition("</text>").Accepts(AcceptedCharacters.None)),
                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("}").AsStatement()));
@@ -439,9 +571,11 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.Code(" if (i > 0) {").AsStatement(),
                                new MarkupBlock(
                                    Factory.Markup(" "),
-                                   Factory.MarkupTransition("<text>").Accepts(AcceptedCharacters.None),
-                                   Factory.Markup(";"),
-                                   Factory.MarkupTransition("</text>").Accepts(AcceptedCharacters.None),
+                                   new MarkupTagBlock(
+                                        Factory.MarkupTransition("<text>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup(";").Accepts(AcceptedCharacters.None),
+                                   new MarkupTagBlock(
+                                        Factory.MarkupTransition("</text>").Accepts(AcceptedCharacters.None)),
                                    Factory.Markup(" ").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("} ").AsStatement(),
@@ -474,18 +608,26 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.Code("    }\r\n    foreach (var p in Enumerable.Range(1, 10)) {\r\n").AsStatement(),
                                new MarkupBlock(
                                    Factory.Markup("        "),
-                                   Factory.MarkupTransition("<text>").Accepts(AcceptedCharacters.None),
-                                   Factory.Markup("The number is "),
+                                   new MarkupTagBlock(
+                                        Factory.MarkupTransition("<text>").Accepts(AcceptedCharacters.None)),
+                                   Factory.Markup("The number is ").Accepts(AcceptedCharacters.None),
                                    new ExpressionBlock(
                                        Factory.CodeTransition(),
                                        Factory.Code("p").AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)
                                        ),
-                                   Factory.MarkupTransition("</text>").Accepts(AcceptedCharacters.None),
+                                   new MarkupTagBlock(
+                                        Factory.MarkupTransition("</text>").Accepts(AcceptedCharacters.None)),
                                    Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("    }\r\n    if(!false) {\r\n").AsStatement(),
                                new MarkupBlock(
-                                   Factory.Markup("        <p>A real tag!</p>\r\n").Accepts(AcceptedCharacters.None)
+                                   Factory.Markup("        "),
+                                   new MarkupTagBlock(
+                                       Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("A real tag!"),
+                                    new MarkupTagBlock(
+                                        Factory.Markup("</p>").Accepts(AcceptedCharacters.None)),
+                                    Factory.Markup("\r\n").Accepts(AcceptedCharacters.None)
                                    ),
                                Factory.Code("    }\r\n").AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)));

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlAttributeTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlAttributeTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser;
@@ -19,12 +20,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href='Foo' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 12, 0, 12)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        Factory.Markup("Foo").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(string.Empty, 9, 0, 9), value: new LocationTagged<string>("Foo", 9, 0, 9))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 12, 0, 12)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            Factory.Markup("Foo").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(string.Empty, 9, 0, 9), value: new LocationTagged<string>("Foo", 9, 0, 9))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -32,14 +34,15 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href='Foo Bar Baz' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 20, 0, 20)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        Factory.Markup("Foo").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(string.Empty, 9, 0, 9), value: new LocationTagged<string>("Foo", 9, 0, 9))),
-                        Factory.Markup(" Bar").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(" ", 12, 0, 12), value: new LocationTagged<string>("Bar", 13, 0, 13))),
-                        Factory.Markup(" Baz").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(" ", 16, 0, 16), value: new LocationTagged<string>("Baz", 17, 0, 17))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 20, 0, 20)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            Factory.Markup("Foo").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(string.Empty, 9, 0, 9), value: new LocationTagged<string>("Foo", 9, 0, 9))),
+                            Factory.Markup(" Bar").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(" ", 12, 0, 12), value: new LocationTagged<string>("Bar", 13, 0, 13))),
+                            Factory.Markup(" Baz").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(" ", 16, 0, 16), value: new LocationTagged<string>("Baz", 17, 0, 17))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -47,14 +50,15 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href=\"Foo Bar Baz\" />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href=\"", 2, 0, 2), suffix: new LocationTagged<string>("\"", 20, 0, 20)),
-                        Factory.Markup(" href=\"").With(SpanCodeGenerator.Null),
-                        Factory.Markup("Foo").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(string.Empty, 9, 0, 9), value: new LocationTagged<string>("Foo", 9, 0, 9))),
-                        Factory.Markup(" Bar").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(" ", 12, 0, 12), value: new LocationTagged<string>("Bar", 13, 0, 13))),
-                        Factory.Markup(" Baz").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(" ", 16, 0, 16), value: new LocationTagged<string>("Baz", 17, 0, 17))),
-                        Factory.Markup("\"").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href=\"", 2, 0, 2), suffix: new LocationTagged<string>("\"", 20, 0, 20)),
+                            Factory.Markup(" href=\"").With(SpanCodeGenerator.Null),
+                            Factory.Markup("Foo").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(string.Empty, 9, 0, 9), value: new LocationTagged<string>("Foo", 9, 0, 9))),
+                            Factory.Markup(" Bar").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(" ", 12, 0, 12), value: new LocationTagged<string>("Bar", 13, 0, 13))),
+                            Factory.Markup(" Baz").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(" ", 16, 0, 16), value: new LocationTagged<string>("Baz", 17, 0, 17))),
+                            Factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -62,11 +66,12 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href=Foo Bar Baz />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href=", 2, 0, 2), suffix: new LocationTagged<string>(string.Empty, 11, 0, 11)),
-                        Factory.Markup(" href=").With(SpanCodeGenerator.Null),
-                        Factory.Markup("Foo").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(string.Empty, 8, 0, 8), value: new LocationTagged<string>("Foo", 8, 0, 8)))),
-                    Factory.Markup(" Bar Baz />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href=", 2, 0, 2), suffix: new LocationTagged<string>(string.Empty, 11, 0, 11)),
+                            Factory.Markup(" href=").With(SpanCodeGenerator.Null),
+                            Factory.Markup("Foo").With(new LiteralAttributeCodeGenerator(prefix: new LocationTagged<string>(string.Empty, 8, 0, 8), value: new LocationTagged<string>("Foo", 8, 0, 8)))),
+                        Factory.Markup(" Bar Baz />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -74,17 +79,18 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href='@foo' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 13, 0, 13)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 9, 0, 9), 9, 0, 9),
-                            new ExpressionBlock(
-                                Factory.CodeTransition(),
-                                Factory.Code("foo")
-                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                       .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 13, 0, 13)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 9, 0, 9), 9, 0, 9),
+                                new ExpressionBlock(
+                                    Factory.CodeTransition(),
+                                    Factory.Code("foo")
+                                           .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                           .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -92,25 +98,26 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href='@foo bar @baz' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 22, 0, 22)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 9, 0, 9), 9, 0, 9),
-                            new ExpressionBlock(
-                                Factory.CodeTransition(),
-                                Factory.Code("foo")
-                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                       .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                        Factory.Markup(" bar").With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(" ", 13, 0, 13), new LocationTagged<string>("bar", 14, 0, 14))),
-                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(" ", 17, 0, 17), 18, 0, 18),
-                            Factory.Markup(" ").With(SpanCodeGenerator.Null),
-                            new ExpressionBlock(
-                                Factory.CodeTransition(),
-                                Factory.Code("baz")
-                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                       .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 22, 0, 22)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 9, 0, 9), 9, 0, 9),
+                                new ExpressionBlock(
+                                    Factory.CodeTransition(),
+                                    Factory.Code("foo")
+                                           .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                           .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                            Factory.Markup(" bar").With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(" ", 13, 0, 13), new LocationTagged<string>("bar", 14, 0, 14))),
+                            new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(" ", 17, 0, 17), 18, 0, 18),
+                                Factory.Markup(" ").With(SpanCodeGenerator.Null),
+                                new ExpressionBlock(
+                                    Factory.CodeTransition(),
+                                    Factory.Code("baz")
+                                           .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                           .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -118,22 +125,23 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href='@foo ~/Foo/Bar' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 23, 0, 23)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 9, 0, 9), 9, 0, 9),
-                            new ExpressionBlock(
-                                Factory.CodeTransition(),
-                                Factory.Code("foo")
-                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                       .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                        Factory.Markup(" ~/Foo/Bar")
-                               .WithEditorHints(EditorHints.VirtualPath)
-                               .With(new LiteralAttributeCodeGenerator(
-                                   new LocationTagged<string>(" ", 13, 0, 13),
-                                   new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 14, 0, 14))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 23, 0, 23)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 9, 0, 9), 9, 0, 9),
+                                new ExpressionBlock(
+                                    Factory.CodeTransition(),
+                                    Factory.Code("foo")
+                                           .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                           .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                            Factory.Markup(" ~/Foo/Bar")
+                                   .WithEditorHints(EditorHints.VirtualPath)
+                                   .With(new LiteralAttributeCodeGenerator(
+                                       new LocationTagged<string>(" ", 13, 0, 13),
+                                       new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 14, 0, 14))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -141,16 +149,17 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<input value=@foo />",
                 new MarkupBlock(
-                    Factory.Markup("<input"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "value", prefix: new LocationTagged<string>(" value=", 6, 0, 6), suffix: new LocationTagged<string>(string.Empty, 17, 0, 17)),
-                        Factory.Markup(" value=").With(SpanCodeGenerator.Null),
-                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 13, 0, 13), 13, 0, 13),
-                            new ExpressionBlock(
-                                Factory.CodeTransition(),
-                                Factory.Code("foo")
-                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                       .Accepts(AcceptedCharacters.NonWhiteSpace)))),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<input"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "value", prefix: new LocationTagged<string>(" value=", 6, 0, 6), suffix: new LocationTagged<string>(string.Empty, 17, 0, 17)),
+                            Factory.Markup(" value=").With(SpanCodeGenerator.Null),
+                            new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 13, 0, 13), 13, 0, 13),
+                                new ExpressionBlock(
+                                    Factory.CodeTransition(),
+                                    Factory.Code("foo")
+                                           .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                           .Accepts(AcceptedCharacters.NonWhiteSpace)))),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -158,16 +167,17 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseDocumentTest("<input value=@foo />",
                 new MarkupBlock(
-                    Factory.Markup("<input"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "value", prefix: new LocationTagged<string>(" value=", 6, 0, 6), suffix: new LocationTagged<string>(string.Empty, 17, 0, 17)),
-                        Factory.Markup(" value=").With(SpanCodeGenerator.Null),
-                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 13, 0, 13), 13, 0, 13),
-                            new ExpressionBlock(
-                                Factory.CodeTransition(),
-                                Factory.Code("foo")
-                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                       .Accepts(AcceptedCharacters.NonWhiteSpace)))),
-                    Factory.Markup(" />")));
+                    new MarkupTagBlock(
+                        Factory.Markup("<input"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "value", prefix: new LocationTagged<string>(" value=", 6, 0, 6), suffix: new LocationTagged<string>(string.Empty, 17, 0, 17)),
+                            Factory.Markup(" value=").With(SpanCodeGenerator.Null),
+                            new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(string.Empty, 13, 0, 13), 13, 0, 13),
+                                new ExpressionBlock(
+                                    Factory.CodeTransition(),
+                                    Factory.Code("foo")
+                                           .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                           .Accepts(AcceptedCharacters.NonWhiteSpace)))),
+                        Factory.Markup(" />"))));
         }
 
         [Fact]
@@ -182,16 +192,17 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
             Assert.Equal(0, results.ParserErrors.Count);
             EvaluateParseTree(rewritten,
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 18, 0, 18)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        Factory.Markup("~/Foo/Bar")
-                               .WithEditorHints(EditorHints.VirtualPath)
-                               .With(new LiteralAttributeCodeGenerator(
-                                   new LocationTagged<string>(string.Empty, 9, 0, 9),
-                                   new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />")));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator(name: "href", prefix: new LocationTagged<string>(" href='", 2, 0, 2), suffix: new LocationTagged<string>("'", 18, 0, 18)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            Factory.Markup("~/Foo/Bar")
+                                   .WithEditorHints(EditorHints.VirtualPath)
+                                   .With(new LiteralAttributeCodeGenerator(
+                                       new LocationTagged<string>(string.Empty, 9, 0, 9),
+                                       new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />"))));
         }
 
         [Fact]
@@ -264,7 +275,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
 
             // Assert
             Assert.Equal(0, results.ParserErrors.Count);
-            EvaluateParseTree(rewritten, new MarkupBlock(Factory.Markup(code)));
+            Assert.Equal(rewritten.Children.Count(), results.Document.Children.Count());
         }
 
         [Fact]
@@ -272,16 +283,19 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<span data-foo='@foo'></span>",
                 new MarkupBlock(
-                    Factory.Markup("<span"),
-                    new MarkupBlock(
-                        Factory.Markup(" data-foo='"),
-                        new ExpressionBlock(
-                            Factory.CodeTransition(),
-                            Factory.Code("foo")
-                                   .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                   .Accepts(AcceptedCharacters.NonWhiteSpace)),
-                        Factory.Markup("'")),
-                    Factory.Markup("></span>").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<span"),
+                        new MarkupBlock(
+                            Factory.Markup(" data-foo='"),
+                            new ExpressionBlock(
+                                Factory.CodeTransition(),
+                                Factory.Code("foo")
+                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                       .Accepts(AcceptedCharacters.NonWhiteSpace)),
+                            Factory.Markup("'")),
+                        Factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                    new MarkupTagBlock(
+                        Factory.Markup("</span>").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -289,16 +303,19 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseDocumentTest("<span data-foo='@foo'></span>",
                 new MarkupBlock(
-                    Factory.Markup("<span"),
-                    new MarkupBlock(
-                        Factory.Markup(" data-foo='"),
-                        new ExpressionBlock(
-                            Factory.CodeTransition(),
-                            Factory.Code("foo")
-                                   .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                   .Accepts(AcceptedCharacters.NonWhiteSpace)),
-                        Factory.Markup("'")),
-                    Factory.Markup("></span>")));
+                    new MarkupTagBlock(
+                        Factory.Markup("<span"),
+                        new MarkupBlock(
+                            Factory.Markup(" data-foo='"),
+                            new ExpressionBlock(
+                                Factory.CodeTransition(),
+                                Factory.Code("foo")
+                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                       .Accepts(AcceptedCharacters.NonWhiteSpace)),
+                            Factory.Markup("'")),
+                        Factory.Markup(">")),
+                    new MarkupTagBlock(
+                        Factory.Markup("</span>"))));
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlParserTestUtils.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlParserTestUtils.cs
@@ -15,9 +15,12 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
             var factory = SpanFactory.CreateCsHtml();
             testMethod("<foo>@@bar</foo>",
                 new MarkupBlock(
-                    factory.Markup("<foo>"),
+                    new MarkupTagBlock(
+                        factory.Markup("<foo>").Accepts(lastSpanAcceptedCharacters)),
                     factory.Markup("@").Hidden(),
-                    factory.Markup("@bar</foo>").Accepts(lastSpanAcceptedCharacters)));
+                    factory.Markup("@bar"),
+                    new MarkupTagBlock(
+                        factory.Markup("</foo>").Accepts(lastSpanAcceptedCharacters))));
         }
 
         public static void RunMultiAtEscapeTest(Action<string, Block> testMethod, AcceptedCharacters lastSpanAcceptedCharacters = AcceptedCharacters.None)
@@ -25,7 +28,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
             var factory = SpanFactory.CreateCsHtml();
             testMethod("<foo>@@@@@bar</foo>",
                 new MarkupBlock(
-                    factory.Markup("<foo>"),
+                    new MarkupTagBlock(
+                        factory.Markup("<foo>").Accepts(lastSpanAcceptedCharacters)),
                     factory.Markup("@").Hidden(),
                     factory.Markup("@"),
                     factory.Markup("@").Hidden(),
@@ -35,7 +39,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                         factory.Code("bar")
                                .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                .Accepts(AcceptedCharacters.NonWhiteSpace)),
-                    factory.Markup("</foo>").Accepts(lastSpanAcceptedCharacters)));
+                    new MarkupTagBlock(
+                        factory.Markup("</foo>").Accepts(lastSpanAcceptedCharacters))));
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlUrlAttributeTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlUrlAttributeTest.cs
@@ -19,16 +19,17 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href='~/Foo/Bar/Baz' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 22, 0, 22)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        Factory.Markup("~/Foo/Bar/Baz")
-                               .WithEditorHints(EditorHints.VirtualPath)
-                               .With(new LiteralAttributeCodeGenerator(
-                                   new LocationTagged<string>(String.Empty, 9, 0, 9),
-                                   new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 22, 0, 22)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            Factory.Markup("~/Foo/Bar/Baz")
+                                   .WithEditorHints(EditorHints.VirtualPath)
+                                   .With(new LiteralAttributeCodeGenerator(
+                                       new LocationTagged<string>(String.Empty, 9, 0, 9),
+                                       new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -36,16 +37,17 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseDocumentTest("<a href='~/Foo/Bar/Baz' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 22, 0, 22)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        Factory.Markup("~/Foo/Bar/Baz")
-                               .WithEditorHints(EditorHints.VirtualPath)
-                               .With(new LiteralAttributeCodeGenerator(
-                                   new LocationTagged<string>(String.Empty, 9, 0, 9),
-                                   new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />")));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 22, 0, 22)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            Factory.Markup("~/Foo/Bar/Baz")
+                                   .WithEditorHints(EditorHints.VirtualPath)
+                                   .With(new LiteralAttributeCodeGenerator(
+                                       new LocationTagged<string>(String.Empty, 9, 0, 9),
+                                       new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />"))));
         }
 
         [Fact]
@@ -60,16 +62,20 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                                .AutoCompleteWith(null, atEndOfSpan: true)
                                .Accepts(AcceptedCharacters.Any),
                         new MarkupBlock(
-                            Factory.Markup(" <a"),
-                            new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 17, 0, 17), new LocationTagged<string>("'", 37, 0, 37)),
-                                Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                                Factory.Markup("~/Foo/Bar/Baz")
-                                       .WithEditorHints(EditorHints.VirtualPath)
-                                       .With(new LiteralAttributeCodeGenerator(
-                                           new LocationTagged<string>(String.Empty, 24, 0, 24),
-                                           new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 24, 0, 24))),
-                                Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                            Factory.Markup(" /> ")),
+                            Factory.Markup(" "),
+                            new MarkupTagBlock(
+                                Factory.Markup("<a"),
+                                new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 17, 0, 17), new LocationTagged<string>("'", 37, 0, 37)),
+                                    Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                                    Factory.Markup("~/Foo/Bar/Baz")
+                                           .WithEditorHints(EditorHints.VirtualPath)
+                                           .With(new LiteralAttributeCodeGenerator(
+                                               new LocationTagged<string>(String.Empty, 24, 0, 24),
+                                               new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 24, 0, 24))),
+                                    Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                                Factory.Markup(" />")),
+                            Factory.Markup(" ")
+                        ),
                         Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));
         }
@@ -79,14 +85,41 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href='~/Foo/@id/Baz' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                            new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 22, 0, 22)),
+                                Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                                Factory.Markup("~/Foo/")
+                                        .WithEditorHints(EditorHints.VirtualPath)
+                                        .With(new LiteralAttributeCodeGenerator(
+                                            new LocationTagged<string>(String.Empty, 9, 0, 9),
+                                            new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
+                                new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 15, 0, 15), 15, 0, 15),
+                                    new ExpressionBlock(
+                                        Factory.CodeTransition().Accepts(AcceptedCharacters.None),
+                                        Factory.Code("id")
+                                               .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                               .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                Factory.Markup("/Baz")
+                                       .With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 18, 0, 18), new LocationTagged<string>("/Baz", 18, 0, 18))),
+                                Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                            Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
+        }
+
+        [Fact]
+        public void UrlWithExpressionsInAttributeInMarkupDocument()
+        {
+            ParseDocumentTest("<a href='~/Foo/@id/Baz' />",
+                new MarkupBlock(
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
                         new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 22, 0, 22)),
                             Factory.Markup(" href='").With(SpanCodeGenerator.Null),
                             Factory.Markup("~/Foo/")
-                                    .WithEditorHints(EditorHints.VirtualPath)
-                                    .With(new LiteralAttributeCodeGenerator(
-                                        new LocationTagged<string>(String.Empty, 9, 0, 9),
-                                        new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
+                                   .WithEditorHints(EditorHints.VirtualPath)
+                                   .With(new LiteralAttributeCodeGenerator(
+                                       new LocationTagged<string>(String.Empty, 9, 0, 9),
+                                       new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
                             new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 15, 0, 15), 15, 0, 15),
                                 new ExpressionBlock(
                                     Factory.CodeTransition().Accepts(AcceptedCharacters.None),
@@ -96,32 +129,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                             Factory.Markup("/Baz")
                                    .With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 18, 0, 18), new LocationTagged<string>("/Baz", 18, 0, 18))),
                             Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                        Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
-        }
-
-        [Fact]
-        public void UrlWithExpressionsInAttributeInMarkupDocument()
-        {
-            ParseDocumentTest("<a href='~/Foo/@id/Baz' />",
-                new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 22, 0, 22)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        Factory.Markup("~/Foo/")
-                               .WithEditorHints(EditorHints.VirtualPath)
-                               .With(new LiteralAttributeCodeGenerator(
-                                   new LocationTagged<string>(String.Empty, 9, 0, 9),
-                                   new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
-                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 15, 0, 15), 15, 0, 15),
-                            new ExpressionBlock(
-                                Factory.CodeTransition().Accepts(AcceptedCharacters.None),
-                                Factory.Code("id")
-                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                       .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                        Factory.Markup("/Baz")
-                               .With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 18, 0, 18), new LocationTagged<string>("/Baz", 18, 0, 18))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />")));
+                        Factory.Markup(" />"))));
         }
 
         [Fact]
@@ -135,24 +143,28 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                         Factory.MetaCode("section Foo {")
                                .AutoCompleteWith(null, atEndOfSpan: true),
                         new MarkupBlock(
-                            Factory.Markup(" <a"),
-                            new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 17, 0, 17), new LocationTagged<string>("'", 37, 0, 37)),
-                                Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                                Factory.Markup("~/Foo/")
-                                       .WithEditorHints(EditorHints.VirtualPath)
-                                       .With(new LiteralAttributeCodeGenerator(
-                                           new LocationTagged<string>(String.Empty, 24, 0, 24),
-                                           new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 24, 0, 24))),
-                                new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 30, 0, 30), 30, 0, 30),
-                                    new ExpressionBlock(
-                                        Factory.CodeTransition().Accepts(AcceptedCharacters.None),
-                                        Factory.Code("id")
-                                               .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                               .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                                Factory.Markup("/Baz")
-                                       .With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 33, 0, 33), new LocationTagged<string>("/Baz", 33, 0, 33))),
-                                Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                            Factory.Markup(" /> ")),
+                            Factory.Markup(" "),
+                            new MarkupTagBlock(
+                                Factory.Markup("<a"),
+                                new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 17, 0, 17), new LocationTagged<string>("'", 37, 0, 37)),
+                                    Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                                    Factory.Markup("~/Foo/")
+                                           .WithEditorHints(EditorHints.VirtualPath)
+                                           .With(new LiteralAttributeCodeGenerator(
+                                               new LocationTagged<string>(String.Empty, 24, 0, 24),
+                                               new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 24, 0, 24))),
+                                    new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 30, 0, 30), 30, 0, 30),
+                                        new ExpressionBlock(
+                                            Factory.CodeTransition().Accepts(AcceptedCharacters.None),
+                                            Factory.Code("id")
+                                                   .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                                   .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                    Factory.Markup("/Baz")
+                                           .With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 33, 0, 33), new LocationTagged<string>("/Baz", 33, 0, 33))),
+                                    Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                                Factory.Markup(" />")),
+                            Factory.Markup(" ")
+                        ),
                         Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));
         }
@@ -162,16 +174,17 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href='~/Foo+Bar:Baz(Biz),Boz' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 31, 0, 31)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        Factory.Markup("~/Foo+Bar:Baz(Biz),Boz")
-                               .WithEditorHints(EditorHints.VirtualPath)
-                               .With(new LiteralAttributeCodeGenerator(
-                                   new LocationTagged<string>(String.Empty, 9, 0, 9),
-                                   new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 31, 0, 31)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            Factory.Markup("~/Foo+Bar:Baz(Biz),Boz")
+                                   .WithEditorHints(EditorHints.VirtualPath)
+                                   .With(new LiteralAttributeCodeGenerator(
+                                       new LocationTagged<string>(String.Empty, 9, 0, 9),
+                                       new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -179,16 +192,17 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseDocumentTest("<a href='~/Foo+Bar:Baz(Biz),Boz' />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 31, 0, 31)),
-                        Factory.Markup(" href='").With(SpanCodeGenerator.Null),
-                        Factory.Markup("~/Foo+Bar:Baz(Biz),Boz")
-                               .WithEditorHints(EditorHints.VirtualPath)
-                               .With(new LiteralAttributeCodeGenerator(
-                                   new LocationTagged<string>(String.Empty, 9, 0, 9),
-                                   new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
-                        Factory.Markup("'").With(SpanCodeGenerator.Null)),
-                    Factory.Markup(" />")));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href='", 2, 0, 2), new LocationTagged<string>("'", 31, 0, 31)),
+                            Factory.Markup(" href='").With(SpanCodeGenerator.Null),
+                            Factory.Markup("~/Foo+Bar:Baz(Biz),Boz")
+                                   .WithEditorHints(EditorHints.VirtualPath)
+                                   .With(new LiteralAttributeCodeGenerator(
+                                       new LocationTagged<string>(String.Empty, 9, 0, 9),
+                                       new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 9, 0, 9))),
+                            Factory.Markup("'").With(SpanCodeGenerator.Null)),
+                        Factory.Markup(" />"))));
         }
 
         [Fact]
@@ -196,23 +210,24 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("<a href=~/Foo+Bar:Baz(Biz),Boz/@id/Boz />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href=", 2, 0, 2), new LocationTagged<string>(String.Empty, 38, 0, 38)),
-                        Factory.Markup(" href=").With(SpanCodeGenerator.Null),
-                        Factory.Markup("~/Foo+Bar:Baz(Biz),Boz/")
-                               .WithEditorHints(EditorHints.VirtualPath)
-                               .With(new LiteralAttributeCodeGenerator(
-                                   new LocationTagged<string>(String.Empty, 8, 0, 8),
-                                   new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 8, 0, 8))),
-                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 31, 0, 31), 31, 0, 31),
-                            new ExpressionBlock(
-                                Factory.CodeTransition()
-                                       .Accepts(AcceptedCharacters.None),
-                                Factory.Code("id")
-                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                            .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                        Factory.Markup("/Boz").With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 34, 0, 34), new LocationTagged<string>("/Boz", 34, 0, 34)))),
-                    Factory.Markup(" />").Accepts(AcceptedCharacters.None)));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href=", 2, 0, 2), new LocationTagged<string>(String.Empty, 38, 0, 38)),
+                            Factory.Markup(" href=").With(SpanCodeGenerator.Null),
+                            Factory.Markup("~/Foo+Bar:Baz(Biz),Boz/")
+                                   .WithEditorHints(EditorHints.VirtualPath)
+                                   .With(new LiteralAttributeCodeGenerator(
+                                       new LocationTagged<string>(String.Empty, 8, 0, 8),
+                                       new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 8, 0, 8))),
+                            new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 31, 0, 31), 31, 0, 31),
+                                new ExpressionBlock(
+                                    Factory.CodeTransition()
+                                           .Accepts(AcceptedCharacters.None),
+                                    Factory.Code("id")
+                                           .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                            Factory.Markup("/Boz").With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 34, 0, 34), new LocationTagged<string>("/Boz", 34, 0, 34)))),
+                        Factory.Markup(" />").Accepts(AcceptedCharacters.None))));
         }
 
         [Fact]
@@ -220,23 +235,24 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseDocumentTest("<a href=~/Foo+Bar:Baz(Biz),Boz/@id/Boz />",
                 new MarkupBlock(
-                    Factory.Markup("<a"),
-                    new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href=", 2, 0, 2), new LocationTagged<string>(String.Empty, 38, 0, 38)),
-                        Factory.Markup(" href=").With(SpanCodeGenerator.Null),
-                        Factory.Markup("~/Foo+Bar:Baz(Biz),Boz/")
-                               .WithEditorHints(EditorHints.VirtualPath)
-                               .With(new LiteralAttributeCodeGenerator(
-                                   new LocationTagged<string>(String.Empty, 8, 0, 8),
-                                   new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 8, 0, 8))),
-                        new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 31, 0, 31), 31, 0, 31),
-                            new ExpressionBlock(
-                                Factory.CodeTransition()
-                                       .Accepts(AcceptedCharacters.None),
-                                Factory.Code("id")
-                                       .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                            .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                        Factory.Markup("/Boz").With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 34, 0, 34), new LocationTagged<string>("/Boz", 34, 0, 34)))),
-                    Factory.Markup(" />")));
+                    new MarkupTagBlock(
+                        Factory.Markup("<a"),
+                        new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href=", 2, 0, 2), new LocationTagged<string>(String.Empty, 38, 0, 38)),
+                            Factory.Markup(" href=").With(SpanCodeGenerator.Null),
+                            Factory.Markup("~/Foo+Bar:Baz(Biz),Boz/")
+                                   .WithEditorHints(EditorHints.VirtualPath)
+                                   .With(new LiteralAttributeCodeGenerator(
+                                       new LocationTagged<string>(String.Empty, 8, 0, 8),
+                                       new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 8, 0, 8))),
+                            new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 31, 0, 31), 31, 0, 31),
+                                new ExpressionBlock(
+                                    Factory.CodeTransition()
+                                           .Accepts(AcceptedCharacters.None),
+                                    Factory.Code("id")
+                                           .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                            Factory.Markup("/Boz").With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 34, 0, 34), new LocationTagged<string>("/Boz", 34, 0, 34)))),
+                        Factory.Markup(" />"))));
         }
 
         [Fact]
@@ -250,23 +266,27 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                         Factory.MetaCode("section Foo {")
                                .AutoCompleteWith(null, atEndOfSpan: true),
                         new MarkupBlock(
-                            Factory.Markup(" <a"),
-                            new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href=", 17, 0, 17), new LocationTagged<string>(String.Empty, 53, 0, 53)),
-                                Factory.Markup(" href=").With(SpanCodeGenerator.Null),
-                                Factory.Markup("~/Foo+Bar:Baz(Biz),Boz/")
-                                        .WithEditorHints(EditorHints.VirtualPath)
-                                        .With(new LiteralAttributeCodeGenerator(
-                                            new LocationTagged<string>(String.Empty, 23, 0, 23),
-                                            new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 23, 0, 23))),
-                                new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 46, 0, 46), 46, 0, 46),
-                                    new ExpressionBlock(
-                                        Factory.CodeTransition()
-                                               .Accepts(AcceptedCharacters.None),
-                                        Factory.Code("id")
-                                               .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                    .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                                Factory.Markup("/Boz").With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 49, 0, 49), new LocationTagged<string>("/Boz", 49, 0, 49)))),
-                            Factory.Markup(" /> ")),
+                            Factory.Markup(" "),
+                            new MarkupTagBlock(
+                                Factory.Markup("<a"),
+                                new MarkupBlock(new AttributeBlockCodeGenerator("href", new LocationTagged<string>(" href=", 17, 0, 17), new LocationTagged<string>(String.Empty, 53, 0, 53)),
+                                    Factory.Markup(" href=").With(SpanCodeGenerator.Null),
+                                    Factory.Markup("~/Foo+Bar:Baz(Biz),Boz/")
+                                            .WithEditorHints(EditorHints.VirtualPath)
+                                            .With(new LiteralAttributeCodeGenerator(
+                                                new LocationTagged<string>(String.Empty, 23, 0, 23),
+                                                new LocationTagged<SpanCodeGenerator>(new ResolveUrlCodeGenerator(), 23, 0, 23))),
+                                    new MarkupBlock(new DynamicAttributeBlockCodeGenerator(new LocationTagged<string>(String.Empty, 46, 0, 46), 46, 0, 46),
+                                        new ExpressionBlock(
+                                            Factory.CodeTransition()
+                                                   .Accepts(AcceptedCharacters.None),
+                                            Factory.Code("id")
+                                                   .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                        .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                    Factory.Markup("/Boz").With(new LiteralAttributeCodeGenerator(new LocationTagged<string>(String.Empty, 49, 0, 49), new LocationTagged<string>("/Boz", 49, 0, 49)))),
+                                Factory.Markup(" />")),
+                                Factory.Markup(" ")    
+                            ),
                         Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                     Factory.EmptyHtml()));
         }


### PR DESCRIPTION
- These are the fixes to the tests that could not be fixed by altering the core parsing code base.
- Most involve adding TagBlock's, breaking out existing markup blocks and altering some AcceptedCharacter formats.
- Was able to loosen the restrictions on AcceptedCharacter's to allow the body of html tags to accept any character.
#75

These test fixes are here due to the changes in this PR: https://github.com/aspnet/Razor/pull/86
