### PR TITLE
Add tagHelperPrefix directive.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -138,6 +138,38 @@ namespace Microsoft.AspNet.Razor.Runtime
             return string.Format(CultureInfo.CurrentCulture, GetString("HtmlElementNameAttribute_InvalidElementName"), p0, p1);
         }
 
+        /// <summary>
+        /// Invalid tag helper directive '{0}'. Cannot have multiple '{0}' directives on a page.
+        /// </summary>
+        internal static string TagHelperDescriptorResolver_InvalidTagHelperDirective
+        {
+            get { return GetString("TagHelperDescriptorResolver_InvalidTagHelperDirective"); }
+        }
+
+        /// <summary>
+        /// Invalid tag helper directive '{0}'. Cannot have multiple '{0}' directives on a page.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorResolver_InvalidTagHelperDirective(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorResolver_InvalidTagHelperDirective"), p0);
+        }
+
+        /// <summary>
+        /// Invalid tag helper directive '{0}' value. '{1} is not allowed in prefix '{2}'.
+        /// </summary>
+        internal static string TagHelperDescriptorResolver_InvalidTagHelperPrefixValue
+        {
+            get { return GetString("TagHelperDescriptorResolver_InvalidTagHelperPrefixValue"); }
+        }
+
+        /// <summary>
+        /// Invalid tag helper directive '{0}' value. '{1} is not allowed in prefix '{2}'.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorResolver_InvalidTagHelperPrefixValue(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorResolver_InvalidTagHelperPrefixValue"), p0, p1, p2);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -141,4 +141,10 @@
   <data name="HtmlElementNameAttribute_InvalidElementName" xml:space="preserve">
     <value>Tag helpers cannot target element name '{0}' because it contains a '{1}' character.</value>
   </data>
+  <data name="TagHelperDescriptorResolver_InvalidTagHelperDirective" xml:space="preserve">
+    <value>Invalid tag helper directive '{0}'. Cannot have multiple '{0}' directives on a page.</value>
+  </data>
+  <data name="TagHelperDescriptorResolver_InvalidTagHelperPrefixValue" xml:space="preserve">
+    <value>Invalid tag helper directive '{0}' value. '{1} is not allowed in prefix '{2}'.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpDesignTimeHelpersVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpDesignTimeHelpersVisitor.cs
@@ -58,17 +58,22 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
             }
         }
 
+        protected override void Visit(TagHelperPrefixDirectiveChunk chunk)
+        {
+            VisitTagHelperDirectiveChunk(chunk.Prefix, chunk);
+        }
+
         protected override void Visit(AddTagHelperChunk chunk)
         {
-            VisitAddOrRemoveTagHelperChunk(chunk.LookupText, chunk);
+            VisitTagHelperDirectiveChunk(chunk.LookupText, chunk);
         }
 
         protected override void Visit(RemoveTagHelperChunk chunk)
         {
-            VisitAddOrRemoveTagHelperChunk(chunk.LookupText, chunk);
+            VisitTagHelperDirectiveChunk(chunk.LookupText, chunk);
         }
 
-        private void VisitAddOrRemoveTagHelperChunk(string lookupText, Chunk chunk)
+        private void VisitTagHelperDirectiveChunk(string text, Chunk chunk)
         {
             // We should always be in design time mode because of the calling AcceptTree method verification.
             Debug.Assert(Context.Host.DesignTimeMode);
@@ -81,12 +86,10 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
 
             Writer.WriteStartAssignment(TagHelperDirectiveSyntaxHelper);
 
-            // The parsing mechanism for the add/remove TagHelper chunk (CSharpCodeParser.TagHelperDirective())
-            // removes quotes that surround the lookupText.
+            // The parsing mechanism for a TagHelper directive chunk (CSharpCodeParser.TagHelperDirective())
+            // removes quotes that surround the text.
             _csharpCodeVisitor.CreateExpressionCodeMapping(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    "\"{0}\"", lookupText),
+                string.Format(CultureInfo.InvariantCulture, "\"{0}\"", text),
                 chunk);
 
             Writer.WriteLine(";");

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/ChunkVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/ChunkVisitor.cs
@@ -57,6 +57,10 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
             {
                 Visit((TagHelperChunk)chunk);
             }
