### PR TITLE
Enforce new invariants around HTML encoding (#335)

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             SelfClosing = selfClosing;
             AllAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-            HTMLAttributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            HTMLAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             TagName = tagName;
             Items = items;
             UniqueId = uniqueId;
@@ -91,7 +91,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// HTML attributes.
         /// </summary>
-        public IDictionary<string, string> HTMLAttributes { get; }
+        public IDictionary<string, object> HTMLAttributes { get; }
 
         /// <summary>
         /// <see cref="ITagHelper"/> bound attributes and HTML attributes.
@@ -138,7 +138,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// </summary>
         /// <param name="name">The HTML attribute name.</param>
         /// <param name="value">The HTML attribute value.</param>
-        public void AddHtmlAttribute([NotNull] string name, string value)
+        public void AddHtmlAttribute([NotNull] string name, object value)
         {
             HTMLAttributes.Add(name, value);
             AllAttributes.Add(name, value);

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         // Internal for testing
         internal TagHelperOutput(string tagName)
-            : this(tagName, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase))
+            : this(tagName, new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase))
         {
         }
 
@@ -31,10 +31,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="attributes">The HTML attributes.</param>
         public TagHelperOutput(
             string tagName,
-            [NotNull] IDictionary<string, string> attributes)
+            [NotNull] IDictionary<string, object> attributes)
         {
             TagName = tagName;
-            Attributes = new Dictionary<string, string>(attributes, StringComparer.OrdinalIgnoreCase);
+            Attributes = new Dictionary<string, object>(attributes, StringComparer.OrdinalIgnoreCase);
             _preContent = new DefaultTagHelperContent();
             _content = new DefaultTagHelperContent();
             _postContent = new DefaultTagHelperContent();
@@ -63,7 +63,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// The HTML element's main content.
         /// </summary>
-        /// <remarks>Value occurs in the <see cref="ITagHelper"/>'s final output after <see cref="PreContent"/> and 
+        /// <remarks>Value occurs in the <see cref="ITagHelper"/>'s final output after <see cref="PreContent"/> and
         /// before <see cref="PostContent"/></remarks>
         public TagHelperContent Content
         {
@@ -104,7 +104,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// The HTML element's attributes.
         /// </summary>
-        public IDictionary<string, string> Attributes { get; }
+        /// <remarks>
+        /// MVC will HTML encode <see cref="string"/> values when generating the start tag. It will not HTML encode
+        /// a <c>Microsoft.AspNet.Mvc.Rendering.HtmlString</c> instance. MVC converts most other types to a
+        /// <see cref="string"/>, then HTML encodes the result.
+        /// </remarks>
+        public IDictionary<string, object> Attributes { get; }
 
         /// <summary>
         /// Changes <see cref="TagHelperOutput"/> to generate nothing.

--- a/src/Microsoft.AspNet.Razor/Generator/GeneratedTagHelperContext.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/GeneratedTagHelperContext.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNet.Razor.Generator
             ExecutionContextAddTagHelperAttributeMethodName = "AddTagHelperAttribute";
             ExecutionContextAddHtmlAttributeMethodName = "AddHtmlAttribute";
             ExecutionContextOutputPropertyName = "Output";
+            MarkAsHtmlEncodedMethodName = "Html.Raw";
             StartTagHelperWritingScopeMethodName = "StartTagHelperWritingScope";
             EndTagHelperWritingScopeMethodName = "EndTagHelperWritingScope";
             RunnerTypeName = "TagHelperRunner";
@@ -70,6 +71,12 @@ namespace Microsoft.AspNet.Razor.Generator
         /// The property accessor for the tag helper's output.
         /// </summary>
         public string ExecutionContextOutputPropertyName { get; set; }
+
+        /// <summary>
+        /// The name of the method used to wrap a <see cref="string"/> value and mark it as HTML-encoded.
+        /// </summary>
+        /// <remarks>Used together with <see cref="ExecutionContextAddHtmlAttributeMethodName"/>.</remarks>
+        public string MarkAsHtmlEncodedMethodName { get; set; }
 
         /// <summary>
         /// The name of the method used to start a new writing scope.

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
@@ -160,7 +160,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             var attribute = Assert.Single(executionContext.HTMLAttributes);
-            Assert.Equal(new KeyValuePair<string, string>(originalName, "something else"), attribute);
+            Assert.Equal(new KeyValuePair<string, object>(originalName, "something else"), attribute);
         }
 
         [MemberData(nameof(DictionaryCaseTestingData))]
@@ -183,7 +183,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
-            var expectedAttributes = new Dictionary<string, string>
+            var expectedAttributes = new Dictionary<string, object>
             {
                 { "class", "btn" },
                 { "foo", "bar" }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p",
-                attributes: new Dictionary<string, string>
+                attributes: new Dictionary<string, object>
                 {
                     { "class", "btn" },
                     { "something", "   spaced    " }
@@ -129,7 +129,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p",
-                attributes: new Dictionary<string, string>
+                attributes: new Dictionary<string, object>
                 {
                     { originalName, "btn" },
                 });
@@ -139,7 +139,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             var attribute = Assert.Single(tagHelperOutput.Attributes);
-            Assert.Equal(new KeyValuePair<string, string>(originalName, "super button"), attribute);
+            Assert.Equal(new KeyValuePair<string, object>(originalName, "super button"), attribute);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/AttributeTargetingTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/AttributeTargetingTagHelpers.cs
@@ -38,7 +38,7 @@ namespace TestOutput
                 , StartTagHelperWritingScope, EndTagHelperWritingScope);
                 __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
                 __tagHelperExecutionContext.Add(__CatchAllTagHelper);
-                __tagHelperExecutionContext.AddHtmlAttribute("catchAll", "hi");
+                __tagHelperExecutionContext.AddHtmlAttribute("catchAll", Html.Raw("hi"));
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 await WriteTagHelperAsync(__tagHelperExecutionContext);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
@@ -81,7 +81,7 @@ namespace TestOutput
                 __tagHelperExecutionContext.AddTagHelperAttribute("checked", __InputTagHelper2.Checked);
                 __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
                 __tagHelperExecutionContext.Add(__CatchAllTagHelper);
-                __tagHelperExecutionContext.AddHtmlAttribute("catchAll", "hi");
+                __tagHelperExecutionContext.AddHtmlAttribute("catchAll", Html.Raw("hi"));
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 await WriteTagHelperAsync(__tagHelperExecutionContext);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
@@ -90,7 +90,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", "btn");
+            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("btn"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
@@ -77,7 +77,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", "Hello World");
+            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.Prefixed.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.Prefixed.cs
@@ -55,7 +55,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", "Hello World");
+            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/BasicTagHelpers.cs
@@ -78,7 +78,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", "Hello World");
+            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/ComplexTagHelpers.cs
@@ -69,8 +69,8 @@ namespace TestOutput
                     __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
                     __tagHelperExecutionContext.Add(__InputTagHelper2);
                     __InputTagHelper2.Type = __InputTagHelper.Type;
-                    __tagHelperExecutionContext.AddHtmlAttribute("value", "");
-                    __tagHelperExecutionContext.AddHtmlAttribute("placeholder", "Enter in a new time...");
+                    __tagHelperExecutionContext.AddHtmlAttribute("value", Html.Raw(""));
+                    __tagHelperExecutionContext.AddHtmlAttribute("placeholder", Html.Raw("Enter in a new time..."));
                     __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                     await WriteTagHelperAsync(__tagHelperExecutionContext);
                     __tagHelperExecutionContext = __tagHelperScopeManager.End();
@@ -100,7 +100,7 @@ namespace TestOutput
                     __tagHelperExecutionContext.Add(__InputTagHelper);
                     StartTagHelperWritingScope();
 #line 16 "ComplexTagHelpers.cshtml"
-Write(checkbox);
+WriteLiteral(checkbox);
 
 #line default
 #line hidden
@@ -134,7 +134,7 @@ Write(checkbox);
                 __tagHelperExecutionContext.Add(__InputTagHelper);
                 StartTagHelperWritingScope();
 #line 17 "ComplexTagHelpers.cshtml"
-Write(true ? "checkbox" : "anything");
+WriteLiteral(true ? "checkbox" : "anything");
 
 #line default
 #line hidden
@@ -203,7 +203,7 @@ Write(DateTime.Now);
 #line default
 #line hidden
             __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-            __tagHelperExecutionContext.AddHtmlAttribute("time", __tagHelperStringValueBuffer.ToString());
+            __tagHelperExecutionContext.AddHtmlAttribute("time", Html.Raw(__tagHelperStringValueBuffer.ToString()));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EmptyAttributeTagHelpers.cs
@@ -45,7 +45,7 @@ __InputTagHelper2.Checked = ;
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("checked", __InputTagHelper2.Checked);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", "");
+            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw(""));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
@@ -70,7 +70,7 @@ __InputTagHelper2.Checked = ;
 #line default
 #line hidden
                 __tagHelperExecutionContext.AddTagHelperAttribute("checked", __InputTagHelper2.Checked);
-                __tagHelperExecutionContext.AddHtmlAttribute("class", "");
+                __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw(""));
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 await WriteTagHelperAsync(__tagHelperExecutionContext);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/EscapedTagHelpers.cs
@@ -45,7 +45,7 @@ namespace TestOutput
             __tagHelperExecutionContext.Add(__InputTagHelper);
             StartTagHelperWritingScope();
 #line 6 "EscapedTagHelpers.cshtml"
