### PR TITLE
Expose GetExportedTypes on TagHelperTypeResolver so tooling can control Assembly resolution.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             IEnumerable<TypeInfo> libraryTypes;
             try
             {
-                libraryTypes = GetLibraryDefinedTypes(assemblyName);
+                libraryTypes = GetExportedTypes(assemblyName);
             }
             catch (Exception ex)
             {
@@ -72,8 +72,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             return validTagHelpers.Select(type => type.AsType());
         }
 
-        // Internal for testing, don't want to be loading assemblies during a test.
-        internal virtual IEnumerable<TypeInfo> GetLibraryDefinedTypes(AssemblyName assemblyName)
+        /// <summary>
+        /// Returns all exported types from the given <paramref name="assemblyName"/>
+        /// </summary>
+        /// <param name="assemblyName">The <see cref="AssemblyName"/> to get <see cref="TypeInfo"/>s from.</param>
+        /// <returns>
+        /// An <see cref="IEnumerable{TypeInfo}"/> of types exported from the given <paramref name="assemblyName"/>.
+        /// </returns>
+        protected virtual IEnumerable<TypeInfo> GetExportedTypes(AssemblyName assemblyName)
         {
             var assembly = Assembly.Load(assemblyName);
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
@@ -358,7 +358,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             // Arrange
             var tagHelperTypeResolver = new TestTagHelperTypeResolver(TestableTagHelpers)
             {
-                OnGetLibraryDefinedTypes = (assemblyName) =>
+                OnGetExportedTypes = (assemblyName) =>
                 {
                     Assert.Equal("MyAssembly", assemblyName.Name);
                 }
@@ -523,7 +523,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 _lookupValues = lookupValues;
             }
 
-            internal override IEnumerable<TypeInfo> GetLibraryDefinedTypes(AssemblyName assemblyName)
+            protected override IEnumerable<TypeInfo> GetExportedTypes(AssemblyName assemblyName)
             {
                 IEnumerable<Type> types;
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
@@ -114,14 +114,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             public TestTagHelperTypeResolver(IEnumerable<Type> assemblyTypes)
             {
                 _assemblyTypeInfos = assemblyTypes.Select(type => type.GetTypeInfo());
-                OnGetLibraryDefinedTypes = (_) => { };
+                OnGetExportedTypes = (_) => { };
             }
 
-            public Action<AssemblyName> OnGetLibraryDefinedTypes { get; set; }
+            public Action<AssemblyName> OnGetExportedTypes { get; set; }
 
-            internal override IEnumerable<TypeInfo> GetLibraryDefinedTypes(AssemblyName assemblyName)
+            protected override IEnumerable<TypeInfo> GetExportedTypes(AssemblyName assemblyName)
             {
-                OnGetLibraryDefinedTypes(assemblyName);
+                OnGetExportedTypes(assemblyName);
 
                 return _assemblyTypeInfos;
             }


### PR DESCRIPTION
- This will enable tooling to provide their own mechanism for resolving assemblies.
