### PR TITLE
Handle unclosed and invalid structure HTML tags for TagHelpers.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.TagHelpers;
 using Microsoft.AspNet.Razor.Text;
-using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 
 namespace Microsoft.AspNet.Razor.Parser.TagHelpers
 {
@@ -18,7 +15,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
     public class TagHelperBlockBuilder : BlockBuilder
     {
         /// <summary>
-        /// Instantiates a new <see cref="TagHelperBlockBuilder"/> instance based on given the
+        /// Instantiates a new <see cref="TagHelperBlockBuilder"/> instance based on the given
         /// <paramref name="original"/>.
         /// </summary>
         /// <param name="original">The original <see cref="TagHelperBlock"/> to copy data from.</param>
@@ -36,20 +33,21 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// and <see cref="BlockBuilder.Type"/> from the <paramref name="startTag"/>.
         /// </summary>
         /// <param name="tagName">An HTML tag name.</param>
+        /// <param name="start">Starting location of the <see cref="TagHelperBlock"/>.</param>
+        /// <param name="attributes">Attributes of the <see cref="TagHelperBlock"/>.</param>
         /// <param name="descriptors">The <see cref="TagHelperDescriptor"/>s associated with the current HTML
         /// tag.</param>
-        /// <param name="startTag">The <see cref="Block"/> that contains all information about the start
-        /// of the HTML element.</param>
-        public TagHelperBlockBuilder(string tagName, IEnumerable<TagHelperDescriptor> descriptors, Block startTag)
+        public TagHelperBlockBuilder(string tagName,
+                                     SourceLocation start,
+                                     IDictionary<string, SyntaxTreeNode> attributes,
+                                     IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;
+            Start = start;
             Descriptors = descriptors;
+            Type = BlockType.Tag;
             CodeGenerator = new TagHelperCodeGenerator(descriptors);
-            Type = startTag.Type;
-            Attributes = GetTagAttributes(startTag, descriptors);
-
-            // There will always be at least one child for the '<'.
-            Start = startTag.Children.First().Start;
+            Attributes = new Dictionary<string, SyntaxTreeNode>(attributes);
         }
 
         // Internal for testing
@@ -113,307 +111,5 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// The starting <see cref="SourceLocation"/> of the tag helper.
         /// </summary>
         public SourceLocation Start { get; private set; }
-
-        private static IDictionary<string, SyntaxTreeNode> GetTagAttributes(
-            Block tagBlock,
-            IEnumerable<TagHelperDescriptor> descriptors)
-        {
-            var attributes = new Dictionary<string, SyntaxTreeNode>(StringComparer.OrdinalIgnoreCase);
-
-            // Build a dictionary so we can easily lookup expected attribute value lookups
-            IReadOnlyDictionary<string, string> attributeValueTypes = 
-                descriptors.SelectMany(descriptor => descriptor.Attributes)
-                           .Distinct(TagHelperAttributeDescriptorComparer.Default)
-                           .ToDictionary(descriptor => descriptor.Name,
-                                       descriptor => descriptor.TypeName,
-                                       StringComparer.OrdinalIgnoreCase);
-
-            // We skip the first child "<tagname" and take everything up to the "ending" portion of the tag ">" or "/>".
-            // The -2 accounts for both the start and end tags.
-            var attributeChildren = tagBlock.Children.Skip(1).Take(tagBlock.Children.Count() - 2);
-
-            foreach (var child in attributeChildren)
-            {
-                KeyValuePair<string, SyntaxTreeNode> attribute;
-
-                if (child.IsBlock)
-                {
-                    attribute = ParseBlock((Block)child, attributeValueTypes);
-                }
-                else
-                {
-                    attribute = ParseSpan((Span)child, attributeValueTypes);
-                }
-
-                attributes.Add(attribute.Key, attribute.Value);
-            }
-
-            return attributes;
-        }
-
-        // This method handles cases when the attribute is a simple span attribute such as
-        // class="something moresomething".  This does not handle complex attributes such as
-        // class="@myclass". Therefore the span.Content is equivalent to the entire attribute.
-        private static KeyValuePair<string, SyntaxTreeNode> ParseSpan(
-            Span span,
-            IReadOnlyDictionary<string, string> attributeValueTypes)
-        {
-            var afterEquals = false;
-            var builder = new SpanBuilder
-            {
-                CodeGenerator = span.CodeGenerator,
-                EditHandler = span.EditHandler,
-                Kind = span.Kind
-            };
-            var htmlSymbols = span.Symbols.OfType<HtmlSymbol>().ToArray();
-            var capturedAttributeValueStart = false;
-            var attributeValueStartLocation = span.Start;
-            var symbolOffset = 1;
-            string name = null;
-
-            // Iterate down through the symbols to find the name and the start of the value.
-            // We subtract the symbolOffset so we don't accept an ending quote of a span.
-            for (var i = 0; i < htmlSymbols.Length - symbolOffset; i++)
-            {
-                var symbol = htmlSymbols[i];
-
-                if (afterEquals)
-                {
-                    // When symbols are accepted into SpanBuilders, their locations get altered to be offset by the 
-                    // parent which is why we need to mark our start location prior to adding the symbol. 
-                    // This is needed to know the location of the attribute value start within the document.
-                    if (!capturedAttributeValueStart)
-                    {
-                        capturedAttributeValueStart = true;
-
-                        attributeValueStartLocation = span.Start + symbol.Start;
-                    }
-
-                    builder.Accept(symbol);
-                }
-                else if (name == null && symbol.Type == HtmlSymbolType.Text)
-                {
-                    name = symbol.Content;
-                    attributeValueStartLocation = SourceLocation.Advance(span.Start, name);
-                }
-                else if (symbol.Type == HtmlSymbolType.Equals)
-                {
-                    // We've found an '=' symbol, this means that the coming symbols will either be a quote
-                    // or value (in the case that the value is unquoted).
-                    // Spaces after/before the equal symbol are not yet supported:
-                    // https://github.com/aspnet/Razor/issues/123
-
-                    // TODO: Handle malformed tags, if there's an '=' then there MUST be a value.
-                    // https://github.com/aspnet/Razor/issues/104
-
-                    SourceLocation symbolStartLocation;
-
-                    // Check for attribute start values, aka single or double quote
-                    if (IsQuote(htmlSymbols[i + 1]))
-                    {
-                        // Move past the attribute start so we can accept the true value.
-                        i++;
-                        symbolStartLocation = htmlSymbols[i + 1].Start;
-                    }
-                    else
-                    {
-                        symbolStartLocation = symbol.Start;
-
-                        // Set the symbol offset to 0 so we don't attempt to skip an end quote that doesn't exist.
-                        symbolOffset = 0;
-                    }
-
-                    attributeValueStartLocation = symbolStartLocation + 
-                                                  span.Start + 
-                                                  new SourceLocation(absoluteIndex: 1,
-                                                                     lineIndex: 0,
-                                                                     characterIndex: 1);
-                    afterEquals = true;
-                }
-            }
-
-            // After all symbols have been added we need to set the builders start position so we do not indirectly
-            // modify each symbol's Start location.
-            builder.Start = attributeValueStartLocation;
-
-            return CreateMarkupAttribute(name, builder, attributeValueTypes);
-        }
-
-        private static KeyValuePair<string, SyntaxTreeNode> ParseBlock(
-            Block block,
-            IReadOnlyDictionary<string, string> attributeValueTypes)
-        {
-            // TODO: Accept more than just spans: https://github.com/aspnet/Razor/issues/96.
-            // The first child will only ever NOT be a Span if a user is doing something like:
-            // <input @checked />
-
-            var childSpan = block.Children.First() as Span;
-
-            if (childSpan == null)
-            {
-                throw new InvalidOperationException(RazorResources.TagHelpers_CannotHaveCSharpInTagDeclaration);
-            }
-
-            var builder = new BlockBuilder(block);
-
-            // If there's only 1 child it means that it's plain text inside of the attribute.
-            // i.e. <div class="plain text in attribute">
-            if (builder.Children.Count == 1)
-            {
-                return ParseSpan(childSpan, attributeValueTypes);
-            }
-
-            var textSymbol = childSpan.Symbols.FirstHtmlSymbolAs(HtmlSymbolType.Text);
-            var name = textSymbol != null ? textSymbol.Content : null;
-
-            if (name == null)
-            {
-                throw new InvalidOperationException(RazorResources.TagHelpers_AttributesMustHaveAName);
-            }
-
-            // Remove first child i.e. foo="
-            builder.Children.RemoveAt(0);
-
-            // Grabbing last child to check if the attribute value is quoted.
-            var endNode = block.Children.Last();
-            if (!endNode.IsBlock)
-            {
-                var endSpan = (Span)endNode;
-                var endSymbol = (HtmlSymbol)endSpan.Symbols.Last();
-
-                // Checking to see if it's a quoted attribute, if so we should remove end quote
-                if (IsQuote(endSymbol))
-                {
-                    builder.Children.RemoveAt(builder.Children.Count - 1);
-                }
-            }
-
-            // We need to rebuild the code generators of the builder and its children (this is needed to
-            // ensure we don't do special attribute code generation since this is a tag helper).
-            block = RebuildCodeGenerators(builder.Build());
-
-            // If there's only 1 child at this point its value could be a simple markup span (treated differently than
-            // block level elements for attributes).
-            if (block.Children.Count() == 1)
-            {
-                var child = block.Children.First() as Span;
-
-                if (child != null)
-                {
-                    // After pulling apart the block we just have a value span.
-
-                    var spanBuilder = new SpanBuilder(child);
-
-                    return CreateMarkupAttribute(name, spanBuilder, attributeValueTypes);
-                }
-            }
-
-            return new KeyValuePair<string, SyntaxTreeNode>(name, block);
-        }
-
-        private static Block RebuildCodeGenerators(Block block)
-        {
-            var builder = new BlockBuilder(block);
-
-            var isDynamic = builder.CodeGenerator is DynamicAttributeBlockCodeGenerator;
-
-            // We don't want any attribute specific logic here, null out the block code generator.
-            if (isDynamic || builder.CodeGenerator is AttributeBlockCodeGenerator)
-            {
-                builder.CodeGenerator = BlockCodeGenerator.Null;
-            }
-
-            for (var i = 0; i < builder.Children.Count; i++)
-            {
-                var child = builder.Children[i];
-
-                if (child.IsBlock)
-                {
-                    // The child is a block, recurse down into the block to rebuild its children
-                    builder.Children[i] = RebuildCodeGenerators((Block)child);
-                }
-                else
-                {
-                    var childSpan = (Span)child;
-                    ISpanCodeGenerator newCodeGenerator = null;
-                    var literalGenerator = childSpan.CodeGenerator as LiteralAttributeCodeGenerator;
-
-                    if (literalGenerator != null)
-                    {
-                        if (literalGenerator.ValueGenerator == null || literalGenerator.ValueGenerator.Value == null)
-                        {
-                            newCodeGenerator = new MarkupCodeGenerator();
-                        }
-                        else
-                        {
-                            newCodeGenerator = literalGenerator.ValueGenerator.Value;
-                        }
-                    }
-                    else if (isDynamic && childSpan.CodeGenerator == SpanCodeGenerator.Null)
-                    {
-                        // Usually the dynamic code generator handles rendering the null code generators underneath
-                        // it. This doesn't make sense in terms of tag helpers though, we need to change null code
-                        // generators to markup code generators.
-
-                        newCodeGenerator = new MarkupCodeGenerator();
-                    }
-
-                    // If we have a new code generator we'll need to re-build the child
-                    if (newCodeGenerator != null)
-                    {
-                        var childSpanBuilder = new SpanBuilder(childSpan)
-                        {
-                            CodeGenerator = newCodeGenerator
-                        };
-
-                        builder.Children[i] = childSpanBuilder.Build();
-                    }
-                }
-            }
-
-            return builder.Build();
-        }
-
-        private static KeyValuePair<string, SyntaxTreeNode> CreateMarkupAttribute(
-            string name, 
-            SpanBuilder builder,
-            IReadOnlyDictionary<string, string> attributeValueTypes)
-        {
-            string attributeTypeName;
-
-            // If the attribute was requested by the tag helper and doesn't happen to be a string then we need to treat
-            // its value as code. Any non-string value can be any C# value so we need to ensure the SyntaxTreeNode
-            // reflects that.
-            if (attributeValueTypes.TryGetValue(name, out attributeTypeName) &&
-                !string.Equals(attributeTypeName, typeof(string).FullName, StringComparison.OrdinalIgnoreCase))
-            {
-                builder.Kind = SpanKind.Code;
-            }
-
-            return new KeyValuePair<string, SyntaxTreeNode>(name, builder.Build());
-        }
-
-        private static bool IsQuote(HtmlSymbol htmlSymbol)
-        {
-            return htmlSymbol.Type == HtmlSymbolType.DoubleQuote ||
-                   htmlSymbol.Type == HtmlSymbolType.SingleQuote;
-        }
-
-        // This class is used to compare tag helper attributes by comparing only the HTML attribute name.
-        private class TagHelperAttributeDescriptorComparer : IEqualityComparer<TagHelperAttributeDescriptor>
-        {
-            public static readonly TagHelperAttributeDescriptorComparer Default =
-                new TagHelperAttributeDescriptorComparer();
-
-            public bool Equals(TagHelperAttributeDescriptor descriptorX, TagHelperAttributeDescriptor descriptorY)
-            {
-                return string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.OrdinalIgnoreCase);
-            }
-
-            public int GetHashCode(TagHelperAttributeDescriptor descriptor)
-            {
-                return StringComparer.OrdinalIgnoreCase.GetHashCode(descriptor.Name);
-            }
-        }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
@@ -1,0 +1,375 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNet.Razor.Generator;
+using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+using Microsoft.AspNet.Razor.TagHelpers;
+using Microsoft.AspNet.Razor.Text;
+using Microsoft.AspNet.Razor.Tokenizer.Symbols;
+
+namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
+{
+    public static class TagHelperBlockRewriter
+    {
+        public static TagHelperBlockBuilder Rewrite(string tagName,
+                                                    bool validStructure,
+                                                    Block tag,
+                                                    IEnumerable<TagHelperDescriptor> descriptors,
+                                                    ParserErrorSink errorSink)
+        {
+            // There will always be at least one child for the '<'.
+            var start = tag.Children.First().Start;
+            var attributes = GetTagAttributes(tagName, validStructure, tag, descriptors, errorSink);
+
+            return new TagHelperBlockBuilder(tagName, start, attributes, descriptors);
+        }
+
+        private static IDictionary<string, SyntaxTreeNode> GetTagAttributes(
+            string tagName,
+            bool validStructure,
+            Block tagBlock,
+            IEnumerable<TagHelperDescriptor> descriptors,
+            ParserErrorSink errorSink)
+        {
+            var attributes = new Dictionary<string, SyntaxTreeNode>(StringComparer.OrdinalIgnoreCase);
+
+            // Build a dictionary so we can easily lookup expected attribute value lookups
+            IReadOnlyDictionary<string, string> attributeValueTypes =
+                descriptors.SelectMany(descriptor => descriptor.Attributes)
+                           .Distinct(TagHelperAttributeDescriptorComparer.Default)
+                           .ToDictionary(descriptor => descriptor.Name,
+                                       descriptor => descriptor.TypeName,
+                                       StringComparer.OrdinalIgnoreCase);
+
+            // We skip the first child "<tagname" and take everything up to the ending portion of the tag ">" or "/>".
+            // The -2 accounts for both the start and end tags. If the tag does not have a valid structure then there's
+            // no end tag to ignore.
+            var symbolOffset = validStructure ? 2 : 1;
+            var attributeChildren = tagBlock.Children.Skip(1).Take(tagBlock.Children.Count() - symbolOffset);
+
+            foreach (var child in attributeChildren)
+            {
+                KeyValuePair<string, SyntaxTreeNode> attribute;
+                bool succeeded = true;
+
+                if (child.IsBlock)
+                {
+                    succeeded = TryParseBlock(tagName, (Block)child, attributeValueTypes, errorSink, out attribute);
+                }
+                else
+                {
+                    succeeded = TryParseSpan((Span)child, attributeValueTypes, errorSink, out attribute);
+                }
+
+                // Only want to track the attribute if we succeeded in parsing its corresponding Block/Span.
+                if (succeeded)
+                {
+                    attributes[attribute.Key] = attribute.Value;
+                }
+            }
+
+            return attributes;
+        }
+
+        // This method handles cases when the attribute is a simple span attribute such as
+        // class="something moresomething".  This does not handle complex attributes such as
+        // class="@myclass". Therefore the span.Content is equivalent to the entire attribute.
+        private static bool TryParseSpan(
+            Span span,
+            IReadOnlyDictionary<string, string> attributeValueTypes,
+            ParserErrorSink errorSink,
+            out KeyValuePair<string, SyntaxTreeNode> attribute)
+        {
+            var afterEquals = false;
+            var builder = new SpanBuilder
+            {
+                CodeGenerator = span.CodeGenerator,
+                EditHandler = span.EditHandler,
+                Kind = span.Kind
+            };
+            var htmlSymbols = span.Symbols.OfType<HtmlSymbol>().ToArray();
+            var capturedAttributeValueStart = false;
+            var attributeValueStartLocation = span.Start;
+            var symbolOffset = 1;
+            string name = null;
+
+            // Iterate down through the symbols to find the name and the start of the value.
+            // We subtract the symbolOffset so we don't accept an ending quote of a span.
+            for (var i = 0; i < htmlSymbols.Length - symbolOffset; i++)
+            {
+                var symbol = htmlSymbols[i];
+
+                if (afterEquals)
+                {
+                    // When symbols are accepted into SpanBuilders, their locations get altered to be offset by the 
+                    // parent which is why we need to mark our start location prior to adding the symbol. 
+                    // This is needed to know the location of the attribute value start within the document.
+                    if (!capturedAttributeValueStart)
+                    {
+                        capturedAttributeValueStart = true;
+
+                        attributeValueStartLocation = span.Start + symbol.Start;
+                    }
+
+                    builder.Accept(symbol);
+                }
+                else if (name == null && symbol.Type == HtmlSymbolType.Text)
+                {
+                    name = symbol.Content;
+                    attributeValueStartLocation = SourceLocation.Advance(span.Start, name);
+                }
+                else if (symbol.Type == HtmlSymbolType.Equals)
+                {
+                    // We've found an '=' symbol, this means that the coming symbols will either be a quote
+                    // or value (in the case that the value is unquoted).
+                    // Spaces after/before the equal symbol are not yet supported:
+                    // https://github.com/aspnet/Razor/issues/123
+
+                    // TODO: Handle malformed tags, if there's an '=' then there MUST be a value.
+                    // https://github.com/aspnet/Razor/issues/104
+
+                    SourceLocation symbolStartLocation;
+
+                    // Check for attribute start values, aka single or double quote
+                    if (IsQuote(htmlSymbols[i + 1]))
+                    {
+                        // Move past the attribute start so we can accept the true value.
+                        i++;
+                        symbolStartLocation = htmlSymbols[i + 1].Start;
+                    }
+                    else
+                    {
+                        symbolStartLocation = symbol.Start;
+
+                        // Set the symbol offset to 0 so we don't attempt to skip an end quote that doesn't exist.
+                        symbolOffset = 0;
+                    }
+
+                    attributeValueStartLocation = symbolStartLocation +
+                                                  span.Start +
+                                                  new SourceLocation(absoluteIndex: 1,
+                                                                     lineIndex: 0,
+                                                                     characterIndex: 1);
+                    afterEquals = true;
+                }
+            }
+
+            // After all symbols have been added we need to set the builders start position so we do not indirectly
+            // modify each symbol's Start location.
+            builder.Start = attributeValueStartLocation;
+
+            if (name == null)
+            {
+                errorSink.OnError(span.Start,
+                                  RazorResources.TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed,
+                                  span.Content.Length);
+
+                attribute = default(KeyValuePair<string, SyntaxTreeNode>);
+
+                return false;
+            }
+
+            attribute = CreateMarkupAttribute(name, builder, attributeValueTypes);
+
+            return true;
+        }
+
+        private static bool TryParseBlock(
+            string tagName,
+            Block block,
+            IReadOnlyDictionary<string, string> attributeValueTypes,
+            ParserErrorSink errorSink,
+            out KeyValuePair<string, SyntaxTreeNode> attribute)
+        {
+            // TODO: Accept more than just spans: https://github.com/aspnet/Razor/issues/96.
+            // The first child will only ever NOT be a Span if a user is doing something like:
+            // <input @checked />
+
+            var childSpan = block.Children.First() as Span;
+
+            if (childSpan == null || childSpan.Kind != SpanKind.Markup)
+            {
+                errorSink.OnError(block.Children.First().Start,
+                                  RazorResources.FormatTagHelpers_CannotHaveCSharpInTagDeclaration(tagName));
+
+                attribute = default(KeyValuePair<string, SyntaxTreeNode>);
+
+                return false;
+            }
+
+            var builder = new BlockBuilder(block);
+
+            // If there's only 1 child it means that it's plain text inside of the attribute.
+            // i.e. <div class="plain text in attribute">
+            if (builder.Children.Count == 1)
+            {
+                return TryParseSpan(childSpan, attributeValueTypes, errorSink, out attribute);
+            }
+
+            var textSymbol = childSpan.Symbols.FirstHtmlSymbolAs(HtmlSymbolType.Text);
+            var name = textSymbol != null ? textSymbol.Content : null;
+
+            if (name == null)
+            {
+                errorSink.OnError(childSpan.Start, RazorResources.FormatTagHelpers_AttributesMustHaveAName(tagName));
+
+                attribute = default(KeyValuePair<string, SyntaxTreeNode>);
+
+                return false;
+            }
+
+            // TODO: Support no attribute values: https://github.com/aspnet/Razor/issues/220
+
+            // Remove first child i.e. foo="
+            builder.Children.RemoveAt(0);
+
+            // Grabbing last child to check if the attribute value is quoted.
+            var endNode = block.Children.Last();
+            if (!endNode.IsBlock)
+            {
+                var endSpan = (Span)endNode;
+                var endSymbol = (HtmlSymbol)endSpan.Symbols.Last();
+
+                // Checking to see if it's a quoted attribute, if so we should remove end quote
+                if (IsQuote(endSymbol))
+                {
+                    builder.Children.RemoveAt(builder.Children.Count - 1);
+                }
+            }
+
+            // We need to rebuild the code generators of the builder and its children (this is needed to
+            // ensure we don't do special attribute code generation since this is a tag helper).
+            block = RebuildCodeGenerators(builder.Build());
+
+            // If there's only 1 child at this point its value could be a simple markup span (treated differently than
+            // block level elements for attributes).
+            if (block.Children.Count() == 1)
+            {
+                var child = block.Children.First() as Span;
+
+                if (child != null)
+                {
+                    // After pulling apart the block we just have a value span.
+
+                    var spanBuilder = new SpanBuilder(child);
+
+                    attribute = CreateMarkupAttribute(name, spanBuilder, attributeValueTypes);
+
+                    return true;
+                }
+            }
+
+            attribute = new KeyValuePair<string, SyntaxTreeNode>(name, block);
+
+            return true;
+        }
+
+        private static Block RebuildCodeGenerators(Block block)
+        {
+            var builder = new BlockBuilder(block);
+
+            var isDynamic = builder.CodeGenerator is DynamicAttributeBlockCodeGenerator;
+
+            // We don't want any attribute specific logic here, null out the block code generator.
+            if (isDynamic || builder.CodeGenerator is AttributeBlockCodeGenerator)
+            {
+                builder.CodeGenerator = BlockCodeGenerator.Null;
+            }
+
+            for (var i = 0; i < builder.Children.Count; i++)
+            {
+                var child = builder.Children[i];
+
+                if (child.IsBlock)
+                {
+                    // The child is a block, recurse down into the block to rebuild its children
+                    builder.Children[i] = RebuildCodeGenerators((Block)child);
+                }
+                else
+                {
+                    var childSpan = (Span)child;
+                    ISpanCodeGenerator newCodeGenerator = null;
+                    var literalGenerator = childSpan.CodeGenerator as LiteralAttributeCodeGenerator;
+
+                    if (literalGenerator != null)
+                    {
+                        if (literalGenerator.ValueGenerator == null || literalGenerator.ValueGenerator.Value == null)
+                        {
+                            newCodeGenerator = new MarkupCodeGenerator();
+                        }
+                        else
+                        {
+                            newCodeGenerator = literalGenerator.ValueGenerator.Value;
+                        }
+                    }
+                    else if (isDynamic && childSpan.CodeGenerator == SpanCodeGenerator.Null)
+                    {
+                        // Usually the dynamic code generator handles rendering the null code generators underneath
+                        // it. This doesn't make sense in terms of tag helpers though, we need to change null code 
+                        // generators to markup code generators.
+
+                        newCodeGenerator = new MarkupCodeGenerator();
+                    }
+
+                    // If we have a new code generator we'll need to re-build the child
+                    if (newCodeGenerator != null)
+                    {
+                        var childSpanBuilder = new SpanBuilder(childSpan)
+                        {
+                            CodeGenerator = newCodeGenerator
+                        };
+
+                        builder.Children[i] = childSpanBuilder.Build();
+                    }
+                }
+            }
+
+            return builder.Build();
+        }
+
+        private static KeyValuePair<string, SyntaxTreeNode> CreateMarkupAttribute(
+            string name,
+            SpanBuilder builder,
+            IReadOnlyDictionary<string, string> attributeValueTypes)
+        {
+            string attributeTypeName;
+
+            // If the attribute was requested by the tag helper and doesn't happen to be a string then we need to treat
+            // its value as code. Any non-string value can be any C# value so we need to ensure the SyntaxTreeNode
+            // reflects that.
+            if (attributeValueTypes.TryGetValue(name, out attributeTypeName) &&
+                !string.Equals(attributeTypeName, typeof(string).FullName, StringComparison.OrdinalIgnoreCase))
+            {
+                builder.Kind = SpanKind.Code;
+            }
+
+            return new KeyValuePair<string, SyntaxTreeNode>(name, builder.Build());
+        }
+
+        private static bool IsQuote(HtmlSymbol htmlSymbol)
+        {
+            return htmlSymbol.Type == HtmlSymbolType.DoubleQuote ||
+                   htmlSymbol.Type == HtmlSymbolType.SingleQuote;
+        }
+
+        // This class is used to compare tag helper attributes by comparing only the HTML attribute name.
+        private class TagHelperAttributeDescriptorComparer : IEqualityComparer<TagHelperAttributeDescriptor>
+        {
+            public static readonly TagHelperAttributeDescriptorComparer Default =
+                new TagHelperAttributeDescriptorComparer();
+
+            public bool Equals(TagHelperAttributeDescriptor descriptorX, TagHelperAttributeDescriptor descriptorY)
+            {
+                return string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public int GetHashCode(TagHelperAttributeDescriptor descriptor)
+            {
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(descriptor.Name);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNet.Razor
 
         /// <summary>
         /// The "@" character must be followed by a ":", "(", or a C# identifier.  If you intended to switch to markup, use an HTML start tag, for example:
-        ///
+        /// 
         /// @if(isLoggedIn) {
         ///     &lt;p&gt;Hello, @user!&lt;/p&gt;
         /// }
@@ -104,7 +104,7 @@ namespace Microsoft.AspNet.Razor
 
         /// <summary>
         /// The "@" character must be followed by a ":", "(", or a C# identifier.  If you intended to switch to markup, use an HTML start tag, for example:
-        ///
+        /// 
         /// @if(isLoggedIn) {
         ///     &lt;p&gt;Hello, @user!&lt;/p&gt;
         /// }
@@ -228,7 +228,7 @@ namespace Microsoft.AspNet.Razor
 
         /// <summary>
         /// Sections cannot be empty.  The "@section" keyword must be followed by a block of markup surrounded by "{}".  For example:
-        ///
+        /// 
         /// @section Sidebar {
         ///    &lt;!-- Markup and text goes here --&gt;
         /// }
@@ -240,7 +240,7 @@ namespace Microsoft.AspNet.Razor
 
         /// <summary>
         /// Sections cannot be empty.  The "@section" keyword must be followed by a block of markup surrounded by "{}".  For example:
-        ///
+        /// 
         /// @section Sidebar {
         ///    &lt;!-- Markup and text goes here --&gt;
         /// }
@@ -252,7 +252,7 @@ namespace Microsoft.AspNet.Razor
 
         /// <summary>
         /// Namespace imports and type aliases cannot be placed within code blocks.  They must immediately follow an "@" character in markup.  It is recommended that you put them at the top of the page, as in the following example:
-        ///
+        /// 
         /// @using System.Drawing;
         /// @{
         ///     // OK here to use types from System.Drawing in the page.
@@ -265,7 +265,7 @@ namespace Microsoft.AspNet.Razor
 
         /// <summary>
         /// Namespace imports and type aliases cannot be placed within code blocks.  They must immediately follow an "@" character in markup.  It is recommended that you put them at the top of the page, as in the following example:
-        ///
+        /// 
         /// @using System.Drawing;
         /// @{
         ///     // OK here to use types from System.Drawing in the page.
@@ -278,12 +278,12 @@ namespace Microsoft.AspNet.Razor
 
         /// <summary>
         /// Expected a "{0}" but found a "{1}".  Block statements must be enclosed in "{{" and "}}".  You cannot use single-statement control-flow statements in CSHTML pages. For example, the following is not allowed:
-        ///
+        /// 
         /// @if(isLoggedIn)
         ///     &lt;p&gt;Hello, @user&lt;/p&gt;
-        ///
+        /// 
         /// Instead, wrap the contents of the block in "{{}}":
-        ///
+        /// 
         /// @if(isLoggedIn) {{
         ///     &lt;p&gt;Hello, @user&lt;/p&gt;
         /// }}
@@ -295,12 +295,12 @@ namespace Microsoft.AspNet.Razor
 
         /// <summary>
         /// Expected a "{0}" but found a "{1}".  Block statements must be enclosed in "{{" and "}}".  You cannot use single-statement control-flow statements in CSHTML pages. For example, the following is not allowed:
-        ///
+        /// 
         /// @if(isLoggedIn)
         ///     &lt;p&gt;Hello, @user&lt;/p&gt;
-        ///
+        /// 
         /// Instead, wrap the contents of the block in "{{}}":
-        ///
+        /// 
         /// @if(isLoggedIn) {{
         ///     &lt;p&gt;Hello, @user&lt;/p&gt;
         /// }}
@@ -1431,7 +1431,7 @@ namespace Microsoft.AspNet.Razor
         }
 
         /// <summary>
-        /// Tag Helper attributes must have a name.
+        /// Tag Helper '{0}'s attributes must have names.
         /// </summary>
         internal static string TagHelpers_AttributesMustHaveAName
         {
@@ -1439,15 +1439,15 @@ namespace Microsoft.AspNet.Razor
         }
 
         /// <summary>
-        /// Tag Helper attributes must have a name.
+        /// Tag Helper '{0}'s attributes must have names.
         /// </summary>
-        internal static string FormatTagHelpers_AttributesMustHaveAName()
+        internal static string FormatTagHelpers_AttributesMustHaveAName(object p0)
         {
-            return GetString("TagHelpers_AttributesMustHaveAName");
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpers_AttributesMustHaveAName"), p0);
         }
 
         /// <summary>
-        /// Tag Helpers cannot have C# in an HTML tag element's attribute declaration area.
+        /// The tag helper '{0}' must not have C# in the element's attribute declaration area.
         /// </summary>
         internal static string TagHelpers_CannotHaveCSharpInTagDeclaration
         {
@@ -1455,11 +1455,11 @@ namespace Microsoft.AspNet.Razor
         }
 
         /// <summary>
-        /// Tag Helpers cannot have C# in an HTML tag element's attribute declaration area.
+        /// The tag helper '{0}' must not have C# in the element's attribute declaration area.
         /// </summary>
-        internal static string FormatTagHelpers_CannotHaveCSharpInTagDeclaration()
+        internal static string FormatTagHelpers_CannotHaveCSharpInTagDeclaration(object p0)
         {
-            return GetString("TagHelpers_CannotHaveCSharpInTagDeclaration");
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpers_CannotHaveCSharpInTagDeclaration"), p0);
         }
 
         /// <summary>
@@ -1540,6 +1540,54 @@ namespace Microsoft.AspNet.Razor
         internal static string FormatTagHelpersParseTreeRewriter_FoundMalformedTagHelper(object p0)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpersParseTreeRewriter_FoundMalformedTagHelper"), p0);
+        }
+
+        /// <summary>
+        /// Missing '{0}' from '{1}' tag helper.
+        /// </summary>
+        internal static string TagHelpersParseTreeRewriter_MissingValueFromTagHelper
+        {
+            get { return GetString("TagHelpersParseTreeRewriter_MissingValueFromTagHelper"); }
+        }
+
+        /// <summary>
+        /// Missing '{0}' from '{1}' tag helper.
+        /// </summary>
+        internal static string FormatTagHelpersParseTreeRewriter_MissingValueFromTagHelper(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpersParseTreeRewriter_MissingValueFromTagHelper"), p0, p1);
+        }
+
+        /// <summary>
+        /// Missing close angle for tag helper '{0}'.
+        /// </summary>
+        internal static string TagHelpersParseTreeRewriter_MissingCloseAngle
+        {
+            get { return GetString("TagHelpersParseTreeRewriter_MissingCloseAngle"); }
+        }
+
+        /// <summary>
+        /// Missing close angle for tag helper '{0}'.
+        /// </summary>
+        internal static string FormatTagHelpersParseTreeRewriter_MissingCloseAngle(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpersParseTreeRewriter_MissingCloseAngle"), p0);
+        }
+
+        /// <summary>
+        /// TagHelper attributes must be welformed.
+        /// </summary>
+        internal static string TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed
+        {
+            get { return GetString("TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed"); }
+        }
+
+        /// <summary>
+        /// TagHelper attributes must be welformed.
+        /// </summary>
+        internal static string FormatTagHelperBlockRewriter_TagHelperAttributesMustBeWelformed()
+        {
+            return GetString("TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed");
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.AspNet.Razor/RazorResources.resx
+++ b/src/Microsoft.AspNet.Razor/RazorResources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -404,10 +404,10 @@ Instead, wrap the contents of the block in "{{}}":
     <value>Section blocks ("{0}") cannot be nested.  Only one level of section blocks are allowed.</value>
   </data>
   <data name="TagHelpers_AttributesMustHaveAName" xml:space="preserve">
-    <value>Tag Helper attributes must have a name.</value>
+    <value>Tag Helper '{0}'s attributes must have names.</value>
   </data>
   <data name="TagHelpers_CannotHaveCSharpInTagDeclaration" xml:space="preserve">
-    <value>Tag Helpers cannot have C# in an HTML tag element's attribute declaration area.</value>
+    <value>The tag helper '{0}' must not have C# in the element's attribute declaration area.</value>
   </data>
   <data name="TagHelpers_TagHelperCodeGeneartorMustBeAssociatedWithATagHelperBlock" xml:space="preserve">
     <value>A TagHelperCodeGenerator must only be used with TagHelperBlocks.</value>
@@ -423,5 +423,14 @@ Instead, wrap the contents of the block in "{{}}":
   </data>
   <data name="TagHelpersParseTreeRewriter_FoundMalformedTagHelper" xml:space="preserve">
     <value>Found a malformed '{0}' tag helper. Tag helpers must have a start and end tag or be self closing.</value>
+  </data>
+  <data name="TagHelpersParseTreeRewriter_MissingValueFromTagHelper" xml:space="preserve">
+    <value>Missing '{0}' from '{1}' tag helper.</value>
+  </data>
+  <data name="TagHelpersParseTreeRewriter_MissingCloseAngle" xml:space="preserve">
+    <value>Missing close angle for tag helper '{0}'.</value>
+  </data>
+  <data name="TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed" xml:space="preserve">
+    <value>TagHelper attributes must be welformed.</value>
   </data>
 </root>


### PR DESCRIPTION
- Added detection of unclosed tags (tags without begin/end).
- Added recovery of potentially unclosed tags.
- Added detection of invalid structure tags (tags that do not end with '>').
- Modified detection of bad attribute values to be parse errors instead of runtime errors.
- Modified RazorParser to sort errors. This made writing tests more intuitive and ultimately ensures that the editor shows errors in the correct order.
- Added tests to validate invalid tag structure.
- Added tests to validate invalid attributes.
- Added tests to validate unclosed tags.
#104
