### PR TITLE
De-dupe TagHelperDescriptors based on Type for rendering.

### DIFF
--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
@@ -19,6 +19,56 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         private static IEnumerable<TagHelperDescriptor> PrefixedPAndInputTagHelperDescriptors
             => BuildPAndInputTagHelperDescriptors("THS");
 
+        private static IEnumerable<TagHelperDescriptor> DuplicateTargetTagHelperDescriptors
+        {
+            get
+            {
+                var inputTypePropertyInfo = typeof(TestType).GetProperty("Type");
+                var inputCheckedPropertyInfo = typeof(TestType).GetProperty("Checked");
+                return new[]
+                {
+                    new TagHelperDescriptor(
+                        tagName: "*",
+                        typeName: "CatchAllTagHelper",
+                        assemblyName: "SomeAssembly",
+                        attributes: new TagHelperAttributeDescriptor[]
+                        {
+                            new TagHelperAttributeDescriptor("type", inputTypePropertyInfo)
+                        },
+                        requiredAttributes: new[] { "type" }),
+                    new TagHelperDescriptor(
+                        tagName: "*",
+                        typeName: "CatchAllTagHelper",
+                        assemblyName: "SomeAssembly",
+                        attributes: new TagHelperAttributeDescriptor[]
+                        {
+                            new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
+                            new TagHelperAttributeDescriptor("checked", inputCheckedPropertyInfo)
+                        },
+                        requiredAttributes: new[] { "type", "checked" }),
+                    new TagHelperDescriptor(
+                        tagName: "input",
+                        typeName: "InputTagHelper",
+                        assemblyName: "SomeAssembly",
+                        attributes: new TagHelperAttributeDescriptor[]
+                        {
+                            new TagHelperAttributeDescriptor("type", inputTypePropertyInfo)
+                        },
+                        requiredAttributes: new[] { "type" }),
+                    new TagHelperDescriptor(
+                        tagName: "input",
+                        typeName: "InputTagHelper",
+                        assemblyName: "SomeAssembly",
+                        attributes: new TagHelperAttributeDescriptor[]
+                        {
+                            new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
+                            new TagHelperAttributeDescriptor("checked", inputCheckedPropertyInfo)
+                        },
+                        requiredAttributes: new[] { "type", "checked" })
+                };
+            }
+        }
+
         private static IEnumerable<TagHelperDescriptor> AttributeTargetingTagHelperDescriptors
         {
             get
@@ -91,6 +141,13 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                         "BasicTagHelpers",
                         DefaultPAndInputTagHelperDescriptors,
                         DefaultPAndInputTagHelperDescriptors,
+                        false
+                    },
+                    {
+                        "DuplicateTargetTagHelper",
+                        "DuplicateTargetTagHelper",
+                        DuplicateTargetTagHelperDescriptors,
+                        DuplicateTargetTagHelperDescriptors,
                         false
                     },
                     {
@@ -410,6 +467,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     { "BasicTagHelpers.RemoveTagHelper", DefaultPAndInputTagHelperDescriptors },
                     { "BasicTagHelpers.Prefixed", PrefixedPAndInputTagHelperDescriptors },
                     { "ComplexTagHelpers", DefaultPAndInputTagHelperDescriptors },
+                    { "DuplicateTargetTagHelper", DuplicateTargetTagHelperDescriptors },
                     { "EmptyAttributeTagHelpers", DefaultPAndInputTagHelperDescriptors },
                     { "EscapedTagHelpers", DefaultPAndInputTagHelperDescriptors },
                     { "AttributeTargetingTagHelpers", AttributeTargetingTagHelperDescriptors },

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/DuplicateTargetTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/DuplicateTargetTagHelper.cs
@@ -1,0 +1,48 @@
+#pragma checksum "DuplicateTargetTagHelper.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "9cd2f5a40be40d26a0756bf6a74cee58bd13927f"
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class DuplicateTargetTagHelper
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private TagHelperContent __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private TagHelperRunner __tagHelperRunner = null;
+        private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private InputTagHelper __InputTagHelper = null;
+        private CatchAllTagHelper __CatchAllTagHelper = null;
+        #line hidden
+        public DuplicateTargetTagHelper()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __tagHelperRunner = __tagHelperRunner ?? new TagHelperRunner();
+            Instrumentation.BeginContext(33, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            __InputTagHelper.Type = "checkbox";
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __InputTagHelper.Type);
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__CatchAllTagHelper);
+            __CatchAllTagHelper.Type = __InputTagHelper.Type;
+            __tagHelperExecutionContext.AddHtmlAttribute("checked", "true");
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/DuplicateTargetTagHelper.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/DuplicateTargetTagHelper.cshtml
@@ -1,0 +1,3 @@
+﻿@addTagHelper "something, nice"
+
+<input type="checkbox" checked="true" />


### PR DESCRIPTION
- This can occur if you have multiple [TargetElement] attributes that overlap. Ultimately the descriptor is the same because its the same type, just the required attributes differ.
- Added tests to validate.

#326