+            else if (chunk is TagHelperPrefixDirectiveChunk)
+            {
+                Visit((TagHelperPrefixDirectiveChunk)chunk);
+            }
             else if (chunk is AddTagHelperChunk)
             {
                 Visit((AddTagHelperChunk)chunk);
@@ -119,6 +123,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
         protected abstract void Visit(ExpressionChunk chunk);
         protected abstract void Visit(StatementChunk chunk);
         protected abstract void Visit(TagHelperChunk chunk);
+        protected abstract void Visit(TagHelperPrefixDirectiveChunk chunk);
         protected abstract void Visit(AddTagHelperChunk chunk);
         protected abstract void Visit(RemoveTagHelperChunk chunk);
         protected abstract void Visit(UsingChunk chunk);

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CodeVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CodeVisitor.cs
@@ -33,6 +33,9 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
         protected override void Visit(TagHelperChunk chunk)
         {
         }
+        protected override void Visit(TagHelperPrefixDirectiveChunk chunk)
+        {
+        }
         protected override void Visit(AddTagHelperChunk chunk)
         {
         }

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperPrefixDirectiveChunk.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/TagHelpers/TagHelperPrefixDirectiveChunk.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Razor.Generator.Compiler
+{
+    /// <summary>
+    /// A <see cref="Chunk"/> for the <c>@tagHelperPrefix</c> directive.
+    /// </summary>
+    public class TagHelperPrefixDirectiveChunk : Chunk
+    {
+        /// <summary>
+        /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available 
+        /// tag helpers.
+        /// </summary>
+        public string Prefix { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/CodeTreeBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/CodeTreeBuilder.cs
@@ -37,6 +37,17 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
             }
         }
 
+        public void AddTagHelperPrefixDirectiveChunk(string prefix, SyntaxTreeNode association)
+        {
+            AddChunk(
+                new TagHelperPrefixDirectiveChunk
+                {
+                    Prefix = prefix
+                },
+                association,
+                topLevel: true);
+        }
+
         public void AddAddTagHelperChunk(string lookupText, SyntaxTreeNode association)
         {
             AddChunk(new AddTagHelperChunk

--- a/src/Microsoft.AspNet.Razor/Generator/TagHelperCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/TagHelperCodeGenerator.cs
@@ -75,9 +75,11 @@ namespace Microsoft.AspNet.Razor.Generator
                 codeGenerator.Context.CodeTreeBuilder = new CodeTreeBuilder();
             }
 
+            var unprefixedTagName = tagHelperBlock.TagName.Substring(_tagHelperDescriptors.First().Prefix.Length);
+
             context.CodeTreeBuilder.StartChunkBlock(
                 new TagHelperChunk(
-                    tagHelperBlock.TagName,
+                    unprefixedTagName,
                     tagHelperBlock.SelfClosing,
                     attributes,
                     _tagHelperDescriptors),

--- a/src/Microsoft.AspNet.Razor/Generator/TagHelpers/TagHelperPrefixDirectiveCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/TagHelpers/TagHelperPrefixDirectiveCodeGenerator.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+
+namespace Microsoft.AspNet.Razor.Generator
+{
+    /// <summary>
+    /// A <see cref="SpanCodeGenerator"/> responsible for generating 
+    /// <see cref="Compiler.TagHelperPrefixDirectiveChunk"/>s.
+    /// </summary>
+    public class TagHelperPrefixDirectiveCodeGenerator : SpanCodeGenerator
+    {
+        /// <summary>
+        /// Instantiates a new <see cref="TagHelperPrefixDirectiveCodeGenerator"/>.
+        /// </summary>
+        /// <param name="prefix">
+        /// Text used as a required prefix when matching HTML.
+        /// </param>
+        public TagHelperPrefixDirectiveCodeGenerator(string prefix)
+        {
+            Prefix = prefix;
+        }
+
+        /// <summary>
+        /// Text used as a required prefix when matching HTML.
+        /// </summary>
+        public string Prefix { get; }
+
+        /// <summary>
+        /// Generates <see cref="Compiler.TagHelperPrefixDirectiveChunk"/>s.
+        /// </summary>
+        /// <param name="target">
+        /// The <see cref="Span"/> responsible for this <see cref="TagHelperPrefixDirectiveCodeGenerator"/>.
+        /// </param>
+        /// <param name="context">A <see cref="CodeGeneratorContext"/> instance that contains information about
+        /// the current code generation process.</param>
+        public override void GenerateCode(Span target, CodeGeneratorContext context)
+        {
+            context.CodeTreeBuilder.AddTagHelperPrefixDirectiveChunk(Prefix, target);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNet.Razor.Parser
 
         internal static ISet<string> DefaultKeywords = new HashSet<string>()
         {
+            SyntaxConstants.CSharp.TagHelperPrefixKeyword,
             SyntaxConstants.CSharp.AddTagHelperKeyword,
             SyntaxConstants.CSharp.RemoveTagHelperKeyword,
             "if",

--- a/src/Microsoft.AspNet.Razor/Parser/RazorParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/RazorParser.cs
@@ -213,7 +213,7 @@ namespace Microsoft.AspNet.Razor.Parser
                                                                                    [NotNull] ParserErrorSink errorSink)
         {
             var addOrRemoveTagHelperSpanVisitor = 
-                new AddOrRemoveTagHelperSpanVisitor(TagHelperDescriptorResolver, errorSink);
+                new TagHelperDirectiveSpanVisitor(TagHelperDescriptorResolver, errorSink);
             return addOrRemoveTagHelperSpanVisitor.GetDescriptors(documentRoot);
         }
 

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxConstants.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxConstants.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNet.Razor.Parser
         public static class CSharp
         {
             public static readonly int UsingKeywordLength = 5;
+            public static readonly string TagHelperPrefixKeyword = "tagHelperPrefix";
             public static readonly string AddTagHelperKeyword = "addTagHelper";
             public static readonly string RemoveTagHelperKeyword = "removeTagHelper";
             public static readonly string InheritsKeyword = "inherits";

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperDirectiveSpanVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperDirectiveSpanVisitor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
     /// A <see cref="ParserVisitor"/> that generates <see cref="TagHelperDescriptor"/>s from
     /// tag helper code generators in a Razor document.
     /// </summary>
-    public class AddOrRemoveTagHelperSpanVisitor : ParserVisitor
+    public class TagHelperDirectiveSpanVisitor : ParserVisitor
     {
         private readonly ITagHelperDescriptorResolver _descriptorResolver;
         private readonly ParserErrorSink _errorSink;
@@ -20,12 +20,12 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         private List<TagHelperDirectiveDescriptor> _directiveDescriptors;
 
         // Internal for testing use
-        internal AddOrRemoveTagHelperSpanVisitor(ITagHelperDescriptorResolver descriptorResolver)
+        internal TagHelperDirectiveSpanVisitor(ITagHelperDescriptorResolver descriptorResolver)
             : this(descriptorResolver, new ParserErrorSink())
         {
         }
 
-        public AddOrRemoveTagHelperSpanVisitor([NotNull] ITagHelperDescriptorResolver descriptorResolver,
+        public TagHelperDirectiveSpanVisitor([NotNull] ITagHelperDescriptorResolver descriptorResolver,
                                                [NotNull] ParserErrorSink errorSink)
         {
             _descriptorResolver = descriptorResolver;
@@ -61,13 +61,26 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
             {
                 var codeGenerator = (AddOrRemoveTagHelperCodeGenerator)span.CodeGenerator;
 
-                var directive = codeGenerator.RemoveTagHelperDescriptors ?
-                                TagHelperDirectiveType.RemoveTagHelper :
-                                TagHelperDirectiveType.AddTagHelper;
+                var directive = 
+                    codeGenerator.RemoveTagHelperDescriptors ?
+                    TagHelperDirectiveType.RemoveTagHelper :
+                    TagHelperDirectiveType.AddTagHelper;
 
-                var directiveDescriptor = new TagHelperDirectiveDescriptor(codeGenerator.LookupText, 
-                                                                           span.Start, 
-                                                                           directive);
+                var directiveDescriptor = new TagHelperDirectiveDescriptor(
+                    codeGenerator.LookupText, 
+                    span.Start, 
+                    directive);
+
+                _directiveDescriptors.Add(directiveDescriptor);
+            }
+            else if (span.CodeGenerator is TagHelperPrefixDirectiveCodeGenerator)
+            {
+                var codeGenerator = (TagHelperPrefixDirectiveCodeGenerator)span.CodeGenerator;
+
+                var directiveDescriptor = new TagHelperDirectiveDescriptor(
+                    codeGenerator.Prefix,
+                    span.Start,
+                    TagHelperDirectiveType.TagHelperPrefix);
 
                 _directiveDescriptors.Add(directiveDescriptor);
             }

--- a/src/Microsoft.AspNet.Razor/ParserResults.cs
+++ b/src/Microsoft.AspNet.Razor/ParserResults.cs
@@ -54,6 +54,7 @@ namespace Microsoft.AspNet.Razor
             TagHelperDescriptors = tagHelperDescriptors;
             ErrorSink = errorSink;
             ParserErrors = errorSink.Errors;
+            Prefix = tagHelperDescriptors.FirstOrDefault()?.Prefix;
         }
 
         /// <summary>
@@ -81,5 +82,10 @@ namespace Microsoft.AspNet.Razor
         /// The <see cref="TagHelperDescriptor"/>s found for the current Razor document.
         /// </summary>
         public IEnumerable<TagHelperDescriptor> TagHelperDescriptors { get; }
+
+        /// <summary>
+        /// Text used as a required prefix when matching HTML.
+        /// </summary>
+        public string Prefix { get; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
@@ -17,10 +17,11 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         internal TagHelperDescriptor([NotNull] string tagName,
                                      [NotNull] string typeName,
                                      [NotNull] string assemblyName)
-            : this(tagName,
-                   typeName,
-                   assemblyName,
-                   Enumerable.Empty<TagHelperAttributeDescriptor>())
+            : this(
+                tagName,
+                typeName,
+                assemblyName,
+                attributes: Enumerable.Empty<TagHelperAttributeDescriptor>())
         {
         }
 
@@ -35,21 +36,66 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <param name="attributes">
         /// The <see cref="TagHelperAttributeDescriptor"/>s to request from the HTML tag.
         /// </param>
-        public TagHelperDescriptor([NotNull] string tagName,
-                                   [NotNull] string typeName,
-                                   [NotNull] string assemblyName,
-                                   [NotNull] IEnumerable<TagHelperAttributeDescriptor> attributes)
+        public TagHelperDescriptor(
+            [NotNull] string tagName,
+            [NotNull] string typeName,
+            [NotNull] string assemblyName,
+            [NotNull] IEnumerable<TagHelperAttributeDescriptor> attributes)
+            : this(
+                prefix: string.Empty,
+                tagName: tagName, 
+                typeName: typeName, 
+                assemblyName: assemblyName, 
+                attributes: attributes)
         {
+        }
+
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="TagHelperDescriptor"/> class with the given
+        /// <paramref name="attributes"/>.
+        /// </summary>
+        /// <param name="prefix">
+        /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available 
+        /// tag helpers.
+        /// </param>
+        /// <param name="tagName">The tag name that the tag helper targets. '*' indicates a catch-all
+        /// <see cref="TagHelperDescriptor"/> which applies to every HTML tag.</param>
+        /// <param name="typeName">The full name of the tag helper class.</param>
+        /// <param name="assemblyName">The name of the assembly containing the tag helper class.</param>
+        /// <param name="attributes">
+        /// The <see cref="TagHelperAttributeDescriptor"/>s to request from the HTML tag.
+        /// </param>
+        public TagHelperDescriptor(
+            string prefix,
+            [NotNull] string tagName,
+            [NotNull] string typeName,
+            [NotNull] string assemblyName,
+            [NotNull] IEnumerable<TagHelperAttributeDescriptor> attributes)
+        {
+            Prefix = prefix ?? string.Empty;
             TagName = tagName;
+            FullTagName = Prefix + TagName;
             TypeName = typeName;
             AssemblyName = assemblyName;
             Attributes = new List<TagHelperAttributeDescriptor>(attributes);
         }
 
         /// <summary>
+        /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available 
+        /// tag helpers.
+        /// </summary>
+        public string Prefix { get; private set; }
+
+        /// <summary>
         /// The tag name that the tag helper should target.
         /// </summary>
         public string TagName { get; private set; }
+
+        /// <summary>
+        /// The full tag name that is required for the tag helper to target an HTML element.
+        /// </summary>
+        /// <remarks>This is equivalent to <see cref="Prefix"/> and <see cref="TagName"/> concatenated.</remarks>
+        public string FullTagName { get; private set; }
 
         /// <summary>
         /// The full name of the tag helper class.

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
@@ -29,12 +29,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <c>false</c> otherwise.</returns>
         /// <remarks>
         /// Determines equality based on <see cref="TagHelperDescriptor.TypeName"/>,
-        /// <see cref="TagHelperDescriptor.AssemblyName"/> and <see cref="TagHelperDescriptor.TagName"/>.
+        /// <see cref="TagHelperDescriptor.AssemblyName"/>, <see cref="TagHelperDescriptor.TagName"/> and
+        /// <see cref="TagHelperDescriptor.Prefix"/>.
         /// </remarks>
         public bool Equals(TagHelperDescriptor descriptorX, TagHelperDescriptor descriptorY)
         {
             return string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal) &&
                    string.Equals(descriptorX.TagName, descriptorY.TagName, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(descriptorX.Prefix, descriptorY.Prefix, StringComparison.OrdinalIgnoreCase) &&
                    string.Equals(descriptorX.AssemblyName, descriptorY.AssemblyName, StringComparison.Ordinal);
         }
 

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveDescriptor.cs
@@ -11,23 +11,24 @@ namespace Microsoft.AspNet.Razor.TagHelpers
     public class TagHelperDirectiveDescriptor
     {
         // Internal for testing purposes.
-        internal TagHelperDirectiveDescriptor(string lookupText,
+        internal TagHelperDirectiveDescriptor(string directiveText,
                                               TagHelperDirectiveType directiveType)
-            : this(lookupText, SourceLocation.Zero, directiveType)
+            : this(directiveText, SourceLocation.Zero, directiveType)
         {
         }
 
         /// <summary>
         /// Instantiates a new instance of <see cref="TagHelperDirectiveDescriptor"/>.
         /// </summary>
-        /// <param name="lookupText">A <see cref="string"/> used to find tag helper <see cref="System.Type"/>s.</param>
+        /// <param name="directiveText">A <see cref="string"/> used to understand tag helper 
+        /// <see cref="System.Type"/>s.</param>
         /// <param name="location">The <see cref="SourceLocation"/> of the directive.</param>
         /// <param name="directiveType">The <see cref="TagHelperDirectiveType"/> of this directive.</param>
-        public TagHelperDirectiveDescriptor([NotNull] string lookupText, 
+        public TagHelperDirectiveDescriptor([NotNull] string directiveText, 
                                             SourceLocation location, 
                                             TagHelperDirectiveType directiveType)
         {
-            LookupText = lookupText;
+            DirectiveText = directiveText;
             Location = location;
             DirectiveType = directiveType;
         }
@@ -35,7 +36,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <summary>
         /// A <see cref="string"/> used to find tag helper <see cref="System.Type"/>s.
         /// </summary>
-        public string LookupText { get; private set; }
+        public string DirectiveText { get; private set; }
 
         /// <summary>
         /// The <see cref="TagHelperDirectiveType"/> of this directive.

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveType.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveType.cs
@@ -9,13 +9,18 @@ namespace Microsoft.AspNet.Razor.TagHelpers
     public enum TagHelperDirectiveType
     {
         /// <summary>
-        /// An @addTagHelper directive.
+        /// An <c>@addTagHelper</c> directive.
         /// </summary>
         AddTagHelper,
 
         /// <summary>
-        /// A @removeTagHelper directive.
+        /// A <c>@removeTagHelper</c> directive.
         /// </summary>
-        RemoveTagHelper
+        RemoveTagHelper,
+
+        /// <summary>
+        /// A <c>@tagHelperPrefix</c> directive.
+        /// </summary>
+        TagHelperPrefix
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
@@ -320,6 +320,11 @@ namespace Microsoft.AspNet.Razor.Test.Framework
                 new AddOrRemoveTagHelperCodeGenerator(removeTagHelperDescriptors: true, lookupText: lookupText));
         }
 
+        public SpanConstructor AsTagHelperPrefixDirective(string prefix)
+        {
+            return _self.With(new TagHelperPrefixDirectiveCodeGenerator(prefix));
+        }
+
         public SpanConstructor As(ISpanCodeGenerator codeGenerator)
         {
             return _self.With(codeGenerator);

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
@@ -14,37 +14,10 @@ namespace Microsoft.AspNet.Razor.Test.Generator
 {
     public class CSharpTagHelperRenderingTest : TagHelperTestBase
     {
-        private static IEnumerable<TagHelperDescriptor> PAndInputTagHelperDescriptors
-        {
-            get
-            {
-                var pAgePropertyInfo = typeof(TestType).GetProperty("Age");
-                var inputTypePropertyInfo = typeof(TestType).GetProperty("Type");
-                var checkedPropertyInfo = typeof(TestType).GetProperty("Checked");
-                return new[]
-                {
-                    new TagHelperDescriptor("p",
-                                            "PTagHelper",
-                                            "SomeAssembly",
-                                            new [] {
-                                                new TagHelperAttributeDescriptor("age", pAgePropertyInfo)
-                                            }),
-                    new TagHelperDescriptor("input",
-                                            "InputTagHelper",
-                                            "SomeAssembly",
-                                            new TagHelperAttributeDescriptor[] {
-                                                new TagHelperAttributeDescriptor("type", inputTypePropertyInfo)
-                                            }),
-                    new TagHelperDescriptor("input",
-                                            "InputTagHelper2",
-                                            "SomeAssembly",
-                                            new TagHelperAttributeDescriptor[] {
-                                                new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
-                                                new TagHelperAttributeDescriptor("checked", checkedPropertyInfo)
-                                            })
-                };
-            }
-        }
+        private static IEnumerable<TagHelperDescriptor> DefaultPAndInputTagHelperDescriptors
+            => BuildPAndInputTagHelperDescriptors(prefix: string.Empty);
+        private static IEnumerable<TagHelperDescriptor> PrefixedPAndInputTagHelperDescriptors
+            => BuildPAndInputTagHelperDescriptors("THS");
 
         public static TheoryData TagHelperDescriptorFlowTestData
         {
@@ -59,50 +32,64 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     {
                         "SingleTagHelper",
                         "SingleTagHelper",
-                        PAndInputTagHelperDescriptors,
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         false
                     },
                     {
                         "SingleTagHelper",
                         "SingleTagHelper.DesignTime",
-                        PAndInputTagHelperDescriptors,
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         true
                     },
                     {
                         "BasicTagHelpers",
                         "BasicTagHelpers",
-                        PAndInputTagHelperDescriptors,
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         false
                     },
                     {
                         "BasicTagHelpers",
                         "BasicTagHelpers.DesignTime",
-                        PAndInputTagHelperDescriptors,
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         true
                     },
                     {
                         "BasicTagHelpers.RemoveTagHelper",
                         "BasicTagHelpers.RemoveTagHelper",
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         Enumerable.Empty<TagHelperDescriptor>(),
                         false
                     },
                     {
+                        "BasicTagHelpers.Prefixed",
+                        "BasicTagHelpers.Prefixed",
+                        PrefixedPAndInputTagHelperDescriptors,
+                        PrefixedPAndInputTagHelperDescriptors,
+                        false
+                    },
+                    {
+                        "BasicTagHelpers.Prefixed",
+                        "BasicTagHelpers.Prefixed.DesignTime",
+                        PrefixedPAndInputTagHelperDescriptors,
+                        PrefixedPAndInputTagHelperDescriptors,
+                        true
+                    },
+                    {
                         "ComplexTagHelpers",
                         "ComplexTagHelpers",
-                        PAndInputTagHelperDescriptors,
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         false
                     },
                     {
                         "ComplexTagHelpers",
                         "ComplexTagHelpers.DesignTime",
-                        PAndInputTagHelperDescriptors,
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         true
                     }
                 };
@@ -141,7 +128,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     {
                         "SingleTagHelper",
                         "SingleTagHelper.DesignTime",
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         new List<LineMapping>
                         {
                             BuildLineMapping(documentAbsoluteIndex: 14,
@@ -161,7 +148,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     {
                         "BasicTagHelpers",
                         "BasicTagHelpers.DesignTime",
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         new List<LineMapping>
                         {
                             BuildLineMapping(documentAbsoluteIndex: 14,
@@ -179,9 +166,35 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                         }
                     },
                     {
+                        "BasicTagHelpers.Prefixed",
+                        "BasicTagHelpers.Prefixed.DesignTime",
+                        PrefixedPAndInputTagHelperDescriptors,
+                        new List<LineMapping>
+                        {
+                            BuildLineMapping(documentAbsoluteIndex: 17,
+                                             documentLineIndex: 0,
+                                             generatedAbsoluteIndex: 496,
+                                             generatedLineIndex: 15,
+                                             characterOffsetIndex: 17,
+                                             contentLength: 5),
+                            BuildLineMapping(documentAbsoluteIndex: 38,
+                                             documentLineIndex: 1,
+                                             generatedAbsoluteIndex: 655,
+                                             generatedLineIndex: 22,
+                                             characterOffsetIndex: 14,
+                                             contentLength: 17),
+                            BuildLineMapping(documentAbsoluteIndex: 228,
+                                             documentLineIndex: 7,
+                                             generatedAbsoluteIndex: 1480,
+                                             generatedLineIndex: 46,
+                                             characterOffsetIndex: 43,
+                                             contentLength: 4)
+                        }
+                    },
+                    {
                         "ComplexTagHelpers",
                         "ComplexTagHelpers.DesignTime",
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         new List<LineMapping>
                         {
                             BuildLineMapping(14, 0, 479, 15, 14, 17),
@@ -217,7 +230,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     {
                         "EmptyAttributeTagHelpers",
                         "EmptyAttributeTagHelpers.DesignTime",
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         new List<LineMapping>
                         {
                             BuildLineMapping(documentAbsoluteIndex: 14,
@@ -251,7 +264,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     {
                         "EscapedTagHelpers",
                         "EscapedTagHelpers.DesignTime",
-                        PAndInputTagHelperDescriptors,
+                        DefaultPAndInputTagHelperDescriptors,
                         new List<LineMapping>
                         {
                             BuildLineMapping(documentAbsoluteIndex: 14,
@@ -308,12 +321,13 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                 // Note: The baseline resource name is equivalent to the test resource name.
                 return new TheoryData<string, IEnumerable<TagHelperDescriptor>>
                 {
-                    { "SingleTagHelper", PAndInputTagHelperDescriptors },
-                    { "BasicTagHelpers", PAndInputTagHelperDescriptors },
-                    { "BasicTagHelpers.RemoveTagHelper", PAndInputTagHelperDescriptors },
-                    { "ComplexTagHelpers", PAndInputTagHelperDescriptors },
-                    { "EmptyAttributeTagHelpers", PAndInputTagHelperDescriptors },
-                    { "EscapedTagHelpers", PAndInputTagHelperDescriptors },
+                    { "SingleTagHelper", DefaultPAndInputTagHelperDescriptors },
+                    { "BasicTagHelpers", DefaultPAndInputTagHelperDescriptors },
+                    { "BasicTagHelpers.RemoveTagHelper", DefaultPAndInputTagHelperDescriptors },
+                    { "BasicTagHelpers.Prefixed", PrefixedPAndInputTagHelperDescriptors },
+                    { "ComplexTagHelpers", DefaultPAndInputTagHelperDescriptors },
+                    { "EmptyAttributeTagHelpers", DefaultPAndInputTagHelperDescriptors },
+                    { "EscapedTagHelpers", DefaultPAndInputTagHelperDescriptors },
                 };
             }
         }
@@ -393,6 +407,41 @@ namespace Microsoft.AspNet.Razor.Test.Generator
 
             // Act & Assert
             RunTagHelperTest(testType, tagHelperDescriptors: tagHelperDescriptors);
+        }
+
+        private static IEnumerable<TagHelperDescriptor> BuildPAndInputTagHelperDescriptors(string prefix)
+        {
+            var pAgePropertyInfo = typeof(TestType).GetProperty("Age");
+            var inputTypePropertyInfo = typeof(TestType).GetProperty("Type");
+            var checkedPropertyInfo = typeof(TestType).GetProperty("Checked");
+            return new[]
+            {
+                new TagHelperDescriptor(
+                    prefix,
+                    tagName: "p",
+                    typeName: "PTagHelper",
+                    assemblyName: "SomeAssembly",
+                    attributes: new [] {
+                        new TagHelperAttributeDescriptor("age", pAgePropertyInfo)
+                    }),
+                new TagHelperDescriptor(
+                    prefix,
+                    tagName: "input",
+                    typeName: "InputTagHelper",
+                    assemblyName: "SomeAssembly",
+                    attributes: new TagHelperAttributeDescriptor[] {
+                        new TagHelperAttributeDescriptor("type", inputTypePropertyInfo)
+                    }),
+                new TagHelperDescriptor(
+                    prefix,
+                    tagName: "input",
+                    typeName: "InputTagHelper2",
+                    assemblyName: "SomeAssembly",
+                    attributes: new TagHelperAttributeDescriptor[] {
+                        new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
+                        new TagHelperAttributeDescriptor("checked", checkedPropertyInfo)
+                    })
+            };
         }
 
         private class TestType

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
@@ -13,6 +13,100 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
     public class CSharpDirectivesTest : CsHtmlCodeParserTestBase
     {
         [Fact]
+        public void TagHelperPrefixDirective_NoValueSucceeds()
+        {
+            ParseBlockTest("@tagHelperPrefix \"\"",
+                new DirectiveBlock(
+                    Factory.CodeTransition(),
+                    Factory
+                        .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
+                        .Accepts(AcceptedCharacters.None),
+                    Factory.Code("\"\"").AsTagHelperPrefixDirective("")));
+        }
+
+        [Fact]
+        public void TagHelperPrefixDirective_Succeeds()
+        {
+            ParseBlockTest("@tagHelperPrefix \"Foo\"",
+                new DirectiveBlock(
+                    Factory.CodeTransition(),
+                    Factory
+                        .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
+                        .Accepts(AcceptedCharacters.None),
+                    Factory.Code("\"Foo\"").AsTagHelperPrefixDirective("Foo")));
+        }
+
+        [Fact]
+        public void TagHelperPrefixDirective_RequiresValue()
+        {
+            ParseBlockTest("@tagHelperPrefix ",
+                new DirectiveBlock(
+                    Factory.CodeTransition(),
+                    Factory
+                        .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
+                        .Accepts(AcceptedCharacters.None),
+                    Factory.EmptyCSharp().AsTagHelperPrefixDirective(string.Empty)),
+                 new RazorError(
+                    RazorResources.FormatParseError_DirectiveMustHaveValue(
+                        SyntaxConstants.CSharp.TagHelperPrefixKeyword),
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17));
+        }
+
+        [Fact]
+        public void TagHelperPrefixDirective_StartQuoteRequiresDoubleQuotesAroundValue()
+        {
+            ParseBlockTest("@tagHelperPrefix \"Foo",
+                new DirectiveBlock(
+                    Factory.CodeTransition(),
+                    Factory
+                        .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
+                        .Accepts(AcceptedCharacters.None),
+                    Factory.Code("\"Foo").AsTagHelperPrefixDirective("Foo")),
+                 new RazorError(
+                     RazorResources.ParseError_Unterminated_String_Literal,
+                     absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
+                 new RazorError(
+                     RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
+                        SyntaxConstants.CSharp.TagHelperPrefixKeyword),
+                        absoluteIndex: 17, lineIndex: 0, columnIndex: 17));
+        }
+
+        [Fact]
+        public void TagHelperPrefixDirective_EndQuoteRequiresDoubleQuotesAroundValue()
+        {
+            ParseBlockTest("@tagHelperPrefix Foo\"",
+                new DirectiveBlock(
+                    Factory.CodeTransition(),
+                    Factory
+                        .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
+                        .Accepts(AcceptedCharacters.None),
+                    Factory.Code("Foo\"").AsTagHelperPrefixDirective("Foo")),
+                 new RazorError(
+                     RazorResources.ParseError_Unterminated_String_Literal,
+                     absoluteIndex: 20, lineIndex: 0, columnIndex: 20),
+                 new RazorError(
+                     RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
+                        SyntaxConstants.CSharp.TagHelperPrefixKeyword),
+                        absoluteIndex: 17, lineIndex: 0, columnIndex: 17));
+        }
+
+        [Fact]
+        public void TagHelperPrefixDirective_RequiresDoubleQuotesAroundValue()
+        {
+            ParseBlockTest("@tagHelperPrefix Foo",
+                new DirectiveBlock(
+                    Factory.CodeTransition(),
+                    Factory
+                        .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
+                        .Accepts(AcceptedCharacters.None),
+                    Factory.Code("Foo").AsTagHelperPrefixDirective("Foo")),
+                 new RazorError(
+                     RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
+                        SyntaxConstants.CSharp.TagHelperPrefixKeyword),
+                        absoluteIndex: 17, lineIndex: 0, columnIndex: 17));
+        }
+
+        [Fact]
         public void RemoveTagHelperDirective_Succeeds()
         {
             ParseBlockTest("@removeTagHelper \"Foo\"",

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.Prefixed.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.Prefixed.DesignTime.cs
@@ -1,0 +1,55 @@
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class BasicTagHelpers.Prefixed
+    {
+        private static object @__o;
+        private void @__RazorDesignTimeHelpers__()
+        {
+            #pragma warning disable 219
+            string __tagHelperDirectiveSyntaxHelper = null;
+            __tagHelperDirectiveSyntaxHelper = 
+#line 1 "BasicTagHelpers.Prefixed.cshtml"
+                 "THS"
+
+#line default
+#line hidden
+            ;
+            __tagHelperDirectiveSyntaxHelper = 
+#line 2 "BasicTagHelpers.Prefixed.cshtml"
+              "something, nice"
+
+#line default
+#line hidden
+            ;
+            #pragma warning restore 219
+        }
+        #line hidden
+        private PTagHelper __PTagHelper = null;
+        private InputTagHelper __InputTagHelper = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        #line hidden
+        public BasicTagHelpers.Prefixed()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper.Type = "checkbox";
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 8 "BasicTagHelpers.Prefixed.cshtml"
+               __InputTagHelper2.Checked = true;
+
+#line default
+#line hidden
+            __PTagHelper = CreateTagHelper<PTagHelper>();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.Prefixed.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.Prefixed.cs
@@ -1,0 +1,97 @@
+#pragma checksum "BasicTagHelpers.Prefixed.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "27630097585fd58e68cb0ac5b772154eff02a52a"
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class BasicTagHelpers.Prefixed
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private System.IO.TextWriter __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private TagHelperRunner __tagHelperRunner = new TagHelperRunner();
+        private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private PTagHelper __PTagHelper = null;
+        private InputTagHelper __InputTagHelper = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        #line hidden
+        public BasicTagHelpers.Prefixed()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            Instrumentation.BeginContext(57, 52, true);
+            WriteLiteral("\r\n<THSdiv class=\"randomNonTagHelperAttribute\">\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", false, "test", async() => {
+                WriteLiteral("\r\n        <p></p>\r\n        <input type=\"text\" />\r\n        ");
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+                }
+                , StartWritingScope, EndWritingScope);
+                __InputTagHelper = CreateTagHelper<InputTagHelper>();
+                __tagHelperExecutionContext.Add(__InputTagHelper);
+                __InputTagHelper.Type = "checkbox";
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __InputTagHelper.Type);
+                __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+                __tagHelperExecutionContext.Add(__InputTagHelper2);
+                __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 8 "BasicTagHelpers.Prefixed.cshtml"
+               __InputTagHelper2.Checked = true;
+
+#line default
+#line hidden
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __InputTagHelper2.Checked);
+                __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+                WriteLiteral(__tagHelperExecutionContext.Output.GeneratePreContent());
+                if (__tagHelperExecutionContext.Output.ContentSet)
+                {
+                    WriteLiteral(__tagHelperExecutionContext.Output.GenerateContent());
+                }
+                else if (__tagHelperExecutionContext.ChildContentRetrieved)
+                {
+                    WriteLiteral(__tagHelperExecutionContext.GetChildContentAsync().Result);
+                }
+                else
+                {
+                    __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+                }
+                WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
+                __tagHelperExecutionContext = __tagHelperScopeManager.End();
+                WriteLiteral("\r\n    ");
+            }
+            , StartWritingScope, EndWritingScope);
+            __PTagHelper = CreateTagHelper<PTagHelper>();
+            __tagHelperExecutionContext.Add(__PTagHelper);
+            __tagHelperExecutionContext.AddHtmlAttribute("class", "Hello World");
+            __tagHelperExecutionContext.Output = __tagHelperRunner.RunAsync(__tagHelperExecutionContext).Result;
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateStartTag());
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePreContent());
+            if (__tagHelperExecutionContext.Output.ContentSet)
+            {
+                WriteLiteral(__tagHelperExecutionContext.Output.GenerateContent());
+            }
+            else if (__tagHelperExecutionContext.ChildContentRetrieved)
+            {
+                WriteLiteral(__tagHelperExecutionContext.GetChildContentAsync().Result);
+            }
+            else
+            {
+                __tagHelperExecutionContext.ExecuteChildContentAsync().Wait();
+            }
+            WriteLiteral(__tagHelperExecutionContext.Output.GeneratePostContent());
+            WriteLiteral(__tagHelperExecutionContext.Output.GenerateEndTag());
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(249, 11, true);
+            WriteLiteral("\r\n</THSdiv>");
+            Instrumentation.EndContext();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/BasicTagHelpers.Prefixed.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/BasicTagHelpers.Prefixed.cshtml
@@ -1,0 +1,10 @@
+﻿@tagHelperPrefix "THS"
+@addTagHelper "something, nice"
+
+<THSdiv class="randomNonTagHelperAttribute">
+    <THSp class="Hello World">
+        <p></p>
+        <input type="text" />
+        <THSinput type="checkbox" checked="true" />
+    </THSp>
+</THSdiv>


### PR DESCRIPTION
Took the approach of attaching the prefix to `TagHelperDescriptor`s to enable tooling to separate `Prefix`s from `TagName`s in the document. Ran design by @rynowak.

*Change notes:*

- Updated TagHelperDescriptor to have a Prefix property. This enables new tooling scenarios such as refactoring prefixes or even giving them their own classification.
- Added invalid prefix cases '@', '!' and whitespace.
- Added TagHelperPrefix chunks, codegenerator, parsing logic to flow the directive through the Razor pipeline.
 Added parsing, sub-rewriting, rewriting and code generation tests for runtime/designtime.
- Fixed existing tests to utilize new class structures.
- Expanded block types to enable easy testing of prefixed TagHelpers.

#309

/cc @dougbu 