### PR TITLE
Fix1571 - Supporting self-closing tags for taghelpers

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -22,13 +22,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Internal for testing purposes only.
         /// </summary>
-        internal TagHelperExecutionContext(string tagName)
+        internal TagHelperExecutionContext(string tagName, bool selfClosing)
             : this(tagName,
                    uniqueId: string.Empty,
                    executeChildContentAsync: async () => await Task.FromResult(result: true),
                    startWritingScope: () => { },
                    endWritingScope: () => new StringWriter(),
-                   selfClosing: false)
+                   selfClosing: selfClosing)
         {
         }
 

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="startWritingScope">A delegate used to start a writing scope in a Razor page.</param>
         /// <param name="endWritingScope">A delegate used to end a writing scope in a Razor page.</param>
         public TagHelperExecutionContext([NotNull] string tagName,
-                                         bool selfClosing, 
+                                         bool selfClosing,
                                          [NotNull] string uniqueId,
                                          [NotNull] Func<Task> executeChildContentAsync,
                                          [NotNull] Action startWritingScope,

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -24,11 +24,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// </summary>
         internal TagHelperExecutionContext(string tagName, bool selfClosing)
             : this(tagName,
+                   selfClosing,
                    uniqueId: string.Empty,
                    executeChildContentAsync: async () => await Task.FromResult(result: true),
                    startWritingScope: () => { },
-                   endWritingScope: () => new StringWriter(),
-                   selfClosing: selfClosing)
+                   endWritingScope: () => new StringWriter())
         {
         }
 
@@ -36,19 +36,19 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// Instantiates a new <see cref="TagHelperExecutionContext"/>.
         /// </summary>
         /// <param name="tagName">The HTML tag name in the Razor source.</param>
+        /// <param name="selfClosing">
+        /// <see cref="bool"/> indicating whether or not the tag in the Razor source was self-closing.
+        /// </param>
         /// <param name="uniqueId">An identifier unique to the HTML element this context is for.</param>
         /// <param name="executeChildContentAsync">A delegate used to execute the child content asynchronously.</param>
         /// <param name="startWritingScope">A delegate used to start a writing scope in a Razor page.</param>
         /// <param name="endWritingScope">A delegate used to end a writing scope in a Razor page.</param>
-        /// <param name="selfClosing">
-        /// The <c>bool</c> indicating whether or not the tag in the Razor soruce is self-closing.
-        /// </param>
         public TagHelperExecutionContext([NotNull] string tagName,
+                                         bool selfClosing, 
                                          [NotNull] string uniqueId,
                                          [NotNull] Func<Task> executeChildContentAsync,
                                          [NotNull] Action startWritingScope,
-                                         [NotNull] Func<TextWriter> endWritingScope, 
-                                         bool selfClosing)
+                                         [NotNull] Func<TextWriter> endWritingScope)
         {
             _tagHelpers = new List<ITagHelper>();
             _executeChildContentAsync = executeChildContentAsync;
@@ -63,7 +63,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         /// <summary>
-        /// Indicates whether or not the tag of the HTML element this context is for self-closing.
+        /// Gets a value indicating whether or not the tag in the Razor source was self-closing.
         /// </summary>
         public bool SelfClosing { get; }
 

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -27,7 +27,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                    uniqueId: string.Empty,
                    executeChildContentAsync: async () => await Task.FromResult(result: true),
                    startWritingScope: () => { },
-                   endWritingScope: () => new StringWriter())
+                   endWritingScope: () => new StringWriter(),
+                   selfClosing: false)
         {
         }
 
@@ -39,22 +40,32 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="executeChildContentAsync">A delegate used to execute the child content asynchronously.</param>
         /// <param name="startWritingScope">A delegate used to start a writing scope in a Razor page.</param>
         /// <param name="endWritingScope">A delegate used to end a writing scope in a Razor page.</param>
+        /// <param name="selfClosing">
+        /// The <c>bool</c> indicating whether or not the tag in the Razor soruce is self-closing.
+        /// </param>
         public TagHelperExecutionContext([NotNull] string tagName,
                                          [NotNull] string uniqueId,
                                          [NotNull] Func<Task> executeChildContentAsync,
                                          [NotNull] Action startWritingScope,
-                                         [NotNull] Func<TextWriter> endWritingScope)
+                                         [NotNull] Func<TextWriter> endWritingScope, 
+                                         bool selfClosing)
         {
             _tagHelpers = new List<ITagHelper>();
             _executeChildContentAsync = executeChildContentAsync;
             _startWritingScope = startWritingScope;
             _endWritingScope = endWritingScope;
 
+            SelfClosing = selfClosing;
             AllAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             HTMLAttributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             TagName = tagName;
             UniqueId = uniqueId;
         }
+
+        /// <summary>
+        /// Indicates whether or not the tag of the HTML element this context is for self-closing.
+        /// </summary>
+        public bool SelfClosing { get; }
 
         /// <summary>
         /// Indicates if <see cref="GetChildContentAsync"/> has been called.

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     {
         private string _content;
         private bool _contentSet;
-        private bool _isTagNameNullOrWhitespaces;
+        private bool _isTagNameNullOrWhitespace;
         private string _tagName;
 
         // Internal for testing
@@ -55,7 +55,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             set
             {
                 _tagName = value;
-                _isTagNameNullOrWhitespaces = string.IsNullOrWhiteSpace(_tagName);
+                _isTagNameNullOrWhitespace = string.IsNullOrWhiteSpace(_tagName);
             }
         }
 
