### PR TITLE
[DESIGN] Add TagHelperOutput.Attributes replacement.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    public class TagHelperAttribute<TValue> where TValue : class
+    {
+        private string _key;
+
+        public TagHelperAttribute()
+        {
+        }
+
+        public TagHelperAttribute([NotNull] string key)
+            : this(key, value: null)
+        {
+        }
+
+        public TagHelperAttribute([NotNull] string key, TValue value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        public string Key
+        {
+            get
+            {
+                return _key;
+            }
+            set
+            {
+                // Keys aren't allowed to be null.
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(Key));
+                }
+
+                _key = value;
+            }
+        }
+
+        public TValue Value { get; set; }
+
+        public bool Minimized { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
@@ -6,7 +6,7 @@ using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 {
-    public class TagHelperAttribute<TValue> where TValue : class
+    public class TagHelperAttribute<TValue>
     {
         private string _key;
 
@@ -15,8 +15,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         public TagHelperAttribute([NotNull] string key)
-            : this(key, value: null)
         {
+            Key = key;
         }
 
         public TagHelperAttribute([NotNull] string key, TValue value)
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 // Keys aren't allowed to be null.
                 if (value == null)
                 {
-                    throw new ArgumentNullException(nameof(Key));
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 _key = value;

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttributes.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttributes.cs
@@ -10,7 +10,6 @@ using Microsoft.Framework.Internal;
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 {
     public class TagHelperAttributes<TAttributeValue> : IList<TagHelperAttribute<TAttributeValue>>
-        where TAttributeValue : class
     {
         private readonly IList<TagHelperAttribute<TAttributeValue>> _attributes;
 

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttributes.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttributes.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    public class TagHelperAttributes<TAttributeValue> : IList<TagHelperAttribute<TAttributeValue>>
+        where TAttributeValue : class
+    {
+        private readonly IList<TagHelperAttribute<TAttributeValue>> _attributes;
+
+        public TagHelperAttributes()
+        {
+            _attributes = new List<TagHelperAttribute<TAttributeValue>>();
+        }
+
+        public int Count => _attributes.Count;
+
+        public bool IsReadOnly => false;
+
+        public IEnumerable<string> Keys => _attributes.Select(attribute => attribute.Key);
+
+        public IEnumerable<TAttributeValue> Values => _attributes.Select(attribute => attribute.Value);
+
+        public TagHelperAttribute<TAttributeValue> this[[NotNull] string key] =>
+            _attributes.LastOrDefault(attribute => MatchesAttribute(key, attribute));
+
+        public TagHelperAttribute<TAttributeValue> this[int index]
+        {
+            get
+            {
+                return _attributes[index];
+            }
+            set
+            {
+                _attributes[index] = value;
+            }
+        }
+
+        public bool TryGetAttribute([NotNull] string key, out TagHelperAttribute<TAttributeValue> attribute)
+        {
+            attribute = this[key];
+
+            return attribute != null;
+        }
+
+        public bool TryGetAttributes([NotNull] string key, out IEnumerable<TagHelperAttribute<TAttributeValue>> attributes)
+        {
+            attributes = _attributes.Where(attribute => MatchesAttribute(key, attribute));
+
+            return attributes.Any();
+        }
+
+        public void Add([NotNull] string key)
+        {
+            _attributes.Add(new TagHelperAttribute<TAttributeValue>(key)
+            {
+                Minimized = true
+            });
+        }
+
+        public void Add([NotNull] string key, TAttributeValue value)
+        {
+            _attributes.Add(new TagHelperAttribute<TAttributeValue>(key, value));
+        }
+
+        public void Add([NotNull] TagHelperAttribute<TAttributeValue> attribute)
+        {
+            _attributes.Add(attribute);
+        }
+
+        public void Insert(int index, TagHelperAttribute<TAttributeValue> item)
+        {
+            _attributes.Insert(index, item);
+        }
+
+        public void CopyTo([NotNull] TagHelperAttribute<TAttributeValue>[] attributes, int index)
+        {
+            _attributes.CopyTo(attributes, index);
+        }
+
+        public bool Remove([NotNull] string key)
+        {
+            IEnumerable<TagHelperAttribute<TAttributeValue>> attributes;
+            if (TryGetAttributes(key, out attributes))
+            {
+                foreach (var attribute in attributes)
+                {
+                    Remove(attribute);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool Remove([NotNull] TagHelperAttribute<TAttributeValue> item)
+        {
+            // REVIEW: Do we want this to be a comparer remove? If so it'd remove more than one.
+            return _attributes.Remove(item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _attributes.RemoveAt(index);
+        }
+
+        public void Clear()
+        {
+            _attributes.Clear();
+        }
+
+        public bool Contains([NotNull] string key)
+        {
+            return _attributes.Any(attribute => MatchesAttribute(key, attribute));
+        }
+
+        public bool Contains([NotNull] TagHelperAttribute<TAttributeValue> item)
+        {
+            // REVIEW: Do we want this to be a comparer check?
+            return _attributes.Contains(item);
+        }
+
+        public int IndexOf([NotNull] TagHelperAttribute<TAttributeValue> item)
+        {
+            return _attributes.IndexOf(item);
+        }
+
+        public IEnumerator<TagHelperAttribute<TAttributeValue>> GetEnumerator()
+        {
+            return _attributes.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private static bool MatchesAttribute(string key, TagHelperAttribute<TAttributeValue> attribute)
+        {
+            return string.Equals(key, attribute.Key, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContext.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="getChildContentAsync">A delegate used to execute and retrieve the rendered child content 
         /// asynchronously.</param>
         public TagHelperContext(
-            [NotNull] IDictionary<string, object> allAttributes,
+            [NotNull] TagHelperAttributes<object> allAttributes,
             [NotNull] IDictionary<object, object> items,
             [NotNull] string uniqueId,
             [NotNull] Func<Task<TagHelperContent>> getChildContentAsync)
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Every attribute associated with the current HTML element.
         /// </summary>
-        public IDictionary<string, object> AllAttributes { get; }
+        public TagHelperAttributes<object> AllAttributes { get; }
 
         /// <summary>
         /// Gets the collection of items used to communicate with other <see cref="ITagHelper"/>s.

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -60,8 +60,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             _endTagHelperWritingScope = endTagHelperWritingScope;
 
             SelfClosing = selfClosing;
-            AllAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-            HTMLAttributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            AllAttributes = new TagHelperAttributes<object>();
+            HTMLAttributes = new TagHelperAttributes<string>();
             TagName = tagName;
             Items = items;
             UniqueId = uniqueId;
@@ -91,12 +91,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// HTML attributes.
         /// </summary>
-        public IDictionary<string, string> HTMLAttributes { get; }
+        public TagHelperAttributes<string> HTMLAttributes { get; }
 
         /// <summary>
         /// <see cref="ITagHelper"/> bound attributes and HTML attributes.
         /// </summary>
-        public IDictionary<string, object> AllAttributes { get; }
+        public TagHelperAttributes<object> AllAttributes { get; }
 
         /// <summary>
         /// An identifier unique to the HTML element this context is for.

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         // Internal for testing
         internal TagHelperOutput(string tagName)
-            : this(tagName, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), null)
+            : this(tagName, new TagHelperAttributes<string>(), null)
         {
         }
 
@@ -37,11 +37,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// to encode HTML attribute values.</param>
         public TagHelperOutput(
             string tagName,
-            [NotNull] IDictionary<string, string> attributes,
+            [NotNull] TagHelperAttributes<string> attributes,
             [NotNull] IHtmlEncoder htmlEncoder)
         {
             TagName = tagName;
-            Attributes = new Dictionary<string, string>(attributes, StringComparer.OrdinalIgnoreCase);
+            Attributes = attributes;
             _preContent = new DefaultTagHelperContent();
             _content = new DefaultTagHelperContent();
             _postContent = new DefaultTagHelperContent();
@@ -123,7 +123,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// The HTML element's attributes.
         /// </summary>
-        public IDictionary<string, string> Attributes { get; }
+        public TagHelperAttributes<string> Attributes { get; }
 
         /// <summary>
         /// Generates the <see cref="TagHelperOutput"/>'s start tag.

--- a/src/Microsoft.AspNet.Razor/Common/HashCodeCombiner.cs
+++ b/src/Microsoft.AspNet.Razor/Common/HashCodeCombiner.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Internal.Web.Utils
 {
-    internal class HashCodeCombiner
+    public class HashCodeCombiner
     {
         private long _combinedHash64 = 0x1505L;
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperAttributeComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperAttributeComparer.cs
@@ -19,9 +19,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers.Test
 
         public bool Equals(TagHelperAttribute<TAttributeValue> attributeX, TagHelperAttribute<TAttributeValue> attributeY)
         {
-            return 
+            return
                 string.Equals(attributeX.Key, attributeY.Key, StringComparison.OrdinalIgnoreCase) &&
-                Equals(attributeX.Value, attributeY.Value);
+                object.Equals(attributeX.Value, attributeY.Value);
         }
 
         public int GetHashCode(TagHelperAttribute<TAttributeValue> attribute)

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperAttributeComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperAttributeComparer.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Internal.Web.Utils;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers.Test
+{
+    public class TagHelperAttributeComparer<TAttributeValue> : IEqualityComparer<TagHelperAttribute<TAttributeValue>>
+        where TAttributeValue : class
+    {
+        public readonly static TagHelperAttributeComparer<TAttributeValue> Default =
+            new TagHelperAttributeComparer<TAttributeValue>();
+
+        private TagHelperAttributeComparer()
+        {
+        }
+
+        public bool Equals(TagHelperAttribute<TAttributeValue> attributeX, TagHelperAttribute<TAttributeValue> attributeY)
+        {
+            return 
+                string.Equals(attributeX.Key, attributeY.Key, StringComparison.OrdinalIgnoreCase) &&
+                Equals(attributeX.Value, attributeY.Value);
+        }
+
+        public int GetHashCode(TagHelperAttribute<TAttributeValue> attribute)
+        {
+            return HashCodeCombiner
+                .Start()
+                .Add(attribute.Key, StringComparer.OrdinalIgnoreCase)
+                .Add(attribute.Value)
+                .CombinedHash;
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperContextTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Act
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(),
+                allAttributes: new TagHelperAttributes<object>(),
                 items: expectedItems,
                 uniqueId: string.Empty,
                 getChildContentAsync: () => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNet.Razor.Runtime.TagHelpers.Test;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
@@ -153,14 +154,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
-            executionContext.HTMLAttributes[originalName] = "hello";
+            executionContext.HTMLAttributes[originalName].Value = "hello";
 
             // Act
-            executionContext.HTMLAttributes[updatedName] = "something else";
+            executionContext.HTMLAttributes[updatedName].Value = "something else";
 
             // Assert
             var attribute = Assert.Single(executionContext.HTMLAttributes);
-            Assert.Equal(new KeyValuePair<string, string>(originalName, "something else"), attribute);
+            Assert.Equal(new TagHelperAttribute<string>(originalName, "something else"), attribute);
         }
 
         [MemberData(nameof(DictionaryCaseTestingData))]
@@ -168,14 +169,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
-            executionContext.AllAttributes[originalName] = false;
+            executionContext.AllAttributes[originalName].Value = false;
 
             // Act
-            executionContext.AllAttributes[updatedName] = true;
+            executionContext.AllAttributes[updatedName].Value = true;
 
             // Assert
             var attribute = Assert.Single(executionContext.AllAttributes);
-            Assert.Equal(new KeyValuePair<string, object>(originalName, true), attribute);
+            Assert.Equal(new TagHelperAttribute<object>(originalName, true), attribute);
         }
 
         [Fact]
@@ -183,7 +184,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
-            var expectedAttributes = new Dictionary<string, string>
+            var expectedAttributes = new TagHelperAttributes<string>
             {
                 { "class", "btn" },
                 { "foo", "bar" }
@@ -194,7 +195,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             executionContext.AddHtmlAttribute("foo", "bar");
 
             // Assert
-            Assert.Equal(expectedAttributes, executionContext.HTMLAttributes);
+            Assert.Equal(
+                expectedAttributes,
+                executionContext.HTMLAttributes,
+                TagHelperAttributeComparer<string>.Default);
         }
 
         [Fact]
@@ -202,7 +206,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
-            var expectedAttributes = new Dictionary<string, object>
+            var expectedAttributes = new TagHelperAttributes<object>
             {
                 { "class", "btn" },
                 { "something", true },
@@ -215,7 +219,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             executionContext.AddHtmlAttribute("foo", "bar");
 
             // Assert
-            Assert.Equal(expectedAttributes, executionContext.AllAttributes);
+            Assert.Equal(
+                expectedAttributes, 
+                executionContext.AllAttributes,
+                TagHelperAttributeComparer<object>.Default);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p", attributes:
-                new Dictionary<string, string>
+                new TagHelperAttributes<string>
                 {
                     { "class", "btn" },
                     { "something", "   spaced    " }
@@ -69,7 +69,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p",
-                attributes: new Dictionary<string, string>
+                new TagHelperAttributes<string>
                 {
                     { "class", "btn" },
                     { "something", "   spaced    " }
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p",
-                attributes: new Dictionary<string, string>
+                new TagHelperAttributes<string>
                 {
                     { "hello", "world" },
                 },
@@ -125,7 +125,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("  ",
-                attributes: new Dictionary<string, string>
+                new TagHelperAttributes<string>
                 {
                     { "class", "btn" },
                     { "something", "   spaced    " }
@@ -382,7 +382,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p",
-                attributes: new Dictionary<string, string>
+                new TagHelperAttributes<string>
                 {
                     { "class", "btn" },
                     { "something", "   spaced    " }
@@ -414,18 +414,21 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p",
-                attributes: new Dictionary<string, string>
+                new TagHelperAttributes<string>
                 {
                     { originalName, "btn" },
                 },
                 htmlEncoder: new NullHtmlEncoder());
 
             // Act
-            tagHelperOutput.Attributes[updateName] = "super button";
+            tagHelperOutput.Attributes[updateName].Value = "super button";
 
             // Assert
             var attribute = Assert.Single(tagHelperOutput.Attributes);
-            Assert.Equal(new KeyValuePair<string, string>(originalName, "super button"), attribute);
+            Assert.Equal(
+                new TagHelperAttribute<string>(originalName, "super button"), 
+                attribute, 
+                TagHelperAttributeComparer<string>.Default);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
@@ -136,8 +136,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.Equal("foo", output.TagName);
-            Assert.Equal("somethingelse", output.Attributes["class"]);
-            Assert.Equal("world", output.Attributes["hello"]);
+            Assert.Equal("somethingelse", output.Attributes["class"].Value);
+            Assert.Equal("world", output.Attributes["hello"].Value);
             Assert.Equal(true, output.SelfClosing);
         }
 
@@ -155,7 +155,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var output = await runner.RunAsync(executionContext);
 
             // Assert
-            Assert.Equal("True", output.Attributes["foo"]);
+            Assert.Equal("True", output.Attributes["foo"].Value);
         }
 
         [Fact]
@@ -200,8 +200,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 Processed = true;
 
                 output.TagName = "foo";
-                output.Attributes["class"] = "somethingelse";
-                output.Attributes["hello"] = "world";
+
+                TagHelperAttribute<string> classAttribute;
+                if (output.Attributes.TryGetAttribute("class", out classAttribute))
+                {
+                    classAttribute.Value = "somethingelse";
+                }
+
+                output.Attributes.Add("hello", "world");
                 output.SelfClosing = true;
             }
         }
@@ -220,7 +226,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             public override void Process(TagHelperContext context, TagHelperOutput output)
             {
-                output.Attributes["foo"] = context.AllAttributes["foo"].ToString();
+                output.Attributes.Add("foo", context.AllAttributes["foo"].Value.ToString());
             }
         }
 


### PR DESCRIPTION
**NOTE:** This is very designy. Just implemented the bare minimum for #279 to get some feedback on how the attribute data structure will work.

- Added a TagHelperAttributes object that's used to hold 1=>many attributes.
- Added a TagHelperAttribute object which can be used to represent attributes that may be minimized.

#279