### PR TITLE
Add TagName attribute for tag helpers.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -78,6 +78,22 @@ namespace Microsoft.AspNet.Razor.Runtime
             return string.Format(CultureInfo.CurrentCulture, GetString("ScopeManager_EndCannotBeCalledWithoutACallToBegin"), p0, p1, p2);
         }
 
+        /// <summary>
+        /// Parameter {0} must not contain null tag names.
+        /// </summary>
+        internal static string TagNameAttribute_AdditionalTagsCannotContainNull
+        {
+            get { return GetString("TagNameAttribute_AdditionalTagsCannotContainNull"); }
+        }
+
+        /// <summary>
+        /// Parameter {0} must not contain null tag names.
+        /// </summary>
+        internal static string FormatTagNameAttribute_AdditionalTagsCannotContainNull(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagNameAttribute_AdditionalTagsCannotContainNull"), p0);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -131,4 +131,7 @@
   <data name="ScopeManager_EndCannotBeCalledWithoutACallToBegin" xml:space="preserve">
     <value>Must call '{2}.{1}' before calling '{2}.{0}'.</value>
   </data>
+  <data name="TagNameAttribute_AdditionalTagsCannotContainNull" xml:space="preserve">
+    <value>Parameter {0} must not contain null tag names.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var tagHelperTypes = ResolveTagHelperTypes(lookupStrings);
 
             // Convert types to TagHelperDescriptors
-            var descriptors = tagHelperTypes.Select(TagHelperDescriptorFactory.CreateDescriptor);
+            var descriptors = tagHelperTypes.SelectMany(TagHelperDescriptorFactory.CreateDescriptors);
 
             return descriptors;
         }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagNameAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagNameAttribute.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// Used to override a <see cref="ITagHelper"/>'s default tag name target.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public sealed class TagNameAttribute : Attribute
+    {
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="TagNameAttribute"/> class.
+        /// </summary>
+        /// <param name="tag">The HTML tag name for the <see cref="TagHelper"/> to target.</param>
+        public TagNameAttribute([NotNull] string tag)
+        {
+            Tags = new[] { tag };
+        }
+
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="TagNameAttribute"/> class.
+        /// </summary>
+        /// <param name="tag">The HTML tag name for the <see cref="TagHelper"/> to target.</param>
+        /// <param name="additionalTags">Additional HTML tag names for the <see cref="TagHelper"/> to target.</param>
+        public TagNameAttribute([NotNull] string tag, [NotNull] params string[] additionalTags)
+        {
+            if (additionalTags.Contains(null))
+            {
+                throw new ArgumentNullException(
+                    nameof(additionalTags),
+                    Resources.FormatTagNameAttribute_AdditionalTagsCannotContainNull(nameof(additionalTags)));
+            };
+
+            var allTags = new List<string>(additionalTags);
+            allTags.Add(tag);
+
+            Tags = allTags;
+        }
+
+        /// <summary>
+        /// An <see cref="IEnumerable{string}"/> of tag names for the <see cref="TagHelper"/> to target.
+        /// </summary>
+        public IEnumerable<string> Tags { get; private set; }
+    }
+}


### PR DESCRIPTION
**Reason for PR:** We initially pushed this out to be done later but this is needed to properly complete https://github.com/aspnet/Mvc/issues/1116 and https://github.com/aspnet/Mvc/issues/1168.
- Made it so the `TagHelperDescriptorFactory` could pull tag name targets from `TagNameAttribute`s on types.
- Tested the behavior between `TagNameAttribute` and `TagHelperDescriptorFactory` (the only consumer of the attribute).
- Made sure to test duplicate and inherited class scenarios.
#120