@@ -113,12 +113,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s start tag.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces. Otherwise, the
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespace. Otherwise, the
         /// <see cref="string"/> representation of the <see cref="TagHelperOutput"/>'s start tag.</returns>
         public string GenerateStartTag()
         {
             // Only render a start tag if the tag name is not whitespace
-            if (_isTagNameNullOrWhitespaces)
+            if (_isTagNameNullOrWhitespace)
             {
                 return string.Empty;
             }
@@ -151,12 +151,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s <see cref="PreContent"/>.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces.
-        /// Otherwise, <see cref="PreContent"/>.
-        /// </returns>
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is not <c>null</c> or whitespace
+        /// and <see cref="SelfClosing"/> is <c>true</c>. Otherwise, <see cref="PreContent"/>.</returns>
         public string GeneratePreContent()
         {
-            if (!_isTagNameNullOrWhitespaces && SelfClosing)
+            if (!_isTagNameNullOrWhitespace && SelfClosing)
             {
                 return string.Empty;
             }
@@ -167,12 +166,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s body.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces.
-        /// Otherwise, <see cref="Content"/>.
-        /// </returns>
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is not <c>null</c> or whitespace
+        /// and <see cref="SelfClosing"/> is <c>true</c>. Otherwise, <see cref="Content"/>.</returns>
         public string GenerateContent()
         {
-            if (!_isTagNameNullOrWhitespaces && SelfClosing)
+            if (!_isTagNameNullOrWhitespace && SelfClosing)
             {
                 return string.Empty;
             }
@@ -183,12 +181,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s <see cref="PostContent"/>.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces.
-        /// Otherwise, <see cref="PostContent"/>.
-        /// </returns>
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is not <c>null</c> or whitespace
+        /// and <see cref="SelfClosing"/> is <c>true</c>. Otherwise, <see cref="PostContent"/>.</returns>
         public string GeneratePostContent()
         {
-            if (!_isTagNameNullOrWhitespaces && SelfClosing)
+            if (!_isTagNameNullOrWhitespace && SelfClosing)
             {
                 return string.Empty;
             }
@@ -199,11 +196,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s end tag.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces. Otherwise, the
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespace. Otherwise, the
         /// <see cref="string"/> representation of the <see cref="TagHelperOutput"/>'s end tag.</returns>
         public string GenerateEndTag()
         {
-            if (SelfClosing || _isTagNameNullOrWhitespaces)
+            if (SelfClosing || _isTagNameNullOrWhitespace)
             {
                 return string.Empty;
             }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -16,6 +16,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     {
         private string _content;
         private bool _contentSet;
+        private bool _isTagNameNullOrWhitespaces;
+        private string _tagName;
 
         // Internal for testing
         internal TagHelperOutput(string tagName)
@@ -44,7 +46,18 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <remarks>
         /// A whitespace or <c>null</c> value results in no start or end tag being rendered.
         /// </remarks>
-        public string TagName { get; set; }
+        public string TagName
+        {
+            get
+            {
+                return _tagName;
+            }
+            set
+            {
+                _tagName = value;
+                _isTagNameNullOrWhitespaces = string.IsNullOrWhiteSpace(_tagName);
+            }
+        }
 
         /// <summary>
         /// The HTML element's pre content.
@@ -88,7 +101,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         /// <summary>
-        /// Indicates whether or not the tag is self closing.
+        /// Indicates whether or not the tag is self-closing.
         /// </summary>
         public bool SelfClosing { get; set; }
 
@@ -100,12 +113,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s start tag.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>string.Empty</c> or whitespace. Otherwise, the
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces. Otherwise, the
         /// <see cref="string"/> representation of the <see cref="TagHelperOutput"/>'s start tag.</returns>
         public string GenerateStartTag()
         {
             // Only render a start tag if the tag name is not whitespace
-            if (string.IsNullOrWhiteSpace(TagName))
+            if (_isTagNameNullOrWhitespaces)
             {
                 return string.Empty;
             }
@@ -138,12 +151,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s <see cref="PreContent"/>.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="SelfClosing"/> is <c>true</c>. <see cref="PreContent"/> 
-        /// otherwise.
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces.
+        /// Otherwise, <see cref="PreContent"/>.
         /// </returns>
         public string GeneratePreContent()
         {
-            if (SelfClosing)
+            if (!_isTagNameNullOrWhitespaces && SelfClosing)
             {
                 return string.Empty;
             }
@@ -154,11 +167,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s body.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="SelfClosing"/> is <c>true</c>. <see cref="Content"/> otherwise.
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces.
+        /// Otherwise, <see cref="Content"/>.
         /// </returns>
         public string GenerateContent()
         {
-            if (SelfClosing)
+            if (!_isTagNameNullOrWhitespaces && SelfClosing)
             {
                 return string.Empty;
             }
@@ -169,12 +183,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s <see cref="PostContent"/>.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="SelfClosing"/> is <c>true</c>. <see cref="PostContent"/> 
-        /// otherwise.
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces.
+        /// Otherwise, <see cref="PostContent"/>.
         /// </returns>
         public string GeneratePostContent()
         {
-            if (SelfClosing)
+            if (!_isTagNameNullOrWhitespaces && SelfClosing)
             {
                 return string.Empty;
             }
@@ -185,11 +199,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s end tag.
         /// </summary>
-        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>string.Empty</c> or whitespace. Otherwise, the
+        /// <returns><c>string.Empty</c> if <see cref="TagName"/> is <c>null</c> or whitespaces. Otherwise, the
         /// <see cref="string"/> representation of the <see cref="TagHelperOutput"/>'s end tag.</returns>
         public string GenerateEndTag()
         {
-            if (SelfClosing || string.IsNullOrWhiteSpace(TagName))
+            if (SelfClosing || _isTagNameNullOrWhitespaces)
             {
                 return string.Empty;
             }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperRunner.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperRunner.cs
@@ -24,7 +24,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 executionContext.AllAttributes,
                 executionContext.UniqueId,
                 executionContext.GetChildContentAsync);
-            var tagHelperOutput = new TagHelperOutput(executionContext.TagName, executionContext.HTMLAttributes);
+            var tagHelperOutput = new TagHelperOutput(executionContext.TagName, executionContext.HTMLAttributes)
+            {
+                SelfClosing = executionContext.SelfClosing,
+            };
             var orderedTagHelpers = executionContext.TagHelpers.OrderBy(tagHelper => tagHelper.Order);
 
             foreach (var tagHelper in orderedTagHelpers)

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperScopeManager.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperScopeManager.cs
@@ -31,18 +31,23 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="executeChildContentAsync">A delegate used to execute the child content asynchronously.</param>
         /// <param name="startWritingScope">A delegate used to start a writing scope in a Razor page.</param>
         /// <param name="endWritingScope">A delegate used to end a writing scope in a Razor page.</param>
+        /// <param name="selfClosing">
+        /// The <c>bool</c> indicating whether or not the tag of this scope is self-closing.
+        /// </param>
         /// <returns>A <see cref="TagHelperExecutionContext"/> to use.</returns>
         public TagHelperExecutionContext Begin([NotNull] string tagName,
                                                [NotNull] string uniqueId,
                                                [NotNull] Func<Task> executeChildContentAsync,
                                                [NotNull] Action startWritingScope,
-                                               [NotNull] Func<TextWriter> endWritingScope)
+                                               [NotNull] Func<TextWriter> endWritingScope,
+                                               bool selfClosing)
         {
             var executionContext = new TagHelperExecutionContext(tagName,
                                                                  uniqueId,
                                                                  executeChildContentAsync,
                                                                  startWritingScope,
-                                                                 endWritingScope);
+                                                                 endWritingScope,
+                                                                 selfClosing);
 
             _executionScopes.Push(executionContext);
 

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperScopeManager.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperScopeManager.cs
@@ -27,27 +27,27 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// Starts a <see cref="TagHelperExecutionContext"/> scope.
         /// </summary>
         /// <param name="tagName">The HTML tag name that the scope is associated with.</param>
+        /// <param name="selfClosing">
+        /// <see cref="bool"/> indicating whether or not the tag of this scope is self-closing.
+        /// </param>
         /// <param name="uniqueId">An identifier unique to the HTML element this scope is for.</param>
         /// <param name="executeChildContentAsync">A delegate used to execute the child content asynchronously.</param>
         /// <param name="startWritingScope">A delegate used to start a writing scope in a Razor page.</param>
         /// <param name="endWritingScope">A delegate used to end a writing scope in a Razor page.</param>
-        /// <param name="selfClosing">
-        /// The <c>bool</c> indicating whether or not the tag of this scope is self-closing.
-        /// </param>
         /// <returns>A <see cref="TagHelperExecutionContext"/> to use.</returns>
         public TagHelperExecutionContext Begin([NotNull] string tagName,
+                                               bool selfClosing,
                                                [NotNull] string uniqueId,
                                                [NotNull] Func<Task> executeChildContentAsync,
                                                [NotNull] Action startWritingScope,
-                                               [NotNull] Func<TextWriter> endWritingScope,
-                                               bool selfClosing)
+                                               [NotNull] Func<TextWriter> endWritingScope)
         {
             var executionContext = new TagHelperExecutionContext(tagName,
+                                                                 selfClosing,
                                                                  uniqueId,
                                                                  executeChildContentAsync,
                                                                  startWritingScope,
-                                                                 endWritingScope,
-                                                                 selfClosing);
+                                                                 endWritingScope);
 
             _executionScopes.Push(executionContext);
 

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
         {
             var tagHelperDescriptors = chunk.Descriptors;
 
-            RenderBeginTagHelperScope(chunk.TagName, chunk.Children);
+            RenderBeginTagHelperScope(chunk.TagName, chunk.Children, chunk.SelfClosing);
 
             RenderTagHelpersCreation(chunk);
 
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
             return "__" + descriptor.TypeName.Replace('.', '_');
         }
 
-        private void RenderBeginTagHelperScope(string tagName, IList<Chunk> children)
+        private void RenderBeginTagHelperScope(string tagName, IList<Chunk> children, bool selfClosing)
         {
             // Scopes/execution contexts are a runtime feature.
             if (_designTimeMode)
@@ -134,6 +134,8 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
                    .Write(_tagHelperContext.StartWritingScopeMethodName)
                    .WriteParameterSeparator()
                    .Write(_tagHelperContext.EndWritingScopeMethodName)
+                   .WriteParameterSeparator()
+                   .WriteBooleanLiteral(selfClosing)
                    .WriteEndMethodInvocation();
         }
 
@@ -466,8 +468,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
 
             _writer.Write(ExecutionContextVariableName)
                    .Write(".")
-                   .Write(_tagHelperContext.ExecutionContextOutputPropertyName)
-                   .Write(" = ")
+                   .WriteStartAssignment(_tagHelperContext.ExecutionContextOutputPropertyName)
                    .WriteStartInstanceMethodInvocation(RunnerVariableName,
                                                        _tagHelperContext.RunnerRunAsyncMethodName);
 

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
         {
             var tagHelperDescriptors = chunk.Descriptors;
 
-            RenderBeginTagHelperScope(chunk.TagName, chunk.Children, chunk.SelfClosing);
+            RenderBeginTagHelperScope(chunk.TagName, chunk.SelfClosing, chunk.Children);
 
             RenderTagHelpersCreation(chunk);
 
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
             return "__" + descriptor.TypeName.Replace('.', '_');
         }
 
-        private void RenderBeginTagHelperScope(string tagName, IList<Chunk> children, bool selfClosing)
+        private void RenderBeginTagHelperScope(string tagName, bool selfClosing, IList<Chunk> children)
         {
             // Scopes/execution contexts are a runtime feature.
             if (_designTimeMode)

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
@@ -109,6 +109,8 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
             // per call site, e.g. if the tag is on the view twice, there should be two IDs.
             _writer.WriteStringLiteral(tagName)
                    .WriteParameterSeparator()
+                   .WriteBooleanLiteral(selfClosing)
+                   .WriteParameterSeparator()
                    .WriteStringLiteral(GenerateUniqueId())
                    .WriteParameterSeparator();
 
@@ -134,8 +136,6 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
                    .Write(_tagHelperContext.StartWritingScopeMethodName)
                    .WriteParameterSeparator()
                    .Write(_tagHelperContext.EndWritingScopeMethodName)
-                   .WriteParameterSeparator()
-                   .WriteBooleanLiteral(selfClosing)
                    .WriteEndMethodInvocation();
         }
 

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperChunk.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperChunk.cs
@@ -29,8 +29,8 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
             IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;
-            Attributes = attributes;
             SelfClosing = selfClosing;
+            Attributes = attributes;
             Descriptors = descriptors;
         }
 

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperChunk.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperChunk.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
         /// <param name="tagName">The tag name associated with the tag helpers HTML element.</param>
         /// <param name="attributes">The attributes associated with the tag helpers HTML element.</param>
         /// <param name="selfClosing">
-        /// Indicates whether or not the tag of the tag helpers HTML element is self-closing.
+        /// The <c>bool</c> indicating whether or not the tag of the tag helpers HTML element is self-closing.
         /// </param>
         /// <param name="descriptors">
         /// The <see cref="TagHelperDescriptor"/>s associated with this tag helpers HTML element.
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
         public string TagName { get; set; }
 
         /// <summary>
-        /// Indicates whether or not the tag is self-closing.
+        /// Indicates whether or not the tag of the tag helpers HTML element is self-closing.
         /// </summary>
         public bool SelfClosing { get; }
     }

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperChunk.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperChunk.cs
@@ -12,6 +12,29 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
     public class TagHelperChunk : ChunkBlock
     {
         /// <summary>
+        /// Instantiates a new <see cref="TagHelperChunk"/>.
+        /// </summary>
+        /// <param name="tagName">The tag name associated with the tag helpers HTML element.</param>
+        /// <param name="attributes">The attributes associated with the tag helpers HTML element.</param>
+        /// <param name="selfClosing">
+        /// Indicates whether or not the tag of the tag helpers HTML element is self-closing.
+        /// </param>
+        /// <param name="descriptors">
+        /// The <see cref="TagHelperDescriptor"/>s associated with this tag helpers HTML element.
+        /// </param>
+        public TagHelperChunk(
+            string tagName,
+            IDictionary<string, Chunk> attributes,
+            bool selfClosing,
+            IEnumerable<TagHelperDescriptor> descriptors)
+        {
+            TagName = tagName;
+            Attributes = attributes;
+            SelfClosing = selfClosing;
+            Descriptors = descriptors;
+        }
+
+        /// <summary>
         /// The HTML attributes.
         /// </summary>
         /// <remarks>
@@ -29,5 +52,10 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
         /// The HTML tag name.
         /// </summary>
         public string TagName { get; set; }
+
+        /// <summary>
+        /// Indicates whether or not the tag is self-closing.
+        /// </summary>
+        public bool SelfClosing { get; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperChunk.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperChunk.cs
@@ -15,17 +15,17 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
         /// Instantiates a new <see cref="TagHelperChunk"/>.
         /// </summary>
         /// <param name="tagName">The tag name associated with the tag helpers HTML element.</param>
-        /// <param name="attributes">The attributes associated with the tag helpers HTML element.</param>
         /// <param name="selfClosing">
-        /// The <c>bool</c> indicating whether or not the tag of the tag helpers HTML element is self-closing.
+        /// <see cref="bool"/> indicating whether or not the tag of the tag helpers HTML element is self-closing.
         /// </param>
+        /// <param name="attributes">The attributes associated with the tag helpers HTML element.</param>
         /// <param name="descriptors">
         /// The <see cref="TagHelperDescriptor"/>s associated with this tag helpers HTML element.
         /// </param>
         public TagHelperChunk(
             string tagName,
-            IDictionary<string, Chunk> attributes,
             bool selfClosing,
+            IDictionary<string, Chunk> attributes,
             IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
         public string TagName { get; set; }
 
         /// <summary>
-        /// Indicates whether or not the tag of the tag helpers HTML element is self-closing.
+        /// Gets a value indicating whether or not the tag of the tag helpers HTML element is self-closing.
         /// </summary>
         public bool SelfClosing { get; }
     }

--- a/src/Microsoft.AspNet.Razor/Generator/TagHelperCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/TagHelperCodeGenerator.cs
@@ -77,7 +77,10 @@ namespace Microsoft.AspNet.Razor.Generator
 
             context.CodeTreeBuilder.StartChunkBlock(
                 new TagHelperChunk(
-                    tagHelperBlock.TagName, attributes, tagHelperBlock.SelfClosing, _tagHelperDescriptors),
+                    tagHelperBlock.TagName,
+                    tagHelperBlock.SelfClosing,
+                    attributes,
+                    _tagHelperDescriptors),
                 target,
                 topLevel: false);
         }

--- a/src/Microsoft.AspNet.Razor/Generator/TagHelperCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/TagHelperCodeGenerator.cs
@@ -76,12 +76,8 @@ namespace Microsoft.AspNet.Razor.Generator
             }
 
             context.CodeTreeBuilder.StartChunkBlock(
-                new TagHelperChunk
-                {
-                    TagName = tagHelperBlock.TagName,
-                    Attributes = attributes,
-                    Descriptors = _tagHelperDescriptors
-                },
+                new TagHelperChunk(
+                    tagHelperBlock.TagName, attributes, tagHelperBlock.SelfClosing, _tagHelperDescriptors),
                 target,
                 topLevel: false);
         }

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
@@ -31,6 +31,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
             Descriptors = source.Descriptors;
             Attributes = new Dictionary<string, SyntaxTreeNode>(source.Attributes);
             _start = source.Start;
+            SelfClosing = source.SelfClosing;
 
             source.Reset();
 
@@ -39,6 +40,11 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
                 attributeChildren.Parent = this;
             }
         }
+
+        /// <summary>
+        /// Indicates whether or not the tag is self closing.
+        /// </summary>
+        public bool SelfClosing { get; }
 
         /// <summary>
         /// <see cref="TagHelperDescriptor"/>s for the HTML element.

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -35,17 +35,20 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// <param name="tagName">An HTML tag name.</param>
         /// <param name="start">Starting location of the <see cref="TagHelperBlock"/>.</param>
         /// <param name="attributes">Attributes of the <see cref="TagHelperBlock"/>.</param>
+        /// <param name="selfClosing">The <c>bool</c> indicating whether or not the tag is self-closing.</param>
         /// <param name="descriptors">The <see cref="TagHelperDescriptor"/>s associated with the current HTML
         /// tag.</param>
         public TagHelperBlockBuilder(string tagName,
                                      SourceLocation start,
                                      IDictionary<string, SyntaxTreeNode> attributes,
+                                     bool selfClosing, 
                                      IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;
             Start = start;
             Descriptors = descriptors;
             Type = BlockType.Tag;
+            SelfClosing = selfClosing;
             CodeGenerator = new TagHelperCodeGenerator(descriptors);
             Attributes = new Dictionary<string, SyntaxTreeNode>(attributes);
         }
@@ -53,10 +56,12 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         // Internal for testing
         internal TagHelperBlockBuilder(string tagName,
                                        IDictionary<string, SyntaxTreeNode> attributes,
+                                       bool selfClosing,
                                        IEnumerable<SyntaxTreeNode> children)
         {
             TagName = tagName;
             Attributes = attributes;
+            SelfClosing = selfClosing;
             Type = BlockType.Tag;
             CodeGenerator = new TagHelperCodeGenerator(tagHelperDescriptors: null);
 
@@ -66,6 +71,11 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
                 Children.Add(child);
             }
         }
+
+        /// <summary>
+        /// Indicates whether or not the tag is self-closing.
+        /// </summary>
+        public bool SelfClosing { get; }
 
         /// <summary>
         /// <see cref="TagHelperDescriptor"/>s for the HTML element.

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -33,15 +33,17 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// and <see cref="BlockBuilder.Type"/> from the <paramref name="startTag"/>.
         /// </summary>
         /// <param name="tagName">An HTML tag name.</param>
+        /// <param name="selfClosing">
+        /// <see cref="bool"/> indicating whether or not the tag in the Razor source was self-closing.
+        /// </param>
         /// <param name="start">Starting location of the <see cref="TagHelperBlock"/>.</param>
         /// <param name="attributes">Attributes of the <see cref="TagHelperBlock"/>.</param>
-        /// <param name="selfClosing">The <c>bool</c> indicating whether or not the current tag is self-closing.</param>
         /// <param name="descriptors">The <see cref="TagHelperDescriptor"/>s associated with the current HTML
         /// tag.</param>
         public TagHelperBlockBuilder(string tagName,
+                                     bool selfClosing,
                                      SourceLocation start,
                                      IDictionary<string, SyntaxTreeNode> attributes,
-                                     bool selfClosing,
                                      IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;
@@ -55,8 +57,8 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
 
         // Internal for testing
         internal TagHelperBlockBuilder(string tagName,
-                                       IDictionary<string, SyntaxTreeNode> attributes,
                                        bool selfClosing,
+                                       IDictionary<string, SyntaxTreeNode> attributes,
                                        IEnumerable<SyntaxTreeNode> children)
         {
             TagName = tagName;
@@ -73,7 +75,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         }
 
         /// <summary>
-        /// Indicates whether or not the tag is self-closing.
+        /// Gets a value indicating whether or not the tag in the Razor source was self-closing.
         /// </summary>
         public bool SelfClosing { get; }
 

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -47,12 +47,12 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
                                      IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;
+            SelfClosing = selfClosing;
             Start = start;
             Descriptors = descriptors;
-            Type = BlockType.Tag;
-            SelfClosing = selfClosing;
-            CodeGenerator = new TagHelperCodeGenerator(descriptors);
             Attributes = new Dictionary<string, SyntaxTreeNode>(attributes);
+            Type = BlockType.Tag;
+            CodeGenerator = new TagHelperCodeGenerator(descriptors);
         }
 
         // Internal for testing
@@ -62,8 +62,8 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
                                        IEnumerable<SyntaxTreeNode> children)
         {
             TagName = tagName;
-            Attributes = attributes;
             SelfClosing = selfClosing;
+            Attributes = attributes;
             Type = BlockType.Tag;
             CodeGenerator = new TagHelperCodeGenerator(tagHelperDescriptors: null);
 

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -35,13 +35,13 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// <param name="tagName">An HTML tag name.</param>
         /// <param name="start">Starting location of the <see cref="TagHelperBlock"/>.</param>
         /// <param name="attributes">Attributes of the <see cref="TagHelperBlock"/>.</param>
-        /// <param name="selfClosing">The <c>bool</c> indicating whether or not the tag is self-closing.</param>
+        /// <param name="selfClosing">The <c>bool</c> indicating whether or not the current tag is self-closing.</param>
         /// <param name="descriptors">The <see cref="TagHelperDescriptor"/>s associated with the current HTML
         /// tag.</param>
         public TagHelperBlockBuilder(string tagName,
                                      SourceLocation start,
                                      IDictionary<string, SyntaxTreeNode> attributes,
-                                     bool selfClosing, 
+                                     bool selfClosing,
                                      IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             var attributes = GetTagAttributes(tagName, validStructure, tag, descriptors, errorSink);
             var selfClosing = IsSelfClosing(tag);
 
-            return new TagHelperBlockBuilder(tagName, start, attributes, selfClosing, descriptors);
+            return new TagHelperBlockBuilder(tagName, selfClosing, start, attributes, descriptors);
         }
 
         private static IDictionary<string, SyntaxTreeNode> GetTagAttributes(

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
@@ -26,8 +26,9 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             // There will always be at least one child for the '<'.
             var start = tag.Children.First().Start;
             var attributes = GetTagAttributes(tagName, validStructure, tag, descriptors, errorSink);
+            var selfClosing = IsSelfClosing(tag);
 
-            return new TagHelperBlockBuilder(tagName, start, attributes, descriptors);
+            return new TagHelperBlockBuilder(tagName, start, attributes, selfClosing, descriptors);
         }
 
         private static IDictionary<string, SyntaxTreeNode> GetTagAttributes(
@@ -92,6 +93,13 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             }
 
             return attributes;
+        }
+
+        private static bool IsSelfClosing(Block beginTagBlock)
+        {
+            var childSpan = beginTagBlock.FindLastDescendentSpan();
+
+            return childSpan?.Content.EndsWith("/>") ?? false;
         }
 
         // This method handles cases when the attribute is a simple span attribute such as

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperParseTreeRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperParseTreeRewriter.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
 
                 // If it's a self closing block then we don't have to worry about nested children 
                 // within the tag... complete it.
