### PR TITLE
Removing Activator.CreateInstance call from CodeTreeBuilder

### DIFF
--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/CodeTreeBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/CodeTreeBuilder.cs
@@ -125,14 +125,14 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
             }, association, topLevel: true);
         }
 
-        public T StartChunkBlock<T>(SyntaxTreeNode association) where T : ChunkBlock
+        public T StartChunkBlock<T>(SyntaxTreeNode association) where T : ChunkBlock, new()
         {
             return StartChunkBlock<T>(association, topLevel: false);
         }
 
-        public T StartChunkBlock<T>(SyntaxTreeNode association, bool topLevel) where T : ChunkBlock
+        public T StartChunkBlock<T>(SyntaxTreeNode association, bool topLevel) where T : ChunkBlock, new()
         {
-            T chunk = (T)Activator.CreateInstance(typeof(T));
+            var chunk = new T();
 
             AddChunk(chunk, association, topLevel);
 


### PR DESCRIPTION
Should be covered by existing tests for HelperResultChunk, ExpressionCodeChunks etc
