### PR TITLE
Add order attribute and corresponding TagHelperDescriptor property.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/ITagHelper.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/ITagHelper.cs
@@ -11,6 +11,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     public interface ITagHelper
     {
         /// <summary>
+        /// Gets the execution order of this <see cref= "ITagHelper" /> relative to others targeting the same element.
+        /// <see cref="ITagHelper"/> instances with lower values are executed first.
+        /// </summary>
+        int Order { get; }
+
+        /// <summary>
         /// Asynchronously executes the <see cref="ITagHelper"/> with the given <paramref name="context"/> and
         /// <paramref name="output"/>.
         /// </summary>

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelper.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelper.cs
@@ -10,6 +10,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     /// </summary>
     public abstract class TagHelper : ITagHelper
     {
+        /// <inheritdoc />
+        /// <remarks>Default order is <c>0</c>.</remarks>
+        public virtual int Order { get; } = 0;
+
         /// <summary>
         /// Synchronously executes the <see cref="TagHelper"/> with the given <paramref name="context"/> and
         /// <paramref name="output"/>.

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperRunner.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperRunner.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
@@ -24,8 +25,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 executionContext.UniqueId,
                 executionContext.GetChildContentAsync);
             var tagHelperOutput = new TagHelperOutput(executionContext.TagName, executionContext.HTMLAttributes);
+            var orderedTagHelpers = executionContext.TagHelpers.OrderBy(tagHelper => tagHelper.Order);
 
-            foreach (var tagHelper in executionContext.TagHelpers)
+            foreach (var tagHelper in orderedTagHelpers)
             {
                 await tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput);
             }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.IO;
-using System.Text;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -10,6 +10,77 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 {
     public class TagHelperRunnerTest
     {
+        public static TheoryData TagHelperOrderData
+        {
+            get
+            {
+                // tagHelperOrders, expectedTagHelperOrders
+                return new TheoryData<int[], int[]>
+                {
+                    {
+                        new[] { 1000, int.MaxValue, 0 },
+                        new[] { 0, 1000, int.MaxValue }
+                    },
+                    {
+                        new[] { int.MaxValue, int.MaxValue, int.MinValue },
+                        new[] { int.MinValue, int.MaxValue, int.MaxValue }
+                    },
+                    {
+                        new[] { 0, 0, int.MinValue },
+                        new[] { int.MinValue, 0, 0 }
+                    },
+                    {
+                        new[] { int.MinValue, -1000, 0 },
+                        new[] { int.MinValue, -1000, 0 }
+                    },
+                    {
+                        new[] { 0, 1000, int.MaxValue },
+                        new[] { 0, 1000, int.MaxValue }
+                    },
+                    {
+                        new[] { int.MaxValue, int.MinValue, int.MaxValue, -1000, int.MaxValue, 0 },
+                        new[] { int.MinValue, -1000, 0, int.MaxValue, int.MaxValue, int.MaxValue }
+                    },
+                    {
+                        new[] { 0, 0, 0, 0 },
+                        new[] { 0, 0, 0, 0 }
+                    },
+
+                    {
+                        new[] { 1000, int.MaxValue, 0, -1000, int.MinValue },
+                        new[] { int.MinValue, -1000, 0, 1000, int.MaxValue }
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TagHelperOrderData))]
+        public async Task RunAsync_OrdersTagHelpers(
+            int[] tagHelperOrders,
+            int[] expectedTagHelperOrders)
+        {
+            // Arrange
+            var runner = new TagHelperRunner();
+            var executionContext = new TagHelperExecutionContext("p");
+            var processOrder = new List<int>();
+
+            foreach (var order in tagHelperOrders)
+            {
+                var orderedTagHelper = new OrderedTagHelper(order)
+                {
+                    ProcessOrderTracker = processOrder
+                };
+                executionContext.Add(orderedTagHelper);
+            }
+
+            // Act
+            await runner.RunAsync(executionContext);
+
+            // Assert
+            Assert.Equal(expectedTagHelperOrders, processOrder);
+        }
+
         [Fact]
         public async Task RunAsync_ProcessesAllTagHelpers()
         {
@@ -86,6 +157,26 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             public override void Process(TagHelperContext context, TagHelperOutput output)
             {
                 output.Attributes["foo"] = context.AllAttributes["foo"].ToString();
+            }
+        }
+
+        private class OrderedTagHelper : TagHelper
+        {
+            public OrderedTagHelper(int order)
+            {
+                Order = order;
+            }
+
+            public override int Order { get; }
+            public IList<int> ProcessOrderTracker { get; set; }
+
+            public override void Process(TagHelperContext context, TagHelperOutput output)
+            {
+                // If using this class for testing, ensure that ProcessOrderTracker is always set prior to Process
+                // execution.
+                Debug.Assert(ProcessOrderTracker != null);
+
+                ProcessOrderTracker.Add(Order);
             }
         }
     }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
@@ -129,6 +129,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         public class Invalid_NestedPublicTagHelper : ITagHelper
         {
+            public int Order { get { return 0; } }
+
             public Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
             {
                 return Task.FromResult(result: true);
@@ -137,6 +139,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         internal class Invalid_NestedInternalTagHelper : ITagHelper
         {
+            public int Order { get { return 0; } }
+
             public Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
             {
                 return Task.FromResult(result: true);
@@ -145,6 +149,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         private class Invalid_PrivateTagHelper : ITagHelper
         {
+            public int Order { get { return 0; } }
+
             public Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
             {
                 return Task.FromResult(result: true);
@@ -153,6 +159,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         protected class Invalid_ProtectedTagHelper : ITagHelper
         {
+            public int Order { get { return 0; } }
+
             public Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
             {
                 return Task.FromResult(result: true);
@@ -164,6 +172,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     // In this case they do not fulfill other TagHelper requirements.
     public abstract class Invalid_AbstractTagHelper : ITagHelper
     {
+        public int Order { get { return 0; } }
+
         public Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             return Task.FromResult(result: true);
@@ -172,6 +182,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
     public class Invalid_GenericTagHelper<T> : ITagHelper
     {
+        public int Order { get { return 0; } }
+
         public Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             return Task.FromResult(result: true);
@@ -180,6 +192,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
     internal class Invalid_InternalTagHelper : ITagHelper
     {
+        public int Order { get { return 0; } }
+
         public Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             return Task.FromResult(result: true);


### PR DESCRIPTION
- Added codegen code to pass appropriate order into the TagHelperExecutionContext. Ultimately decided to make order control a runtime feature to allow flexibility in the future.
- Added functional code generation tests and unit tests.
- Tested runtime and parse time features of the OrderAttribute.
- Modified existing codegen test to further validate the Order attribute value.

#94
