### PR TITLE
Add TagHelper parse level opt-out character '!'. 

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -75,19 +75,19 @@ namespace Microsoft.AspNet.Razor.Runtime
         }
 
         /// <summary>
-        /// Parameter {0} must not contain null tag names.
+        /// Tag name cannot be null or whitespace.
         /// </summary>
-        internal static string HtmlElementNameAttribute_AdditionalTagsCannotContainNull
+        internal static string HtmlElementNameAttribute_ElementNameCannotBeNullOrWhitespace
         {
-            get { return GetString("HtmlElementNameAttribute_AdditionalTagsCannotContainNull"); }
+            get { return GetString("HtmlElementNameAttribute_ElementNameCannotBeNullOrWhitespace"); }
         }
 
         /// <summary>
-        /// Parameter {0} must not contain null tag names.
+        /// Tag name cannot be null or whitespace.
         /// </summary>
-        internal static string FormatHtmlElementNameAttribute_AdditionalTagsCannotContainNull(object p0)
+        internal static string FormatHtmlElementNameAttribute_ElementNameCannotBeNullOrWhitespace()
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("HtmlElementNameAttribute_AdditionalTagsCannotContainNull"), p0);
+            return GetString("HtmlElementNameAttribute_ElementNameCannotBeNullOrWhitespace");
         }
 
         /// <summary>
@@ -120,6 +120,22 @@ namespace Microsoft.AspNet.Razor.Runtime
         internal static string FormatTagHelperDescriptorResolver_EncounteredUnexpectedError(object p0, object p1, object p2)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorResolver_EncounteredUnexpectedError"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// Tag helpers cannot target element name '{0}' because it contains a '{1}' character.
+        /// </summary>
+        internal static string HtmlElementNameAttribute_InvalidElementName
+        {
+            get { return GetString("HtmlElementNameAttribute_InvalidElementName"); }
+        }
+
+        /// <summary>
+        /// Tag helpers cannot target element name '{0}' because it contains a '{1}' character.
+        /// </summary>
+        internal static string FormatHtmlElementNameAttribute_InvalidElementName(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("HtmlElementNameAttribute_InvalidElementName"), p0, p1);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -129,13 +129,16 @@
   <data name="ScopeManager_EndCannotBeCalledWithoutACallToBegin" xml:space="preserve">
     <value>Must call '{2}.{1}' before calling '{2}.{0}'.</value>
   </data>
-  <data name="HtmlElementNameAttribute_AdditionalTagsCannotContainNull" xml:space="preserve">
-    <value>Parameter {0} must not contain null tag names.</value>
+  <data name="HtmlElementNameAttribute_ElementNameCannotBeNullOrWhitespace" xml:space="preserve">
+    <value>Tag name cannot be null or whitespace.</value>
   </data>
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
     <value>The value cannot be null or empty.</value>
   </data>
   <data name="TagHelperDescriptorResolver_EncounteredUnexpectedError" xml:space="preserve">
     <value>Encountered an unexpected error when attempting to resolve tag helper directive '{0}' with value '{1}'. Error: {2}</value>
+  </data>
+  <data name="HtmlElementNameAttribute_InvalidElementName" xml:space="preserve">
+    <value>Tag helpers cannot target element name '{0}' because it contains a '{1}' character.</value>
   </data>
 </root>

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlElementNameAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlElementNameAttribute.cs
@@ -19,6 +19,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="tag">The HTML tag name for the <see cref="TagHelper"/> to target.</param>
         public HtmlElementNameAttribute([NotNull] string tag)
         {
+            ValidateTagName(tag, nameof(tag));
+
             Tags = new[] { tag };
         }
 
@@ -29,12 +31,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="additionalTags">Additional HTML tag names for the <see cref="TagHelper"/> to target.</param>
         public HtmlElementNameAttribute([NotNull] string tag, [NotNull] params string[] additionalTags)
         {
-            if (additionalTags.Contains(null))
+            ValidateTagName(tag, nameof(tag));
+
+            foreach (var tagName in additionalTags)
             {
-                throw new ArgumentNullException(
-                    nameof(additionalTags),
-                    Resources.FormatHtmlElementNameAttribute_AdditionalTagsCannotContainNull(nameof(additionalTags)));
-            };
+                ValidateTagName(tagName, nameof(additionalTags));
+            }
 
             var allTags = new List<string>(additionalTags);
             allTags.Add(tag);
@@ -45,6 +47,23 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// An <see cref="IEnumerable{string}"/> of tag names for the <see cref="TagHelper"/> to target.
         /// </summary>
-        public IEnumerable<string> Tags { get; private set; }
+        public IEnumerable<string> Tags { get; }
+
+        private static void ValidateTagName(string tagName, string parameterName)
+        {
+            if (string.IsNullOrWhiteSpace(tagName))
+            {
+                throw new ArgumentException(
+                    Resources.HtmlElementNameAttribute_ElementNameCannotBeNullOrWhitespace,
+                    parameterName);
+            }
+
+            if (tagName.Contains('!'))
+            {
+                throw new ArgumentException(
+                    Resources.FormatHtmlElementNameAttribute_InvalidElementName(tagName, '!'),
+                    parameterName);
+            }
+        }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
@@ -73,6 +74,43 @@ namespace Microsoft.AspNet.Razor.Parser
             {
                 SpanConfig(span);
             }
+        }
+
+        protected TSymbol Lookahead(int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+            else if (count == 0)
+            {
+                return CurrentSymbol;
+            }
+
+            // We add 1 in order to store the current symbol.
+            var symbols = new TSymbol[count + 1];
+            var currentSymbol = CurrentSymbol;
+
+            symbols[0] = currentSymbol;
+
+            // We need to look forward "count" many times.
+            for (var i = 1; i <= count; i++)
+            {
+                NextToken();
+                symbols[i] = CurrentSymbol;
+            }
+
+            // Restore Tokenizer's location to where it was pointing before the look-ahead.
+            for (var i = count; i >= 0; i--)
+            {
+                PutBack(symbols[i]);
+            }
+
+            // The PutBacks above will set CurrentSymbol to null. EnsureCurrent will set our CurrentSymbol to the 
+            // next symbol.
+            EnsureCurrent();
+
+            return symbols[count];
         }
 
         protected internal bool NextToken()

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/HtmlElementNameAttributeTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/HtmlElementNameAttributeTest.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    public class HtmlElementNameAttributeTest
+    {
+        public static TheoryData InvalidTagNameData
+        {
+            get
+            {
+                var invalidTagNameError =
+                    "Tag helpers cannot target element name '{0}' because it contains a '{1}' character.";
+                var nullOrWhitespaceTagNameError =
+                    "Tag name cannot be null or whitespace.";
+
+                // tagName, expectedExceptionMessage
+                return new TheoryData<string, string>
+                {
+                    { "!", string.Format(invalidTagNameError, "!", "!") },
+                    { "hello!", string.Format(invalidTagNameError, "hello!", "!") },
+                    { "!hello", string.Format(invalidTagNameError, "!hello", "!") },
+                    { "he!lo", string.Format(invalidTagNameError, "he!lo", "!") },
+                    { "!he!lo!", string.Format(invalidTagNameError, "!he!lo!", "!") },
+                    { string.Empty, nullOrWhitespaceTagNameError },
+                    { Environment.NewLine, nullOrWhitespaceTagNameError },
+                    { "\t", nullOrWhitespaceTagNameError },
+                    { " \t ", nullOrWhitespaceTagNameError },
+                    { " ", nullOrWhitespaceTagNameError },
+                    { Environment.NewLine + " ", nullOrWhitespaceTagNameError },
+                    { null, nullOrWhitespaceTagNameError },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTagNameData))]
+        public void SingleArgumentConstructor_ThrowsOnInvalidTagNames(
+            string tagName, 
+            string expectedExceptionMessage)
+        {
+            // Arrange
+            expectedExceptionMessage += Environment.NewLine + "Parameter name: tag";
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(
+                "tag", 
+                () => new HtmlElementNameAttribute(tagName));
+            Assert.Equal(exception.Message, expectedExceptionMessage);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidTagNameData))]
+        public void MultipleArgumentConstructor_ThrowsOnInvalidTagNames(
+            string tagName, 
+            string expectedExceptionMessage)
+        {
+            // Arrange
+            expectedExceptionMessage += Environment.NewLine + "Parameter name: additionalTags";
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(
+                "additionalTags", 
+                () => new HtmlElementNameAttribute("p", "div", "span", tagName));
+            Assert.Equal(exception.Message, expectedExceptionMessage);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/Framework/BlockFactory.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/BlockFactory.cs
@@ -14,6 +14,19 @@ namespace Microsoft.AspNet.Razor.Test.Framework
             _factory = factory;
         }
 
