### PR TITLE
Add ability for wildcards in @addtaghelper and @removetaghelper.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -11,9 +11,7 @@ namespace Microsoft.AspNet.Razor.Runtime
             = new ResourceManager("Microsoft.AspNet.Razor.Runtime.Resources", typeof(Resources).GetTypeInfo().Assembly);
 
         /// <summary>
-        /// Invalid tag helper directive look up text '{0}'. The correct look up text formats are:
-        /// "assemblyName"
-        /// "typeName, assemblyName"
+        /// Invalid tag helper directive look up text '{0}'. The correct look up text format is: "typeName, assemblyName".
         /// </summary>
         internal static string TagHelperDescriptorResolver_InvalidTagHelperLookupText
         {
@@ -21,9 +19,7 @@ namespace Microsoft.AspNet.Razor.Runtime
         }
 
         /// <summary>
-        /// Invalid tag helper directive look up text '{0}'. The correct look up text formats are:
-        /// "assemblyName"
-        /// "typeName, assemblyName"
+        /// Invalid tag helper directive look up text '{0}'. The correct look up text format is: "typeName, assemblyName".
         /// </summary>
         internal static string FormatTagHelperDescriptorResolver_InvalidTagHelperLookupText(object p0)
         {

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -118,9 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="TagHelperDescriptorResolver_InvalidTagHelperLookupText" xml:space="preserve">
-    <value>Invalid tag helper directive look up text '{0}'. The correct look up text formats are:
-"assemblyName"
-"typeName, assemblyName"</value>
+    <value>Invalid tag helper directive look up text '{0}'. The correct look up text format is: "typeName, assemblyName".</value>
   </data>
   <data name="TagHelperTypeResolver_CannotResolveTagHelperAssembly" xml:space="preserve">
     <value>Cannot resolve TagHelper containing assembly '{0}'. Error: {1}</value>

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         [Theory]
         [InlineData("MyType, MyAssembly", "MyAssembly")]
-        [InlineData("MyAssembly2", "MyAssembly2")]
+        [InlineData("*, MyAssembly2", "MyAssembly2")]
         public void Resolve_AllowsOverridenResolveDescriptorsInAssembly(string lookupText, string expectedAssemblyName)
         {
             // Arrange
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper)
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper)
                         },
                         new [] { Valid_PlainTagHelperDescriptor }
                     },
@@ -98,8 +98,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyB, TagHelperDirectiveType.AddTagHelper)
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyB, TagHelperDirectiveType.AddTagHelper)
                         },
                         new [] { Valid_PlainTagHelperDescriptor, stringTagHelperDescriptor }
                     },
@@ -111,8 +111,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyB, TagHelperDirectiveType.RemoveTagHelper)
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyB, TagHelperDirectiveType.RemoveTagHelper)
                         },
                         new [] { Valid_PlainTagHelperDescriptor }
                     },
@@ -124,9 +124,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyB, TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.RemoveTagHelper)
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyB, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper)
                         },
                         new [] { stringTagHelperDescriptor }
                     },
@@ -140,7 +140,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                             new TagHelperDirectiveDescriptor(
                                 Valid_PlainTagHelperType.FullName + ", " + assemblyA,
                                 TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper)
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper)
                         },
                         new [] { Valid_PlainTagHelperDescriptor, Valid_InheritedTagHelperDescriptor }
                     },
@@ -151,7 +151,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
                             new TagHelperDirectiveDescriptor(
                                 Valid_PlainTagHelperType.FullName + ", " + assemblyA,
                                 TagHelperDirectiveType.RemoveTagHelper)
@@ -165,11 +165,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
                             new TagHelperDirectiveDescriptor(
                                 Valid_PlainTagHelperType.FullName + ", " + assemblyA,
                                 TagHelperDirectiveType.RemoveTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper)
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper)
                         },
                         new [] { Valid_InheritedTagHelperDescriptor, Valid_PlainTagHelperDescriptor }
                     },