-Write(DateTime.Now);
+WriteLiteral(DateTime.Now);
 
 #line default
 #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/SingleTagHelper.cs
@@ -39,7 +39,7 @@ namespace TestOutput
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("age", __PTagHelper.Age);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", "Hello World");
+            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/TagHelpersInSection.cs
@@ -64,7 +64,7 @@ namespace TestOutput
                 StartTagHelperWritingScope();
                 WriteLiteral("Current Time: ");
 #line 9 "TagHelpersInSection.cshtml"
-Write(DateTime.Now);
+WriteLiteral(DateTime.Now);
 
 #line default
 #line hidden
@@ -79,7 +79,7 @@ Write(DateTime.Now);
 #line default
 #line hidden
                 __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __tagHelperExecutionContext.AddHtmlAttribute("unboundproperty", __tagHelperStringValueBuffer.ToString());
+                __tagHelperExecutionContext.AddHtmlAttribute("unboundproperty", Html.Raw(__tagHelperStringValueBuffer.ToString()));
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 await WriteTagHelperToAsync(__razor_template_writer, __tagHelperExecutionContext);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();


### PR DESCRIPTION
- bound `string` attribute values are _not_ encoded
 - rework `CSharpCodeVisitor` to enable this case
- values in `TagHelperOutput.Attributes` are encoded unless special-cased elsewhere
 - opens door for `RazorPage` to use `HtmlString`