### PR TITLE
Add hook to add TagHelperDirectiveDescriptors.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/AddOrRemoveTagHelperSpanVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/AddOrRemoveTagHelperSpanVisitor.cs
@@ -32,10 +32,17 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
             // This will recurse through the syntax tree.
             VisitBlock(root);
 
-            var resolutionContext = new TagHelperDescriptorResolutionContext(_directiveDescriptors);
+            var resolutionContext = GetTagHelperDescriptorResolutionContext(_directiveDescriptors);
             var descriptors = _descriptorResolver.Resolve(resolutionContext);
 
             return descriptors;
+        }
+
+        // Allows MVC a chance to override the TagHelperDescriptorResolutionContext
+        protected virtual TagHelperDescriptorResolutionContext GetTagHelperDescriptorResolutionContext(
+            [NotNull] IEnumerable<TagHelperDirectiveDescriptor> descriptors)
+        {
+            return new TagHelperDescriptorResolutionContext(descriptors);
         }
 
         public override void VisitSpan(Span span)


### PR DESCRIPTION
- Also added a test to validate that you can hook into the TagHelperDescriptorResolutionContext.

Ultimately this will be used to tie into the ViewStart finding of `@addtaghelper` and `@removetaghelper`
#214

/cc @pranavkm 