@@ -180,11 +180,226 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
                         },
                         new [] { Valid_InheritedTagHelperDescriptor, Valid_PlainTagHelperDescriptor }
-                    }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor(
+                                Valid_PlainTagHelperType.Namespace + ".Valid_Plain*, " + assemblyA,
+                                TagHelperDirectiveType.AddTagHelper),
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor(
+                                Valid_PlainTagHelperType.Namespace + ".Valid?Plain*, " + assemblyA,
+                                TagHelperDirectiveType.AddTagHelper),
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor(
+                                "*Plain*, " + assemblyA,
+                                TagHelperDirectiveType.AddTagHelper),
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor(
+                                "*Plain?*, " + assemblyA,
+                                TagHelperDirectiveType.AddTagHelper),
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor(
+                                Valid_PlainTagHelperType.Namespace + "*, " + assemblyA,
+                                TagHelperDirectiveType.AddTagHelper),
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor, Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor(
+                                "*_*lain*, " + assemblyA,
+                                TagHelperDirectiveType.AddTagHelper),
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor(
+                                "*?*l?in*, " + assemblyA,
+                                TagHelperDirectiveType.AddTagHelper),
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor(
+                                "*" + Valid_PlainTagHelperType.FullName + "*, " + assemblyA,
+                                TagHelperDirectiveType.AddTagHelper),
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor(
+                                "?*?" + Valid_PlainTagHelperType.FullName + "?*?, " + assemblyA,
+                                TagHelperDirectiveType.AddTagHelper),
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } }
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor(
+                                "*_*la*, " + assemblyA,
+                                TagHelperDirectiveType.RemoveTagHelper)
+                        },
+                        new [] { Valid_InheritedTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor(
+                                "*Plain*, " + assemblyA,
+                                TagHelperDirectiveType.RemoveTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper)
+                        },
+                        new [] { Valid_InheritedTagHelperDescriptor, Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor(
+                                "?*Plain*?, " + assemblyA,
+                                TagHelperDirectiveType.RemoveTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper)
+                        },
+                        new [] { Valid_InheritedTagHelperDescriptor, Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType } },
+                            { assemblyB, new [] { stringType } }
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*ring, " + assemblyB, TagHelperDirectiveType.RemoveTagHelper)
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType } },
+                            { assemblyB, new [] { stringType } }
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("?*?, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*?rin?g?, " + assemblyB, TagHelperDirectiveType.RemoveTagHelper)
+                        },
+                        new [] { Valid_PlainTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                            { assemblyB, new [] { stringType } }
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyB, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("Microsoft.*, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper)
+                        },
+                        new [] { stringTagHelperDescriptor }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                            { assemblyB, new [] { stringType } }
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("*????*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*?, " + assemblyB, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("Microsoft?*, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper)
+                        },
+                        new [] { stringTagHelperDescriptor }
+                    },
                 };
             }
         }
