### PR TITLE
[Design] Add TagHelperTypeResolver.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -42,6 +42,50 @@ namespace Microsoft.AspNet.Razor.Runtime
             return string.Format(CultureInfo.CurrentCulture, GetString("ScopeManager_EndCannotBeCalledWithoutACallToBegin"), p0, p1);
         }
 
+        /// <summary>
+        /// Invalid TagHelper lookup text '{0}'. The correct lookup text formats are:
+        /// "assemblyName"
+        /// "assemblyName, #.#.#.#"
+        /// "assemblyName, #.#.#.#, specificType"
+        /// </summary>
+        internal static string TagHelperTypeResolver_InvalidTagHelperLookupText
+        {
+            get { return GetString("TagHelperTypeResolver_InvalidTagHelperLookupText"); }
+        }
+
+        /// <summary>
+        /// Invalid TagHelper lookup text '{0}'. The correct lookup text formats are:
+        /// "assemblyName"
+        /// "assemblyName, #.#.#.#"
+        /// "assemblyName, #.#.#.#, specificType"
+        /// </summary>
+        internal static string FormatTagHelperTypeResolver_InvalidTagHelperLookupText(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperTypeResolver_InvalidTagHelperLookupText"), p0);
+        }
+
+        /// <summary>
+        /// Invalid TagHelper lookup text assembly version '{0}'. The correct lookup text formats are:
+        /// "assemblyName"
+        /// "assemblyName, #.#.#.#"
+        /// "assemblyName, #.#.#.#, specificType"
+        /// </summary>
+        internal static string TagHelperTypeResolver_InvalidTagHelperLookupTextAssemblyVersion
+        {
+            get { return GetString("TagHelperTypeResolver_InvalidTagHelperLookupTextAssemblyVersion"); }
+        }
+
+        /// <summary>
+        /// Invalid TagHelper lookup text assembly version '{0}'. The correct lookup text formats are:
+        /// "assemblyName"
+        /// "assemblyName, #.#.#.#"
+        /// "assemblyName, #.#.#.#, specificType"
+        /// </summary>
+        internal static string FormatTagHelperTypeResolver_InvalidTagHelperLookupTextAssemblyVersion(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperTypeResolver_InvalidTagHelperLookupTextAssemblyVersion"), p0);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -123,4 +123,16 @@
   <data name="ScopeManager_EndCannotBeCalledWithoutACallToBegin" xml:space="preserve">
     <value>You cannot call '{0}' without first calling '{1}' on the TagHelperScopeManager.</value>
   </data>
+  <data name="TagHelperTypeResolver_InvalidTagHelperLookupText" xml:space="preserve">
+    <value>Invalid TagHelper lookup text '{0}'. The correct lookup text formats are:
+"assemblyName"
+"assemblyName, #.#.#.#"
+"assemblyName, #.#.#.#, specificType"</value>
+  </data>
+  <data name="TagHelperTypeResolver_InvalidTagHelperLookupTextAssemblyVersion" xml:space="preserve">
+    <value>Invalid TagHelper lookup text assembly version '{0}'. The correct lookup text formats are:
+"assemblyName"
+"assemblyName, #.#.#.#"
+"assemblyName, #.#.#.#, specificType"</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Framework.Runtime;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    /// <inheritdoc />
+    public class TagHelperTypeResolver : ITagHelperTypeResolver
+    {
+        private static readonly TypeInfo TagHelperTypeInfo = typeof(TagHelper).GetTypeInfo();
+
+        private ILibraryManager _libraryManager;
+
+        // Internal for testing
+        internal TagHelperTypeResolver()
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new instance of <see cref="TagHelperTypeResolver"/>.
+        /// </summary>
+        /// <param name="libraryManager">The <see cref="ILibraryManager"/> used to locate assemblies.</param>
+	    public TagHelperTypeResolver([NotNull] ILibraryManager libraryManager)
+        {
+            _libraryManager = libraryManager;
+        }
+
+        /// <inheritdoc />
+        public virtual IEnumerable<Type> Resolve(string lookupText)
+        {
+            var data = lookupText.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Ensure that we have enough data to work with. Valid formats are:
+            // "assemblyName"
+            // "assemblyName, #.#.#.#"
+            // "assemblyName, #.#.#.#, specificType"
+            if (data.Length == 0 || data.Length > 3)
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatTagHelperTypeResolver_InvalidTagHelperLookupText(lookupText));
+            }
+
+            var assemblyRef = GetAssemblyRef(data);
+            var types = GetAssemblyTypeInfos(assemblyRef);
+            var typeLookup = GetTypeLookup(data);
+
+            // Check if the lookupText specifies a type to add.
+            if (typeLookup != null)
+            {
+                // Iterate through the assembly and find the specified type..
+                types = types.Where(type => type.Namespace + "." + type.Name == typeLookup && IsTagHelper(type));
+            }
+            else
+            {
+                // The assembly was the only piece specified, pull all tag helpers from assembly.
+                types = types.Where(IsTagHelper);
+            }
+
+            // Convert back from TypeInfo[] to Type[].
+            return types.Select(type => type.AsType());
+        }
+
+        // Internal for testing
+        internal virtual string GetAssemblyName(string lookupName)
+        {
+            return _libraryManager.GetLibraryInformation(lookupName).Name;
+        }
+
+        // Internal for testing
+        internal virtual IEnumerable<TypeInfo> GetAssemblyTypeInfos(AssemblyName assemblyRef)
+        {
+            var assembly = Assembly.Load(assemblyRef);
+            return assembly.DefinedTypes;
+        }
+
+        private AssemblyName GetAssemblyRef(string[] lookupTextData)
+        {
+            // Assembly name must always be provided
+            var assemblyName = GetAssemblyName(lookupTextData[0].Trim());
+            var assemblyRef = new AssemblyName(assemblyName);
+            var assemblyVersionSpecified = lookupTextData.Length > 1;
+
+            if (assemblyVersionSpecified)
+            {
+                Version assemblyVersion;
+                var strAssemblyVersion = lookupTextData[1].Trim();
+
+                // Try and parse the assembly version, if unsuccessful throw.
+                if (!Version.TryParse(strAssemblyVersion, out assemblyVersion))
+                {
+                    throw new InvalidOperationException(
+                        Resources.FormatTagHelperTypeResolver_InvalidTagHelperLookupTextAssemblyVersion(
+                            strAssemblyVersion));
+                }
+
+                assemblyRef.Version = assemblyVersion;
+            }
+
+            return assemblyRef;
+        }
+
+        private string GetTypeLookup(string[] lookupTextData)
+        {
+            var typeSpecified = lookupTextData.Length == 3;
+
+            if (typeSpecified)
+            {
+                return lookupTextData[2].Trim();
+            }
+
+            return null;
+        }
+
+        private static bool IsTagHelper(TypeInfo typeInfo)
+        {
+            return !typeInfo.IsAbstract &&
+                   !typeInfo.IsGenericType &&
+                   typeInfo.IsPublic &&
+                   !typeInfo.IsNested &&
+                   TagHelperTypeInfo.IsAssignableFrom(typeInfo);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor.Runtime/project.json
+++ b/src/Microsoft.AspNet.Razor.Runtime/project.json
@@ -1,7 +1,8 @@
 {
     "version": "4.0.0-*",
     "dependencies": {
-        "Microsoft.AspNet.Razor": ""
+        "Microsoft.AspNet.Razor": "",
+        "Microsoft.Framework.Runtime.Interfaces": "1.0.0-*"
     },
     "frameworks": {
         "net45": { },

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
@@ -1,0 +1,276 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
+{
+    public class TagHelperTypeResolverTest
+    {
+        private static readonly Type[] AllValidTestableTagHelpers = new[]
+        {
+            typeof(Valid_PlainTagHelper),
+            typeof(Valid_InheritedTagHelper)
+        };
+        private static readonly Type[] AllInvalidTestableTagHelpers = new[]
+        {
+            typeof(Invalid_AbstractTagHelper),
+            typeof(Invalid_GenericTagHelper<>),
+            typeof(Invalid_NestedPublicTagHelper),
+            typeof(Invalid_NestedInternalTagHelper),
+            typeof(Invalid_PrivateTagHelper),
+            typeof(Invalid_ProtectedTagHelper),
+            typeof(Invalid_InternalTagHelper)
+        };
+        private static readonly Type[] AllTestableTagHelpers =
+            AllValidTestableTagHelpers.Concat(AllInvalidTestableTagHelpers).ToArray();
+
+        [Fact]
+        public void TypeResolver_OnlyReturnsValidTagHelpersForUnversionedAssemblyLookup()
+        {
+            // Arrange
+            var tagHelperTypeResolver = new TestTagHelperTypeResolver(AllTestableTagHelpers);
+            var expectedTypes = new[] {
+                    typeof(Valid_PlainTagHelper),
+                    typeof(Valid_InheritedTagHelper),
+            };
+
+            // Act
+            var types = tagHelperTypeResolver.Resolve("Foo");
+
+            // Assert
+            Assert.Equal(expectedTypes, types);
+        }
+
+        [Fact]
+        public void TypeResolver_OnlyReturnsValidTagHelpersForVersionedAssemblyLookup()
+        {
+            // Arrange
+            var tagHelperTypeResolver = new TestTagHelperTypeResolver(AllTestableTagHelpers);
+            var expectedTypes = new[] {
+                    typeof(Valid_PlainTagHelper),
+                    typeof(Valid_InheritedTagHelper),
+            };
+
+            // Act
+            var types = tagHelperTypeResolver.Resolve("Foo, 1.0.0.0");
+
+            // Assert
+            Assert.Equal(expectedTypes, types);
+        }
+
+        [Fact]
+        public void TypeResolver_ReturnsIndividualValidTagHelpersIfRequested()
+        {
+            // Arrange
+            var tagHelperTypeResolver = new TestTagHelperTypeResolver(AllTestableTagHelpers);
+            var expectedTypes = new[] {
+                    typeof(Valid_PlainTagHelper)
+            };
+
+            // Act
+            var types = tagHelperTypeResolver.Resolve(
+                "Foo, 1.0.0.0, Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper");
+
+            // Assert
+            Assert.Equal(expectedTypes, types);
+        }
+
+        [Theory]
+        [InlineData("Foo,1.0.0.0,Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper")]
+        [InlineData("    Foo,1.0.0.0,Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper")]
+        [InlineData("Foo    ,1.0.0.0,Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper")]
+        [InlineData("     Foo    ,1.0.0.0,Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper")]
+        [InlineData("Foo,    1.0.0.0,Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper")]
+        [InlineData("Foo,1.0.0.0    ,Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper")]
+        [InlineData("Foo,     1.0.0.0    ,Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper")]
+        [InlineData("Foo,1.0.0.0,    Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper")]
+        [InlineData("Foo,1.0.0.0,Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper    ")]
+        [InlineData("Foo,1.0.0.0,     Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper    ")]
+        [InlineData("  Foo  ,  1.0.0.0  ,  Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Valid_PlainTagHelper  ")]
+        public void TypeResolver_IgnoresSpaces(string lookupText)
+        {
+            // Arrange
+            var expectedVersion = new Version("1.0.0.0");
+            var tagHelperTypeResolver = new TestTagHelperTypeResolver(AllTestableTagHelpers)
+            {
+                OnGetAssemblyTypeInfos = (assemblyRef) =>
+                {
+                    Assert.Equal("Foo", assemblyRef.Name);
+                    Assert.Equal(expectedVersion, assemblyRef.Version);
+                }
+            };
+            var expectedTypes = new[] {
+                    typeof(Valid_PlainTagHelper)
+            };
+
+            // Act
+            var types = tagHelperTypeResolver.Resolve(lookupText);
+
+            // Assert
+            Assert.Equal(expectedTypes, types);
+        }
+
+        [Fact]
+        public void TypeResolver_DoesntReturnInvalidTagHelpersEvenWhenSpecified()
+        {
+            // Arrange
+            var tagHelperTypeResolver = new TestTagHelperTypeResolver(AllTestableTagHelpers);
+
+            // Act
+            var types = tagHelperTypeResolver.Resolve(
+                "Foo, 1.0.0.0, Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Invalid_AbstractTagHelper");
+            types = types.Concat(tagHelperTypeResolver.Resolve(
+                "Foo, 1.0.0.0, Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Invalid_GenericTagHelper`"));
+            types = types.Concat(tagHelperTypeResolver.Resolve(
+                "Foo, 1.0.0.0, Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Invalid_NestedPublicTagHelper"));
+            types = types.Concat(tagHelperTypeResolver.Resolve(
+                "Foo, 1.0.0.0, Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Invalid_NestedInternalTagHelper"));
+            types = types.Concat(tagHelperTypeResolver.Resolve(
+                "Foo, 1.0.0.0, Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Invalid_PrivateTagHelper"));
+            types = types.Concat(tagHelperTypeResolver.Resolve(
+                "Foo, 1.0.0.0, Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Invalid_ProtectedTagHelper"));
+            types = types.Concat(tagHelperTypeResolver.Resolve(
+                "Foo, 1.0.0.0, Microsoft.AspNet.Razor.Runtime.Test.TagHelpers.Invalid_InternalTagHelper"));
+
+            // Assert
+            Assert.Empty(types);
+        }
+
+        [Fact]
+        public void TypeResolver_ReturnsEmptyEnumerableIfNoValidTagHelpersFound()
+        {
+            // Arrange
+            var tagHelperTypeResolver = new TestTagHelperTypeResolver(AllInvalidTestableTagHelpers);
+
+            // Act
+            var types = tagHelperTypeResolver.Resolve("Foo");
+
+            // Assert
+            Assert.Empty(types);
+        }
+
+        [Theory]
+        [InlineData("Foo, 1.2.3.4", "1.2.3.4")]
+        [InlineData("Foo, 1.2.3.4, Bar", "1.2.3.4")]
+        public void TypeResolver_LookupTextVersionIsUsed(string lookupText, string version)
+        {
+            // Arrange
+            var expectedVersion = new Version(version);
+            var tagHelperTypeResolver = new TestTagHelperTypeResolver(AllInvalidTestableTagHelpers)
+            {
+                OnGetAssemblyTypeInfos = (assemblyRef) =>
+                {
+                    Assert.Equal(expectedVersion, assemblyRef.Version);
+                }
+            };
+
+            // Act & Assert
+            tagHelperTypeResolver.Resolve(lookupText);
+        }
+
+        [Fact]
+        public void TypeResolver_ResolveThrowsIfEmptyLookupText()
+        {
+            // Arrange
+            var tagHelperTypeResolver = new TestTagHelperTypeResolver(AllInvalidTestableTagHelpers);
+            var expectedMessage = Resources.FormatTagHelperTypeResolver_InvalidTagHelperLookupText(string.Empty);
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                tagHelperTypeResolver.Resolve(string.Empty);
+            });
+
+            Assert.Equal(expectedMessage, ex.Message);
+        }
+
+
+        [Theory]
+        [InlineData("Foo, abcdefgh", "abcdefgh")]
+        [InlineData("Foo, abcdefgh, Bar", "abcdefgh")]
+        public void TypeResolver_ResolveThrowsIfInvalidVersion(string lookupText, string invalidVersion)
+        {
+            // Arrange
+            var tagHelperTypeResolver = new TestTagHelperTypeResolver(AllInvalidTestableTagHelpers);
+            var expectedMessage =
+                Resources.FormatTagHelperTypeResolver_InvalidTagHelperLookupTextAssemblyVersion(invalidVersion);
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                tagHelperTypeResolver.Resolve(lookupText);
+            });
+
+            Assert.Equal(expectedMessage, ex.Message);
+        }
+
+        private class TestTagHelperTypeResolver : TagHelperTypeResolver
+        {
+            private IEnumerable<TypeInfo> _assemblyTypeInfos;
+
+            public TestTagHelperTypeResolver(IEnumerable<Type> assemblyTypes)
+            {
+                _assemblyTypeInfos = assemblyTypes.Select(type => type.GetTypeInfo());
+                OnGetAssemblyTypeInfos = (_) => { };
+            }
+
+            public Action<AssemblyName> OnGetAssemblyTypeInfos { get; set; }
+
+            internal override string GetAssemblyName(string lookupName)
+            {
+                // Doesn't matter because we override the way its used via GetAssemblyTypeInfos
+                return lookupName;
+            }
+
+            internal override IEnumerable<TypeInfo> GetAssemblyTypeInfos(AssemblyName assemblyRef)
+            {
+                OnGetAssemblyTypeInfos(assemblyRef);
+
+                return _assemblyTypeInfos;
+            }
+        }
+
+        public class Invalid_NestedPublicTagHelper : TagHelper
+        {
+        }
+
+        internal class Invalid_NestedInternalTagHelper : TagHelper
+        {
+        }
+
+        private class Invalid_PrivateTagHelper : TagHelper
+        {
+        }
+
+        protected class Invalid_ProtectedTagHelper : TagHelper
+        {
+        }
+    }
+
+    // These tag helper types must be unnested and public to be valid tag helpers.
+    public class Valid_PlainTagHelper : TagHelper
+    {
+    }
+
+    public class Valid_InheritedTagHelper : Valid_PlainTagHelper
+    {
+    }
+
+    public abstract class Invalid_AbstractTagHelper : TagHelper
+    {
+    }
+
+    public class Invalid_GenericTagHelper<T> : TagHelper
+    {
+    }
+
+    internal class Invalid_InternalTagHelper : TagHelper
+    {
+    }
+}


### PR DESCRIPTION
- The `TagHelperTypeResolver` is responsible for determining the format of lookup texts used throughout the tag helper system.  By default it handles the following formats:

```
"assemblyName"
"assemblyName, #.#.#.#"
"assemblyName, #.#.#.#, specificType"
```
- It also restricts what types are considered `TagHelper`s.  In this implementation we only accept public, non-nested, non-abstract, non-generic `TagHelper`s.
- Added tests to validate the expected functionality.
#158
