### PR TITLE
Expose TagHelperDescriptors on TagHelperBlock.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+using Microsoft.AspNet.Razor.TagHelpers;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.Internal.Web.Utils;
 
@@ -27,6 +28,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
             : base(source.Type, source.Children, source.CodeGenerator)
         {
             TagName = source.TagName;
+            Descriptors = source.Descriptors;
             Attributes = new Dictionary<string, SyntaxTreeNode>(source.Attributes);
             _start = source.Start;
 
@@ -37,6 +39,11 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
                 attributeChildren.Parent = this;
             }
         }
+
+        /// <summary>
+        /// <see cref="TagHelperDescriptor"/>s for the HTML element.
+        /// </summary>
+        public IEnumerable<TagHelperDescriptor> Descriptors { get; }
 
         /// <summary>
         /// The HTML attributes.

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
             : base(original)
         {
             TagName = original.TagName;
+            Descriptors = original.Descriptors;
             Attributes = new Dictionary<string, SyntaxTreeNode>(original.Attributes);
         }
 
@@ -42,6 +43,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         public TagHelperBlockBuilder(string tagName, IEnumerable<TagHelperDescriptor> descriptors, Block startTag)
         {
             TagName = tagName;
+            Descriptors = descriptors;
             CodeGenerator = new TagHelperCodeGenerator(descriptors);
             Type = startTag.Type;
             Attributes = GetTagAttributes(startTag, descriptors);
@@ -66,6 +68,11 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
                 Children.Add(child);
             }
         }
+
+        /// <summary>
+        /// <see cref="TagHelperDescriptor"/>s for the HTML element.
+        /// </summary>
+        public IEnumerable<TagHelperDescriptor> Descriptors { get; }
 
         /// <summary>
         /// The HTML attributes.


### PR DESCRIPTION
- This will enable tooling to determine which descriptors are relevant to which TagHelperBlocks in the syntax tree.