@@ -239,8 +454,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.RemoveTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
                         }
                     },
                     {
@@ -250,7 +465,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
                             new TagHelperDirectiveDescriptor(Valid_PlainTagHelperType.FullName + ", " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
                             new TagHelperDirectiveDescriptor(Valid_InheritedTagHelperType.FullName + ", " + assemblyA, TagHelperDirectiveType.RemoveTagHelper)
                         }
@@ -263,10 +478,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyB, TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.RemoveTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyB, TagHelperDirectiveType.RemoveTagHelper)
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyB, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyB, TagHelperDirectiveType.RemoveTagHelper)
                         }
                     },
                     {
@@ -277,8 +492,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         },
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.AddTagHelper),
-                            new TagHelperDirectiveDescriptor(assemblyB, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyB, TagHelperDirectiveType.AddTagHelper),
                             new TagHelperDirectiveDescriptor(Valid_PlainTagHelperType.FullName + ", " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
                             new TagHelperDirectiveDescriptor(Valid_InheritedTagHelperType.FullName + ", " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
                             new TagHelperDirectiveDescriptor(stringType.FullName + ", " + assemblyB, TagHelperDirectiveType.RemoveTagHelper)
@@ -288,8 +503,70 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         new Dictionary<string, IEnumerable<Type>>(),
                         new []
                         {
-                            new TagHelperDirectiveDescriptor(assemblyA, TagHelperDirectiveType.RemoveTagHelper),
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
                             new TagHelperDirectiveDescriptor(Valid_PlainTagHelperType.FullName + ", " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
+                        }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*TagHelper, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
+                        }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*TagHelpe?, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
+                        }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("*_*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*Plain*, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
+                            new TagHelperDirectiveDescriptor("*_*Inhe*ed*, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper)
+                        }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                            { assemblyB, new [] { stringType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("Microsoft.*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("System.*, " + assemblyB, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*Helper, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
+                            new TagHelperDirectiveDescriptor("System.*, " + assemblyB, TagHelperDirectiveType.RemoveTagHelper)
+                        }
+                    },
+                    {
+                        new Dictionary<string, IEnumerable<Type>>
+                        {
+                            { assemblyA, new [] { Valid_PlainTagHelperType, Valid_InheritedTagHelperType } },
+                            { assemblyB, new [] { stringType } },
+                        },
+                        new []
+                        {
+                            new TagHelperDirectiveDescriptor("?icrosoft.*, " + assemblyA, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("?ystem.*, " + assemblyB, TagHelperDirectiveType.AddTagHelper),
+                            new TagHelperDirectiveDescriptor("*?????r, " + assemblyA, TagHelperDirectiveType.RemoveTagHelper),
+                            new TagHelperDirectiveDescriptor("Sy????em.*, " + assemblyB, TagHelperDirectiveType.RemoveTagHelper)
                         }
                     }
                 };
@@ -408,7 +685,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             };
 
             // Act
-            var descriptors = resolver.Resolve(AssemblyName).ToArray();
+            var descriptors = resolver.Resolve("*, " + AssemblyName).ToArray();
 
             // Assert
             Assert.Equal(descriptors.Length, 2);
@@ -431,7 +708,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     }));
 
             // Act
-            var descriptors = resolver.Resolve("lookupText").ToArray();
+            var descriptors = resolver.Resolve("*, lookupText").ToArray();
 
             // Assert
             Assert.Empty(descriptors);
@@ -440,7 +717,18 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void DescriptorResolver_CreatesErrorIfNullOrEmptyLookupText_DoesNotThrow(string lookupText)
+        [InlineData("*,")]
+        [InlineData("?,")]
+        [InlineData(",")]
+        [InlineData(",,,")]
+        [InlineData("First, ")]
+        [InlineData("First , ")]
+        [InlineData(" ,Second")]
+        [InlineData(" , Second")]
+        [InlineData("SomeType,")]
+        [InlineData("SomeAssembly")]
+        [InlineData("First,Second,Third")]
+        public void DescriptorResolver_CreatesErrorIfInvalidLookupText_DoesNotThrow(string lookupText)
         {
             // Arrange
             var errorSink = new ParserErrorSink();
@@ -449,8 +737,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     new TestTagHelperTypeResolver(InvalidTestableTagHelpers));
             var documentLocation = new SourceLocation(1, 2, 3);
             var directiveType = TagHelperDirectiveType.AddTagHelper;
-            var expectedErrorMessage =
-                Resources.FormatTagHelperDescriptorResolver_InvalidTagHelperLookupText(lookupText);
+            var expectedErrorMessage = string.Format(
+                "Invalid tag helper directive look up text '{0}'. The correct look up text " +
+                "format is: \"typeName, assemblyName\".",
+                lookupText);
             var resolutionContext = new TagHelperDescriptorResolutionContext(
                 new [] { new TagHelperDirectiveDescriptor(lookupText, documentLocation, directiveType)},
                 errorSink);