+        public Block EscapedMarkupTagBlock(string prefix, string suffix)
+        {
+            return EscapedMarkupTagBlock(prefix, suffix, AcceptedCharacters.Any);
+        }
+
+        public Block EscapedMarkupTagBlock(string prefix, string suffix, AcceptedCharacters acceptedCharacters)
+        {
+            return new MarkupTagBlock(
+                _factory.Markup(prefix),
+                _factory.BangEscape(),
+                _factory.Markup(suffix).Accepts(acceptedCharacters));
+        }
+
         public Block MarkupTagBlock(string content)
         {
             return MarkupTagBlock(content, AcceptedCharacters.Any);

--- a/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
@@ -104,6 +104,14 @@ namespace Microsoft.AspNet.Razor.Test.Framework
             return self.Span(SpanKind.Comment, content, type);
         }
 
+        public static SpanConstructor BangEscape(this SpanFactory self)
+        {
+            return self
+                .Span(SpanKind.MetaCode, "!", markup: true)
+                .With(SpanCodeGenerator.Null)
+                .Accepts(AcceptedCharacters.None);
+        }
+
         public static SpanConstructor Markup(this SpanFactory self, string content)
         {
             return self.Span(SpanKind.Markup, content, markup: true).With(new MarkupCodeGenerator());

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
@@ -248,6 +248,39 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                              contentLength: 0)
                         }
                     },
+                    {
+                        "EscapedTagHelpers",
+                        "EscapedTagHelpers.DesignTime",
+                        PAndInputTagHelperDescriptors,
+                        new List<LineMapping>
+                        {
+                            BuildLineMapping(documentAbsoluteIndex: 14,
+                                             documentLineIndex: 0,
+                                             generatedAbsoluteIndex: 479,
+                                             generatedLineIndex: 15,
+                                             characterOffsetIndex: 14,
+                                             contentLength: 11),
+                            BuildLineMapping(documentAbsoluteIndex: 102,
+                                             documentLineIndex: 3,
+                                             generatedAbsoluteIndex: 975,
+                                             generatedLineIndex: 34,
+                                             characterOffsetIndex: 29,
+                                             contentLength: 12),
+                            BuildLineMapping(documentAbsoluteIndex: 200,
+                                             documentLineIndex: 5,
+                                             documentCharacterOffsetIndex: 51,
+                                             generatedAbsoluteIndex: 1130,
+                                             generatedLineIndex: 40,
+                                             generatedCharacterOffsetIndex: 6,
+                                             contentLength: 12),
+                            BuildLineMapping(documentAbsoluteIndex: 223,
+                                             documentLineIndex: 5,
+                                             generatedAbsoluteIndex: 1467,
+                                             generatedLineIndex: 48,
+                                             characterOffsetIndex: 74,
+                                             contentLength: 4)
+                        }
+                    },
                 };
             }
         }
@@ -280,6 +313,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     { "BasicTagHelpers.RemoveTagHelper", PAndInputTagHelperDescriptors },
                     { "ComplexTagHelpers", PAndInputTagHelperDescriptors },
                     { "EmptyAttributeTagHelpers", PAndInputTagHelperDescriptors },
+                    { "EscapedTagHelpers", PAndInputTagHelperDescriptors },
                 };
             }
         }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlDocumentTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlDocumentTest.cs
