### PR TITLE
Fix build break in razor tests

### DIFF
--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
@@ -46,8 +46,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 #if DNX451
                 "abcd' or one of its dependencies. The system cannot find the file specified.";
 #else
-                "abcd, Culture=neutral, PublicKeyToken=null' or one of its dependencies. Could not find or load a " +
-                "specific file. (Exception from HRESULT: 0x80131621)";
+                "abcd, Culture=neutral, PublicKeyToken=null' or one of its dependencies. " +
+                "The system cannot find the file specified.";
 #endif
 
             // Act


### PR DESCRIPTION
This message changed because we got a fix in CoreCLR for a bug in the
host that was impacting Type.GetType and breaking data contract
serializer.