@@ -470,7 +760,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var expectedErrorMessage = "Encountered an unexpected error when attempting to resolve tag helper " +
-                                       "directive '@addtaghelper' with value 'A custom lookup text'. Error: A " +
+                                       "directive '@addtaghelper' with value 'A custom, lookup text'. Error: A " +
                                        "custom exception";
             var documentLocation = new SourceLocation(1, 2, 3);
             var directiveType = TagHelperDirectiveType.AddTagHelper;
@@ -478,7 +768,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var expectedError = new Exception("A custom exception");
             var tagHelperDescriptorResolver = new ThrowingTagHelperDescriptorResolver(expectedError);
             var resolutionContext = new TagHelperDescriptorResolutionContext(
-                new[] { new TagHelperDirectiveDescriptor("A custom lookup text", documentLocation, directiveType) },
+                new[] { new TagHelperDirectiveDescriptor("A custom, lookup text", documentLocation, directiveType) },
                 errorSink);
 
 

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
@@ -149,10 +149,10 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                              generatedAbsoluteIndex: 475,
                                              generatedLineIndex: 15,
                                              characterOffsetIndex: 14,
-                                             contentLength: 11),
-                            BuildLineMapping(documentAbsoluteIndex: 57,
+                                             contentLength: 17),
+                            BuildLineMapping(documentAbsoluteIndex: 63,
                                              documentLineIndex: 2,
-                                             generatedAbsoluteIndex: 958,
+                                             generatedAbsoluteIndex: 964,
                                              generatedLineIndex: 34,
                                              characterOffsetIndex: 28,
                                              contentLength: 4)
@@ -169,10 +169,10 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                              generatedAbsoluteIndex: 475,
                                              generatedLineIndex: 15,
                                              characterOffsetIndex: 14,
-                                             contentLength: 11),
-                            BuildLineMapping(documentAbsoluteIndex: 189,
+                                             contentLength: 17),
+                            BuildLineMapping(documentAbsoluteIndex: 195,
                                              documentLineIndex: 6,
-                                             generatedAbsoluteIndex: 1574,
+                                             generatedAbsoluteIndex: 1580,
                                              generatedLineIndex: 44,
                                              characterOffsetIndex: 40,
                                              contentLength: 4)
