### PR TITLE
Make TagHelperOutput.Attributes case insensitive.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -19,8 +19,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="tagName">The HTML tag name in the Razor source.</param>
         public TagHelperExecutionContext([NotNull] string tagName)
         {
-            AllAttributes = new Dictionary<string, object>(StringComparer.Ordinal);
-            HTMLAttributes = new Dictionary<string, string>(StringComparer.Ordinal);
+            AllAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            HTMLAttributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _tagHelpers = new List<ITagHelper>();
             TagName = tagName;
         }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         internal TagHelperOutput(string tagName)
         {
             TagName = tagName;
-            Attributes = new Dictionary<string, string>(StringComparer.Ordinal);
+            Attributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         // Internal for testing
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             TagName = tagName;
             Content = content;
-            Attributes = new Dictionary<string, string>(attributes, StringComparer.Ordinal);
+            Attributes = new Dictionary<string, string>(attributes, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
@@ -9,6 +9,49 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 {
     public class TagHelperExecutionContextTest
     {
+        public static TheoryData<string, string> DictionaryCaseTestingData
+        {
+            get
+            {
+                return new TheoryData<string, string>
+                {
+                    { "class", "CLaSS" },
+                    { "Class", "class" },
+                    { "Class", "claSS" }
+                };
+            }
+        }
+
+        [MemberData(nameof(DictionaryCaseTestingData))]
+        public void HtmlAttributes_IgnoresCase(string originalName, string updatedName)
+        {
+            // Arrange
+            var executionContext = new TagHelperExecutionContext("p");
+            executionContext.HTMLAttributes[originalName] = "hello";
+
+            // Act
+            executionContext.HTMLAttributes[updatedName] = "something else";
+
+            // Assert
+            var attribute = Assert.Single(executionContext.HTMLAttributes);
+            Assert.Equal(new KeyValuePair<string, string>(originalName, "something else"), attribute);
+        }
+
+        [MemberData(nameof(DictionaryCaseTestingData))]
+        public void AllAttributes_IgnoresCase(string originalName, string updatedName)
+        {
+            // Arrange
+            var executionContext = new TagHelperExecutionContext("p");
+            executionContext.AllAttributes[originalName] = false;
+
+            // Act
+            executionContext.AllAttributes[updatedName] = true;
+
+            // Assert
+            var attribute = Assert.Single(executionContext.AllAttributes);
+            Assert.Equal(new KeyValuePair<string, object>(originalName, true), attribute);
+        }
+
         [Fact]
         public void AddHtmlAttribute_MaintainsHTMLAttributes()
         {

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -208,5 +208,26 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             // Assert
             Assert.Empty(output);
         }
+
+        [Theory]
+        [InlineData("class", "ClASs")]
+        [InlineData("CLaSs", "class")]
+        [InlineData("cLaSs", "cLasS")]
+        public void Attributes_IgnoresCase(string originalName, string updateName)
+        {
+            // Arrange
+            var tagHelperOutput = new TagHelperOutput("p",
+                attributes: new Dictionary<string, string>
+                {
+                    { originalName, "btn" },
+                });
+
+            // Act
+            tagHelperOutput.Attributes[updateName] = "super button";
+
+            // Assert
+            var attribute = Assert.Single(tagHelperOutput.Attributes);
+            Assert.Equal(new KeyValuePair<string, string>(originalName, "super button"), attribute);
+        }
     }
 }


### PR DESCRIPTION
- Changed the Attributes dictionary to utilize a StringComparer.OrdinalIgnoreCase comparer.
- Added a test to validate the new attribute mechanic.
#186