-                if (IsSelfClosing(tagBlock))
+                if (builder.SelfClosing)
                 {
                     BuildCurrentlyTrackedTagHelperBlock();
                 }
@@ -332,15 +332,6 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             }
 
             return textSymbol.Type == HtmlSymbolType.WhiteSpace ? null : textSymbol.Content;
-        }
-
-        private static bool IsSelfClosing(Block beginTagBlock)
-        {
-            EnsureTagBlock(beginTagBlock);
-
-            var childSpan = beginTagBlock.Children.Last() as Span;
-
-            return childSpan?.Content.EndsWith("/>") ?? false;
         }
 
         private static bool IsEndTag(Block tagBlock)

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void HtmlAttributes_IgnoresCase(string originalName, string updatedName)
         {
             // Arrange
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             executionContext.HTMLAttributes[originalName] = "hello";
 
             // Act
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void AllAttributes_IgnoresCase(string originalName, string updatedName)
         {
             // Arrange
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             executionContext.AllAttributes[originalName] = false;
 
             // Act
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void AddHtmlAttribute_MaintainsHTMLAttributes()
         {
             // Arrange
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             var expectedAttributes = new Dictionary<string, string>
             {
                 { "class", "btn" },
@@ -139,7 +139,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void TagHelperExecutionContext_MaintainsAllAttributes()
         {
             // Arrange
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             var expectedAttributes = new Dictionary<string, object>
             {
                 { "class", "btn" },
@@ -160,7 +160,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void Add_MaintainsTagHelpers()
         {
             // Arrange
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             var tagHelper = new PTagHelper();
 
             // Act
@@ -175,7 +175,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void Add_MaintainsMultipleTagHelpers()
         {
             // Arrange
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             var tagHelper1 = new PTagHelper();
             var tagHelper2 = new PTagHelper();
 
@@ -198,26 +198,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void SelfClosing_ReturnsTrueOrFalseAsExpected(bool isSelfClosing)
+        public void SelfClosing_ReturnsTrueOrFalseAsExpected(bool selfClosing)
         {
-            // Arrange
-            var writer = new StringWriter();
-            Func<Task> executeChildContent = () =>
-            {
-                return Task.FromResult(result: true);
-            };
-
-            // Act
-            var executionContext = new TagHelperExecutionContext(
-                tagName: string.Empty,
-                uniqueId: string.Empty,
-                executeChildContentAsync: executeChildContent,
-                startWritingScope: () => { },
-                endWritingScope:  () => writer,
-                selfClosing: isSelfClosing);
+            // Arrange & Act
+            var executionContext = new TagHelperExecutionContext("p", selfClosing);
 
             // Assert 
-            Assert.Equal(isSelfClosing, executionContext.SelfClosing);
+            Assert.Equal(selfClosing, executionContext.SelfClosing);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
@@ -33,7 +33,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     return Task.FromResult(result: true);
                 },
                 startWritingScope: () => { },
-                endWritingScope: () => writer);
+                endWritingScope: () => writer,
+                selfClosing: false);
 
             // Act
             var content1 = await executionContext.GetChildContentAsync();
@@ -60,7 +61,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     return Task.FromResult(result: true);
                 },
                 startWritingScope: () => { },
-                endWritingScope: () => new StringWriter());
+                endWritingScope: () => new StringWriter(),
+                selfClosing: false);
 
             // Act
             await executionContext.ExecuteChildContentAsync();
@@ -191,6 +193,31 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         private class PTagHelper : TagHelper
         {
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SelfClosing_ReturnsTrueOrFalseAsExpected(bool isSelfClosing)
+        {
+            // Arrange
+            var writer = new StringWriter();
+            Func<Task> executeChildContent = () =>
+            {
+                return Task.FromResult(result: true);
+            };
+
+            // Act
+            var executionContext = new TagHelperExecutionContext(
+                tagName: string.Empty,
+                uniqueId: string.Empty,
+                executeChildContentAsync: executeChildContent,
+                startWritingScope: () => { },
+                endWritingScope:  () => writer,
+                selfClosing: isSelfClosing);
+
+            // Assert 
+            Assert.Equal(isSelfClosing, executionContext.SelfClosing);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
@@ -12,6 +12,19 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 {
     public class TagHelperExecutionContextTest
     {
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SelfClosing_ReturnsTrueOrFalseAsExpected(bool selfClosing)
+        {
+            // Arrange & Act
+            var executionContext = new TagHelperExecutionContext("p", selfClosing);
+
+            // Assert 
+            Assert.Equal(selfClosing, executionContext.SelfClosing);
+        }
+
         [Fact]
         public async Task GetChildContentAsync_CachesValue()
         {
@@ -193,18 +206,6 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         private class PTagHelper : TagHelper
         {
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void SelfClosing_ReturnsTrueOrFalseAsExpected(bool selfClosing)
-        {
-            // Arrange & Act
-            var executionContext = new TagHelperExecutionContext("p", selfClosing);
-
-            // Assert 
-            Assert.Equal(selfClosing, executionContext.SelfClosing);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var expectedContent = string.Empty;
             var executionContext = new TagHelperExecutionContext(
                 "p",
+                selfClosing: false,
                 uniqueId: string.Empty,
                 executeChildContentAsync: () =>
                 {
@@ -46,8 +47,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     return Task.FromResult(result: true);
                 },
                 startWritingScope: () => { },
-                endWritingScope: () => writer,
-                selfClosing: false);
+                endWritingScope: () => writer);
 
             // Act
             var content1 = await executionContext.GetChildContentAsync();

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void GeneratePreContent_ReturnsNothingIfSelfClosing()
+        public void GeneratePreContent_ReturnsNothingWhenTagNameIsNotEmptyAndSelfClosing()
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p")
@@ -205,6 +205,29 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.Empty(output);
+        }
+
+        [Theory]
+        [InlineData(true, null)]
+        [InlineData(true, "\t")]
+        [InlineData(false, null)]
+        [InlineData(false, "\t")]
+        public void GeneratePreContent_ReturnsPreContentIfTagNameIsEmpty(bool selfClosing, string tagName)
+        {
+            // Arrange
+            var expectedContent = "Hello World";
+
+            var tagHelperOutput = new TagHelperOutput(tagName)
+            {
+                SelfClosing = selfClosing,
+                PreContent = expectedContent
+            };
+
+            // Act
+            var output = tagHelperOutput.GeneratePreContent();
+
+            // Assert
+            Assert.Same(expectedContent, output);
         }
 
         [Fact]
@@ -225,7 +248,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
 
         [Fact]
-        public void GenerateContent_ReturnsNothingIfSelfClosing()
+        public void GenerateContent_ReturnsNothingWhenTagNameIsNotEmptyAndSelfClosing()
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p")
@@ -239,6 +262,29 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.Empty(output);
+        }
+
+        [Theory]
+        [InlineData(true, null)]
+        [InlineData(true, "\t")]
+        [InlineData(false, null)]
+        [InlineData(false, "\t")]
+        public void GenerateContent_ReturnsContentIfTagNameIsEmpty(bool selfClosing, string tagName)
+        {
+            // Arrange
+            var expectedContent = "Hello World";
+
+            var tagHelperOutput = new TagHelperOutput(tagName)
+            {
+                SelfClosing = selfClosing,
+                Content = expectedContent
+            };
+
+            // Act
+            var output = tagHelperOutput.GenerateContent();
+
+            // Assert
+            Assert.Same(expectedContent, output);
         }
 
         [Fact]
@@ -258,7 +304,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void GeneratePostContent_ReturnsNothingIfSelfClosing()
+        public void GeneratePostContent_ReturnsNothingWhenTagNameIsNotEmptyAndSelfClosing()
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p")
@@ -285,6 +331,29 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.Equal("</p>", output);
+        }
+
+        [Theory]
+        [InlineData(true, null)]
+        [InlineData(true, "\t")]
+        [InlineData(false, null)]
+        [InlineData(false, "\t")]
+        public void GeneratePostContent_ReturnsPostContentIfTagNameIsEmpty(bool selfClosing, string tagName)
+        {
+            // Arrange
+            var expectedContent = "Hello World";
+
+            var tagHelperOutput = new TagHelperOutput(tagName)
+            {
+                SelfClosing = selfClosing,
+                PostContent = expectedContent
+            };
+
+            // Act
+            var output = tagHelperOutput.GeneratePostContent();
+
+            // Assert
+            Assert.Equal(expectedContent, output);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void GeneratePreContent_ReturnsNothingWhenTagNameIsNotEmptyAndSelfClosing()
+        public void GeneratePreContent_ReturnsNothingIfSelfClosingWhenTagNameIsNotNullOrWhitespace()
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p")
@@ -208,11 +208,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Theory]
-        [InlineData(true, null)]
-        [InlineData(true, "\t")]
-        [InlineData(false, null)]
-        [InlineData(false, "\t")]
-        public void GeneratePreContent_ReturnsPreContentIfTagNameIsEmpty(bool selfClosing, string tagName)
+        [InlineData(null, true)]
+        [InlineData("\t", true )]
+        [InlineData(null, false)]
+        [InlineData("\t", false)]
+        public void GeneratePreContent_ReturnsPreContentIfTagNameIsNullOrWhitespace(string tagName, bool selfClosing)
         {
             // Arrange
             var expectedContent = "Hello World";
@@ -248,7 +248,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
 
         [Fact]
-        public void GenerateContent_ReturnsNothingWhenTagNameIsNotEmptyAndSelfClosing()
+        public void GenerateContent_ReturnsNothingIfSelfClosingWhenTagNameIsNotNullOrWhitespace()
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p")
@@ -265,11 +265,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Theory]
-        [InlineData(true, null)]
-        [InlineData(true, "\t")]
-        [InlineData(false, null)]
-        [InlineData(false, "\t")]
-        public void GenerateContent_ReturnsContentIfTagNameIsEmpty(bool selfClosing, string tagName)
+        [InlineData(null, true)]
+        [InlineData("\t", true )]
+        [InlineData(null, false)]
+        [InlineData("\t", false)]
+        public void GenerateContent_ReturnsContentIfTagNameIsNullOrWhitespace(string tagName, bool selfClosing)
         {
             // Arrange
             var expectedContent = "Hello World";
@@ -304,7 +304,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void GeneratePostContent_ReturnsNothingWhenTagNameIsNotEmptyAndSelfClosing()
+        public void GeneratePostContent_ReturnsNothingIfSelfClosingWhenTagNameIsNotNullOrWhitespace()
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p")
@@ -334,11 +334,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Theory]
-        [InlineData(true, null)]
-        [InlineData(true, "\t")]
-        [InlineData(false, null)]
-        [InlineData(false, "\t")]
-        public void GeneratePostContent_ReturnsPostContentIfTagNameIsEmpty(bool selfClosing, string tagName)
+        [InlineData(null, true)]
+        [InlineData("\t", true )]
+        [InlineData(null, false)]
+        [InlineData("\t", false)]
+        public void GeneratePostContent_ReturnsPostContentIfTagNameIsNullOrWhitespace(string tagName, bool selfClosing)
         {
             // Arrange
             var expectedContent = "Hello World";

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -80,6 +79,26 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.Equal(expectedTagHelperOrders, processOrder);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task RunAsync_SetTagHelperOutputSelfClosing(bool selfClosing)
+        {
+            // Arrange
+            var runner = new TagHelperRunner();
+            var executionContext = new TagHelperExecutionContext("p", selfClosing);
+            var tagHelper = new TagHelperContextTouchingTagHelper();
+
+            executionContext.Add(tagHelper);
+            executionContext.AddTagHelperAttribute("foo", true);
+
+            // Act
+            var output = await runner.RunAsync(executionContext);
+
+            // Assert
+            Assert.Equal(selfClosing, output.SelfClosing);
         }
 
         [Fact]
@@ -179,26 +198,6 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
                 ProcessOrderTracker.Add(Order);
             }
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task RunAsync_SetTagHelperOutputSelfClosing(bool selfClosing)
-        {
-            // Arrange
-            var runner = new TagHelperRunner();
-            var executionContext = new TagHelperExecutionContext("p", selfClosing);
-            var tagHelper = new TagHelperContextTouchingTagHelper();
-
-            executionContext.Add(tagHelper);
-            executionContext.AddTagHelperAttribute("foo", true);
-
-            // Act
-            var output = await runner.RunAsync(executionContext);
-
-            // Assert
-            Assert.Equal(selfClosing, output.SelfClosing);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var runner = new TagHelperRunner();
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             var processOrder = new List<int>();
 
             foreach (var order in tagHelperOrders)
@@ -87,7 +87,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var runner = new TagHelperRunner();
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             var executableTagHelper1 = new ExecutableTagHelper();
             var executableTagHelper2 = new ExecutableTagHelper();
 
@@ -106,7 +106,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var runner = new TagHelperRunner();
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             var executableTagHelper = new ExecutableTagHelper();
 
             // Act
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var runner = new TagHelperRunner();
-            var executionContext = new TagHelperExecutionContext("p");
+            var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
             var tagHelper = new TagHelperContextTouchingTagHelper();
 
             // Act
@@ -184,22 +184,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task RunAsync_SetTagHelperOutputSelfClosing(bool isSelfClosing)
+        public async Task RunAsync_SetTagHelperOutputSelfClosing(bool selfClosing)
         {
             // Arrange
             var runner = new TagHelperRunner();
-            var executionContext = new TagHelperExecutionContext(
-                "p",
-                uniqueId: string.Empty,
-                executeChildContentAsync: () =>
-                {
-                    return Task.FromResult(result: true);
-                },
-                startWritingScope: () => {}, 
-                endWritingScope: () => new StringWriter(),
-                selfClosing: isSelfClosing);
-
+            var executionContext = new TagHelperExecutionContext("p", selfClosing);
             var tagHelper = new TagHelperContextTouchingTagHelper();
+
             executionContext.Add(tagHelper);
             executionContext.AddTagHelperAttribute("foo", true);
 
@@ -207,7 +198,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var output = await runner.RunAsync(executionContext);
 
             // Assert
-            Assert.Equal(isSelfClosing, output.SelfClosing);
+            Assert.Equal(selfClosing, output.SelfClosing);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -178,6 +179,35 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
                 ProcessOrderTracker.Add(Order);
             }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task RunAsync_SetTagHelperOutputSelfClosing(bool isSelfClosing)
+        {
+            // Arrange
+            var runner = new TagHelperRunner();
+            var executionContext = new TagHelperExecutionContext(
+                "p",
+                uniqueId: string.Empty,
+                executeChildContentAsync: () =>
+                {
+                    return Task.FromResult(result: true);
+                },
+                startWritingScope: () => {}, 
+                endWritingScope: () => new StringWriter(),
+                selfClosing: isSelfClosing);
+
+            var tagHelper = new TagHelperContextTouchingTagHelper();
+            executionContext.Add(tagHelper);
+            executionContext.AddTagHelperAttribute("foo", true);
+
+            // Act
+            var output = await runner.RunAsync(executionContext);
+
+            // Assert
+            Assert.Equal(isSelfClosing, output.SelfClosing);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
@@ -23,7 +23,8 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
             var scopeManager = new TagHelperScopeManager();
 
             // Act
-            var executionContext = scopeManager.Begin("p",
+            var executionContext = scopeManager.Begin(
+                "p",
                 selfClosing: false,
                 uniqueId: string.Empty,
                 executeChildContentAsync: DefaultExecuteChildContentAsync,
@@ -41,14 +42,16 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
             var scopeManager = new TagHelperScopeManager();
 
             // Act
-            var executionContext = scopeManager.Begin("p",
+            var executionContext = scopeManager.Begin(
+                "p",
                 selfClosing: false,
                 uniqueId: string.Empty,
                 executeChildContentAsync: DefaultExecuteChildContentAsync,
                 startWritingScope: DefaultStartWritingScope,
                 endWritingScope: DefaultEndWritingScope);
 
-            executionContext = scopeManager.Begin("div",
+            executionContext = scopeManager.Begin(
+               "div",
                selfClosing: false,
                uniqueId: string.Empty,
                executeChildContentAsync: DefaultExecuteChildContentAsync,
@@ -68,7 +71,8 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
             var scopeManager = new TagHelperScopeManager();
 
             // Act
-            var executionContext = scopeManager.Begin("p",
+            var executionContext = scopeManager.Begin(
+                "p",
                 selfClosing: selfClosing,
                 uniqueId: string.Empty,
                 executeChildContentAsync: DefaultExecuteChildContentAsync,
@@ -86,14 +90,16 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
             var scopeManager = new TagHelperScopeManager();
 
             // Act
-            var executionContext = scopeManager.Begin("p",
+            var executionContext = scopeManager.Begin(
+                "p",
                 selfClosing: false,
                 uniqueId: string.Empty,
                 executeChildContentAsync: DefaultExecuteChildContentAsync,
                 startWritingScope: DefaultStartWritingScope,
                 endWritingScope: DefaultEndWritingScope);
 
-            executionContext = scopeManager.Begin("div",
+            executionContext = scopeManager.Begin(
+               "div",
                selfClosing: false,
                uniqueId: string.Empty,
                executeChildContentAsync: DefaultExecuteChildContentAsync,
@@ -113,14 +119,16 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
             var scopeManager = new TagHelperScopeManager();
 
             // Act
-            var executionContext = scopeManager.Begin("p",
+            var executionContext = scopeManager.Begin(
+                "p",
                 selfClosing: false,
                 uniqueId: string.Empty,
                 executeChildContentAsync: DefaultExecuteChildContentAsync,
                 startWritingScope: DefaultStartWritingScope,
                 endWritingScope: DefaultEndWritingScope);
 
-            executionContext = scopeManager.Begin("div",
+            executionContext = scopeManager.Begin(
+               "div",
                selfClosing: false,
                uniqueId: string.Empty,
                executeChildContentAsync: DefaultExecuteChildContentAsync,

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
@@ -24,11 +24,11 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
 
             // Act
             var executionContext = scopeManager.Begin("p",
-                                                      string.Empty,
-                                                      DefaultExecuteChildContentAsync,
-                                                      DefaultStartWritingScope,
-                                                      DefaultEndWritingScope,
-                                                      selfClosing: false);
+                selfClosing: false,
+                uniqueId: string.Empty,
+                executeChildContentAsync: DefaultExecuteChildContentAsync,
+                startWritingScope: DefaultStartWritingScope,
+                endWritingScope: DefaultEndWritingScope);
 
             // Assert
             Assert.Equal("p", executionContext.TagName);
@@ -42,17 +42,18 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
 
             // Act
             var executionContext = scopeManager.Begin("p",
-                                                      string.Empty,
-                                                      DefaultExecuteChildContentAsync,
-                                                      DefaultStartWritingScope,
-                                                      DefaultEndWritingScope,
-                                                      selfClosing: false);
+                selfClosing: false,
+                uniqueId: string.Empty,
+                executeChildContentAsync: DefaultExecuteChildContentAsync,
+                startWritingScope: DefaultStartWritingScope,
+                endWritingScope: DefaultEndWritingScope);
+
             executionContext = scopeManager.Begin("div",
-                                                  string.Empty,
-                                                  DefaultExecuteChildContentAsync,
-                                                  DefaultStartWritingScope,
-                                                  DefaultEndWritingScope,
-                                                  selfClosing: false);
+               selfClosing: false,
+               uniqueId: string.Empty,
+               executeChildContentAsync: DefaultExecuteChildContentAsync,
+               startWritingScope: DefaultStartWritingScope,
+               endWritingScope: DefaultEndWritingScope);
 
             // Assert
             Assert.Equal("div", executionContext.TagName);
@@ -68,11 +69,11 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
 
             // Act
             var executionContext = scopeManager.Begin("p",
-                                                      string.Empty,
-                                                      DefaultExecuteChildContentAsync,
-                                                      DefaultStartWritingScope,
-                                                      DefaultEndWritingScope,
-                                                      selfClosing: selfClosing);
+                selfClosing: selfClosing,
+                uniqueId: string.Empty,
+                executeChildContentAsync: DefaultExecuteChildContentAsync,
+                startWritingScope: DefaultStartWritingScope,
+                endWritingScope: DefaultEndWritingScope);
 
             // Assert
             Assert.Equal(selfClosing, executionContext.SelfClosing);
@@ -86,17 +87,19 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
 
             // Act
             var executionContext = scopeManager.Begin("p",
-                                                      string.Empty,
-                                                      DefaultExecuteChildContentAsync,
-                                                      DefaultStartWritingScope,
-                                                      DefaultEndWritingScope,
-                                                      selfClosing: false);
+                selfClosing: false,
+                uniqueId: string.Empty,
+                executeChildContentAsync: DefaultExecuteChildContentAsync,
+                startWritingScope: DefaultStartWritingScope,
+                endWritingScope: DefaultEndWritingScope);
+
             executionContext = scopeManager.Begin("div",
-                                                  string.Empty,
-                                                  DefaultExecuteChildContentAsync,
-                                                  DefaultStartWritingScope,
-                                                  DefaultEndWritingScope,
-                                                  selfClosing: false);
+               selfClosing: false,
+               uniqueId: string.Empty,
+               executeChildContentAsync: DefaultExecuteChildContentAsync,
+               startWritingScope: DefaultStartWritingScope,
+               endWritingScope: DefaultEndWritingScope);
+
             executionContext = scopeManager.End();
 
             // Assert
@@ -111,17 +114,19 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
 
             // Act
             var executionContext = scopeManager.Begin("p",
-                                                      string.Empty,
-                                                      DefaultExecuteChildContentAsync,
-                                                      DefaultStartWritingScope,
-                                                      DefaultEndWritingScope,
-                                                      selfClosing: false);
+                selfClosing: false,
+                uniqueId: string.Empty,
+                executeChildContentAsync: DefaultExecuteChildContentAsync,
+                startWritingScope: DefaultStartWritingScope,
+                endWritingScope: DefaultEndWritingScope);
+
             executionContext = scopeManager.Begin("div",
-                                                  string.Empty,
-                                                  DefaultExecuteChildContentAsync,
-                                                  DefaultStartWritingScope,
-                                                  DefaultEndWritingScope,
-                                                  selfClosing: false);
+               selfClosing: false,
+               uniqueId: string.Empty,
+               executeChildContentAsync: DefaultExecuteChildContentAsync,
+               startWritingScope: DefaultStartWritingScope,
+               endWritingScope: DefaultEndWritingScope);
+
             executionContext = scopeManager.End();
             executionContext = scopeManager.End();
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
         [Theory]
         [InlineData("true")]
         [InlineData("false")]
-        public void Begin_SetExecutionContextSelfClosing(bool isSelfClosing)
+        public void Begin_SetExecutionContextSelfClosing(bool selfClosing)
         {
             // Arrange
             var scopeManager = new TagHelperScopeManager();
@@ -72,10 +72,10 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
                                                       DefaultExecuteChildContentAsync,
                                                       DefaultStartWritingScope,
                                                       DefaultEndWritingScope,
-                                                      selfClosing: isSelfClosing);
+                                                      selfClosing: selfClosing);
 
             // Assert
-            Assert.Equal(isSelfClosing, executionContext.SelfClosing);
+            Assert.Equal(selfClosing, executionContext.SelfClosing);
         }
 
     [Fact]

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
@@ -27,7 +27,8 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
                                                       string.Empty,
                                                       DefaultExecuteChildContentAsync,
                                                       DefaultStartWritingScope,
-                                                      DefaultEndWritingScope);
+                                                      DefaultEndWritingScope,
+                                                      selfClosing: false);
 
             // Assert
             Assert.Equal("p", executionContext.TagName);
@@ -44,18 +45,40 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
                                                       string.Empty,
                                                       DefaultExecuteChildContentAsync,
                                                       DefaultStartWritingScope,
-                                                      DefaultEndWritingScope);
+                                                      DefaultEndWritingScope,
+                                                      selfClosing: false);
             executionContext = scopeManager.Begin("div",
                                                   string.Empty,
                                                   DefaultExecuteChildContentAsync,
                                                   DefaultStartWritingScope,
-                                                  DefaultEndWritingScope);
+                                                  DefaultEndWritingScope,
+                                                  selfClosing: false);
 
             // Assert
             Assert.Equal("div", executionContext.TagName);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void Begin_SetExecutionContextSelfClosing(bool isSelfClosing)
+        {
+            // Arrange
+            var scopeManager = new TagHelperScopeManager();
+
+            // Act
+            var executionContext = scopeManager.Begin("p",
+                                                      string.Empty,
+                                                      DefaultExecuteChildContentAsync,
+                                                      DefaultStartWritingScope,
+                                                      DefaultEndWritingScope,
+                                                      selfClosing: isSelfClosing);
+
+            // Assert
+            Assert.Equal(isSelfClosing, executionContext.SelfClosing);
+        }
+
+    [Fact]
         public void End_ReturnsParentExecutionContext()
         {
             // Arrange
@@ -66,12 +89,14 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
                                                       string.Empty,
                                                       DefaultExecuteChildContentAsync,
                                                       DefaultStartWritingScope,
-                                                      DefaultEndWritingScope);
+                                                      DefaultEndWritingScope,
+                                                      selfClosing: false);
             executionContext = scopeManager.Begin("div",
                                                   string.Empty,
                                                   DefaultExecuteChildContentAsync,
                                                   DefaultStartWritingScope,
-                                                  DefaultEndWritingScope);
+                                                  DefaultEndWritingScope,
+                                                  selfClosing: false);
             executionContext = scopeManager.End();
 
             // Assert
@@ -89,12 +114,14 @@ namespace Microsoft.AspNet.Razor.Runtime.Test.TagHelpers
                                                       string.Empty,
                                                       DefaultExecuteChildContentAsync,
                                                       DefaultStartWritingScope,
-                                                      DefaultEndWritingScope);
+                                                      DefaultEndWritingScope,
+                                                      selfClosing: false);
             executionContext = scopeManager.Begin("div",
                                                   string.Empty,
                                                   DefaultExecuteChildContentAsync,
                                                   DefaultStartWritingScope,
-                                                  DefaultEndWritingScope);
+                                                  DefaultEndWritingScope,
+                                                  selfClosing: false);
             executionContext = scopeManager.End();
             executionContext = scopeManager.End();
 

--- a/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
@@ -177,41 +177,53 @@ namespace Microsoft.AspNet.Razor.Test.Framework
 
     public class MarkupTagHelperBlock : TagHelperBlock
     {
-        public MarkupTagHelperBlock(string tagName, bool selfClosing = false)
-            : this(tagName, new Dictionary<string, SyntaxTreeNode>(), selfClosing)
+        public MarkupTagHelperBlock(string tagName)
+            : this(tagName, selfClosing: false, attributes: new Dictionary<string, SyntaxTreeNode>())
+        {
+        }
+
+        public MarkupTagHelperBlock(string tagName, bool selfClosing)
+            : this(tagName, selfClosing, new Dictionary<string, SyntaxTreeNode>())
+        {
+        }
+
+        public MarkupTagHelperBlock(string tagName,
+                                    IDictionary<string, SyntaxTreeNode> attributes)
+            : this(tagName, selfClosing: false, attributes: attributes, children: new SyntaxTreeNode[0])
+        {
+        }
+
+        public MarkupTagHelperBlock(string tagName,
+                                    bool selfClosing,
+                                    IDictionary<string, SyntaxTreeNode> attributes)
+            : this(tagName, selfClosing, attributes, new SyntaxTreeNode[0])
+        {
+        }
+
+        public MarkupTagHelperBlock(string tagName, params SyntaxTreeNode[] children)
+            : this(
+                  tagName,
+                  selfClosing: false,
+                  attributes: new Dictionary<string, SyntaxTreeNode>(),
+                  children: children)
+        {
+        }
+
+        public MarkupTagHelperBlock(string tagName, bool selfClosing, params SyntaxTreeNode[] children)
+            : this(tagName, selfClosing, new Dictionary<string, SyntaxTreeNode>(), children)
         {
         }
 
         public MarkupTagHelperBlock(string tagName,
                                     IDictionary<string, SyntaxTreeNode> attributes,
-                                    bool selfClosing = false)
-            : this(tagName, attributes, selfClosing, new SyntaxTreeNode[0])
-        {
-        }
-
-        public MarkupTagHelperBlock(string tagName,
                                     params SyntaxTreeNode[] children)
-            : this(tagName, new Dictionary<string, SyntaxTreeNode>(), false, children)
-        {
-        }
-
-        public MarkupTagHelperBlock(string tagName, 
-                                    bool selfClosing, 
-                                    params SyntaxTreeNode[] children)
-            : this(tagName, new Dictionary<string, SyntaxTreeNode>(), selfClosing, children)
-        {
-        }
-
-        public MarkupTagHelperBlock(string tagName,
-                                    IDictionary<string, SyntaxTreeNode> attributes,
-                                    params SyntaxTreeNode[] children)
-            : base(new TagHelperBlockBuilder(tagName, false, attributes, children))
+            : base(new TagHelperBlockBuilder(tagName, selfClosing: false, attributes: attributes, children: children))
         {
         }
         
         public MarkupTagHelperBlock(string tagName,
+                                    bool selfClosing,
                                     IDictionary<string, SyntaxTreeNode> attributes,
-                                    bool selfClosing, 
                                     params SyntaxTreeNode[] children)
             : base(new TagHelperBlockBuilder(tagName, selfClosing, attributes, children))
         {

--- a/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
@@ -205,7 +205,7 @@ namespace Microsoft.AspNet.Razor.Test.Framework
         public MarkupTagHelperBlock(string tagName,
                                     IDictionary<string, SyntaxTreeNode> attributes,
                                     params SyntaxTreeNode[] children)
-            : base(new TagHelperBlockBuilder(tagName, attributes, false, children))
+            : base(new TagHelperBlockBuilder(tagName, false, attributes, children))
         {
         }
         
@@ -213,7 +213,7 @@ namespace Microsoft.AspNet.Razor.Test.Framework
                                     IDictionary<string, SyntaxTreeNode> attributes,
                                     bool selfClosing, 
                                     params SyntaxTreeNode[] children)
-            : base(new TagHelperBlockBuilder(tagName, attributes, selfClosing, children))
+            : base(new TagHelperBlockBuilder(tagName, selfClosing, attributes, children))
         {
         }
     }

--- a/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
@@ -177,27 +177,43 @@ namespace Microsoft.AspNet.Razor.Test.Framework
 
     public class MarkupTagHelperBlock : TagHelperBlock
     {
-        public MarkupTagHelperBlock(string tagName)
-            : this(tagName, new Dictionary<string, SyntaxTreeNode>())
+        public MarkupTagHelperBlock(string tagName, bool selfClosing = false)
+            : this(tagName, new Dictionary<string, SyntaxTreeNode>(), selfClosing)
         {
         }
 
         public MarkupTagHelperBlock(string tagName,
-                                    IDictionary<string, SyntaxTreeNode> attributes)
-            : this(tagName, attributes, new SyntaxTreeNode[0])
+                                    IDictionary<string, SyntaxTreeNode> attributes,
+                                    bool selfClosing = false)
+            : this(tagName, attributes, selfClosing, new SyntaxTreeNode[0])
         {
         }
 
         public MarkupTagHelperBlock(string tagName,
                                     params SyntaxTreeNode[] children)
-            : this(tagName, new Dictionary<string, SyntaxTreeNode>(), children)
+            : this(tagName, new Dictionary<string, SyntaxTreeNode>(), false, children)
+        {
+        }
+
+        public MarkupTagHelperBlock(string tagName, 
+                                    bool selfClosing, 
+                                    params SyntaxTreeNode[] children)
+            : this(tagName, new Dictionary<string, SyntaxTreeNode>(), selfClosing, children)
         {
         }
 
         public MarkupTagHelperBlock(string tagName,
                                     IDictionary<string, SyntaxTreeNode> attributes,
                                     params SyntaxTreeNode[] children)
-            : base(new TagHelperBlockBuilder(tagName, attributes, children))
+            : base(new TagHelperBlockBuilder(tagName, attributes, false, children))
+        {
+        }
+        
+        public MarkupTagHelperBlock(string tagName,
+                                    IDictionary<string, SyntaxTreeNode> attributes,
+                                    bool selfClosing, 
+                                    params SyntaxTreeNode[] children)
+            : base(new TagHelperBlockBuilder(tagName, attributes, selfClosing, children))
         {
         }
     }