@@ -184,34 +184,34 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                         PAndInputTagHelperDescriptors,
                         new List<LineMapping>
                         {
-                            BuildLineMapping(14, 0, 479, 15, 14, 11),
-                            BuildLineMapping(30, 2, 1, 995, 35, 0, 48),
-                            BuildLineMapping(205, 9, 1113, 44, 0, 12),
-                            BuildLineMapping(218, 9, 13, 1209, 50, 12, 27),
-                            BuildLineMapping(346, 12, 1607, 62, 0, 48),
-                            BuildLineMapping(440, 15, 46, 1798, 71, 6, 8),
-                            BuildLineMapping(457, 15, 2121, 79, 63, 4),
-                            BuildLineMapping(501, 16, 31, 2328, 86, 6, 30),
-                            BuildLineMapping(568, 17, 30, 2677, 95, 0, 10),
-                            BuildLineMapping(601, 17, 63, 2759, 101, 0, 8),
-                            BuildLineMapping(632, 17, 94, 2839, 107, 0, 1),
-                            BuildLineMapping(639, 18, 3093, 116, 0, 15),
-                            BuildLineMapping(157, 7, 32, 3242, 123, 6, 12),
-                            BuildLineMapping(719, 21, 3325, 128, 0, 12),
-                            BuildLineMapping(733, 21, 3423, 134, 14, 21),
-                            BuildLineMapping(787, 22, 30, 3680, 142, 28, 7),
-                            BuildLineMapping(685, 20, 17, 3836, 148, 19, 23),
-                            BuildLineMapping(708, 20, 40, 3859, 148, 42, 7),
-                            BuildLineMapping(897, 25, 30, 4101, 155, 28, 30),
-                            BuildLineMapping(831, 24, 16, 4280, 161, 19, 8),
-                            BuildLineMapping(840, 24, 25, 4288, 161, 27, 23),
-                            BuildLineMapping(1026, 28, 4546, 168, 28, 30),
-                            BuildLineMapping(964, 27, 16, 4725, 174, 19, 30),
-                            BuildLineMapping(1156, 31, 4990, 181, 28, 3),
-                            BuildLineMapping(1161, 31, 33, 4993, 181, 31, 27),
-                            BuildLineMapping(1189, 31, 61, 5020, 181, 58, 10),
-                            BuildLineMapping(1094, 30, 18, 5179, 187, 19, 29),
-                            BuildLineMapping(1231, 34, 5279, 192, 0, 1),
+                            BuildLineMapping(14, 0, 479, 15, 14, 17),
+                            BuildLineMapping(36, 2, 1, 1001, 35, 0, 48),
+                            BuildLineMapping(211, 9, 1119, 44, 0, 12),
+                            BuildLineMapping(224, 9, 13, 1215, 50, 12, 27),
+                            BuildLineMapping(352, 12, 1613, 62, 0, 48),
+                            BuildLineMapping(446, 15, 46, 1804, 71, 6, 8),
+                            BuildLineMapping(463, 15, 2127, 79, 63, 4),
+                            BuildLineMapping(507, 16, 31, 2334, 86, 6, 30),
+                            BuildLineMapping(574, 17, 30, 2683, 95, 0, 10),
+                            BuildLineMapping(607, 17, 63, 2765, 101, 0, 8),
+                            BuildLineMapping(638, 17, 94, 2845, 107, 0, 1),
+                            BuildLineMapping(645, 18, 3099, 116, 0, 15),
+                            BuildLineMapping(163, 7, 32, 3248, 123, 6, 12),
+                            BuildLineMapping(725, 21, 3331, 128, 0, 12),
+                            BuildLineMapping(739, 21, 3429, 134, 14, 21),
+                            BuildLineMapping(793, 22, 30, 3686, 142, 28, 7),
+                            BuildLineMapping(691, 20, 17, 3842, 148, 19, 23),
+                            BuildLineMapping(714, 20, 40, 3865, 148, 42, 7),
+                            BuildLineMapping(903, 25, 30, 4107, 155, 28, 30),
+                            BuildLineMapping(837, 24, 16, 4286, 161, 19, 8),
+                            BuildLineMapping(846, 24, 25, 4294, 161, 27, 23),
+                            BuildLineMapping(1032, 28, 4552, 168, 28, 30),
+                            BuildLineMapping(970, 27, 16, 4731, 174, 19, 30),
+                            BuildLineMapping(1162, 31, 4996, 181, 28, 3),
+                            BuildLineMapping(1167, 31, 33, 4999, 181, 31, 27),
+                            BuildLineMapping(1195, 31, 61, 5026, 181, 58, 10),
+                            BuildLineMapping(1100, 30, 18, 5185, 187, 19, 29),
+                            BuildLineMapping(1237, 34, 5285, 192, 0, 1),
                         }
                     },
                     {
@@ -306,7 +306,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                                      generatedAbsoluteIndex: 442,
                                                      generatedLineIndex: 14,
                                                      characterOffsetIndex: 17,
-                                                     contentLength: 11)
+                                                     contentLength: 17)
                              });
         }
 
@@ -323,7 +323,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                                      generatedAbsoluteIndex: 433,
                                                      generatedLineIndex: 14,
                                                      characterOffsetIndex: 14,
