### PR TITLE
Add error mechanism for TagHelperParseTreeRewriter.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/ISyntaxTreeRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/ISyntaxTreeRewriter.cs
@@ -6,19 +6,17 @@ using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 namespace Microsoft.AspNet.Razor.Parser
 {
     /// <summary>
-    /// Defines the contract for rewriting a syntax tree.
+    /// Contract for rewriting a syntax tree.
     /// </summary>
     public interface ISyntaxTreeRewriter
     {
         /// <summary>
-        /// Rewrites the provided <paramref name="input"/> syntax tree.
+        /// Rewrites the provided <paramref name="context"/>s <see cref= "RewritingContext.SyntaxTree" />.
         /// </summary>
-        /// <param name="input">The current syntax tree.</param>
-        /// <returns>The <paramref name="input"/> syntax tree or a syntax tree to be used instead of the 
-        /// <paramref name="input"/> tree.</returns>
+        /// <param name="context">Contains information on the rewriting of the syntax tree.</param>
         /// <remarks>
-        /// If you choose not to modify the syntax tree you can always return <paramref name="input"/>.
+        /// To modify the syntax tree replace the <paramref name="context"/>s <see cref="RewritingContext.SyntaxTree"/>.
         /// </remarks>
-        Block Rewrite(Block input);
+        void Rewrite(RewritingContext context);
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/MarkupRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/MarkupRewriter.cs
@@ -28,11 +28,11 @@ namespace Microsoft.AspNet.Razor.Parser
             get { return _blocks.Count > 0 ? _blocks.Peek() : null; }
         }
 
-        public virtual Block Rewrite(Block input)
+        public virtual void Rewrite(RewritingContext context)
         {
-            input.Accept(this);
+            context.SyntaxTree.Accept(this);
             Debug.Assert(_blocks.Count == 1);
-            return _blocks.Pop().Build();
+            context.SyntaxTree = _blocks.Pop().Build();
         }
 
         public override void VisitBlock(Block block)

--- a/src/Microsoft.AspNet.Razor/Parser/RewritingContext.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/RewritingContext.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+using Microsoft.AspNet.Razor.Text;
+
+namespace Microsoft.AspNet.Razor.Parser
+{
+    /// <summary>
+    /// Informational class for rewriting a syntax tree.
+    /// </summary>
+    public class RewritingContext
+    {
+        private readonly List<RazorError> _errors;
+
+        /// <summary>
+        /// Instantiates a new <see cref="RewritingContext"/>.
+        /// </summary>
+        public RewritingContext(Block syntaxTree)
+        {
+            _errors = new List<RazorError>();
+            SyntaxTree = syntaxTree;
+        }
+
+        /// <summary>
+        /// The documents syntax tree.
+        /// </summary>
+        public Block SyntaxTree { get; set; }
+
+        /// <summary>
+        /// <see cref="RazorError"/>s collected.
+        /// </summary>
+        public IEnumerable<RazorError> Errors
+        {
+            get
+            {
+                return _errors;
+            }
+        }
+
+        /// <summary>
+        /// Creates and tracks a new <see cref="RazorError"/>.
+        /// </summary>
+        /// <param name="location"><see cref="SourceLocation"/> of the error.</param>
+        /// <param name="message">A message describing the error.</param>        
+        public void OnError(SourceLocation location, string message)
+        {
+            _errors.Add(new RazorError(message, location));
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+using Microsoft.AspNet.Razor.Text;
 using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Parser.TagHelpers
@@ -16,6 +17,8 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
     /// </summary>
     public class TagHelperBlock : Block, IEquatable<TagHelperBlock>
     {
+        private readonly SourceLocation _start;
+
         /// <summary>
         /// Instantiates a new instance of a <see cref="TagHelperBlock"/>.
         /// </summary>
@@ -26,6 +29,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         {
             TagName = source.TagName;
             Attributes = new Dictionary<string, SyntaxTreeNode>(source.Attributes);
+            _start = source.Start;
 
             source.Reset();
 
@@ -39,6 +43,15 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// The HTML attributes.
         /// </summary>
         public IDictionary<string, SyntaxTreeNode> Attributes { get; private set; }
+
+        /// <inheritdoc />
+        public override SourceLocation Start
+        {
+            get
+            {
+                return _start;
+            }
+        }
 
         /// <summary>
         /// The HTML tag name.

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.TagHelpers;
+using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 
 namespace Microsoft.AspNet.Razor.Parser.TagHelpers
@@ -44,6 +45,9 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
             CodeGenerator = new TagHelperCodeGenerator(descriptors);
             Type = startTag.Type;
             Attributes = GetTagAttributes(startTag);
+
+            // There will always be at least one child for the '<'.
+            Start = startTag.Children.First().Start;
         }
 
         // Internal for testing
@@ -97,6 +101,11 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
 
             base.Reset();
         }
+
+        /// <summary>
+        /// The starting <see cref="SourceLocation"/> of the tag helper.
+        /// </summary>
+        public SourceLocation Start { get; private set; }
 
         private static IDictionary<string, SyntaxTreeNode> GetTagAttributes(Block tagBlock)
         {

--- a/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
@@ -1542,6 +1542,22 @@ namespace Microsoft.AspNet.Razor
             return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpers_CannotUseDirectiveWithNoTagHelperDescriptorResolver"), p0, p1, p2);
         }
 
+        /// <summary>
+        /// Found a malformed '{0}' tag helper. Tag helpers must have a start and end tag or be self closing.
+        /// </summary>
+        internal static string TagHelpersParseTreeRewriter_FoundMalformedTagHelper
+        {
+            get { return GetString("TagHelpersParseTreeRewriter_FoundMalformedTagHelper"); }
+        }
+
+        /// <summary>
+        /// Found a malformed '{0}' tag helper. Tag helpers must have a start and end tag or be self closing.
+        /// </summary>
+        internal static string FormatTagHelpersParseTreeRewriter_FoundMalformedTagHelper(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpersParseTreeRewriter_FoundMalformedTagHelper"), p0);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Razor/RazorResources.resx
+++ b/src/Microsoft.AspNet.Razor/RazorResources.resx
@@ -424,4 +424,7 @@ Instead, wrap the contents of the block in "{{}}":
   <data name="TagHelpers_CannotUseDirectiveWithNoTagHelperDescriptorResolver" xml:space="preserve">
     <value>Cannot use directive '{0}' when a {1} has not been provided to the {2}.</value>
   </data>
+  <data name="TagHelpersParseTreeRewriter_FoundMalformedTagHelper" xml:space="preserve">
+    <value>Found a malformed '{0}' tag helper. Tag helpers must have a start and end tag or be self closing.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlAttributeTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlAttributeTest.cs
@@ -185,8 +185,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             // Act
             ParserResults results = ParseDocument("<a href='~/Foo/Bar' />");
-            Block rewritten = new ConditionalAttributeCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(results.Document);
-            rewritten = new MarkupCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritten);
+            var rewritingContext = new RewritingContext(results.Document);
+            new ConditionalAttributeCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritingContext);
+            new MarkupCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritingContext);
+            var rewritten = rewritingContext.SyntaxTree;
 
             // Assert
             Assert.Equal(0, results.ParserErrors.Count);
@@ -270,8 +272,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
 
             // Act
             ParserResults results = ParseDocument(code);
-            Block rewritten = new ConditionalAttributeCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(results.Document);
-            rewritten = new MarkupCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritten);
+            var rewritingContext = new RewritingContext(results.Document);
+            new ConditionalAttributeCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritingContext);
+            new MarkupCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritingContext);
+            var rewritten = rewritingContext.SyntaxTree;
 
             // Assert
             Assert.Equal(0, results.ParserErrors.Count);

--- a/test/Microsoft.AspNet.Razor.Test/Parser/WhitespaceRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/WhitespaceRewriterTest.cs
@@ -32,14 +32,15 @@ namespace Microsoft.AspNet.Razor.Test.Parser
                 factory.Markup("test")
                 );
             WhiteSpaceRewriter rewriter = new WhiteSpaceRewriter(new HtmlMarkupParser().BuildSpan);
+            var rewritingContext = new RewritingContext(start);
 
             // Act
-            Block actual = rewriter.Rewrite(start);
+            rewriter.Rewrite(rewritingContext);
 
             factory.Reset();
 
             // Assert
-            ParserTestBase.EvaluateParseTree(actual, new MarkupBlock(
+            ParserTestBase.EvaluateParseTree(rewritingContext.SyntaxTree, new MarkupBlock(
                                                          factory.Markup("test"),
                                                          factory.Markup("    "),
                                                          new ExpressionBlock(


### PR DESCRIPTION
- Replaced customer facing Debug.Assert with a new error mechanism to surface errors to GenerateCode callers.
- The new mechanism is a general purpose way for `ISyntaxTreeRewriters` to add errors to the parsing phase.
- Added tests to validate `RazorError`s.
#174
