### PR TITLE
Fix inherited TagHelper properties.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -62,8 +62,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         private static IEnumerable<TagHelperAttributeDescriptor> GetAttributeDescriptors(Type type)
         {
-            var typeInfo = type.GetTypeInfo();
-            var properties = typeInfo.DeclaredProperties.Where(IsValidProperty);
+            var properties = type.GetRuntimeProperties().Where(IsValidProperty);
             var attributeDescriptors = properties.Select(ToAttributeDescriptor);
 
             return attributeDescriptors;

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -23,6 +23,28 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
+        public void CreateDescriptor_BuildsDescriptorsWithInheritedProperties()
+        {
+            // Arrange
+            var intProperty = typeof(InheritedSingleAttributeTagHelper).GetProperty(
+                nameof(InheritedSingleAttributeTagHelper.IntAttribute));
+            var expectedDescriptor = new TagHelperDescriptor(
+                "InheritedSingleAttribute",
+                typeof(InheritedSingleAttributeTagHelper).FullName,
+                ContentBehavior.None,
+                new[] {
+                    new TagHelperAttributeDescriptor(nameof(InheritedSingleAttributeTagHelper.IntAttribute), intProperty)
+                });
+
+            // Act
+            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(typeof(InheritedSingleAttributeTagHelper));
+
+            // Assert
+            var descriptor = Assert.Single(descriptors);
+            Assert.Equal(descriptor, expectedDescriptor, CompleteTagHelperDescriptorComparer.Default);
+        }
+
+        [Fact]
         public void CreateDescriptor_BuildsDescriptorsWithConventionNames()
         {
             // Arrange
@@ -255,6 +277,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         [TagName("span")]
         [TagName("div", "p")]
         private class MultipleAttributeTagHelper
+        {
+        }
+
+        private class InheritedSingleAttributeTagHelper : SingleAttributeTagHelper
         {
         }
     }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/project.json
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/project.json
@@ -8,6 +8,6 @@
         "test": "Xunit.KRunner"
     },
     "frameworks": {
-        "net45": { }
+        "aspnet50": { }
     }
 }


### PR DESCRIPTION
- Used to only look at declared properties on the tag helper type, now we get the runtime properties.
- Fixed Runtime test projec to work with new CLR changes (looks like it was missed).
#189