-                                                     contentLength: 11)
+                                                     contentLength: 17)
                              });
         }
 

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/AddTagHelperDirective.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/AddTagHelperDirective.cs
@@ -12,7 +12,7 @@ namespace TestOutput
             string __tagHelperDirectiveSyntaxHelper = null;
             __tagHelperDirectiveSyntaxHelper = 
 #line 1 "AddTagHelperDirective.cshtml"
-              "something"
+              "something, nice"
 
 #line default
 #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
@@ -1,4 +1,4 @@
-#pragma checksum "BasicTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "897cb2042003c7f319b5265ba8e1878fb3043e8e"
+#pragma checksum "BasicTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "15cf58241a278a7bfadfefa9ef44742b3fd1074e"
 namespace TestOutput
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -24,7 +24,7 @@ namespace TestOutput
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
-            Instrumentation.BeginContext(27, 49, true);
+            Instrumentation.BeginContext(33, 49, true);
             WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
@@ -140,7 +140,7 @@ namespace TestOutput
             WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(206, 8, true);
+            Instrumentation.BeginContext(212, 8, true);
             WriteLiteral("\r\n</div>");
             Instrumentation.EndContext();
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.DesignTime.cs
@@ -13,7 +13,7 @@ namespace TestOutput
             string __tagHelperDirectiveSyntaxHelper = null;
             __tagHelperDirectiveSyntaxHelper = 
 #line 1 "BasicTagHelpers.cshtml"
-              "something"
+              "something, nice"
 
 #line default
 #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.RemoveTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.RemoveTagHelper.cs
@@ -1,4 +1,4 @@
-#pragma checksum "BasicTagHelpers.RemoveTagHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "631e4af360bd37f540b637596d5f059c7abc0ac2"
+#pragma checksum "BasicTagHelpers.RemoveTagHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "15609cf7c0bff12794453caa4d04e6f5a562e6ed"
 namespace TestOutput
 {
     using System;
@@ -14,7 +14,7 @@ namespace TestOutput
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
-            Instrumentation.BeginContext(60, 187, true);
+            Instrumentation.BeginContext(72, 187, true);
             WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    <p class=\"Hello World\">\r\n       " +
 " <p></p>\r\n        <input type=\"text\" />\r\n        <input type=\"checkbox\" checked=" +
 "\"true\"/>\r\n    </p>\r\n</div>");

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
@@ -1,4 +1,4 @@
-#pragma checksum "BasicTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "897cb2042003c7f319b5265ba8e1878fb3043e8e"
+#pragma checksum "BasicTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "15cf58241a278a7bfadfefa9ef44742b3fd1074e"
 namespace TestOutput
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -25,7 +25,7 @@ namespace TestOutput
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
-            Instrumentation.BeginContext(27, 49, true);
+            Instrumentation.BeginContext(33, 49, true);
             WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
@@ -141,7 +141,7 @@ namespace TestOutput
             WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(206, 8, true);
+            Instrumentation.BeginContext(212, 8, true);
             WriteLiteral("\r\n</div>");
             Instrumentation.EndContext();
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.DesignTime.cs
@@ -13,7 +13,7 @@ namespace TestOutput
             string __tagHelperDirectiveSyntaxHelper = null;
             __tagHelperDirectiveSyntaxHelper = 
 #line 1 "ComplexTagHelpers.cshtml"
-              "something"
+              "something, nice"
 
 #line default
 #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