@@ -199,7 +199,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         [Fact]
         public void ParseDocumentReturnsOneMarkupSegmentIfNoCodeBlocksEncountered()
         {
-            SingleSpanDocumentTest("Foo Baz<!--Foo-->Bar<!-F> Qux", BlockType.Markup, SpanKind.Markup);
+            SingleSpanDocumentTest("Foo Baz<!--Foo-->Bar<!--F> Qux", BlockType.Markup, SpanKind.Markup);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -19,6 +19,1642 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
 {
     public class TagHelperParseTreeRewriterTest : CsHtmlMarkupParserTestBase
     {
+        public static TheoryData OptOut_WithAttributeTextTagData
+        {
+            get
+            {
+                var factory = CreateDefaultSpanFactory();
+                var blockFactory = new BlockFactory(factory);
+                var errorFormatNormalUnclosed =
+                    "The \"{0}\" element was not closed.  All elements must be either self-closing or have a " +
+                    "matching end tag.";
+                var errorMatchingBrace =
+                    "The code block is missing a closing \"}\" character.  Make sure you have a matching \"}\" " +
+                    "character for all the \"{\" characters within this block, and that none of the \"}\" " +
+                    "characters are being interpreted as markup.";
+
+                Func<Func<MarkupBlock>, MarkupBlock> buildStatementBlock = (insideBuilder) =>
+                {
+                    return new MarkupBlock(
+                        factory.EmptyHtml(),
+                        new StatementBlock(
+                            factory.CodeTransition(),
+                            factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                            insideBuilder(),
+                            factory.EmptyCSharp().AsStatement(),
+                            factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                        factory.EmptyHtml());
+                };
+
+                // documentContent, expectedOutput, expectedErrors
+                return new TheoryData<string, MarkupBlock, RazorError[]>
+                {
+                    {
+                        "@{<!text class=\"btn\">}",
+                        new MarkupBlock(
+                        factory.EmptyHtml(),
+                        new StatementBlock(
+                            factory.CodeTransition(),
+                            factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                new MarkupBlock(
+                                    new MarkupTagBlock(
+                                        factory.Markup("<"),
+                                        factory.BangEscape(),
+                                        factory.Markup("text"),
+                                        new MarkupBlock(
+                                            new AttributeBlockCodeGenerator(
+                                                name: "class",
+                                                prefix: new LocationTagged<string>(" class=\"", 8, 0, 8),
+                                                suffix: new LocationTagged<string>("\"", 19, 0, 19)),
+                                            factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                            factory.Markup("btn").With(
+                                                new LiteralAttributeCodeGenerator(
+                                                    prefix: new LocationTagged<string>(string.Empty, 16, 0, 16),
+                                                    value: new LocationTagged<string>("btn", 16, 0, 16))),
+                                            factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                        factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                    factory.Markup("}")))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "!text"), 
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!text class=\"btn\"></!text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("text"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 8, 0, 8),
+                                            suffix: new LocationTagged<string>("\"", 19, 0, 19)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 16, 0, 16),
+                                                value: new LocationTagged<string>("btn", 16, 0, 16))),
+                                        factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                    factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!text class=\"btn\">words with spaces</!text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("text"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 8, 0, 8),
+                                            suffix: new LocationTagged<string>("\"", 19, 0, 19)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 16, 0, 16),
+                                                value: new LocationTagged<string>("btn", 16, 0, 16))),
+                                        factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                    factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                factory.Markup("words with spaces"),
+                                blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!text class='btn1 btn2' class2=btn></!text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("text"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class='", 8, 0, 8),
+                                            suffix: new LocationTagged<string>("'", 25, 0, 25)),
+                                        factory.Markup(" class='").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn1").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 16, 0, 16),
+                                                value: new LocationTagged<string>("btn1", 16, 0, 16))),
+                                        factory.Markup(" btn2").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(" ", 20, 0, 20),
+                                                value: new LocationTagged<string>("btn2", 21, 0, 21))),
+                                        factory.Markup("'").With(SpanCodeGenerator.Null)),
+                                        new MarkupBlock(
+                                            new AttributeBlockCodeGenerator(
+                                                name: "class2",
+                                                prefix: new LocationTagged<string>(" class2=", 26, 0, 26),
+                                                suffix: new LocationTagged<string>(string.Empty, 37, 0, 37)),
+                                            factory.Markup(" class2=").With(SpanCodeGenerator.Null),
+                                            factory.Markup("btn").With(
+                                                new LiteralAttributeCodeGenerator(
+                                                    prefix: new LocationTagged<string>(string.Empty, 34, 0, 34),
+                                                    value: new LocationTagged<string>("btn", 34, 0, 34)))),
+                                    factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!text class='btn1 @DateTime.Now btn2'></!text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("text"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class='", 8, 0, 8),
+                                            suffix: new LocationTagged<string>("'", 39, 0, 39)),
+                                        factory.Markup(" class='").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn1").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 16, 0, 16),
+                                                value: new LocationTagged<string>("btn1", 16, 0, 16))),
+                                        new MarkupBlock(
+                                            new DynamicAttributeBlockCodeGenerator(
+                                                new LocationTagged<string>(" ", 20, 0, 20), 21, 0, 21),
+                                            factory.Markup(" ").With(SpanCodeGenerator.Null),
+                                            new ExpressionBlock(
+                                                factory.CodeTransition(),
+                                                factory.Code("DateTime.Now")
+                                                    .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                                    .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                    factory.Markup(" btn2").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(" ", 34, 0, 34),
+                                                value: new LocationTagged<string>("btn2", 35, 0, 35))),
+                                        factory.Markup("'").With(SpanCodeGenerator.Null)),
+                                    factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                };
+            }
+        }
+
+        public static TheoryData OptOut_WithBlockTextTagData
+        {
+            get
+            {
+                var factory = CreateDefaultSpanFactory();
+                var blockFactory = new BlockFactory(factory);
+                var errorFormatMalformed =
+                    "Found a malformed '{0}' tag helper. Tag helpers must have a start and end tag or be self " +
+                    "closing.";
+                var errorFormatNormalUnclosed =
+                    "The \"{0}\" element was not closed.  All elements must be either self-closing or have a " +
+                    "matching end tag.";
+                var errorFormatNormalNotStarted =
+                    "Encountered end tag \"{0}\" with no matching start tag.  Are your start/end tags properly " +
+                    "balanced?";
+                var errorMatchingBrace =
+                    "The code block is missing a closing \"}\" character.  Make sure you have a matching \"}\" " +
+                    "character for all the \"{\" characters within this block, and that none of the \"}\" " +
+                    "characters are being interpreted as markup.";
+
+                Func<Func<MarkupBlock>, MarkupBlock> buildStatementBlock = (insideBuilder) =>
+                {
+                    return new MarkupBlock(
+                        factory.EmptyHtml(),
+                        new StatementBlock(
+                            factory.CodeTransition(),
+                            factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                            insideBuilder(),
+                            factory.EmptyCSharp().AsStatement(),
+                            factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                        factory.EmptyHtml());
+                };
+
+                // documentContent, expectedOutput, expectedErrors
+                return new TheoryData<string, MarkupBlock, RazorError[]>
+                {
+                    {
+                        "@{<!text>}",
+                        new MarkupBlock(
+                            factory.EmptyHtml(),
+                            new StatementBlock(
+                                factory.CodeTransition(),
+                                factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                new MarkupBlock(
+                                    blockFactory.EscapedMarkupTagBlock("<", "text>", AcceptedCharacters.None),
+                                    factory.Markup("}")))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "!text", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                        }
+                    },
+                    {
+                        "@{</!text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None))),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalNotStarted, "!text", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                        }
+                    },
+                    {
+                        "@{<!text></!text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                blockFactory.EscapedMarkupTagBlock("<", "text>", AcceptedCharacters.None),
+                                blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!text>words and spaces</!text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                blockFactory.EscapedMarkupTagBlock("<", "text>", AcceptedCharacters.None),
+                                factory.Markup("words and spaces"),
+                                blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!text></text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                blockFactory.EscapedMarkupTagBlock("<", "text>", AcceptedCharacters.None),
+                                blockFactory.MarkupTagBlock("</text>", AcceptedCharacters.None))),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "!text", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "text", CultureInfo.InvariantCulture),
+                                absoluteIndex: 9, lineIndex: 0, columnIndex: 9)
+                        }
+                    },
+                    {
+                        "@{<text></!text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(factory.MarkupTransition("<text>")),
+                                new MarkupTagBlock(
+                                    factory.Markup("</").Accepts(AcceptedCharacters.None),
+                                    factory.BangEscape(),
+                                    factory.Markup("text>").Accepts(AcceptedCharacters.None)))),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "text", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!text><text></text></!text>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                blockFactory.EscapedMarkupTagBlock("<", "text>", AcceptedCharacters.None),
+                                new MarkupTagHelperBlock("text"),
+                                blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<text><!text></!text>}",
+                        new MarkupBlock(
+                            factory.EmptyHtml(),
+                            new StatementBlock(
+                                factory.CodeTransition(),
+                                factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                new MarkupBlock(
+                                    new MarkupTagBlock(factory.MarkupTransition("<text>")),
+                                    new MarkupTagBlock(
+                                        factory.Markup("<").Accepts(AcceptedCharacters.None),
+                                        factory.BangEscape(),
+                                        factory.Markup("text>").Accepts(AcceptedCharacters.None)),
+                                    blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None),
+                                    factory.Markup("}")))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "text", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!text></!text></text>}",
+                        new MarkupBlock(
+                            factory.EmptyHtml(),
+                            new StatementBlock(
+                                factory.CodeTransition(),
+                                factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                new MarkupBlock(
+                                    blockFactory.EscapedMarkupTagBlock("<", "text>", AcceptedCharacters.None),
+                                    blockFactory.EscapedMarkupTagBlock("</", "text>", AcceptedCharacters.None)),
+                                new MarkupBlock(
+                                    blockFactory.MarkupTagBlock("</text>", AcceptedCharacters.None)),
+                                factory.EmptyCSharp().AsStatement(),
+                                factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                            factory.EmptyHtml()),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalNotStarted, "text", CultureInfo.InvariantCulture),
+                                absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "text", CultureInfo.InvariantCulture),
+                                absoluteIndex: 17, lineIndex: 0, columnIndex: 17)
+                        }
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(OptOut_WithAttributeTextTagData))]
+        [MemberData(nameof(OptOut_WithBlockTextTagData))]
+        public void Rewrite_AllowsTagHelperElementOptForCompleteTextTagInCSharpBlock(
+            string documentContent,
+            MarkupBlock expectedOutput,
+            RazorError[] expectedErrors)
+        {
+            RunParseTreeRewriterTest(documentContent, expectedOutput, expectedErrors, "p", "text");
+        }
+
+        public static TheoryData OptOut_WithPartialTextTagData
+        {
+            get
+            {
+                var factory = CreateDefaultSpanFactory();
+                var blockFactory = new BlockFactory(factory);
+                var errorMatchingBrace =
+                    "The code block is missing a closing \"}\" character.  Make sure you have a matching \"}\" " +
+                    "character for all the \"{\" characters within this block, and that none of the \"}\" " +
+                    "characters are being interpreted as markup.";
+                var errorEOFMatchingBrace =
+                    "End of file or an unexpected character was reached before the \"{0}\" tag could be parsed.  " +
+                    "Elements inside markup blocks must be complete. They must either be self-closing " +
+                    "(\"<br />\") or have matching end tags (\"<p>Hello</p>\").  If you intended " +
+                    "to display a \"<\" character, use the \"&lt;\" HTML entity.";
+
+                Func<Func<MarkupBlock>, MarkupBlock> buildPartialStatementBlock = (insideBuilder) =>
+                {
+                    return new MarkupBlock(
+                        factory.EmptyHtml(),
+                        new StatementBlock(
+                            factory.CodeTransition(),
+                            factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                            insideBuilder()));
+                };
+
+                // documentContent, expectedOutput, expectedErrors
+                return new TheoryData<string, MarkupBlock, RazorError[]>
+                {
+                    {
+                        "@{<!text}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(blockFactory.EscapedMarkupTagBlock("<", "text}"))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorEOFMatchingBrace, "!text}"),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!text /}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(blockFactory.EscapedMarkupTagBlock("<", "text /}"))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorEOFMatchingBrace, "!text"),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!text class=}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("text"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=", 8, 0, 8),
+                                            suffix: new LocationTagged<string>(string.Empty, 16, 0, 16)),
+                                        factory.Markup(" class=").With(SpanCodeGenerator.Null),
+                                        factory.Markup("}").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 15, 0, 15),
+                                                value: new LocationTagged<string>("}", 15, 0, 15))))))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorEOFMatchingBrace, "!text"),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!text class=\"btn}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("text"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 8, 0, 8),
+                                            suffix: new LocationTagged<string>(string.Empty, 20, 0, 20)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn}").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 16, 0, 16),
+                                                value: new LocationTagged<string>("btn}", 16, 0, 16))))))),
+                            new []
+                            {
+                                new RazorError(
+                                    errorMatchingBrace,
+                                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                new RazorError(
+                                    string.Format(errorEOFMatchingBrace, "!text"),
+                                    absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                            }
+                    },
+                    {
+                        "@{<!text class=\"btn\"}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("text"),
+
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 8, 0, 8),
+                                            suffix: new LocationTagged<string>("\"", 19, 0, 19)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 16, 0, 16),
+                                                value: new LocationTagged<string>("btn", 16, 0, 16))),
+                                        factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                    factory.Markup("}")))),
+                                new []
+                                {
+                                    new RazorError(
+                                        errorMatchingBrace,
+                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                    new RazorError(
+                                        string.Format(errorEOFMatchingBrace, "!text"),
+                                        absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                }
+                    },
+                    {
+                        "@{<!text class=\"btn\" /}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("text"),
+
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 8, 0, 8),
+                                            suffix: new LocationTagged<string>("\"", 19, 0, 19)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 16, 0, 16),
+                                                value: new LocationTagged<string>("btn", 16, 0, 16))),
+                                        factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                    factory.Markup(" /}")))),
+                                new []
+                                {
+                                    new RazorError(
+                                        errorMatchingBrace,
+                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                    new RazorError(
+                                        string.Format(errorEOFMatchingBrace, "!text"),
+                                        absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(OptOut_WithPartialTextTagData))]
+        public void Rewrite_AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock(
+            string documentContent,
+            MarkupBlock expectedOutput,
+            RazorError[] expectedErrors)
+        {
+            RunParseTreeRewriterTest(documentContent, expectedOutput, expectedErrors, "text");
+        }
+
+        public static TheoryData OptOut_WithPartialData_CSharp
+        {
+            get
+            {
+                var factory = CreateDefaultSpanFactory();
+                var blockFactory = new BlockFactory(factory);
+                var errorMatchingBrace =
+                    "The code block is missing a closing \"}\" character.  Make sure you have a matching \"}\" " +
+                    "character for all the \"{\" characters within this block, and that none of the \"}\" " +
+                    "characters are being interpreted as markup.";
+                var errorEOFMatchingBrace =
+                    "End of file or an unexpected character was reached before the \"{0}\" tag could be parsed.  " +
+                    "Elements inside markup blocks must be complete. They must either be self-closing " +
+                    "(\"<br />\") or have matching end tags (\"<p>Hello</p>\").  If you intended " +
+                    "to display a \"<\" character, use the \"&lt;\" HTML entity.";
+
+                Func<Func<MarkupBlock>, MarkupBlock> buildPartialStatementBlock = (insideBuilder) =>
+                {
+                    return new MarkupBlock(
+                        factory.EmptyHtml(),
+                        new StatementBlock(
+                            factory.CodeTransition(),
+                            factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                            insideBuilder()));
+                };
+
+                // documentContent, expectedOutput, expectedErrors
+                return new TheoryData<string, MarkupBlock, RazorError[]>
+                {
+                    {
+                        "@{<!}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(blockFactory.EscapedMarkupTagBlock("<", "}"))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorEOFMatchingBrace, "!}"),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!p}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(blockFactory.EscapedMarkupTagBlock("<", "p}"))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorEOFMatchingBrace, "!p}"),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!p /}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(blockFactory.EscapedMarkupTagBlock("<", "p /}"))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorEOFMatchingBrace, "!p"),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!p class=}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("p"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=", 5, 0, 5),
+                                            suffix: new LocationTagged<string>(string.Empty, 13, 0, 13)),
+                                        factory.Markup(" class=").With(SpanCodeGenerator.Null),
+                                        factory.Markup("}").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 12, 0, 12),
+                                                value: new LocationTagged<string>("}", 12, 0, 12))))))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorEOFMatchingBrace, "!p"),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!p class=\"btn}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("p"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 5, 0, 5),
+                                            suffix: new LocationTagged<string>(string.Empty, 17, 0, 17)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn}").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 13, 0, 13),
+                                                value: new LocationTagged<string>("btn}", 13, 0, 13))))))),
+                            new []
+                            {
+                                new RazorError(
+                                    errorMatchingBrace,
+                                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                new RazorError(
+                                    string.Format(errorEOFMatchingBrace, "!p"),
+                                    absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                            }
+                    },
+                    {
+                        "@{<!p class=\"btn\"}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("p"),
+
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 5, 0, 5),
+                                            suffix: new LocationTagged<string>("\"", 16, 0, 16)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 13, 0, 13),
+                                                value: new LocationTagged<string>("btn", 13, 0, 13))),
+                                        factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                    factory.Markup("}")))),
+                                new []
+                                {
+                                    new RazorError(
+                                        errorMatchingBrace,
+                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                    new RazorError(
+                                        string.Format(errorEOFMatchingBrace, "!p"),
+                                        absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                }
+                    },
+                    {
+                        "@{<!p class=\"btn\" /}",
+                        buildPartialStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("p"),
+
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 5, 0, 5),
+                                            suffix: new LocationTagged<string>("\"", 16, 0, 16)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 13, 0, 13),
+                                                value: new LocationTagged<string>("btn", 13, 0, 13))),
+                                        factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                    factory.Markup(" /}")))),
+                                new []
+                                {
+                                    new RazorError(
+                                        errorMatchingBrace,
+                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                    new RazorError(
+                                        string.Format(errorEOFMatchingBrace, "!p"),
+                                        absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(OptOut_WithPartialData_CSharp))]
+        public void Rewrite_AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock(
+            string documentContent,
+            MarkupBlock expectedOutput,
+            RazorError[] expectedErrors)
+        {
+            RunParseTreeRewriterTest(documentContent, expectedOutput, expectedErrors, "strong", "p");
+        }
+
+        public static TheoryData OptOut_WithPartialData_HTML
+        {
+            get
+            {
+                var factory = CreateDefaultSpanFactory();
+                var blockFactory = new BlockFactory(factory);
+
+                // documentContent, expectedOutput
+                return new TheoryData<string, MarkupBlock>
+                {
+                    {
+                        "<!",
+                        new MarkupBlock(factory.Markup("<!"))
+                    },
+                    {
+                        "<!p",
+                        new MarkupBlock(blockFactory.EscapedMarkupTagBlock("<", "p"))
+                    },
+                    {
+                        "<!p /",
+                        new MarkupBlock(blockFactory.EscapedMarkupTagBlock("<", "p /"))
+                    },
+                    {
+                        "<!p class=",
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                factory.Markup("<"),
+                                factory.BangEscape(),
+                                factory.Markup("p"),
+                                new MarkupBlock(
+                                    new AttributeBlockCodeGenerator(
+                                        name: "class",
+                                        prefix: new LocationTagged<string>(" class=", 3, 0, 3),
+                                        suffix: new LocationTagged<string>(string.Empty, 10, 0, 10)),
+                                    factory.Markup(" class=").With(SpanCodeGenerator.Null))))
+                    },
+                    {
+                        "<!p class=\"btn",
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                factory.Markup("<"),
+                                factory.BangEscape(),
+                                factory.Markup("p"),
+                                new MarkupBlock(
+                                    new AttributeBlockCodeGenerator(
+                                        name: "class",
+                                        prefix: new LocationTagged<string>(" class=\"", 3, 0, 3),
+                                        suffix: new LocationTagged<string>(string.Empty, 14, 0, 14)),
+                                    factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                    factory.Markup("btn").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(string.Empty, 11, 0, 11),
+                                            value: new LocationTagged<string>("btn", 11, 0, 11))))))
+                    },
+                    {
+                        "<!p class=\"btn\"",
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                factory.Markup("<"),
+                                factory.BangEscape(),
+                                factory.Markup("p"),
+                                new MarkupBlock(
+                                    new AttributeBlockCodeGenerator(
+                                        name: "class",
+                                        prefix: new LocationTagged<string>(" class=\"", 3, 0, 3),
+                                        suffix: new LocationTagged<string>("\"", 14, 0, 14)),
+                                    factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                    factory.Markup("btn").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(string.Empty, 11, 0, 11),
+                                            value: new LocationTagged<string>("btn", 11, 0, 11))),
+                                    factory.Markup("\"").With(SpanCodeGenerator.Null))))
+                    },
+                    {
+                        "<!p class=\"btn\" /",
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                factory.Markup("<"),
+                                factory.BangEscape(),
+                                factory.Markup("p"),
+
+                                new MarkupBlock(
+                                    new AttributeBlockCodeGenerator(
+                                        name: "class",
+                                        prefix: new LocationTagged<string>(" class=\"", 3, 0, 3),
+                                        suffix: new LocationTagged<string>("\"", 14, 0, 14)),
+                                    factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                    factory.Markup("btn").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(string.Empty, 11, 0, 11),
+                                            value: new LocationTagged<string>("btn", 11, 0, 11))),
+                                    factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                factory.Markup(" /")))
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(OptOut_WithPartialData_HTML))]
+        public void Rewrite_AllowsTagHelperElementOptForIncompleteHTML(
+            string documentContent,
+            MarkupBlock expectedOutput)
+        {
+            RunParseTreeRewriterTest(documentContent, expectedOutput, new RazorError[0], "strong", "p");
+        }
+
+        public static TheoryData OptOut_WithBlockData_CSharp
+        {
+            get
+            {
+                var factory = CreateDefaultSpanFactory();
+                var blockFactory = new BlockFactory(factory);
+                var errorFormatMalformed =
+                    "Found a malformed '{0}' tag helper. Tag helpers must have a start and end tag or be self " +
+                    "closing.";
+                var errorFormatNormalUnclosed =
+                    "The \"{0}\" element was not closed.  All elements must be either self-closing or have a " +
+                    "matching end tag.";
+                var errorFormatNormalNotStarted =
+                    "Encountered end tag \"{0}\" with no matching start tag.  Are your start/end tags properly " +
+                    "balanced?";
+                var errorMatchingBrace =
+                    "The code block is missing a closing \"}\" character.  Make sure you have a matching \"}\" " +
+                    "character for all the \"{\" characters within this block, and that none of the \"}\" " +
+                    "characters are being interpreted as markup.";
+
+                Func<Func<MarkupBlock>, MarkupBlock> buildStatementBlock = (insideBuilder) =>
+                {
+                    return new MarkupBlock(
+                        factory.EmptyHtml(),
+                        new StatementBlock(
+                            factory.CodeTransition(),
+                            factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                            insideBuilder(),
+                            factory.EmptyCSharp().AsStatement(),
+                            factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                        factory.EmptyHtml());
+                };
+
+                // documentContent, expectedOutput, expectedErrors
+                return new TheoryData<string, MarkupBlock, RazorError[]>
+                {
+                    {
+                        "@{<!p>}",
+                        new MarkupBlock(
+                            factory.EmptyHtml(),
+                            new StatementBlock(
+                                factory.CodeTransition(),
+                                factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                new MarkupBlock(
+                                    blockFactory.EscapedMarkupTagBlock("<", "p>", AcceptedCharacters.None),
+                                    factory.Markup("}")))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "!p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                        }
+                    },
+                    {
+                        "@{</!p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None))),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalNotStarted, "!p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                        }
+                    },
+                    {
+                        "@{<!p></!p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                blockFactory.EscapedMarkupTagBlock("<", "p>", AcceptedCharacters.None),
+                                blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!p>words and spaces</!p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                blockFactory.EscapedMarkupTagBlock("<", "p>", AcceptedCharacters.None),
+                                factory.Markup("words and spaces"),
+                                blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!p></p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                blockFactory.EscapedMarkupTagBlock("<", "p>", AcceptedCharacters.None),
+                                blockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None))),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "!p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 6, lineIndex: 0, columnIndex: 6)
+                        }
+                    },
+                    {
+                        "@{<p></!p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagHelperBlock("p",
+                                    blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None)))),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<p><!p></!p></p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagHelperBlock("p",
+                                    blockFactory.EscapedMarkupTagBlock("<", "p>", AcceptedCharacters.None),
+                                    blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None)))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<p><!p></!p>}",
+                        new MarkupBlock(
+                            factory.EmptyHtml(),
+                            new StatementBlock(
+                                factory.CodeTransition(),
+                                factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                new MarkupBlock(
+                                    new MarkupTagHelperBlock("p",
+                                        blockFactory.EscapedMarkupTagBlock("<", "p>", AcceptedCharacters.None),
+                                        blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None),
+                                        factory.Markup("}"))))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!p></!p></p>}",
+                        new MarkupBlock(
+                            factory.EmptyHtml(),
+                            new StatementBlock(
+                                factory.CodeTransition(),
+                                factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                new MarkupBlock(
+                                    blockFactory.EscapedMarkupTagBlock("<", "p>", AcceptedCharacters.None),
+                                    blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None)),
+                                new MarkupBlock(
+                                    blockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None)),
+                                factory.EmptyCSharp().AsStatement(),
+                                factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                            factory.EmptyHtml()),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalNotStarted, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 11, lineIndex: 0, columnIndex: 11),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 11, lineIndex: 0, columnIndex: 11)
+                        }
+                    },
+                    {
+                        "@{<strong></!p></strong>}",
+                        new MarkupBlock(
+                        factory.EmptyHtml(),
+                        new StatementBlock(
+                            factory.CodeTransition(),
+                            factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                            new MarkupBlock(
+                                new MarkupTagHelperBlock("strong",
+                                    blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None))),
+                            new MarkupBlock(
+                                blockFactory.MarkupTagBlock("</strong>", AcceptedCharacters.None)),
+                            factory.EmptyCSharp().AsStatement(),
+                            factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                        factory.EmptyHtml()),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "strong", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "strong", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                            new RazorError(
+                                string.Format(errorFormatNormalNotStarted, "strong", CultureInfo.InvariantCulture),
+                                absoluteIndex: 15, lineIndex: 0, columnIndex: 15),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "strong", CultureInfo.InvariantCulture),
+                                absoluteIndex: 15, lineIndex: 0, columnIndex: 15)
+                        }
+                    },
+                    {
+                        "@{<strong></strong><!p></!p>}",
+                        new MarkupBlock(
+                            factory.EmptyHtml(),
+                            new StatementBlock(
+                                factory.CodeTransition(),
+                                factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                new MarkupBlock(
+                                    new MarkupTagHelperBlock("strong")),
+                                new MarkupBlock(
+                                    blockFactory.EscapedMarkupTagBlock("<", "p>", AcceptedCharacters.None),
+                                    blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None)),
+                                factory.EmptyCSharp().AsStatement(),
+                                factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                            factory.EmptyHtml()),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<p><strong></!strong><!p></strong></!p>}",
+                            new MarkupBlock(
+                                factory.EmptyHtml(),
+                                new StatementBlock(
+                                    factory.CodeTransition(),
+                                    factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                    new MarkupBlock(
+                                        new MarkupTagHelperBlock("p",
+                                            new MarkupTagHelperBlock("strong",
+                                                blockFactory.EscapedMarkupTagBlock("</", "strong>", AcceptedCharacters.None)))),
+                                    new MarkupBlock(
+                                        blockFactory.EscapedMarkupTagBlock("<", "p>", AcceptedCharacters.None),
+                                        blockFactory.MarkupTagBlock("</strong>", AcceptedCharacters.None)),
+                                    new MarkupBlock(
+                                        blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None)),
+                                    factory.EmptyCSharp().AsStatement(),
+                                    factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                                factory.EmptyHtml()),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "strong", CultureInfo.InvariantCulture),
+                                absoluteIndex: 5, lineIndex: 0, columnIndex: 5),
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "!p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 23, lineIndex: 0, columnIndex: 23),
+                            new RazorError(
+                                string.Format(errorFormatMalformed, "strong", CultureInfo.InvariantCulture),
+                                absoluteIndex: 27, lineIndex: 0, columnIndex: 27),
+                            new RazorError(
+                                string.Format(errorFormatNormalNotStarted, "!p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 36, lineIndex: 0, columnIndex: 36),
+                        }
+                    },
+                };
+            }
+        }
+
+        public static TheoryData OptOut_WithAttributeData_CSharp
+        {
+            get
+            {
+                var factory = CreateDefaultSpanFactory();
+                var blockFactory = new BlockFactory(factory);
+                var errorFormatNormalUnclosed =
+                    "The \"{0}\" element was not closed.  All elements must be either self-closing or have a " +
+                    "matching end tag.";
+                var errorMatchingBrace =
+                    "The code block is missing a closing \"}\" character.  Make sure you have a matching \"}\" " +
+                    "character for all the \"{\" characters within this block, and that none of the \"}\" " +
+                    "characters are being interpreted as markup.";
+
+                Func<Func<MarkupBlock>, MarkupBlock> buildStatementBlock = (insideBuilder) =>
+                {
+                    return new MarkupBlock(
+                        factory.EmptyHtml(),
+                        new StatementBlock(
+                            factory.CodeTransition(),
+                            factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                            insideBuilder(),
+                            factory.EmptyCSharp().AsStatement(),
+                            factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                        factory.EmptyHtml());
+                };
+
+                // documentContent, expectedOutput, expectedErrors
+                return new TheoryData<string, MarkupBlock, RazorError[]>
+                {
+                    {
+                        "@{<!p class=\"btn\">}",
+                        new MarkupBlock(
+                        factory.EmptyHtml(),
+                        new StatementBlock(
+                            factory.CodeTransition(),
+                            factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                                new MarkupBlock(
+                                    new MarkupTagBlock(
+                                        factory.Markup("<"),
+                                        factory.BangEscape(),
+                                        factory.Markup("p"),
+                                        new MarkupBlock(
+                                            new AttributeBlockCodeGenerator(
+                                                name: "class",
+                                                prefix: new LocationTagged<string>(" class=\"", 5, 0, 5),
+                                                suffix: new LocationTagged<string>("\"", 16, 0, 16)),
+                                            factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                            factory.Markup("btn").With(
+                                                new LiteralAttributeCodeGenerator(
+                                                    prefix: new LocationTagged<string>(string.Empty, 13, 0, 13),
+                                                    value: new LocationTagged<string>("btn", 13, 0, 13))),
+                                            factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                        factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                    factory.Markup("}")))),
+                        new []
+                        {
+                            new RazorError(
+                                errorMatchingBrace,
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                            new RazorError(
+                                string.Format(errorFormatNormalUnclosed, "!p"),
+                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                        }
+                    },
+                    {
+                        "@{<!p class=\"btn\"></!p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("p"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 5, 0, 5),
+                                            suffix: new LocationTagged<string>("\"", 16, 0, 16)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 13, 0, 13),
+                                                value: new LocationTagged<string>("btn", 13, 0, 13))),
+                                        factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                    factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!p class=\"btn\">words with spaces</!p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("p"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class=\"", 5, 0, 5),
+                                            suffix: new LocationTagged<string>("\"", 16, 0, 16)),
+                                        factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 13, 0, 13),
+                                                value: new LocationTagged<string>("btn", 13, 0, 13))),
+                                        factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                    factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                factory.Markup("words with spaces"),
+                                blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!p class='btn1 btn2' class2=btn></!p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("p"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class='", 5, 0, 5),
+                                            suffix: new LocationTagged<string>("'", 22, 0, 22)),
+                                        factory.Markup(" class='").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn1").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 13, 0, 13),
+                                                value: new LocationTagged<string>("btn1", 13, 0, 13))),
+                                        factory.Markup(" btn2").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(" ", 17, 0, 17),
+                                                value: new LocationTagged<string>("btn2", 18, 0, 18))),
+                                        factory.Markup("'").With(SpanCodeGenerator.Null)),
+                                        new MarkupBlock(
+                                            new AttributeBlockCodeGenerator(
+                                                name: "class2",
+                                                prefix: new LocationTagged<string>(" class2=", 23, 0, 23),
+                                                suffix: new LocationTagged<string>(string.Empty, 34, 0, 34)),
+                                            factory.Markup(" class2=").With(SpanCodeGenerator.Null),
+                                            factory.Markup("btn").With(
+                                                new LiteralAttributeCodeGenerator(
+                                                    prefix: new LocationTagged<string>(string.Empty, 31, 0, 31),
+                                                    value: new LocationTagged<string>("btn", 31, 0, 31)))),
+                                    factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                    {
+                        "@{<!p class='btn1 @DateTime.Now btn2'></!p>}",
+                        buildStatementBlock(
+                            () => new MarkupBlock(
+                                new MarkupTagBlock(
+                                    factory.Markup("<"),
+                                    factory.BangEscape(),
+                                    factory.Markup("p"),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class",
+                                            prefix: new LocationTagged<string>(" class='", 5, 0, 5),
+                                            suffix: new LocationTagged<string>("'", 36, 0, 36)),
+                                        factory.Markup(" class='").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn1").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 13, 0, 13),
+                                                value: new LocationTagged<string>("btn1", 13, 0, 13))),
+                                        new MarkupBlock(
+                                            new DynamicAttributeBlockCodeGenerator(
+                                                new LocationTagged<string>(" ", 17, 0, 17), 18, 0, 18),
+                                            factory.Markup(" ").With(SpanCodeGenerator.Null),
+                                            new ExpressionBlock(
+                                                factory.CodeTransition(),
+                                                factory.Code("DateTime.Now")
+                                                    .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                                    .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                    factory.Markup(" btn2").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(" ", 31, 0, 31),
+                                                value: new LocationTagged<string>("btn2", 32, 0, 32))),
+                                        factory.Markup("'").With(SpanCodeGenerator.Null)),
+                                    factory.Markup(">").Accepts(AcceptedCharacters.None)),
+                                blockFactory.EscapedMarkupTagBlock("</", "p>", AcceptedCharacters.None))),
+                        new RazorError[0]
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(OptOut_WithBlockData_CSharp))]
+        [MemberData(nameof(OptOut_WithAttributeData_CSharp))]
+        public void Rewrite_AllowsTagHelperElementOptOutCSharp(
+            string documentContent,
+            MarkupBlock expectedOutput,
+            RazorError[] expectedErrors)
+        {
+            RunParseTreeRewriterTest(documentContent, expectedOutput, expectedErrors, "strong", "p");
+        }
+
+        public static TheoryData OptOut_WithBlockData_HTML
+        {
+            get
+            {
+                var factory = CreateDefaultSpanFactory();
+                var blockFactory = new BlockFactory(factory);
+                var errorFormatUnclosed = "Found a malformed '{0}' tag helper. Tag helpers must have a start and " +
+                                          "end tag or be self closing.";
+
+                // documentContent, expectedOutput, expectedErrors
+                return new TheoryData<string, MarkupBlock, RazorError[]>
+                {
+                    {
+                        "<!p>",
+                        new MarkupBlock(
+                            blockFactory.EscapedMarkupTagBlock("<", "p>")),
+                        new RazorError[0]
+                    },
+                    {
+                        "</!p>",
+                        new MarkupBlock(
+                            blockFactory.EscapedMarkupTagBlock("</", "p>")),
+                        new RazorError[0]
+                    },
+                    {
+                        "<!p></!p>",
+                        new MarkupBlock(
+                            blockFactory.EscapedMarkupTagBlock("<", "p>"),
+                            blockFactory.EscapedMarkupTagBlock("</", "p>")),
+                        new RazorError[0]
+                    },
+                    {
+                        "<!p>words and spaces</!p>",
+                        new MarkupBlock(
+                            blockFactory.EscapedMarkupTagBlock("<", "p>"),
+                            factory.Markup("words and spaces"),
+                            blockFactory.EscapedMarkupTagBlock("</", "p>")),
+                        new RazorError[0]
+                    },
+                    {
+                        "<!p></p>",
+                        new MarkupBlock(
+                            blockFactory.EscapedMarkupTagBlock("<", "p>"),
+                            blockFactory.MarkupTagBlock("</p>")),
+                        new []
+                        {
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
+                                absoluteIndex: 4, lineIndex: 0, columnIndex: 4)
+                        }
+                    },
+                    {
+                        "<p></!p>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock("p", blockFactory.EscapedMarkupTagBlock("</", "p>"))),
+                        new []
+                        {
+                            new RazorError(string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
+                            SourceLocation.Zero)
+                        }
+                    },
+                    {
+                        "<p><!p></!p></p>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock("p",
+                                blockFactory.EscapedMarkupTagBlock("<", "p>"),
+                                blockFactory.EscapedMarkupTagBlock("</", "p>"))),
+                        new RazorError[0]
+                    },
+                    {
+                        "<p><!p></!p>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock("p",
+                                blockFactory.EscapedMarkupTagBlock("<", "p>"),
+                                blockFactory.EscapedMarkupTagBlock("</", "p>"))),
+                        new []
+                        {
+                            new RazorError(string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
+                            SourceLocation.Zero)
+                        }
+                    },
+                    {
+                        "<!p></!p></p>",
+                        new MarkupBlock(
+                            blockFactory.EscapedMarkupTagBlock("<", "p>"),
+                            blockFactory.EscapedMarkupTagBlock("</", "p>"),
+                            blockFactory.MarkupTagBlock("</p>")),
+                        new []
+                        {
+                            new RazorError(string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
+                            absoluteIndex: 9, lineIndex: 0, columnIndex: 9)
+                        }
+                    },
+                    {
+                        "<strong></!p></strong>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock("strong",
+                                blockFactory.EscapedMarkupTagBlock("</", "p>"))),
+                        new RazorError[0]
+                    },
+                    {
+                        "<strong></strong><!p></!p>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock("strong"),
+                            blockFactory.EscapedMarkupTagBlock("<", "p>"),
+                            blockFactory.EscapedMarkupTagBlock("</", "p>")),
+                        new RazorError[0]
+                    },
+                    {
+                        "<p><strong></!strong><!p></strong></!p>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock("p",
+                                new MarkupTagHelperBlock("strong",
+                                    blockFactory.EscapedMarkupTagBlock("</", "strong>"),
+                                    blockFactory.EscapedMarkupTagBlock("<", "p>")),
+                                blockFactory.EscapedMarkupTagBlock("</", "p>"))),
+                        new []
+                        {
+                            new RazorError(string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
+                            SourceLocation.Zero)
+                        }
+                    },
+                };
+            }
+        }
+
+        public static TheoryData OptOut_WithAttributeData_HTML
+        {
+            get
+            {
+                var factory = CreateDefaultSpanFactory();
+                var blockFactory = new BlockFactory(factory);
+
+                // documentContent, expectedOutput, expectedErrors
+                return new TheoryData<string, MarkupBlock, RazorError[]>
+                {
+                    {
+                        "<!p class=\"btn\">",
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                factory.Markup("<"),
+                                factory.BangEscape(),
+                                factory.Markup("p"),
+                                new MarkupBlock(
+                                    new AttributeBlockCodeGenerator(
+                                        name: "class",
+                                        prefix: new LocationTagged<string>(" class=\"", 3, 0, 3),
+                                        suffix: new LocationTagged<string>("\"", 14, 0, 14)),
+                                    factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                    factory.Markup("btn").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(string.Empty, 11, 0, 11),
+                                            value: new LocationTagged<string>("btn", 11, 0, 11))),
+                                    factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                factory.Markup(">"))),
+                        new RazorError[0]
+                    },
+                    {
+                        "<!p class=\"btn\"></!p>",
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                factory.Markup("<"),
+                                factory.BangEscape(),
+                                factory.Markup("p"),
+                                new MarkupBlock(
+                                    new AttributeBlockCodeGenerator(
+                                        name: "class",
+                                        prefix: new LocationTagged<string>(" class=\"", 3, 0, 3),
+                                        suffix: new LocationTagged<string>("\"", 14, 0, 14)),
+                                    factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                    factory.Markup("btn").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(string.Empty, 11, 0, 11),
+                                            value: new LocationTagged<string>("btn", 11, 0, 11))),
+                                    factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                factory.Markup(">")),
+                            blockFactory.EscapedMarkupTagBlock("</", "p>")),
+                        new RazorError[0]
+                    },
+                    {
+                        "<!p class=\"btn\">words and spaces</!p>",
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                factory.Markup("<"),
+                                factory.BangEscape(),
+                                factory.Markup("p"),
+                                new MarkupBlock(
+                                    new AttributeBlockCodeGenerator(
+                                        name: "class",
+                                        prefix: new LocationTagged<string>(" class=\"", 3, 0, 3),
+                                        suffix: new LocationTagged<string>("\"", 14, 0, 14)),
+                                    factory.Markup(" class=\"").With(SpanCodeGenerator.Null),
+                                    factory.Markup("btn").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(string.Empty, 11, 0, 11),
+                                            value: new LocationTagged<string>("btn", 11, 0, 11))),
+                                    factory.Markup("\"").With(SpanCodeGenerator.Null)),
+                                factory.Markup(">")),
+                            factory.Markup("words and spaces"),
+                            blockFactory.EscapedMarkupTagBlock("</", "p>")),
+                        new RazorError[0]
+                    },
+                    {
+                        "<!p class='btn1 btn2' class2=btn></!p>",
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                factory.Markup("<"),
+                                factory.BangEscape(),
+                                factory.Markup("p"),
+                                new MarkupBlock(
+                                    new AttributeBlockCodeGenerator(
+                                        name: "class",
+                                        prefix: new LocationTagged<string>(" class='", 3, 0, 3),
+                                        suffix: new LocationTagged<string>("'", 20, 0, 20)),
+                                    factory.Markup(" class='").With(SpanCodeGenerator.Null),
+                                    factory.Markup("btn1").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(string.Empty, 11, 0, 11),
+                                            value: new LocationTagged<string>("btn1", 11, 0, 11))),
+                                    factory.Markup(" btn2").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(" ", 15, 0, 15),
+                                            value: new LocationTagged<string>("btn2", 16, 0, 16))),
+                                    factory.Markup("'").With(SpanCodeGenerator.Null)),
+                                    new MarkupBlock(
+                                        new AttributeBlockCodeGenerator(
+                                            name: "class2",
+                                            prefix: new LocationTagged<string>(" class2=", 21, 0, 21),
+                                            suffix: new LocationTagged<string>(string.Empty, 32, 0, 32)),
+                                        factory.Markup(" class2=").With(SpanCodeGenerator.Null),
+                                        factory.Markup("btn").With(
+                                            new LiteralAttributeCodeGenerator(
+                                                prefix: new LocationTagged<string>(string.Empty, 29, 0, 29),
+                                                value: new LocationTagged<string>("btn", 29, 0, 29)))),
+                                factory.Markup(">")),
+                            blockFactory.EscapedMarkupTagBlock("</", "p>")),
+                        new RazorError[0]
+                    },
+                    {
+                        "<!p class='btn1 @DateTime.Now btn2'></!p>",
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                factory.Markup("<"),
+                                factory.BangEscape(),
+                                factory.Markup("p"),
+                                new MarkupBlock(
+                                    new AttributeBlockCodeGenerator(
+                                        name: "class",
+                                        prefix: new LocationTagged<string>(" class='", 3, 0, 3),
+                                        suffix: new LocationTagged<string>("'", 34, 0, 34)),
+                                    factory.Markup(" class='").With(SpanCodeGenerator.Null),
+                                    factory.Markup("btn1").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(string.Empty, 11, 0, 11),
+                                            value: new LocationTagged<string>("btn1", 11, 0, 11))),
+                                    new MarkupBlock(
+                                        new DynamicAttributeBlockCodeGenerator(
+                                            new LocationTagged<string>(" ", 15, 0, 15), 16, 0, 16),
+                                        factory.Markup(" ").With(SpanCodeGenerator.Null),
+                                        new ExpressionBlock(
+                                            factory.CodeTransition(),
+                                            factory.Code("DateTime.Now")
+                                                .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                                .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                factory.Markup(" btn2").With(
+                                        new LiteralAttributeCodeGenerator(
+                                            prefix: new LocationTagged<string>(" ", 29, 0, 29),
+                                            value: new LocationTagged<string>("btn2", 30, 0, 30))),
+                                    factory.Markup("'").With(SpanCodeGenerator.Null)),
+                                factory.Markup(">")),
+                            blockFactory.EscapedMarkupTagBlock("</", "p>")),
+                        new RazorError[0]
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(OptOut_WithBlockData_HTML))]
+        [MemberData(nameof(OptOut_WithAttributeData_HTML))]
+        public void Rewrite_AllowsTagHelperElementOptOutHTML(
+            string documentContent,
+            MarkupBlock expectedOutput,
+            RazorError[] expectedErrors)
+        {
+            RunParseTreeRewriterTest(documentContent, expectedOutput, expectedErrors, "strong", "p");
+        }
+        
         public static TheoryData EmptyAttributeTagHelperData
         {
             get

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.DesignTime.cs
@@ -1,0 +1,56 @@
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class EscapedTagHelpers
+    {
+        private static object @__o;
+        private void @__RazorDesignTimeHelpers__()
+        {
+            #pragma warning disable 219
+            string __tagHelperDirectiveSyntaxHelper = null;
+            __tagHelperDirectiveSyntaxHelper = 
+#line 1 "EscapedTagHelpers.cshtml"
+              "something"
+
+#line default
+#line hidden
+            ;
+            #pragma warning restore 219
+        }
+        #line hidden
+        private InputTagHelper __InputTagHelper = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        #line hidden
+        public EscapedTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+#line 4 "EscapedTagHelpers.cshtml"
+                       __o = DateTime.Now;
+
+#line default
+#line hidden
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+#line 6 "EscapedTagHelpers.cshtml"
+__o = DateTime.Now;
+
+#line default
+#line hidden
+            __InputTagHelper.Type = string.Empty;
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 6 "EscapedTagHelpers.cshtml"
+                                              __InputTagHelper2.Checked = true;
+
+#line default
+#line hidden
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.cs
@@ -1,0 +1,87 @@
+#pragma checksum "EscapedTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "f1f93dcc77691cc626112fe0475f5c350e5fa802"
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class EscapedTagHelpers
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
+        private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private InputTagHelper __InputTagHelper = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        #line hidden
+        public EscapedTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            Instrumentation.BeginContext(27, 72, true);
+            WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    <p class=\"Hello World\" ");
+            Instrumentation.EndContext();
+            Instrumentation.BeginContext(102, 12, false);
+#line 4 "EscapedTagHelpers.cshtml"
+                       Write(DateTime.Now);
+
+#line default
+#line hidden
+            Instrumentation.EndContext();
+            Instrumentation.BeginContext(114, 69, true);
+            WriteLiteral(">\r\n        <input type=\"text\" />\r\n        <em>Not a TagHelper: </em> ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+            }
+            , StartWritingScope, EndWritingScope);
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            StartWritingScope();
+#line 6 "EscapedTagHelpers.cshtml"
+Write(DateTime.Now);
+
+#line default
+#line hidden
+            __tagHelperStringValueBuffer = EndWritingScope();
+            __InputTagHelper.Type = __tagHelperStringValueBuffer.ToString();
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __InputTagHelper.Type);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 6 "EscapedTagHelpers.cshtml"
+                                              __InputTagHelper2.Checked = true;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __InputTagHelper2.Checked);
+            __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePreContent());
+            if (__tagHelperExecutionContext.Output.ContentSet)
+            {
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateContent());
+            }
+            else if (__tagHelperExecutionContext.ChildContentRetrieved)
+            {
+                WriteLiteral(__tagHelperExecutionContext.GetChildContentAsync().Result);
+            }
+            else
+            {
+                __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+            }
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(231, 18, true);
+            WriteLiteral("\r\n    </p>\r\n</div>");
+            Instrumentation.EndContext();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/EscapedTagHelpers.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/EscapedTagHelpers.cshtml
@@ -1,0 +1,8 @@
+﻿@addtaghelper "something"
+
+<!div class="randomNonTagHelperAttribute">
+    <!p class="Hello World" @DateTime.Now>
+        <!input type="text" />
+        <!em>Not a TagHelper: </!em> <input type="@DateTime.Now" checked="true" />
+    </!p>
+</!div>


### PR DESCRIPTION
- Added the ability to opt-out of TagHelper parsing by adding a '!' to the beginning of a tag name.
- Modified parsing logic to allow bangs in tags.
- Added a new EscapedTagHelperCodeGenerator to strip '!' from escaped TagHelper output.
- Added extensive unit tests.
- Added functional test to validate output for runtime and design time.

#187

/cc @dougbu @pranavkm 