--- a/test/Microsoft.AspNet.Razor.Test/Framework/ParserTestBase.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/ParserTestBase.cs
@@ -398,7 +398,7 @@ namespace Microsoft.AspNet.Razor.Test.Framework
             }
             else
             {
-                if (!string.Equals(actual.TagName, expected.TagName, StringComparison.Ordinal))
+                if (!string.Equals(expected.TagName, actual.TagName, StringComparison.Ordinal))
                 {
                     collector.AddError(
                         "{0} - FAILED :: TagName mismatch for TagHelperBlock :: ACTUAL: {1}",
@@ -406,10 +406,13 @@ namespace Microsoft.AspNet.Razor.Test.Framework
                         actual.TagName);
                 }
 
-                if (actual.SelfClosing != expected.SelfClosing)
+                if (expected.SelfClosing != actual.SelfClosing)
                 {
                     collector.AddError(
-                        "{0} - FAILED :: SelfClosing should be {1}", actual.TagName, expected.SelfClosing);
+                        "{0} - FAILED :: SelfClosing for TagHelperBlock {1} :: ACTUAL: {2}",
+                        expected.SelfClosing,
+                        actual.TagName,
+                        actual.SelfClosing);
                 }
                 
                 var expectedAttributes = expected.Attributes.GetEnumerator();

