### PR TITLE
Add warning disable for unused variable warnings for TagHelper fields.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
@@ -34,9 +34,13 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
                 // Runtime fields aren't useful during design time.
                 if (!Context.Host.DesignTimeMode)
                 {
+                    // Need to disable the warning "X is assigned to but never used." for the value buffer since
+                    // whether it's used depends on how a TagHelper is used.
+                    Writer.WritePragma("warning disable 0414");
                     WritePrivateField(typeof(TextWriter).FullName,
                                       CSharpTagHelperCodeRenderer.StringValueBufferVariableName,
                                       value: null);
+                    Writer.WritePragma("warning restore 0414");
 
                     WritePrivateField(_tagHelperContext.ExecutionContextTypeName,
                                       CSharpTagHelperCodeRenderer.ExecutionContextVariableName,

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
@@ -7,7 +7,9 @@ namespace TestOutput
     public class BasicTagHelpers
     {
         #line hidden
+        #pragma warning disable 0414
         private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
@@ -8,7 +8,9 @@ namespace TestOutput
     public class BasicTagHelpers
     {
         #line hidden
+        #pragma warning disable 0414
         private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
@@ -8,7 +8,9 @@ namespace TestOutput
     public class ComplexTagHelpers
     {
         #line hidden
+        #pragma warning disable 0414
         private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ContentBehaviorTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ContentBehaviorTagHelpers.cs
@@ -8,7 +8,9 @@ namespace TestOutput
     public class ContentBehaviorTagHelpers
     {
         #line hidden
+        #pragma warning disable 0414
         private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
@@ -8,7 +8,9 @@ namespace TestOutput
     public class SingleTagHelper
     {
         #line hidden
+        #pragma warning disable 0414
         private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInHelper.cs
@@ -89,7 +89,9 @@ Write(DateTime.Now);
 #line hidden
 
         #line hidden
+        #pragma warning disable 0414
         private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
@@ -7,7 +7,9 @@ namespace TestOutput
     public class TagHelpersInSection
     {
         #line hidden
+        #pragma warning disable 0414
         private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();


### PR DESCRIPTION
- Added a 0414 warning disable/restore around the __tagHelperStringValueBuffer since it's the only TagHelper utility field that "may" never be used.
- Regenerated baselines for TagHelper test files.

#260