### PR TITLE
Allow invalid HTML to be in Razor pages.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperParseTreeRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperParseTreeRewriter.cs
@@ -56,8 +56,10 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
                         // Get tag name of the current block (doesn't matter if it's an end or start tag)
                         var tagName = GetTagName(childBlock);
 
+                        // Could not determine tag name, it can't be a TagHelper, continue on and track the element.
                         if (tagName == null)
                         {
+                            _currentBlock.Children.Add(child);
                             continue;
                         }
 
@@ -224,9 +226,14 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             }
 
             var childSpan = (Span)child;
-            var textSymbol = childSpan.Symbols.FirstHtmlSymbolAs(HtmlSymbolType.Text);
+            var textSymbol = childSpan.Symbols.FirstHtmlSymbolAs(HtmlSymbolType.WhiteSpace | HtmlSymbolType.Text);
 
-            return textSymbol != null ? textSymbol.Content : null;
+            if (textSymbol == null)
+            {
+                return null;
+            }
+
+            return textSymbol.Type == HtmlSymbolType.WhiteSpace ? null :  textSymbol.Content;
         }
 
         private static bool IsSelfClosing(Block beginTagBlock)

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/HtmlSymbolType.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/HtmlSymbolType.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
 {
+    [Flags]
     public enum HtmlSymbolType
     {
         Unknown,

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/SymbolExtensions.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/SymbolExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
         /// <returns>The first <see cref="HtmlSymbol"/> of type <paramref name="type"/>.</returns>
         public static HtmlSymbol FirstHtmlSymbolAs(this IEnumerable<ISymbol> symbols, HtmlSymbolType type)
         {
-            return symbols.OfType<HtmlSymbol>().FirstOrDefault(sym => sym.Type == type);
+            return symbols.OfType<HtmlSymbol>().FirstOrDefault(sym => (type & sym.Type) == sym.Type);
         }
     }
 }


### PR DESCRIPTION
- Modified the TagHelperParseTreeRewriter to not remove invalid HTML snippets.
- Added tests to validate invalid HTML is allowed.
#212