--- a/test/Microsoft.AspNet.Razor.Test/Framework/ParserTestBase.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/ParserTestBase.cs
@@ -398,6 +398,20 @@ namespace Microsoft.AspNet.Razor.Test.Framework
             }
             else
             {
+                if (!string.Equals(actual.TagName, expected.TagName, StringComparison.Ordinal))
+                {
+                    collector.AddError(
+                        "{0} - FAILED :: TagName mismatch for TagHelperBlock :: ACTUAL: {1}",
+                        expected.TagName,
+                        actual.TagName);
+                }
+
+                if (actual.SelfClosing != expected.SelfClosing)
+                {
+                    collector.AddError(
+                        "{0} - FAILED :: SelfClosing should be {1}", actual.TagName, expected.SelfClosing);
+                }
+                
                 var expectedAttributes = expected.Attributes.GetEnumerator();
                 var actualAttributes = actual.Attributes.GetEnumerator();
 

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingUnitTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingUnitTest.cs
@@ -131,12 +131,13 @@ namespace Microsoft.AspNet.Razor.Test.Generator
 
         private static TagHelperChunk CreateTagHelperChunk(string tagName, IEnumerable<TagHelperDescriptor> tagHelperDescriptors)
         {
-            return new TagHelperChunk
+            return new TagHelperChunk(
+                tagName,
+                attributes: new Dictionary<string, Chunk>(),
+                selfClosing: false,
+                descriptors: tagHelperDescriptors)
             {
-                TagName = tagName,
-                Descriptors = tagHelperDescriptors,
                 Children = new List<Chunk>(),
-                Attributes = new Dictionary<string, Chunk>()
             };
         }
 

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingUnitTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingUnitTest.cs
@@ -133,8 +133,8 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         {
             return new TagHelperChunk(
                 tagName,
-                attributes: new Dictionary<string, Chunk>(),
                 selfClosing: false,
+                attributes: new Dictionary<string, Chunk>(),
                 descriptors: tagHelperDescriptors)
             {
                 Children = new List<Chunk>(),

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -40,7 +40,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", new MarkupBlock() }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -56,7 +57,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup("    true") }
-                                })),
+                                },
+                                selfClosing: true)),
                         new RazorError[0]
                     },
                     {
@@ -67,7 +69,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup("    ") }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -83,7 +86,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", new MarkupBlock() }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -102,7 +106,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup("  ") }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -121,7 +126,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -138,7 +144,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 {
                                     { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
                                     { "name", new MarkupBlock() }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -155,7 +162,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 {
                                     { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
                                     { "name", factory.Markup("  ") }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -172,7 +180,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 {
                                     { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
                                     { "name", factory.Markup(string.Empty).With(SpanCodeGenerator.Null) }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -188,7 +197,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "BouND", new MarkupBlock() }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -204,7 +214,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "BOUND", new MarkupBlock() }
-                                })),
+                                },
+                                selfClosing: true)),
                         new[]
                         {
                             new RazorError(
@@ -251,7 +262,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                                     .Accepts(AcceptedCharacters.NonWhiteSpace))),
                                         factory.Markup("  "))
                                     }
