### PR TITLE
Create parser error for duplicate TagHelper bound attributes.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
@@ -1530,6 +1530,22 @@ namespace Microsoft.AspNet.Razor
             return string.Format(CultureInfo.CurrentCulture, GetString("TagHelpers_InlineMarkupBlocks_NotSupported_InAttributes"), p0);
         }
 
+        /// <summary>
+        /// Attribute "{0}" is bound by tag helper "{1}" and already exists on the element "{2}". Attributes are case insensitive.
+        /// </summary>
+        internal static string RewriterError_DuplicateTagHelperBoundAttribute
+        {
+            get { return GetString("RewriterError_DuplicateTagHelperBoundAttribute"); }
+        }
+
+        /// <summary>
+        /// Attribute "{0}" is bound by tag helper "{1}" and already exists on the element "{2}". Attributes are case insensitive.
+        /// </summary>
+        internal static string FormatRewriterError_DuplicateTagHelperBoundAttribute(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("RewriterError_DuplicateTagHelperBoundAttribute"), p0, p1, p2);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Razor/RazorResources.resx
+++ b/src/Microsoft.AspNet.Razor/RazorResources.resx
@@ -422,4 +422,7 @@ Instead, wrap the contents of the block in "{{}}":
     <value>Inline markup blocks (e.g. @&lt;p&gt;content&lt;/p&gt;) must not appear in non-string tag helper attribute values.
  Expected a '{0}' attribute value, not a string.</value>
   </data>
+  <data name="RewriterError_DuplicateTagHelperBoundAttribute" xml:space="preserve">
+    <value>Attribute "{0}" is bound by tag helper "{1}" and already exists on the element "{2}". Attributes are case insensitive.</value>
+  </data>
 </root>


### PR DESCRIPTION
- Added tests to validate error cases for duplicate TagHelper bound attributes.

#199