@@ -1,4 +1,4 @@
-#pragma checksum "ComplexTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "7158abc69d261099393d49d82670ec64a94d9770"
+#pragma checksum "ComplexTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "b7d9a4dd63a71dcfc8c97a5ee7598214e387e1b6"
 namespace TestOutput
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -25,7 +25,7 @@ namespace TestOutput
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
-            Instrumentation.BeginContext(27, 2, true);
+            Instrumentation.BeginContext(33, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
 #line 3 "ComplexTagHelpers.cshtml"
@@ -37,7 +37,7 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(78, 55, true);
+            Instrumentation.BeginContext(84, 55, true);
             WriteLiteral("    <div class=\"randomNonTagHelperAttribute\">\r\n        ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
@@ -311,7 +311,7 @@ Write(DateTime.Now);
             WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(666, 10, true);
+            Instrumentation.BeginContext(672, 10, true);
             WriteLiteral("\r\n        ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
@@ -389,7 +389,7 @@ __PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
             WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(813, 10, true);
+            Instrumentation.BeginContext(819, 10, true);
             WriteLiteral("\r\n        ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
@@ -454,7 +454,7 @@ __PTagHelper.Age = -1970 + DateTimeOffset.Now.Year;
             WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(946, 10, true);
+            Instrumentation.BeginContext(952, 10, true);
             WriteLiteral("\r\n        ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
@@ -519,7 +519,7 @@ __PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
             WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(1074, 10, true);
+            Instrumentation.BeginContext(1080, 10, true);
             WriteLiteral("\r\n        ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
@@ -584,7 +584,7 @@ __PTagHelper.Age = "My age is this long.".Length;
             WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(1217, 14, true);
+            Instrumentation.BeginContext(1223, 14, true);
             WriteLiteral("\r\n    </div>\r\n");
             Instrumentation.EndContext();
 #line 35 "ComplexTagHelpers.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/RemoveTagHelperDirective.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/RemoveTagHelperDirective.cs
@@ -12,7 +12,7 @@ namespace TestOutput
             string __tagHelperDirectiveSyntaxHelper = null;
             __tagHelperDirectiveSyntaxHelper = 
 #line 1 "RemoveTagHelperDirective.cshtml"
-                 "something"
+                 "something, nice"
 
 #line default
 #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.DesignTime.cs
@@ -13,7 +13,7 @@ namespace TestOutput
             string __tagHelperDirectiveSyntaxHelper = null;
             __tagHelperDirectiveSyntaxHelper = 
 #line 1 "SingleTagHelper.cshtml"
-              "something"
+              "something, nice"
 
 #line default
 #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
@@ -1,4 +1,4 @@
-#pragma checksum "SingleTagHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "a4d3eab407a97d5beebc7d3a319223ece03f3733"
+#pragma checksum "SingleTagHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "72db799463dab7865f759d0e3ed3660485d7871d"
 namespace TestOutput
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -23,7 +23,7 @@ namespace TestOutput
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
-            Instrumentation.BeginContext(27, 2, true);
+            Instrumentation.BeginContext(33, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInHelper.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TagHelpersInHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "864bdf0afabc2aecf57904d5793a20bb6d12a6a3"
+#pragma checksum "TagHelpersInHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "daf9e656da8fef546fe782b39687a5029a852c48"
 namespace TestOutput
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -21,7 +21,7 @@ MyHelper(string val)
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(62, 19, true);
+            Instrumentation.BeginContext(68, 19, true);
             WriteLiteralTo(__razor_helper_writer, "    <div>\r\n        ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", "test", async() => {
@@ -99,7 +99,7 @@ Write(DateTime.Now);
             WriteLiteralTo(__razor_helper_writer, __tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteralTo(__razor_helper_writer, __tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(336, 14, true);
+            Instrumentation.BeginContext(342, 14, true);
             WriteLiteralTo(__razor_helper_writer, "\r\n    </div>\r\n");
             Instrumentation.EndContext();
 #line 11 "TagHelpersInHelper.cshtml"
@@ -132,7 +132,7 @@ Write(DateTime.Now);
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
-            Instrumentation.BeginContext(27, 2, true);
+            Instrumentation.BeginContext(33, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", "test", async() => {
@@ -192,7 +192,7 @@ Write(MyHelper(item => new Template((__razor_template_writer) => {
             WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
             WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(439, 2, true);
+            Instrumentation.BeginContext(445, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TagHelpersInSection.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "2571c1678f925672aa18f5e7ae50916089e8f5cb"
+#pragma checksum "TagHelpersInSection.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "f7dda6348dbd0043f1421eacbbdce3d3c4f21d75"
 namespace TestOutput
 {
     using System;
@@ -23,7 +23,7 @@ namespace TestOutput
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
-            Instrumentation.BeginContext(27, 2, true);
+            Instrumentation.BeginContext(33, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
 #line 3 "TagHelpersInSection.cshtml"
@@ -33,11 +33,11 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(63, 4, true);
+            Instrumentation.BeginContext(69, 4, true);
             WriteLiteral("\r\n\r\n");
             Instrumentation.EndContext();
             DefineSection("MySection", async(__razor_template_writer) => {
-                Instrumentation.BeginContext(87, 21, true);
+                Instrumentation.BeginContext(93, 21, true);
                 WriteLiteralTo(__razor_template_writer, "\r\n    <div>\r\n        ");
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", "test", async() => {
@@ -115,7 +115,7 @@ Write(DateTime.Now);
                 WriteLiteralTo(__razor_template_writer, __tagHelperExecutionContext.Output.GeneratePostContent());
                 WriteLiteralTo(__razor_template_writer, __tagHelperExecutionContext.Output.GenerateEndTag());
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                Instrumentation.BeginContext(353, 14, true);
+                Instrumentation.BeginContext(359, 14, true);
                 WriteLiteralTo(__razor_template_writer, "\r\n    </div>\r\n");
                 Instrumentation.EndContext();
             }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/AddTagHelperDirective.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/AddTagHelperDirective.cshtml
@@ -1,1 +1,1 @@
-﻿@addtaghelper "something"
+﻿@addtaghelper "something, nice"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/BasicTagHelpers.RemoveTagHelper.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/BasicTagHelpers.RemoveTagHelper.cshtml
@@ -1,5 +1,5 @@
-﻿@addtaghelper "something"
-@removetaghelper "doesntmatter"
+﻿@addtaghelper "something, nice"
+@removetaghelper "doesntmatter, nice"
 
 <div class="randomNonTagHelperAttribute">
     <p class="Hello World">

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/BasicTagHelpers.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/BasicTagHelpers.cshtml
@@ -1,4 +1,4 @@
-﻿@addtaghelper "something"
+﻿@addtaghelper "something, nice"
 
 <div class="randomNonTagHelperAttribute">
     <p class="Hello World">

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/ComplexTagHelpers.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/ComplexTagHelpers.cshtml
@@ -1,4 +1,4 @@
-﻿@addtaghelper "something"
+﻿@addtaghelper "something, nice"
 
 @if (true)
 {

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/RemoveTagHelperDirective.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/RemoveTagHelperDirective.cshtml
@@ -1,1 +1,1 @@
-﻿@removetaghelper "something"
+﻿@removetaghelper "something, nice"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/SingleTagHelper.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/SingleTagHelper.cshtml
@@ -1,3 +1,3 @@
-﻿@addtaghelper "something"
+﻿@addtaghelper "something, nice"
 
 <p class="Hello World" age="1337">Body of Tag</p>

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/TagHelpersInHelper.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/TagHelpersInHelper.cshtml
@@ -1,4 +1,4 @@
-﻿@addtaghelper "something"
+﻿@addtaghelper "something, nice"
 
 @helper MyHelper(string val)
 {

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/TagHelpersInSection.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/TagHelpersInSection.cshtml
@@ -1,4 +1,4 @@
-﻿@addtaghelper "something"
+﻿@addtaghelper "something, nice"
 
 @{
     var code = "some code";


### PR DESCRIPTION
- @addtaghelper and @removetaghelper can now utilize the '*' wild card to represent 0 or more characters.
- Restricted the @addtaghelper to need the TypeName. @addtaghelper "MyAssemblyName" => @addtaghelper "*, MyAssemblyName".
- Also added tests to ensure cases of @addtaghelper "MyAssemblyName" create an error.
- Regenerated all CS files to folow new format.

#285