-                                })),
+                                },
+                                selfClosing: true)),
                         new RazorError[0]
                     },
                     {
@@ -273,7 +285,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                                 factory.MetaCode(")").Accepts(AcceptedCharacters.None))),
                                         factory.Markup("  "))
                                     }
-                                })),
+                                },
+                                selfClosing: true)),
                         new RazorError[0]
                     },
                 };
@@ -1995,7 +2008,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 { "class1",  new MarkupBlock() },
                                 { "class2",  factory.Markup("").With(SpanCodeGenerator.Null) },
                                 { "class3",  new MarkupBlock() },
-                            }))
+                            },
+                            selfClosing: true))
                     },
                     {
                         "<p class1=''class2=\"\"class3= />",
@@ -2006,7 +2020,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 { "class1",  new MarkupBlock() },
                                 { "class2",  new MarkupBlock() },
                                 { "class3",  factory.Markup("").With(SpanCodeGenerator.Null) },
-                            }))
+                            },
+                            selfClosing: true))
                     },
                 };
             }
@@ -2465,7 +2480,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new Dictionary<string, SyntaxTreeNode>
                             {
                                 { "age", factory.CodeMarkup("12") }
-                            }))
+                            },
+                            selfClosing: true))
                     },
                     {
                         "<person birthday=\"DateTime.Now\" />",
@@ -2474,7 +2490,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new Dictionary<string, SyntaxTreeNode>
                             {
                                 { "birthday", factory.CodeMarkup("DateTime.Now") }
-                            }))
+                            },
+                            selfClosing: true))
                     },
                     {
                         "<person name=\"John\" />",
@@ -2483,7 +2500,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new Dictionary<string, SyntaxTreeNode>
                             {
                                 { "name", factory.Markup("John") }
-                            }))
+                            },
+                            selfClosing: true))
                     },
                     {
                         "<person name=\"Time: @DateTime.Now\" />",
@@ -2492,7 +2510,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new Dictionary<string, SyntaxTreeNode>
                             {
                                 { "name", new MarkupBlock(factory.Markup("Time:"), dateTimeNow) }
-                            }))
+                            },
+                            selfClosing: true))
                     },
                     {
                         "<person age=\"12\" birthday=\"DateTime.Now\" name=\"Time: @DateTime.Now\" />",
@@ -2503,7 +2522,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 { "age", factory.CodeMarkup("12") },
                                 { "birthday", factory.CodeMarkup("DateTime.Now") },
                                 { "name", new MarkupBlock(factory.Markup("Time:"), dateTimeNow) }
-                            }))
+                            },
+                            selfClosing: true))
                     },
                 };
             }
@@ -2668,7 +2688,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<<p />",
                         new MarkupBlock(
                             blockFactory.MarkupTagBlock("<"),
-                            new MarkupTagHelperBlock("p"))
+                            new MarkupTagHelperBlock("p", selfClosing: true))
                     },
                     {
                         "< p />",
@@ -2679,7 +2699,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<input <p />",
                         new MarkupBlock(
                             blockFactory.MarkupTagBlock("<input "),
-                            new MarkupTagHelperBlock("p"))
+                            new MarkupTagHelperBlock("p", selfClosing: true))
                     },
                     {
                         "< class=\"foo\" <p />",
@@ -2697,7 +2717,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                         value: new LocationTagged<string>("foo", 9, 0, 9))),
                                     factory.Markup("\"").With(SpanCodeGenerator.Null)),
                                 factory.Markup(" ")),
-                            new MarkupTagHelperBlock("p"))
+                            new MarkupTagHelperBlock("p", selfClosing: true))
                     },
                     {
                         "</<<p>/></p>>",
@@ -3323,7 +3343,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             { "class", factory.Markup("foo") },
                             { "style", factory.Markup("color:red;") }
-                        }))
+                        },
+                        selfClosing: true))
                 };
                 yield return new object[] {
                     "<p>Hello <script class=\"foo\" style=\"color:red;\"></script> World</p>",
@@ -3364,7 +3385,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             { "class", factory.Markup("foo") },
                             { "style", factory.Markup("color:red;") }
-                        }))
+                        },
+                        selfClosing: true))
                 };
                 yield return new object[] {
                     "<p>Hello <p class=\"foo\" style=\"color:red;\" /> World</p>",
@@ -3376,7 +3398,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 {
                                     { "class", factory.Markup("foo") },
                                     { "style", factory.Markup("color:red;") }
-                                }),
+                                },
+                                selfClosing: true),
                             factory.Markup(" World")))
                 };
                 yield return new object[] {
@@ -3387,13 +3410,15 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new Dictionary<string, SyntaxTreeNode>
                             {
                                 { "class", factory.Markup("foo") }
-                            }),
+                            },
+                            selfClosing: true),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
                             new Dictionary<string, SyntaxTreeNode>
                             {
                                 { "style", factory.Markup("color:red;") }
-                            }),
+                            },
+                            selfClosing: true),
                         factory.Markup("World"))
                 };
             }

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -37,11 +37,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", new MarkupBlock() }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -54,11 +54,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup("    true") }
-                                },
-                                selfClosing: true)),
+                                })),
                         new RazorError[0]
                     },
                     {
@@ -66,11 +66,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup("    ") }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -83,11 +83,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", new MarkupBlock() }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -103,11 +103,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup("  ") }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -123,11 +123,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -140,12 +140,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
                                     { "name", new MarkupBlock() }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -158,12 +158,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
                                     { "name", factory.Markup("  ") }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -176,12 +176,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
                                     { "name", factory.Markup(string.Empty).With(SpanCodeGenerator.Null) }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -194,11 +194,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "BouND", new MarkupBlock() }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -211,11 +211,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     { "BOUND", new MarkupBlock() }
-                                },
-                                selfClosing: true)),
+                                })),
                         new[]
                         {
                             new RazorError(
@@ -248,7 +248,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     {
                                         "bound",
@@ -262,8 +263,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                                     .Accepts(AcceptedCharacters.NonWhiteSpace))),
                                         factory.Markup("  "))
                                     }
-                                },
-                                selfClosing: true)),
+                                })),
                         new RazorError[0]
                     },
                     {
@@ -271,7 +271,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
                                 {
                                     {
                                         "bound",
@@ -285,8 +286,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                                 factory.MetaCode(")").Accepts(AcceptedCharacters.None))),
                                         factory.Markup("  "))
                                     }
