### PR TITLE
Tag Helpers: Change tag and attribute names to be kebab-cased.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/project.json
+++ b/src/Microsoft.AspNet.Razor.Runtime/project.json
@@ -9,7 +9,8 @@
         "aspnet50": { },
         "aspnetcore50": {
             "dependencies": {
-                "System.Reflection.Extensions": "4.0.0-beta-*"
+                "System.Reflection.Extensions": "4.0.0-beta-*",
+                "System.Text.RegularExpressions": "4.0.10-beta-*"
             }
         }
     }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CompleteTagHelperDescriptorComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CompleteTagHelperDescriptorComparer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.Razor.TagHelpers;
@@ -20,6 +21,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         bool IEqualityComparer<TagHelperDescriptor>.Equals(TagHelperDescriptor descriptorX, TagHelperDescriptor descriptorY)
         {
             return base.Equals(descriptorX, descriptorY) &&
+                   // Tests should be exact casing
+                   string.Equals(descriptorX.TagName, descriptorY.TagName, StringComparison.Ordinal) &&
                    descriptorX.Attributes.SequenceEqual(descriptorY.Attributes,
                                                         CompleteTagHelperAttributeDescriptorComparer.Default);
         }
@@ -43,17 +46,17 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             public bool Equals(TagHelperAttributeDescriptor descriptorX, TagHelperAttributeDescriptor descriptorY)
             {
-                return descriptorX.Name == descriptorY.Name &&
-                       descriptorX.PropertyName == descriptorY.PropertyName &&
-                       descriptorX.TypeName == descriptorY.TypeName;
+                return string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal) &&
+                       string.Equals(descriptorX.PropertyName, descriptorY.PropertyName, StringComparison.Ordinal) &&
+                       string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal);
             }
 
             public int GetHashCode(TagHelperAttributeDescriptor descriptor)
             {
                 return HashCodeCombiner.Start()
-                                       .Add(descriptor.Name)
-                                       .Add(descriptor.PropertyName)
-                                       .Add(descriptor.TypeName)
+                                       .Add(descriptor.Name, StringComparer.Ordinal)
+                                       .Add(descriptor.PropertyName, StringComparer.Ordinal)
+                                       .Add(descriptor.TypeName, StringComparer.Ordinal)
                                        .CombinedHash;
             }
         }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             get
             {
-                return new TagHelperDescriptor("Valid_Plain",
+                return new TagHelperDescriptor("valid_plain",
                                                Valid_PlainTagHelperType.FullName,
                                                AssemblyName,
                                                ContentBehavior.None);
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             get
             {
-                return new TagHelperDescriptor("Valid_Inherited",
+                return new TagHelperDescriptor("valid_inherited",
                                                Valid_InheritedTagHelperType.FullName,
                                                AssemblyName,
                                                ContentBehavior.None);


### PR DESCRIPTION
- Lower kebab-cased casing is the HTML convention.
- Modified tests to account for new tag and attribute names.
- Also added additional tests to validate new lower snake casing.

#240