### PR TITLE
Fix empty attribute projections for TagHelpers.

### DIFF
--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
@@ -213,7 +213,41 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                             BuildLineMapping(1094, 30, 18, 5179, 187, 19, 29),
                             BuildLineMapping(1231, 34, 5279, 192, 0, 1),
                         }
-                    }
+                    },
+                    {
+                        "EmptyAttributeTagHelpers",
+                        "EmptyAttributeTagHelpers.DesignTime",
+                        PAndInputTagHelperDescriptors,
+                        new List<LineMapping>
+                        {
+                            BuildLineMapping(documentAbsoluteIndex: 14,
+                                             documentLineIndex: 0,
+                                             generatedAbsoluteIndex: 493,
+                                             generatedLineIndex: 15,
+                                             characterOffsetIndex: 14,
+                                             contentLength: 11),
+                            BuildLineMapping(documentAbsoluteIndex: 62,
+                                             documentLineIndex: 3,
+                                             documentCharacterOffsetIndex: 26,
+                                             generatedAbsoluteIndex: 1289,
+                                             generatedLineIndex: 39,
+                                             generatedCharacterOffsetIndex: 28,
+                                             contentLength: 0),
+                            BuildLineMapping(documentAbsoluteIndex: 122,
+                                             documentLineIndex: 5,
+                                             generatedAbsoluteIndex: 1634,
+                                             generatedLineIndex: 48,
+                                             characterOffsetIndex: 30,
+                                             contentLength: 0),
+                            BuildLineMapping(documentAbsoluteIndex: 88,
+                                             documentLineIndex: 4,
+                                             documentCharacterOffsetIndex: 12,
+                                             generatedAbsoluteIndex: 1789,
+                                             generatedLineIndex: 54,
+                                             generatedCharacterOffsetIndex: 19,
+                                             contentLength: 0)
+                        }
+                    },
                 };
             }
         }
@@ -245,6 +279,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     { "BasicTagHelpers", PAndInputTagHelperDescriptors },
                     { "BasicTagHelpers.RemoveTagHelper", PAndInputTagHelperDescriptors },
                     { "ComplexTagHelpers", PAndInputTagHelperDescriptors },
+                    { "EmptyAttributeTagHelpers", PAndInputTagHelperDescriptors },
                 };
             }
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.DesignTime.cs
@@ -1,0 +1,62 @@
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class EmptyAttributeTagHelpers
+    {
+        private static object @__o;
+        private void @__RazorDesignTimeHelpers__()
+        {
+            #pragma warning disable 219
+            string __tagHelperDirectiveSyntaxHelper = null;
+            __tagHelperDirectiveSyntaxHelper = 
+#line 1 "EmptyAttributeTagHelpers.cshtml"
+              "something"
+
+#line default
+#line hidden
+            ;
+            #pragma warning restore 219
+        }
+        #line hidden
+        private InputTagHelper __InputTagHelper = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        private PTagHelper __PTagHelper = null;
+        #line hidden
+        public EmptyAttributeTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper.Type = "";
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 4 "EmptyAttributeTagHelpers.cshtml"
+__InputTagHelper2.Checked = ;
+
+#line default
+#line hidden
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper.Type = "";
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 6 "EmptyAttributeTagHelpers.cshtml"
+  __InputTagHelper2.Checked = ;
+
+#line default
+#line hidden
+            __PTagHelper = CreateTagHelper<PTagHelper>();
+#line 5 "EmptyAttributeTagHelpers.cshtml"
+__PTagHelper.Age = ;
+
+#line default
+#line hidden
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.cs
@@ -1,0 +1,141 @@
+#pragma checksum "EmptyAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "828f744feb52d497814b7a018f817f31d92085ce"
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class EmptyAttributeTagHelpers
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
+        private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private InputTagHelper __InputTagHelper = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        private PTagHelper __PTagHelper = null;
+        #line hidden
+        public EmptyAttributeTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            Instrumentation.BeginContext(27, 13, true);
+            WriteLiteral("\r\n<div>\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+            }
+            , StartWritingScope, EndWritingScope);
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            __InputTagHelper.Type = "";
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __InputTagHelper.Type);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 4 "EmptyAttributeTagHelpers.cshtml"
+__InputTagHelper2.Checked = ;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __InputTagHelper2.Checked);
+            __tagHelperExecutionContext.AddHtmlAttribute("class", "");
+            __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePreContent());
+            if (__tagHelperExecutionContext.Output.ContentSet)
+            {
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateContent());
+            }
+            else if (__tagHelperExecutionContext.ChildContentRetrieved)
+            {
+                WriteLiteral(__tagHelperExecutionContext.GetChildContentAsync().Result);
+            }
+            else
+            {
+                __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+            }
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(74, 6, true);
+            WriteLiteral("\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+                WriteLiteral("\r\n        ");
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                }
+                , StartWritingScope, EndWritingScope);
+                __InputTagHelper = CreateTagHelper<InputTagHelper>();
+                __tagHelperExecutionContext.Add(__InputTagHelper);
+                __InputTagHelper.Type = "";
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __InputTagHelper.Type);
+                __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+                __tagHelperExecutionContext.Add(__InputTagHelper2);
+                __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 6 "EmptyAttributeTagHelpers.cshtml"
+  __InputTagHelper2.Checked = ;
+
+#line default
+#line hidden
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddHtmlAttribute("class", "");
+                __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+                WriteLiteral(__tagHelperExecutionContext.Output.GeneratePreContent());
+                if (__tagHelperExecutionContext.Output.ContentSet)
+                {
+                    WriteLiteral(__tagHelperExecutionContext.Output.GenerateContent());
+                }
+                else if (__tagHelperExecutionContext.ChildContentRetrieved)
+                {
+                    WriteLiteral(__tagHelperExecutionContext.GetChildContentAsync().Result);
+                }
+                else
+                {
+                    __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+                }
+                WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
+                __tagHelperExecutionContext = __tagHelperScopeManager.End();
+                WriteLiteral("\r\n    ");
+            }
+            , StartWritingScope, EndWritingScope);
+            __PTagHelper = CreateTagHelper<PTagHelper>();
+            __tagHelperExecutionContext.Add(__PTagHelper);
+#line 5 "EmptyAttributeTagHelpers.cshtml"
+__PTagHelper.Age = ;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __PTagHelper.Age);
+            __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePreContent());
+            if (__tagHelperExecutionContext.Output.ContentSet)
+            {
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateContent());
+            }
+            else if (__tagHelperExecutionContext.ChildContentRetrieved)
+            {
+                WriteLiteral(__tagHelperExecutionContext.GetChildContentAsync().Result);
+            }
+            else
+            {
+                __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+            }
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(144, 8, true);
+            WriteLiteral("\r\n</div>");
+            Instrumentation.EndContext();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/EmptyAttributeTagHelpers.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/EmptyAttributeTagHelpers.cshtml
@@ -1,0 +1,8 @@
+﻿@addtaghelper "something"
+
+<div>
+    <input type= checked=""class="" />
+    <p age=''>
+        <input type=""checked= class="" />
+    </p>
+</div>


### PR DESCRIPTION
- Added TagHelperParseTreeRewriter tests, attempted to cover all empty attribute edge cases.
- Added Codegen tests to validate output and DesignTimeLineMappings.

#271