-                                },
-                                selfClosing: true)),
+                                })),
                         new RazorError[0]
                     },
                 };
@@ -2003,25 +2003,25 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class1='' class2= class3=\"\" />",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
-                            {
-                                { "class1",  new MarkupBlock() },
-                                { "class2",  factory.Markup("").With(SpanCodeGenerator.Null) },
-                                { "class3",  new MarkupBlock() },
-                            },
-                            selfClosing: true))
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                {
+                                    { "class1",  new MarkupBlock() },
+                                    { "class2",  factory.Markup("").With(SpanCodeGenerator.Null) },
+                                    { "class3",  new MarkupBlock() },
+                                }))
                     },
                     {
                         "<p class1=''class2=\"\"class3= />",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
-                            {
-                                { "class1",  new MarkupBlock() },
-                                { "class2",  new MarkupBlock() },
-                                { "class3",  factory.Markup("").With(SpanCodeGenerator.Null) },
-                            },
-                            selfClosing: true))
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                {
+                                    { "class1",  new MarkupBlock() },
+                                    { "class2",  new MarkupBlock() },
+                                    { "class3",  factory.Markup("").With(SpanCodeGenerator.Null) },
+                                }))
                     },
                 };
             }
@@ -2477,53 +2477,53 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<person age=\"12\" />",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
-                            new Dictionary<string, SyntaxTreeNode>
-                            {
-                                { "age", factory.CodeMarkup("12") }
-                            },
-                            selfClosing: true))
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                {
+                                    { "age", factory.CodeMarkup("12") }
+                                }))
                     },
                     {
                         "<person birthday=\"DateTime.Now\" />",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
-                            new Dictionary<string, SyntaxTreeNode>
-                            {
-                                { "birthday", factory.CodeMarkup("DateTime.Now") }
-                            },
-                            selfClosing: true))
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                {
+                                    { "birthday", factory.CodeMarkup("DateTime.Now") }
+                                }))
                     },
                     {
                         "<person name=\"John\" />",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
-                            new Dictionary<string, SyntaxTreeNode>
-                            {
-                                { "name", factory.Markup("John") }
-                            },
-                            selfClosing: true))
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                {
+                                    { "name", factory.Markup("John") }
+                                }))
                     },
                     {
                         "<person name=\"Time: @DateTime.Now\" />",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
-                            new Dictionary<string, SyntaxTreeNode>
-                            {
-                                { "name", new MarkupBlock(factory.Markup("Time:"), dateTimeNow) }
-                            },
-                            selfClosing: true))
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                {
+                                    { "name", new MarkupBlock(factory.Markup("Time:"), dateTimeNow) }
+                                }))
                     },
                     {
                         "<person age=\"12\" birthday=\"DateTime.Now\" name=\"Time: @DateTime.Now\" />",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
-                            new Dictionary<string, SyntaxTreeNode>
-                            {
-                                { "age", factory.CodeMarkup("12") },
-                                { "birthday", factory.CodeMarkup("DateTime.Now") },
-                                { "name", new MarkupBlock(factory.Markup("Time:"), dateTimeNow) }
-                            },
-                            selfClosing: true))
+                                selfClosing: true,
+                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                {
+                                    { "age", factory.CodeMarkup("12") },
+                                    { "birthday", factory.CodeMarkup("DateTime.Now") },
+                                    { "name", new MarkupBlock(factory.Markup("Time:"), dateTimeNow) }
+                                }))
                     },
                 };
             }
@@ -3339,12 +3339,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<script class=\"foo\" style=\"color:red;\" />",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("script",
-                        new Dictionary<string, SyntaxTreeNode>
-                        {
-                            { "class", factory.Markup("foo") },
-                            { "style", factory.Markup("color:red;") }
-                        },
-                        selfClosing: true))
+                            selfClosing: true,
+                            attributes: new Dictionary<string, SyntaxTreeNode>
+                            {
+                                { "class", factory.Markup("foo") },
+                                { "style", factory.Markup("color:red;") }
+                            }))
                 };
                 yield return new object[] {
                     "<p>Hello <script class=\"foo\" style=\"color:red;\"></script> World</p>",
@@ -3381,44 +3381,48 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p class=\"foo\" style=\"color:red;\" />",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new Dictionary<string, SyntaxTreeNode>
-                        {
-                            { "class", factory.Markup("foo") },
-                            { "style", factory.Markup("color:red;") }
-                        },
-                        selfClosing: true))
+                            selfClosing: true,
+                            attributes:  new Dictionary<string, SyntaxTreeNode>
+                            {
+                                { "class", factory.Markup("foo") },
+                                { "style", factory.Markup("color:red;") }
+                            }))
                 };
                 yield return new object[] {
                     "<p>Hello <p class=\"foo\" style=\"color:red;\" /> World</p>",
                     new MarkupBlock(
-                        new MarkupTagHelperBlock("p",
-                            factory.Markup("Hello "),
-                            new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
-                                {
-                                    { "class", factory.Markup("foo") },
-                                    { "style", factory.Markup("color:red;") }
-                                },
-                                selfClosing: true),
-                            factory.Markup(" World")))
+                        new MarkupTagHelperBlock(
+                            "p",
+                            selfClosing: false,
+                            children: new SyntaxTreeNode[] {
+                                factory.Markup("Hello "),
+                                new MarkupTagHelperBlock(
+                                    "p",
+                                    selfClosing: true,
+                                    attributes: new Dictionary<string, SyntaxTreeNode>
+                                        {
+                                            { "class", factory.Markup("foo") },
+                                            { "style", factory.Markup("color:red;") }
+                                        }),
+                                factory.Markup(" World")}))
                 };
                 yield return new object[] {
                     "Hello<p class=\"foo\" /> <p style=\"color:red;\" />World",
                     new MarkupBlock(
                         factory.Markup("Hello"),
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            selfClosing: true,
+                            attributes: new Dictionary<string, SyntaxTreeNode>
                             {
                                 { "class", factory.Markup("foo") }
-                            },
-                            selfClosing: true),
+                            }),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            selfClosing: true,
+                            attributes: new Dictionary<string, SyntaxTreeNode>
                             {
                                 { "style", factory.Markup("color:red;") }
-                            },
-                            selfClosing: true),
+                            }),
                         factory.Markup("World"))
                 };
             }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
@@ -31,7 +31,7 @@ namespace TestOutput
                 WriteLiteral("\r\n        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, false);
                 __PTagHelper = CreateTagHelper<PTagHelper>();
                 __tagHelperExecutionContext.Add(__PTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -55,7 +55,7 @@ namespace TestOutput
                 WriteLiteral("\r\n        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = **From custom attribute code renderer**: "text";
@@ -84,7 +84,7 @@ namespace TestOutput
                 WriteLiteral("\r\n        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = **From custom attribute code renderer**: "checkbox";
@@ -118,7 +118,7 @@ namespace TestOutput
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n    ");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
             __tagHelperExecutionContext.AddHtmlAttribute("class", "Hello World");

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
@@ -27,11 +27,11 @@ namespace TestOutput
             Instrumentation.BeginContext(33, 49, true);
             WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 WriteLiteral("\r\n        ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, false);
+                , StartWritingScope, EndWritingScope);
                 __PTagHelper = CreateTagHelper<PTagHelper>();
                 __tagHelperExecutionContext.Add(__PTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -53,9 +53,9 @@ namespace TestOutput
                 WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = **From custom attribute code renderer**: "text";
@@ -82,9 +82,9 @@ namespace TestOutput
                 WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = **From custom attribute code renderer**: "checkbox";
@@ -118,7 +118,7 @@ namespace TestOutput
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n    ");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
             __tagHelperExecutionContext.AddHtmlAttribute("class", "Hello World");

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
@@ -32,7 +32,7 @@ namespace TestOutput
                 WriteLiteral("\r\n        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, false);
                 __PTagHelper = CreateTagHelper<PTagHelper>();
                 __tagHelperExecutionContext.Add(__PTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -56,7 +56,7 @@ namespace TestOutput
                 WriteLiteral("\r\n        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = "text";
@@ -85,7 +85,7 @@ namespace TestOutput
                 WriteLiteral("\r\n        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = "checkbox";
@@ -119,7 +119,7 @@ namespace TestOutput
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n    ");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
             __tagHelperExecutionContext.AddHtmlAttribute("class", "Hello World");

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
@@ -28,11 +28,11 @@ namespace TestOutput
             Instrumentation.BeginContext(33, 49, true);
             WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 WriteLiteral("\r\n        ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, false);
+                , StartWritingScope, EndWritingScope);
                 __PTagHelper = CreateTagHelper<PTagHelper>();
                 __tagHelperExecutionContext.Add(__PTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -54,9 +54,9 @@ namespace TestOutput
                 WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = "text";
@@ -83,9 +83,9 @@ namespace TestOutput
                 WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = "checkbox";
@@ -119,7 +119,7 @@ namespace TestOutput
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n    ");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
             __tagHelperExecutionContext.AddHtmlAttribute("class", "Hello World");

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
@@ -60,7 +60,7 @@ namespace TestOutput
                     WriteLiteral("New Time: ");
                     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                     }
-                    , StartWritingScope, EndWritingScope);
+                    , StartWritingScope, EndWritingScope, true);
                     __InputTagHelper = CreateTagHelper<InputTagHelper>();
                     __tagHelperExecutionContext.Add(__InputTagHelper);
                     __InputTagHelper.Type = "text";
@@ -89,7 +89,7 @@ namespace TestOutput
                     WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                     __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, false);
                 __PTagHelper = CreateTagHelper<PTagHelper>();
                 __tagHelperExecutionContext.Add(__PTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -124,7 +124,7 @@ namespace TestOutput
                     WriteLiteral("Current Time: ");
                     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                     }
-                    , StartWritingScope, EndWritingScope);
+                    , StartWritingScope, EndWritingScope, true);
                     __InputTagHelper = CreateTagHelper<InputTagHelper>();
                     __tagHelperExecutionContext.Add(__InputTagHelper);
                     StartWritingScope();
@@ -164,7 +164,7 @@ Write(checkbox);
                     WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                     __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, false);
                 __PTagHelper = CreateTagHelper<PTagHelper>();
                 __tagHelperExecutionContext.Add(__PTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -188,7 +188,7 @@ Write(checkbox);
                 WriteLiteral("\r\n                ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 StartWritingScope();
@@ -224,7 +224,7 @@ Write(true ? "checkbox" : "anything");
                 WriteLiteral("\r\n                ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 StartWritingScope();
@@ -281,7 +281,7 @@ if(true) {
 
                 WriteLiteral("        ");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
             StartWritingScope();
@@ -331,7 +331,7 @@ Write(DateTime.Now);
                 WriteLiteral("\r\n            ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
@@ -362,7 +362,7 @@ __InputTagHelper2.Checked = @object;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 21 "ComplexTagHelpers.cshtml"
@@ -396,7 +396,7 @@ __PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
                 WriteLiteral("\r\n            ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
@@ -427,7 +427,7 @@ __InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 25 "ComplexTagHelpers.cshtml"
@@ -461,7 +461,7 @@ __PTagHelper.Age = -1970 + DateTimeOffset.Now.Year;
                 WriteLiteral("\r\n            ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
@@ -492,7 +492,7 @@ __InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 28 "ComplexTagHelpers.cshtml"
@@ -526,7 +526,7 @@ __PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
                 WriteLiteral("\r\n            ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
@@ -557,7 +557,7 @@ __InputTagHelper2.Checked =      DateTimeOffset.Now.Year   > 2014   ;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 31 "ComplexTagHelpers.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
@@ -40,7 +40,7 @@ namespace TestOutput
             Instrumentation.BeginContext(84, 55, true);
             WriteLiteral("    <div class=\"randomNonTagHelperAttribute\">\r\n        ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 WriteLiteral("\r\n            <h1>Set Time:</h1>\r\n");
 #line 10 "ComplexTagHelpers.cshtml"
             
@@ -56,11 +56,11 @@ namespace TestOutput
 #line hidden
 
                 WriteLiteral("                ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                     WriteLiteral("New Time: ");
-                    __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                    __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                     }
-                    , StartWritingScope, EndWritingScope, true);
+                    , StartWritingScope, EndWritingScope);
                     __InputTagHelper = CreateTagHelper<InputTagHelper>();
                     __tagHelperExecutionContext.Add(__InputTagHelper);
                     __InputTagHelper.Type = "text";
@@ -89,7 +89,7 @@ namespace TestOutput
                     WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                     __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 }
-                , StartWritingScope, EndWritingScope, false);
+                , StartWritingScope, EndWritingScope);
                 __PTagHelper = CreateTagHelper<PTagHelper>();
                 __tagHelperExecutionContext.Add(__PTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -120,11 +120,11 @@ namespace TestOutput
 #line hidden
 
                 WriteLiteral("                ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                     WriteLiteral("Current Time: ");
-                    __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                    __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                     }
-                    , StartWritingScope, EndWritingScope, true);
+                    , StartWritingScope, EndWritingScope);
                     __InputTagHelper = CreateTagHelper<InputTagHelper>();
                     __tagHelperExecutionContext.Add(__InputTagHelper);
                     StartWritingScope();
@@ -164,7 +164,7 @@ Write(checkbox);
                     WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                     __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 }
-                , StartWritingScope, EndWritingScope, false);
+                , StartWritingScope, EndWritingScope);
                 __PTagHelper = CreateTagHelper<PTagHelper>();
                 __tagHelperExecutionContext.Add(__PTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -186,9 +186,9 @@ Write(checkbox);
                 WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n                ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 StartWritingScope();
@@ -222,9 +222,9 @@ Write(true ? "checkbox" : "anything");
                 WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n                ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 StartWritingScope();
@@ -281,7 +281,7 @@ if(true) {
 
                 WriteLiteral("        ");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
             StartWritingScope();
@@ -314,7 +314,7 @@ Write(DateTime.Now);
             Instrumentation.BeginContext(672, 10, true);
             WriteLiteral("\r\n        ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 WriteLiteral("\r\n");
 #line 22 "ComplexTagHelpers.cshtml"
             
@@ -329,9 +329,9 @@ Write(DateTime.Now);
 #line hidden
 
                 WriteLiteral("\r\n            ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
@@ -362,7 +362,7 @@ __InputTagHelper2.Checked = @object;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 21 "ComplexTagHelpers.cshtml"
@@ -392,11 +392,11 @@ __PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
             Instrumentation.BeginContext(819, 10, true);
             WriteLiteral("\r\n        ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 WriteLiteral("\r\n            ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
@@ -427,7 +427,7 @@ __InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 25 "ComplexTagHelpers.cshtml"
@@ -457,11 +457,11 @@ __PTagHelper.Age = -1970 + DateTimeOffset.Now.Year;
             Instrumentation.BeginContext(952, 10, true);
             WriteLiteral("\r\n        ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 WriteLiteral("\r\n            ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
@@ -492,7 +492,7 @@ __InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 28 "ComplexTagHelpers.cshtml"
@@ -522,11 +522,11 @@ __PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
             Instrumentation.BeginContext(1080, 10, true);
             WriteLiteral("\r\n        ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 WriteLiteral("\r\n            ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
@@ -557,7 +557,7 @@ __InputTagHelper2.Checked =      DateTimeOffset.Now.Year   > 2014   ;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 31 "ComplexTagHelpers.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.cs
@@ -30,7 +30,7 @@ namespace TestOutput
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, true);
             __InputTagHelper = CreateTagHelper<InputTagHelper>();
             __tagHelperExecutionContext.Add(__InputTagHelper);
             __InputTagHelper.Type = "";
@@ -70,7 +70,7 @@ __InputTagHelper2.Checked = ;
                 WriteLiteral("\r\n        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, true);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = "";
@@ -105,7 +105,7 @@ __InputTagHelper2.Checked = ;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n    ");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 5 "EmptyAttributeTagHelpers.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.cs
@@ -28,9 +28,9 @@ namespace TestOutput
             Instrumentation.BeginContext(27, 13, true);
             WriteLiteral("\r\n<div>\r\n    ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
             }
-            , StartWritingScope, EndWritingScope, true);
+            , StartWritingScope, EndWritingScope);
             __InputTagHelper = CreateTagHelper<InputTagHelper>();
             __tagHelperExecutionContext.Add(__InputTagHelper);
             __InputTagHelper.Type = "";
@@ -66,11 +66,11 @@ __InputTagHelper2.Checked = ;
             Instrumentation.BeginContext(74, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 WriteLiteral("\r\n        ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
                 }
-                , StartWritingScope, EndWritingScope, true);
+                , StartWritingScope, EndWritingScope);
                 __InputTagHelper = CreateTagHelper<InputTagHelper>();
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 __InputTagHelper.Type = "";
@@ -105,7 +105,7 @@ __InputTagHelper2.Checked = ;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n    ");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 5 "EmptyAttributeTagHelpers.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.cs
@@ -37,9 +37,9 @@ namespace TestOutput
             Instrumentation.BeginContext(114, 69, true);
             WriteLiteral(">\r\n        <input type=\"text\" />\r\n        <em>Not a TagHelper: </em> ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
             }
-            , StartWritingScope, EndWritingScope, true);
+            , StartWritingScope, EndWritingScope);
             __InputTagHelper = CreateTagHelper<InputTagHelper>();
             __tagHelperExecutionContext.Add(__InputTagHelper);
             StartWritingScope();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.cs
@@ -39,7 +39,7 @@ namespace TestOutput
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", "test", async() => {
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, true);
             __InputTagHelper = CreateTagHelper<InputTagHelper>();
             __tagHelperExecutionContext.Add(__InputTagHelper);
             StartWritingScope();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
@@ -29,7 +29,7 @@ namespace TestOutput
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
                 WriteLiteral("Body of Tag");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 3 "SingleTagHelper.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
@@ -26,10 +26,10 @@ namespace TestOutput
             Instrumentation.BeginContext(33, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
                 WriteLiteral("Body of Tag");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
 #line 3 "SingleTagHelper.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInHelper.cs
@@ -34,7 +34,7 @@ MyHelper(string val)
 #line default
 #line hidden
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, false);
                 __NestedTagHelper = CreateTagHelper<NestedTagHelper>();
                 __tagHelperExecutionContext.Add(__NestedTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -57,7 +57,7 @@ MyHelper(string val)
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __MyTagHelper = CreateTagHelper<MyTagHelper>();
             __tagHelperExecutionContext.Add(__MyTagHelper);
             StartWritingScope();
@@ -141,7 +141,7 @@ Write(MyHelper(item => new Template((__razor_template_writer) => {
     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("nestedtaghelper", "test", async() => {
         WriteLiteral("Custom Value");
     }
-    , StartWritingScope, EndWritingScope);
+    , StartWritingScope, EndWritingScope, false);
     __NestedTagHelper = CreateTagHelper<NestedTagHelper>();
     __tagHelperExecutionContext.Add(__NestedTagHelper);
     __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -171,7 +171,7 @@ Write(MyHelper(item => new Template((__razor_template_writer) => {
 #line default
 #line hidden
             }
-            , StartWritingScope, EndWritingScope);
+            , StartWritingScope, EndWritingScope, false);
             __MyTagHelper = CreateTagHelper<MyTagHelper>();
             __tagHelperExecutionContext.Add(__MyTagHelper);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInHelper.cs
@@ -24,9 +24,9 @@ MyHelper(string val)
             Instrumentation.BeginContext(68, 19, true);
             WriteLiteralTo(__razor_helper_writer, "    <div>\r\n        ");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", false, "test", async() => {
                 WriteLiteral("\r\n            In None ContentBehavior.\r\n            ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("nestedtaghelper", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("nestedtaghelper", false, "test", async() => {
                     WriteLiteral("Some buffered values with a value of ");
 #line 8 "TagHelpersInHelper.cshtml"
                                             Write(val);
@@ -34,7 +34,7 @@ MyHelper(string val)
 #line default
 #line hidden
                 }
-                , StartWritingScope, EndWritingScope, false);
+                , StartWritingScope, EndWritingScope);
                 __NestedTagHelper = CreateTagHelper<NestedTagHelper>();
                 __tagHelperExecutionContext.Add(__NestedTagHelper);
                 __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -57,7 +57,7 @@ MyHelper(string val)
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n        ");
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __MyTagHelper = CreateTagHelper<MyTagHelper>();
             __tagHelperExecutionContext.Add(__MyTagHelper);
             StartWritingScope();
@@ -135,13 +135,13 @@ Write(DateTime.Now);
             Instrumentation.BeginContext(33, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", false, "test", async() => {
 #line 12 "TagHelpersInHelper.cshtml"
 Write(MyHelper(item => new Template((__razor_template_writer) => {
-    __tagHelperExecutionContext = __tagHelperScopeManager.Begin("nestedtaghelper", "test", async() => {
+    __tagHelperExecutionContext = __tagHelperScopeManager.Begin("nestedtaghelper", false, "test", async() => {
         WriteLiteral("Custom Value");
     }
-    , StartWritingScope, EndWritingScope, false);
+    , StartWritingScope, EndWritingScope);
     __NestedTagHelper = CreateTagHelper<NestedTagHelper>();
     __tagHelperExecutionContext.Add(__NestedTagHelper);
     __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -171,7 +171,7 @@ Write(MyHelper(item => new Template((__razor_template_writer) => {
 #line default
 #line hidden
             }
-            , StartWritingScope, EndWritingScope, false);
+            , StartWritingScope, EndWritingScope);
             __MyTagHelper = CreateTagHelper<MyTagHelper>();
             __tagHelperExecutionContext.Add(__MyTagHelper);
             __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
@@ -50,7 +50,7 @@ namespace TestOutput
 #line default
 #line hidden
                     }
-                    , StartWritingScope, EndWritingScope);
+                    , StartWritingScope, EndWritingScope, false);
                     __NestedTagHelper = CreateTagHelper<NestedTagHelper>();
                     __tagHelperExecutionContext.Add(__NestedTagHelper);
                     __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -73,7 +73,7 @@ namespace TestOutput
                     __tagHelperExecutionContext = __tagHelperScopeManager.End();
                     WriteLiteral("\r\n        ");
                 }
-                , StartWritingScope, EndWritingScope);
+                , StartWritingScope, EndWritingScope, false);
                 __MyTagHelper = CreateTagHelper<MyTagHelper>();
                 __tagHelperExecutionContext.Add(__MyTagHelper);
                 StartWritingScope();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
@@ -40,9 +40,9 @@ namespace TestOutput
                 Instrumentation.BeginContext(93, 21, true);
                 WriteLiteralTo(__razor_template_writer, "\r\n    <div>\r\n        ");
                 Instrumentation.EndContext();
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", false, "test", async() => {
                     WriteLiteral("\r\n            In None ContentBehavior.\r\n            ");
-                    __tagHelperExecutionContext = __tagHelperScopeManager.Begin("nestedtaghelper", "test", async() => {
+                    __tagHelperExecutionContext = __tagHelperScopeManager.Begin("nestedtaghelper", false, "test", async() => {
                         WriteLiteral("Some buffered values with ");
 #line 11 "TagHelpersInSection.cshtml"
                                  Write(code);
@@ -50,7 +50,7 @@ namespace TestOutput
 #line default
 #line hidden
                     }
-                    , StartWritingScope, EndWritingScope, false);
+                    , StartWritingScope, EndWritingScope);
                     __NestedTagHelper = CreateTagHelper<NestedTagHelper>();
                     __tagHelperExecutionContext.Add(__NestedTagHelper);
                     __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
@@ -73,7 +73,7 @@ namespace TestOutput
                     __tagHelperExecutionContext = __tagHelperScopeManager.End();
                     WriteLiteral("\r\n        ");
                 }
-                , StartWritingScope, EndWritingScope, false);
+                , StartWritingScope, EndWritingScope);
                 __MyTagHelper = CreateTagHelper<MyTagHelper>();
                 __tagHelperExecutionContext.Add(__MyTagHelper);
                 StartWritingScope();


### PR DESCRIPTION
@yishaigalatzer, @NTaylorMullen and @dougbu 

This is the design PR for supporting the self closing tags for TagHelpers. It doesn't contain any unit tests, but I already ran all the MVC functional tests, which contains many samples of self-closing tags. 
Once this design PR is signed-off, I'll add unit tests. 