### PR TITLE
Rationalize some names and namespaces

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.TagHelpers;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public static IEnumerable<TagHelperDescriptor> CreateDescriptors(
             string assemblyName,
             [NotNull] Type type,
-            [NotNull] ParserErrorSink errorSink)
+            [NotNull] ErrorSink errorSink)
         {
             var typeInfo = type.GetTypeInfo();
             var attributeDescriptors = GetAttributeDescriptors(type);
@@ -60,7 +60,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         private static IEnumerable<TargetElementAttribute> GetValidTargetElementAttributes(
             TypeInfo typeInfo,
-            ParserErrorSink errorSink)
+            ErrorSink errorSink)
         {
             var targetElementAttributes = typeInfo.GetCustomAttributes<TargetElementAttribute>(inherit: false);
 
@@ -146,7 +146,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// </summary>
         internal static bool ValidTargetElementAttributeNames(
             TargetElementAttribute attribute,
-            ParserErrorSink errorSink)
+            ErrorSink errorSink)
         {
             var validTagName = ValidateName(attribute.Tag, targetingAttributes: false, errorSink: errorSink);
             var validAttributeNames = true;
@@ -166,7 +166,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         private static bool ValidateName(
             string name,
             bool targetingAttributes,
-            ParserErrorSink errorSink)
+            ErrorSink errorSink)
         {
             var targetName = targetingAttributes ?
                 Resources.TagHelperDescriptorFactory_Attribute :

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         protected virtual IEnumerable<TagHelperDescriptor> ResolveDescriptorsInAssembly(
             string assemblyName,
             SourceLocation documentLocation,
-            ParserErrorSink errorSink)
+            ErrorSink errorSink)
         {
             // Resolve valid tag helper types from the assembly.
             var tagHelperTypes = _typeResolver.Resolve(assemblyName, documentLocation, errorSink);
@@ -191,7 +191,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         private static bool EnsureValidPrefix(
             string prefix,
             SourceLocation directiveLocation,
-            ParserErrorSink errorSink)
+            ErrorSink errorSink)
         {
             foreach (var character in prefix)
             {
@@ -233,7 +233,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         private static LookupInfo GetLookupInfo(TagHelperDirectiveDescriptor directiveDescriptor,
-                                                ParserErrorSink errorSink)
+                                                ErrorSink errorSink)
         {
             var lookupText = directiveDescriptor.DirectiveText;
             var lookupStrings = lookupText?.Split(new[] { ',' });

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.TagHelpers;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperScopeManager.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperScopeManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Framework.Internal;
 

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
@@ -33,13 +33,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="documentLocation">The <see cref="SourceLocation"/> of the associated
         /// <see cref="Parser.SyntaxTree.SyntaxTreeNode"/> responsible for the current <see cref="Resolve"/> call.
         /// </param>
-        /// <param name="errorSink">The <see cref="ParserErrorSink"/> used to record errors found when resolving 
+        /// <param name="errorSink">The <see cref="ErrorSink"/> used to record errors found when resolving
         /// <see cref="ITagHelper"/> <see cref="Type"/>s.</param>
         /// <returns>An <see cref="IEnumerable{Type}"/> of valid <see cref="ITagHelper"/> <see cref="Type"/>s.
-        /// </returns>        
+        /// </returns>
         public IEnumerable<Type> Resolve(string name, 
                                          SourceLocation documentLocation, 
-                                         [NotNull] ParserErrorSink errorSink)
+                                         [NotNull] ErrorSink errorSink)
         {
             if (string.IsNullOrEmpty(name))
             {

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Microsoft.AspNet.Razor.Parser;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers

--- a/src/Microsoft.AspNet.Razor/Editor/RazorEditorTrace.cs
+++ b/src/Microsoft.AspNet.Razor/Editor/RazorEditorTrace.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+#if NET45
 using System.Globalization;
+#endif
 
 namespace Microsoft.AspNet.Razor.Editor
 {

--- a/src/Microsoft.AspNet.Razor/ErrorSink.cs
+++ b/src/Microsoft.AspNet.Razor/ErrorSink.cs
@@ -2,22 +2,20 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 
-namespace Microsoft.AspNet.Razor.Parser
+namespace Microsoft.AspNet.Razor
 {
     /// <summary>
     /// Used to manage <see cref="RazorError"/>s encountered during the Razor parsing phase.
     /// </summary>
-    public class ParserErrorSink
+    public class ErrorSink
     {
         private readonly List<RazorError> _errors;
 
         /// <summary>
-        /// Instantiates a new instance of <see cref="ParserErrorSink"/>.
+        /// Instantiates a new instance of <see cref="ErrorSink"/>.
         /// </summary>
-        public ParserErrorSink()
+        public ErrorSink()
         {
             _errors = new List<RazorError>();
         }

--- a/src/Microsoft.AspNet.Razor/Generator/CodeBuilderContext.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/CodeBuilderContext.cs
@@ -15,10 +15,10 @@ namespace Microsoft.AspNet.Razor.Generator
         /// </summary>
         /// <param name="generatorContext">A <see cref="CodeGeneratorContext"/> to copy information from.</param>
         /// <param name="errorSink">
-        /// The <see cref="ParserErrorSink"/> used to collect <see cref="Parser.SyntaxTree.RazorError"/>s encountered
+        /// The <see cref="ErrorSink"/> used to collect <see cref="RazorError"/>s encountered
         /// when parsing the current Razor document.
         /// </param>
-        public CodeBuilderContext(CodeGeneratorContext generatorContext, ParserErrorSink errorSink)
+        public CodeBuilderContext(CodeGeneratorContext generatorContext, ErrorSink errorSink)
             : base(generatorContext)
         {
             ErrorSink = errorSink;
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Razor.Generator
                                     string rootNamespace,
                                     string sourceFile,
                                     bool shouldGenerateLinePragmas,
-                                    ParserErrorSink errorSink)
+                                    ErrorSink errorSink)
             : base(host, className, rootNamespace, sourceFile, shouldGenerateLinePragmas)
         {
             ErrorSink = errorSink;
@@ -67,8 +67,8 @@ namespace Microsoft.AspNet.Razor.Generator
         public string Checksum { get; set; }
 
         /// <summary>
-        /// Used to aggregate <see cref="Parser.SyntaxTree.RazorError"/>s.
+        /// Used to aggregate <see cref="RazorError"/>s.
         /// </summary>
-        public ParserErrorSink ErrorSink { get; }
+        public ErrorSink ErrorSink { get; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/CodeBuilderContext.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/CodeBuilderContext.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Razor.Parser;
-
 namespace Microsoft.AspNet.Razor.Generator
 {
     /// <summary>

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpLineMappingWriter.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpLineMappingWriter.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
 {

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpCodeVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpCodeVisitor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Globalization;
 using System.Linq;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
 {

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
 {

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CodeWriter.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CodeWriter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler
 {

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/Chunk.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeTree/Chunks/Chunk.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler
 {

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/MappingLocation.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/MappingLocation.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Globalization;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler
 {

--- a/src/Microsoft.AspNet.Razor/Generator/TagHelperCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/TagHelperCodeGenerator.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNet.Razor.Generator.Compiler;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Parser.TagHelpers;
 using Microsoft.AspNet.Razor.TagHelpers;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Generator
 {

--- a/src/Microsoft.AspNet.Razor/GeneratorResults.cs
+++ b/src/Microsoft.AspNet.Razor/GeneratorResults.cs
@@ -39,14 +39,14 @@ namespace Microsoft.AspNet.Razor
         /// The <see cref="TagHelperDescriptor"/>s that apply to the current Razor document.
         /// </param>
         /// <param name="errorSink">
-        /// The <see cref="ParserErrorSink"/> used to collect <see cref="RazorError"/>s encountered when parsing the
+        /// The <see cref="ErrorSink"/> used to collect <see cref="RazorError"/>s encountered when parsing the
         /// current Razor document.
         /// </param>
         /// <param name="codeBuilderResult">The results of generating code for the document.</param>
         /// <param name="codeTree">A <see cref="CodeTree"/> for the document.</param>
         public GeneratorResults([NotNull] Block document,
                                 [NotNull] IEnumerable<TagHelperDescriptor> tagHelperDescriptors,
-                                [NotNull] ParserErrorSink errorSink,
+                                [NotNull] ErrorSink errorSink,
                                 [NotNull] CodeBuilderResult codeBuilderResult,
                                 [NotNull] CodeTree codeTree)
             : base(document, tagHelperDescriptors, errorSink)

--- a/src/Microsoft.AspNet.Razor/GeneratorResults.cs
+++ b/src/Microsoft.AspNet.Razor/GeneratorResults.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNet.Razor.Generator.Compiler;
-using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.TagHelpers;
 

--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
@@ -5,11 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 
 namespace Microsoft.AspNet.Razor.Parser

--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Statements.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Statements.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 
 namespace Microsoft.AspNet.Razor.Parser

--- a/src/Microsoft.AspNet.Razor/Parser/CSharpLanguageCharacteristics.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpLanguageCharacteristics.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;

--- a/src/Microsoft.AspNet.Razor/Parser/ConditionalAttributeCollapser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/ConditionalAttributeCollapser.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer;
 
 namespace Microsoft.AspNet.Razor.Parser

--- a/src/Microsoft.AspNet.Razor/Parser/HtmlLanguageCharacteristics.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/HtmlLanguageCharacteristics.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;

--- a/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.Document.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.Document.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 

--- a/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 

--- a/src/Microsoft.AspNet.Razor/Parser/LanguageCharacteristics.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/LanguageCharacteristics.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;

--- a/src/Microsoft.AspNet.Razor/Parser/MarkupCollapser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/MarkupCollapser.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Parser
 {

--- a/src/Microsoft.AspNet.Razor/Parser/MarkupRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/MarkupRewriter.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Parser
 {

--- a/src/Microsoft.AspNet.Razor/Parser/ParserBase.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/ParserBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Parser
 {

--- a/src/Microsoft.AspNet.Razor/Parser/ParserContext.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/ParserContext.cs
@@ -22,13 +22,13 @@ namespace Microsoft.AspNet.Razor.Parser
         private bool _terminated = false;
 
         private Stack<BlockBuilder> _blockStack = new Stack<BlockBuilder>();
-        private readonly ParserErrorSink _errorSink;
+        private readonly ErrorSink _errorSink;
 
         public ParserContext([NotNull] ITextDocument source,
                              [NotNull] ParserBase codeParser,
                              [NotNull] ParserBase markupParser,
                              [NotNull] ParserBase activeParser,
-                             [NotNull] ParserErrorSink errorSink)
+                             [NotNull] ErrorSink errorSink)
         {
             if (activeParser != codeParser && activeParser != markupParser)
             {

--- a/src/Microsoft.AspNet.Razor/Parser/ParserVisitorExtensions.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/ParserVisitorExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 
 namespace Microsoft.AspNet.Razor.Parser
 {

--- a/src/Microsoft.AspNet.Razor/Parser/RazorParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/RazorParser.cs
@@ -148,7 +148,7 @@ namespace Microsoft.AspNet.Razor.Parser
         private ParserResults ParseCore(ITextDocument input)
         {
             // Setup the parser context
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var context = new ParserContext(input, CodeParser, MarkupParser, MarkupParser, errorSink)
             {
                 DesignTimeMode = DesignTimeMode
@@ -210,7 +210,7 @@ namespace Microsoft.AspNet.Razor.Parser
         /// <returns><see cref="TagHelperDescriptor"/>s that are applicable to the <paramref name="documentRoot"/>
         /// </returns>
         protected virtual IEnumerable<TagHelperDescriptor> GetTagHelperDescriptors([NotNull] Block documentRoot,
-                                                                                   [NotNull] ParserErrorSink errorSink)
+                                                                                   [NotNull] ErrorSink errorSink)
         {
             var addOrRemoveTagHelperSpanVisitor = 
                 new TagHelperDirectiveSpanVisitor(TagHelperDescriptorResolver, errorSink);

--- a/src/Microsoft.AspNet.Razor/Parser/RewritingContext.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/RewritingContext.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.Razor.Parser
         /// <summary>
         /// Instantiates a new <see cref="RewritingContext"/>.
         /// </summary>
-        public RewritingContext(Block syntaxTree, ParserErrorSink errorSink)
+        public RewritingContext(Block syntaxTree, ErrorSink errorSink)
         {
             _errors = new List<RazorError>();
             SyntaxTree = syntaxTree;
@@ -29,6 +29,6 @@ namespace Microsoft.AspNet.Razor.Parser
         /// </summary>
         public Block SyntaxTree { get; set; }
 
-        public ParserErrorSink ErrorSink { get; }
+        public ErrorSink ErrorSink { get; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/SyntaxTreeNode.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/SyntaxTreeNode.cs
@@ -35,7 +35,8 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         /// </summary>
         /// <param name="node">The node to compare this node with</param>
         /// <returns>
-        /// true if the provided node has all the same content and metadata, though the specific quantity and type of symbols may be different.
+        /// true if the provided node has all the same content and metadata, though the specific quantity and type of
+        /// symbols may be different.
         /// </returns>
         public abstract bool EquivalentTo(SyntaxTreeNode node);
     }

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/SyntaxTreeNode.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/SyntaxTreeNode.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Razor.Text;
-
 namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 {
     public abstract class SyntaxTreeNode

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.TagHelpers;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Parser.TagHelpers

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.TagHelpers;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Parser.TagHelpers
 {

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.TagHelpers;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 
 namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             bool validStructure,
             Block tag,
             IEnumerable<TagHelperDescriptor> descriptors,
-            ParserErrorSink errorSink)
+            ErrorSink errorSink)
         {
             // There will always be at least one child for the '<'.
             var start = tag.Children.First().Start;
@@ -37,7 +37,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             bool validStructure,
             Block tagBlock,
             IEnumerable<TagHelperDescriptor> descriptors,
-            ParserErrorSink errorSink)
+            ErrorSink errorSink)
         {
             var attributes = new Dictionary<string, SyntaxTreeNode>(StringComparer.OrdinalIgnoreCase);
 
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
         private static bool TryParseSpan(
             Span span,
             IReadOnlyDictionary<string, string> attributeValueTypes,
-            ParserErrorSink errorSink,
+            ErrorSink errorSink,
             out KeyValuePair<string, SyntaxTreeNode> attribute)
         {
             var afterEquals = false;
@@ -249,7 +249,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             string tagName,
             Block block,
             IReadOnlyDictionary<string, string> attributeValueTypes,
-            ParserErrorSink errorSink,
+            ErrorSink errorSink,
             out KeyValuePair<string, SyntaxTreeNode> attribute)
         {
             // TODO: Accept more than just spans: https://github.com/aspnet/Razor/issues/96.

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperDirectiveSpanVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperDirectiveSpanVisitor.cs
@@ -15,18 +15,18 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
     public class TagHelperDirectiveSpanVisitor : ParserVisitor
     {
         private readonly ITagHelperDescriptorResolver _descriptorResolver;
-        private readonly ParserErrorSink _errorSink;
+        private readonly ErrorSink _errorSink;
 
         private List<TagHelperDirectiveDescriptor> _directiveDescriptors;
 
         // Internal for testing use
         internal TagHelperDirectiveSpanVisitor(ITagHelperDescriptorResolver descriptorResolver)
-            : this(descriptorResolver, new ParserErrorSink())
+            : this(descriptorResolver, new ErrorSink())
         {
         }
 
         public TagHelperDirectiveSpanVisitor([NotNull] ITagHelperDescriptorResolver descriptorResolver,
-                                               [NotNull] ParserErrorSink errorSink)
+                                               [NotNull] ErrorSink errorSink)
         {
             _descriptorResolver = descriptorResolver;
             _errorSink = errorSink;
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         // Allows MVC a chance to override the TagHelperDescriptorResolutionContext
         protected virtual TagHelperDescriptorResolutionContext GetTagHelperDescriptorResolutionContext(
             [NotNull] IEnumerable<TagHelperDirectiveDescriptor> descriptors,
-            [NotNull] ParserErrorSink errorSink)
+            [NotNull] ErrorSink errorSink)
         {
             return new TagHelperDescriptorResolutionContext(descriptors, errorSink);
         }

--- a/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.Helpers.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.Helpers.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 using Microsoft.AspNet.Razor.Utils;

--- a/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 

--- a/src/Microsoft.AspNet.Razor/Parser/WhitespaceRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/WhitespaceRewriter.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Parser
 {

--- a/src/Microsoft.AspNet.Razor/ParserResults.cs
+++ b/src/Microsoft.AspNet.Razor/ParserResults.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.TagHelpers;
 

--- a/src/Microsoft.AspNet.Razor/ParserResults.cs
+++ b/src/Microsoft.AspNet.Razor/ParserResults.cs
@@ -22,12 +22,12 @@ namespace Microsoft.AspNet.Razor
         /// The <see cref="TagHelperDescriptor"/>s that apply to the current Razor document.
         /// </param>
         /// <param name="errorSink">
-        /// The <see cref="ParserErrorSink"/> used to collect <see cref="RazorError"/>s encountered when parsing the
+        /// The <see cref="ErrorSink"/> used to collect <see cref="RazorError"/>s encountered when parsing the
         /// current Razor document.
         /// </param>
         public ParserResults([NotNull] Block document,
                              [NotNull] IEnumerable<TagHelperDescriptor> tagHelperDescriptors,
-                             [NotNull] ParserErrorSink errorSink)
+                             [NotNull] ErrorSink errorSink)
             : this(!errorSink.Errors.Any(), document, tagHelperDescriptors, errorSink)
         {
         }
@@ -41,13 +41,13 @@ namespace Microsoft.AspNet.Razor
         /// The <see cref="TagHelperDescriptor"/>s that apply to the current Razor document.
         /// </param>
         /// <param name="errorSink">
-        /// The <see cref="ParserErrorSink"/> used to collect <see cref="RazorError"/>s encountered when parsing the
+        /// The <see cref="ErrorSink"/> used to collect <see cref="RazorError"/>s encountered when parsing the
         /// current Razor document.
         /// </param>
         protected ParserResults(bool success,
                                 [NotNull] Block document,
                                 [NotNull] IEnumerable<TagHelperDescriptor> tagHelperDescriptors,
-                                [NotNull] ParserErrorSink errorSink)
+                                [NotNull] ErrorSink errorSink)
         {
             Success = success;
             Document = document;
@@ -71,7 +71,7 @@ namespace Microsoft.AspNet.Razor
         /// <summary>
         /// Used to aggregate <see cref="RazorError"/>s.
         /// </summary>
-        public ParserErrorSink ErrorSink { get; }
+        public ErrorSink ErrorSink { get; }
 
         /// <summary>
         /// The list of errors which occurred during parsing.

--- a/src/Microsoft.AspNet.Razor/RazorError.cs
+++ b/src/Microsoft.AspNet.Razor/RazorError.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Globalization;
-using Microsoft.AspNet.Razor.Text;
 
-namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
+namespace Microsoft.AspNet.Razor
 {
     public class RazorError : IEquatable<RazorError>
     {
@@ -48,7 +47,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         public override bool Equals(object obj)
         {
             var err = obj as RazorError;
-            return (err != null) && (Equals(err));
+            return (err != null) && Equals(err);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/SourceLocation.cs
+++ b/src/Microsoft.AspNet.Razor/SourceLocation.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Globalization;
+using Microsoft.AspNet.Razor.Text;
 
-namespace Microsoft.AspNet.Razor.Text
+namespace Microsoft.AspNet.Razor
 {
 #if NET45
     // No Serializable attribute in CoreCLR (no need for it anymore?)
@@ -36,7 +37,12 @@ namespace Microsoft.AspNet.Razor.Text
 
         public override string ToString()
         {
-            return String.Format(CultureInfo.CurrentCulture, "({0}:{1},{2})", AbsoluteIndex, LineIndex, CharacterIndex);
+            return String.Format(
+                CultureInfo.CurrentCulture,
+                "({0}:{1},{2})",
+                AbsoluteIndex,
+                LineIndex,
+                CharacterIndex);
         }
 
         public override bool Equals(object obj)
@@ -74,19 +80,26 @@ namespace Microsoft.AspNet.Razor.Text
             if (right.LineIndex > 0)
             {
                 // Column index doesn't matter
-                return new SourceLocation(left.AbsoluteIndex + right.AbsoluteIndex, left.LineIndex + right.LineIndex, right.CharacterIndex);
+                return new SourceLocation(
+                    left.AbsoluteIndex + right.AbsoluteIndex,
+                    left.LineIndex + right.LineIndex,
+                    right.CharacterIndex);
             }
             else
             {
-                return new SourceLocation(left.AbsoluteIndex + right.AbsoluteIndex, left.LineIndex + right.LineIndex, left.CharacterIndex + right.CharacterIndex);
+                return new SourceLocation(
+                    left.AbsoluteIndex + right.AbsoluteIndex,
+                    left.LineIndex + right.LineIndex,
+                    left.CharacterIndex + right.CharacterIndex);
             }
         }
 
         public static SourceLocation Subtract(SourceLocation left, SourceLocation right)
         {
-            return new SourceLocation(left.AbsoluteIndex - right.AbsoluteIndex,
-                                      left.LineIndex - right.LineIndex,
-                                      left.LineIndex != right.LineIndex ? left.CharacterIndex : left.CharacterIndex - right.CharacterIndex);
+            return new SourceLocation(
+                left.AbsoluteIndex - right.AbsoluteIndex,
+                left.LineIndex - right.LineIndex,
+                left.LineIndex != right.LineIndex ? left.CharacterIndex : left.CharacterIndex - right.CharacterIndex);
         }
 
         private static SourceLocation CreateUndefined()

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorResolutionContext.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorResolutionContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
     {
         // Internal for testing purposes
         internal TagHelperDescriptorResolutionContext(IEnumerable<TagHelperDirectiveDescriptor> directiveDescriptors)
-            : this(directiveDescriptors, new ParserErrorSink())
+            : this(directiveDescriptors, new ErrorSink())
         {
         }
 
@@ -22,10 +22,10 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// </summary>
         /// <param name="directiveDescriptors"><see cref="TagHelperDirectiveDescriptor"/>s used to resolve
         /// <see cref="TagHelperDescriptor"/>s.</param>
-        /// <param name="errorSink">Used to aggregate <see cref="Parser.SyntaxTree.RazorError"/>s.</param>
+        /// <param name="errorSink">Used to aggregate <see cref="RazorError"/>s.</param>
         public TagHelperDescriptorResolutionContext(
             [NotNull] IEnumerable<TagHelperDirectiveDescriptor> directiveDescriptors,
-            [NotNull] ParserErrorSink errorSink)
+            [NotNull] ErrorSink errorSink)
         {
             DirectiveDescriptors = new List<TagHelperDirectiveDescriptor>(directiveDescriptors);
             ErrorSink = errorSink;
@@ -37,8 +37,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         public IList<TagHelperDirectiveDescriptor> DirectiveDescriptors { get; private set; }
 
         /// <summary>
-        /// Used to aggregate <see cref="Parser.SyntaxTree.RazorError"/>s.
+        /// Used to aggregate <see cref="RazorError"/>s.
         /// </summary>
-        public ParserErrorSink ErrorSink { get; private set; }
+        public ErrorSink ErrorSink { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorResolutionContext.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorResolutionContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.AspNet.Razor.Parser;
 
 namespace Microsoft.AspNet.Razor.TagHelpers
 {

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveDescriptor.cs
@@ -20,12 +20,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <summary>
         /// Instantiates a new instance of <see cref="TagHelperDirectiveDescriptor"/>.
         /// </summary>
-        /// <param name="directiveText">A <see cref="string"/> used to understand tag helper 
+        /// <param name="directiveText">A <see cref="string"/> used to understand tag helper
         /// <see cref="System.Type"/>s.</param>
         /// <param name="location">The <see cref="SourceLocation"/> of the directive.</param>
         /// <param name="directiveType">The <see cref="TagHelperDirectiveType"/> of this directive.</param>
-        public TagHelperDirectiveDescriptor([NotNull] string directiveText, 
-                                            SourceLocation location, 
+        public TagHelperDirectiveDescriptor([NotNull] string directiveText,
+                                            SourceLocation location,
                                             TagHelperDirectiveType directiveType)
         {
             DirectiveText = directiveText;

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveDescriptor.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Razor.Text;
-
 namespace Microsoft.AspNet.Razor.TagHelpers
 {
     /// <summary>

--- a/src/Microsoft.AspNet.Razor/Tokenizer/CSharpTokenizer.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/CSharpTokenizer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.AspNet.Razor.Parser;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 

--- a/src/Microsoft.AspNet.Razor/Tokenizer/HtmlTokenizer.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/HtmlTokenizer.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.AspNet.Razor.Parser;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/CSharpSymbol.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/CSharpSymbol.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
 {

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/HtmlSymbol.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/HtmlSymbol.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 
 namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
 {

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/ISymbol.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/ISymbol.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Razor.Text;
-
 namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
 {
     public interface ISymbol

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/SymbolBase.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/SymbolBase.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Tokenizer.Symbols

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Tokenizer.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Tokenizer.cs
@@ -5,11 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+#if DEBUG
 using System.Globalization;
+#endif
 using System.Linq;
 using System.Text;
 using Microsoft.AspNet.Razor.Parser;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -5,9 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.TagHelpers;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -181,7 +181,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             IEnumerable<TagHelperDescriptor> expectedDescriptors)
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
 
             // Act
             var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
@@ -229,7 +229,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             string expectedAttributeName)
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
 
             // Act
             var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
@@ -249,7 +249,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_OverridesAttributeNameFromAttribute()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var validProperty1 = typeof(OverriddenAttributeTagHelper).GetProperty(
                 nameof(OverriddenAttributeTagHelper.ValidAttribute1));
             var validProperty2 = typeof(OverriddenAttributeTagHelper).GetProperty(
@@ -280,7 +280,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_DoesNotInheritOverridenAttributeName()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var validProperty1 = typeof(InheritedOverriddenAttributeTagHelper).GetProperty(
                 nameof(InheritedOverriddenAttributeTagHelper.ValidAttribute1));
             var validProperty2 = typeof(InheritedOverriddenAttributeTagHelper).GetProperty(
@@ -312,7 +312,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_AllowsOverridenAttributeNameOnUnimplementedVirtual()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var validProperty1 = typeof(InheritedNotOverriddenAttributeTagHelper).GetProperty(
                 nameof(InheritedNotOverriddenAttributeTagHelper.ValidAttribute1));
             var validProperty2 = typeof(InheritedNotOverriddenAttributeTagHelper).GetProperty(
@@ -343,7 +343,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_BuildsDescriptorsFromSimpleTypes()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var objectAssemblyName = typeof(object).GetTypeInfo().Assembly.GetName().Name;
             var expectedDescriptor =
                 new TagHelperDescriptor("object", "System.Object", objectAssemblyName);
@@ -364,7 +364,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_BuildsDescriptorsWithInheritedProperties()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var intProperty = typeof(InheritedSingleAttributeTagHelper).GetProperty(
                 nameof(InheritedSingleAttributeTagHelper.IntAttribute));
             var expectedDescriptor = new TagHelperDescriptor(
@@ -391,7 +391,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_BuildsDescriptorsWithConventionNames()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var intProperty = typeof(SingleAttributeTagHelper).GetProperty(nameof(SingleAttributeTagHelper.IntAttribute));
             var expectedDescriptor = new TagHelperDescriptor(
                 "single-attribute",
@@ -405,7 +405,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
                 AssemblyName,
                 typeof(SingleAttributeTagHelper),
-                new ParserErrorSink());
+                new ErrorSink());
 
             // Assert
             Assert.Empty(errorSink.Errors);
@@ -417,7 +417,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_OnlyAcceptsPropertiesWithGetAndSet()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var validProperty = typeof(MissingAccessorTagHelper).GetProperty(
                 nameof(MissingAccessorTagHelper.ValidAttribute));
             var expectedDescriptor = new TagHelperDescriptor(
@@ -444,7 +444,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_OnlyAcceptsPropertiesWithPublicGetAndSet()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var validProperty = typeof(PrivateAccessorTagHelper).GetProperty(
                 nameof(PrivateAccessorTagHelper.ValidAttribute));
             var expectedDescriptor = new TagHelperDescriptor(
@@ -472,7 +472,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_ResolvesMultipleTagHelperDescriptorsFromSingleType()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var validProp = typeof(MultiTagTagHelper).GetProperty(nameof(MultiTagTagHelper.ValidAttribute));
             var expectedDescriptors = new[] {
                 new TagHelperDescriptor(
@@ -511,7 +511,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_DoesntResolveInheritedTagNames()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var validProp = typeof(InheritedMultiTagTagHelper).GetProperty(nameof(InheritedMultiTagTagHelper.ValidAttribute));
             var expectedDescriptor = new TagHelperDescriptor(
                     "inherited-multi-tag",
@@ -537,7 +537,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_IgnoresDuplicateTagNamesFromAttribute()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var expectedDescriptors = new[] {
                 new TagHelperDescriptor(
                     "div",
@@ -569,7 +569,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void CreateDescriptor_OverridesTagNameFromAttribute()
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var expectedDescriptors = new[] {
                 new TagHelperDescriptor("data-condition",
                                         typeof(OverrideNameTagHelper).FullName,
@@ -801,7 +801,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             string name, string[] expectedErrorMessages)
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var attribute = new TargetElementAttribute(name);
 
             // Act

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
@@ -326,7 +326,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var tagHelperDescriptorResolver =
                 new TestTagHelperDescriptorResolver(
                     new LookupBasedTagHelperTypeResolver(descriptorAssemblyLookups));
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var resolutionContext = new TagHelperDescriptorResolutionContext(
                 directiveDescriptors,
                 errorSink);
@@ -513,7 +513,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     new LookupBasedTagHelperTypeResolver(descriptorAssemblyLookups));
             var resolutionContext = new TagHelperDescriptorResolutionContext(
                 directiveDescriptors,
-                new ParserErrorSink());
+                new ErrorSink());
 
             // Act
             var descriptors = tagHelperDescriptorResolver.Resolve(resolutionContext);
@@ -536,7 +536,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var tagHelperDescriptorResolver = new AssemblyCheckingTagHelperDescriptorResolver();
             var context = new TagHelperDescriptorResolutionContext(
                 new[] { new TagHelperDirectiveDescriptor(lookupText, TagHelperDirectiveType.AddTagHelper) },
-                new ParserErrorSink());
+                new ErrorSink());
 
             // Act
             tagHelperDescriptorResolver.Resolve(context);
@@ -964,7 +964,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     new LookupBasedTagHelperTypeResolver(descriptorAssemblyLookups));
             var resolutionContext = new TagHelperDescriptorResolutionContext(
                 directiveDescriptors,
-                new ParserErrorSink());
+                new ErrorSink());
 
             // Act
             var descriptors = tagHelperDescriptorResolver.Resolve(resolutionContext);
@@ -1144,7 +1144,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     new LookupBasedTagHelperTypeResolver(descriptorAssemblyLookups));
             var resolutionContext = new TagHelperDescriptorResolutionContext(
                 directiveDescriptors,
-                new ParserErrorSink());
+                new ErrorSink());
 
             // Act
             var descriptors = tagHelperDescriptorResolver.Resolve(resolutionContext);
@@ -1307,7 +1307,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void DescriptorResolver_CreatesErrorIfInvalidLookupText_DoesNotThrow(string lookupText)
         {
             // Arrange
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var tagHelperDescriptorResolver =
                 new TestTagHelperDescriptorResolver(
                     new TestTagHelperTypeResolver(InvalidTestableTagHelpers));
@@ -1340,7 +1340,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                        "custom exception";
             var documentLocation = new SourceLocation(1, 2, 3);
             var directiveType = TagHelperDirectiveType.AddTagHelper;
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var expectedError = new Exception("A custom exception");
             var tagHelperDescriptorResolver = new ThrowingTagHelperDescriptorResolver(expectedError);
             var resolutionContext = new TagHelperDescriptorResolutionContext(
@@ -1416,7 +1416,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         lookupTexts.Select(
                             lookupText =>
                                 new TagHelperDirectiveDescriptor(lookupText, TagHelperDirectiveType.AddTagHelper)),
-                    new ParserErrorSink()));
+                    new ErrorSink()));
             }
         }
 
@@ -1451,7 +1451,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             protected override IEnumerable<TagHelperDescriptor> ResolveDescriptorsInAssembly(
                 string assemblyName,
                 SourceLocation documentLocation,
-                ParserErrorSink errorSink)
+                ErrorSink errorSink)
             {
                 CalledWithAssemblyName = assemblyName;
 
@@ -1471,7 +1471,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             protected override IEnumerable<TagHelperDescriptor> ResolveDescriptorsInAssembly(
                 string assemblyName,
                 SourceLocation documentLocation,
-                ParserErrorSink errorSink)
+                ErrorSink errorSink)
             {
                 throw _error;
             }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Razor.Parser;
-using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.TagHelpers;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperScopeManagerTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 using Xunit;

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperTypeResolver = new TagHelperTypeResolver();
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var documentLocation = new SourceLocation(1, 2, 3);
             var expectedErrorMessage = "Cannot resolve TagHelper containing assembly 'abcd'. Error: " +
                 "Could not load file or assembly '" +
@@ -67,7 +67,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var tagHelperTypeResolver = new TestTagHelperTypeResolver(TestableTagHelpers);
 
             // Act
-            var types = tagHelperTypeResolver.Resolve("Foo", SourceLocation.Zero, new ParserErrorSink());
+            var types = tagHelperTypeResolver.Resolve("Foo", SourceLocation.Zero, new ErrorSink());
 
             // Assert
             Assert.Equal(ValidTestableTagHelpers, types);
@@ -80,7 +80,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var tagHelperTypeResolver = new TestTagHelperTypeResolver(InvalidTestableTagHelpers);
 
             // Act
-            var types = tagHelperTypeResolver.Resolve("Foo", SourceLocation.Zero, new ParserErrorSink());
+            var types = tagHelperTypeResolver.Resolve("Foo", SourceLocation.Zero, new ErrorSink());
 
             // Assert
             Assert.Empty(types);
@@ -93,7 +93,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperTypeResolver = new TestTagHelperTypeResolver(InvalidTestableTagHelpers);
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var documentLocation = new SourceLocation(1, 2, 3);
             var expectedErrorMessage = "Tag helper directive assembly name cannot be null or empty.";
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Razor.Parser;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers

--- a/test/Microsoft.AspNet.Razor.Test/CSharpRazorCodeLanguageTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/CSharpRazorCodeLanguageTest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNet.Razor.Test
                 "myns",
                 string.Empty,
                 shouldGenerateLinePragmas: false,
-                errorSink: new ParserErrorSink());
+                errorSink: new ErrorSink());
 
             // Act
             var generator = language.CreateCodeBuilder(codeBuilderContext);

--- a/test/Microsoft.AspNet.Razor.Test/Framework/ParserTestBase.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/ParserTestBase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Razor.Test.Framework
         public virtual ParserContext CreateParserContext(ITextDocument input,
                                                          ParserBase codeParser,
                                                          ParserBase markupParser,
-                                                         ParserErrorSink errorSink)
+                                                         ErrorSink errorSink)
         {
             return new ParserContext(input,
                                      codeParser,
@@ -161,14 +161,14 @@ namespace Microsoft.AspNet.Razor.Test.Framework
             return ParseDocument(document, designTimeParser: false, errorSink: null);
         }
 
-        protected virtual ParserResults ParseDocument(string document, ParserErrorSink errorSink)
+        protected virtual ParserResults ParseDocument(string document, ErrorSink errorSink)
         {
             return ParseDocument(document, designTimeParser: false, errorSink: errorSink);
         }
 
         protected virtual ParserResults ParseDocument(string document,
                                                       bool designTimeParser,
-                                                      ParserErrorSink errorSink)
+                                                      ErrorSink errorSink)
         {
             return RunParse(document,
                             parser => parser.ParseDocument,
@@ -191,10 +191,10 @@ namespace Microsoft.AspNet.Razor.Test.Framework
                                                  Func<ParserBase, Action> parserActionSelector,
                                                  bool designTimeParser,
                                                  Func<ParserContext, ParserBase> parserSelector = null,
-                                                 ParserErrorSink errorSink = null)
+                                                 ErrorSink errorSink = null)
         {
             parserSelector = parserSelector ?? (c => c.ActiveParser);
-            errorSink = errorSink ?? new ParserErrorSink();
+            errorSink = errorSink ?? new ErrorSink();
 
             // Create the source
             ParserResults results = null;

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpRazorCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpRazorCodeGeneratorTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Generator.Compiler;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Generator

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingUnitTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingUnitTest.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Generator.Compiler;
 using Microsoft.AspNet.Razor.Generator.Compiler.CSharp;
-using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.TagHelpers;
 using Xunit;
 

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingUnitTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingUnitTest.cs
@@ -163,7 +163,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     "MyNamespace",
                     string.Empty,
                     shouldGenerateLinePragmas: true),
-                new ParserErrorSink());
+                new ErrorSink());
         }
 
         private class TrackingUniqueIdsTagHelperCodeRenderer : CSharpTagHelperCodeRenderer

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CSharpCodeBuilderTests.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CSharpCodeBuilderTests.cs
@@ -3,7 +3,6 @@
 
 #if !DNXCORE50
 using Microsoft.AspNet.Razor.Generator;
-using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Utils;
 using Moq;

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CSharpCodeBuilderTests.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/CSharpCodeBuilderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator.CodeTree
                 "TestNamespace",
                 "Foo.cs",
                 shouldGenerateLinePragmas: false,
-                errorSink: new ParserErrorSink());
+                errorSink: new ErrorSink());
             codeBuilderContext.CodeTreeBuilder.AddUsingChunk("FakeNamespace1", syntaxTreeNode.Object);
             codeBuilderContext.CodeTreeBuilder.AddUsingChunk("FakeNamespace2.SubNamespace", syntaxTreeNode.Object);
             var codeBuilder = new CodeGenTestCodeBuilder(codeBuilderContext);

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/ChunkVisitorTests.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/ChunkVisitorTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Razor
                 "myns",
                 string.Empty,
                 shouldGenerateLinePragmas: false,
-                errorSink: new ParserErrorSink());
+                errorSink: new ErrorSink());
             var writer = Mock.Of<CodeWriter>();
             return new Mock<ChunkVisitor<CodeWriter>>(writer, codeBuilderContext);
         }

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/ChunkVisitorTests.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CodeTree/ChunkVisitorTests.cs
@@ -4,7 +4,6 @@
 #if !DNXCORE50
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Generator.Compiler;
-using Microsoft.AspNet.Razor.Parser;
 using Moq;
 using Moq.Protected;
 using Xunit;

--- a/test/Microsoft.AspNet.Razor.Test/Generator/Compiler/CSharpLineMappingWriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/Compiler/CSharpLineMappingWriterTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp

--- a/test/Microsoft.AspNet.Razor.Test/Generator/Compiler/CodeWriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/Compiler/CodeWriterTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler

--- a/test/Microsoft.AspNet.Razor.Test/Generator/LineMappingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/LineMappingTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.Razor.Generator.Compiler;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Generator

--- a/test/Microsoft.AspNet.Razor.Test/Generator/TagHelperTestBase.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/TagHelperTestBase.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Generator.Compiler;
 using Microsoft.AspNet.Razor.Generator.Compiler.CSharp;
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.TagHelpers;
-using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Generator
 {

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpAutoCompleteTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpAutoCompleteTest.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 using Xunit;
 

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Parser.CSharp

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpErrorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpErrorTest.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Parser.CSharp

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpExplicitExpressionTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpExplicitExpressionTest.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Parser.CSharp

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpImplicitExpressionTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpImplicitExpressionTest.cs
@@ -4,7 +4,6 @@
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Parser.CSharp

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpReservedWordsTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpReservedWordsTest.cs
@@ -4,7 +4,6 @@
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Parser.CSharp

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSpecialBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSpecialBlockTest.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Parser.CSharp

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpTemplateTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpTemplateTest.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
 using Xunit;
 

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpVerbatimBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpVerbatimBlockTest.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Test.Parser.CSharp

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CallbackParserListenerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CallbackParserListenerTest.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
-using Microsoft.AspNet.Razor.Text;
 #if !DNXCORE50
 using Moq;
 #endif

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlAttributeTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlAttributeTest.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             // Act
             var results = ParseDocument("<a href='~/Foo/Bar' />");
-            var rewritingContext = new RewritingContext(results.Document, new ParserErrorSink());
+            var rewritingContext = new RewritingContext(results.Document, new ErrorSink());
             new ConditionalAttributeCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritingContext);
             new MarkupCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritingContext);
             var rewritten = rewritingContext.SyntaxTree;
@@ -271,7 +271,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
 
             // Act
             var results = ParseDocument(code);
-            var rewritingContext = new RewritingContext(results.Document, new ParserErrorSink());
+            var rewritingContext = new RewritingContext(results.Document, new ErrorSink());
             new ConditionalAttributeCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritingContext);
             new MarkupCollapser(new HtmlMarkupParser().BuildSpan).Rewrite(rewritingContext);
             var rewritten = rewritingContext.SyntaxTree;

--- a/test/Microsoft.AspNet.Razor.Test/Parser/ParserContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/ParserContextTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
                                                                  codeParser: new CSharpCodeParser(),
                                                                  markupParser: new HtmlMarkupParser(),
                                                                  activeParser: new CSharpCodeParser(),
-                                                                 errorSink: new ParserErrorSink()));
+                                                                 errorSink: new ErrorSink()));
             ExceptionHelpers.ValidateArgumentException(parameterName, RazorResources.ActiveParser_Must_Be_Code_Or_Markup_Parser, exception);
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
         {
             var codeParser = new CSharpCodeParser();
             var markupParser = new HtmlMarkupParser();
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             new ParserContext(
                 new SeekableTextReader(TextReader.Null), codeParser, markupParser, codeParser, errorSink);
             new ParserContext(
@@ -56,7 +56,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
                                             expectedCodeParser,
                                             expectedMarkupParser,
                                             expectedCodeParser,
-                                            new ParserErrorSink());
+                                            new ErrorSink());
 
             // Assert
             Assert.NotNull(context.Source);
@@ -233,7 +233,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
                 codeParser,
                 markupParser,
                 activeParser,
-                new ParserErrorSink());
+                new ErrorSink());
 
             positioningAction(context.Source);
             return context;

--- a/test/Microsoft.AspNet.Razor.Test/Parser/ParserVisitorExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/ParserVisitorExtensionsTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
         public void VisitThrowsOnNullVisitor()
         {
             ParserVisitor target = null;
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var results = new ParserResults(new BlockBuilder() { Type = BlockType.Comment }.Build(),
                                             Enumerable.Empty<TagHelperDescriptor>(),
                                             errorSink);
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
             // Arrange
             Mock<ParserVisitor> targetMock = new Mock<ParserVisitor>();
             var root = new BlockBuilder() { Type = BlockType.Comment }.Build();
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var results = new ParserResults(root,
                                             Enumerable.Empty<TagHelperDescriptor>(),
                                             errorSink);
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
             // Arrange
             Mock<ParserVisitor> targetMock = new Mock<ParserVisitor>();
             var root = new BlockBuilder() { Type = BlockType.Comment }.Build();
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             List<RazorError> errors = new List<RazorError>
             {
                 new RazorError("Foo", 1, 0, 1),
@@ -84,7 +84,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
             // Arrange
             Mock<ParserVisitor> targetMock = new Mock<ParserVisitor>();
             var root = new BlockBuilder() { Type = BlockType.Comment }.Build();
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             errorSink.OnError(new RazorError("Foo", 1, 0, 1));
             errorSink.OnError(new RazorError("Bar", 2, 0, 2));
             var results = new ParserResults(root, Enumerable.Empty<TagHelperDescriptor>(), errorSink);

--- a/test/Microsoft.AspNet.Razor.Test/Parser/RazorParserTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/RazorParserTest.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
             parser.Protected()
                   .Setup<IEnumerable<TagHelperDescriptor>>("GetTagHelperDescriptors", 
                                                            ItExpr.IsAny<Block>(), 
-                                                           ItExpr.IsAny<ParserErrorSink>())
+                                                           ItExpr.IsAny<ErrorSink>())
                   .Returns(Enumerable.Empty<TagHelperDescriptor>())
                   .Verifiable();
 
@@ -152,7 +152,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
                 get { return Context.CodeParser; }
             }
 
-            public override void BuildSpan(SpanBuilder span, Razor.Text.SourceLocation start, string content)
+            public override void BuildSpan(SpanBuilder span, SourceLocation start, string content)
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/WhitespaceRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/WhitespaceRewriterTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
                 factory.Markup("test")
                 );
             var rewriter = new WhiteSpaceRewriter(new HtmlMarkupParser().BuildSpan);
-            var rewritingContext = new RewritingContext(start, new ParserErrorSink());
+            var rewritingContext = new RewritingContext(start, new ErrorSink());
 
             // Act
             rewriter.Rewrite(rewritingContext);

--- a/test/Microsoft.AspNet.Razor.Test/RazorErrorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/RazorErrorTest.cs
@@ -2,11 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNet.Razor.Text;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
+namespace Microsoft.AspNet.Razor
 {
     public class RazorErrorTest
     {

--- a/test/Microsoft.AspNet.Razor.Test/RazorTemplateEngineTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/RazorTemplateEngineTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.Razor.Test
                 "different-ns",
                 string.Empty,
                 shouldGenerateLinePragmas: true,
-                errorSink: new ParserErrorSink());
+                errorSink: new ErrorSink());
 
             var expected = new CSharpCodeBuilder(codeBuilderContext);
 

--- a/test/Microsoft.AspNet.Razor.Test/SourceLocationTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/SourceLocationTest.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Razor.Text;
 using Xunit;
 
-namespace Microsoft.AspNet.Razor.Test.Text
+namespace Microsoft.AspNet.Razor
 {
     public class SourceLocationTest
     {

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDirectiveSpanVisitorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDirectiveSpanVisitorTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     .Returns(Enumerable.Empty<TagHelperDescriptor>());
             var tagHelperDirectiveSpanVisitor = new TagHelperDirectiveSpanVisitor(
                 resolver.Object, 
-                new ParserErrorSink());
+                new ErrorSink());
             var document = new MarkupBlock(
                 Factory.Code("\"one\"").AsAddTagHelper("one"),
                 Factory.Code("\"two\"").AsRemoveTagHelper("two"),
@@ -50,7 +50,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         {
             // Arrange
             var resolver = new TestTagHelperDescriptorResolver();
-            var tagHelperDirectiveSpanVisitor = new TagHelperDirectiveSpanVisitor(resolver, new ParserErrorSink());
+            var tagHelperDirectiveSpanVisitor = new TagHelperDirectiveSpanVisitor(resolver, new ErrorSink());
             var document = new MarkupBlock(
                 Factory.Code("\"one\"").AsAddTagHelper("one"),
                 Factory.Code("\"two\"").AsRemoveTagHelper("two"),
@@ -122,7 +122,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         {
             // Arrange
             var resolver = new TestTagHelperDescriptorResolver();
-            var tagHelperDirectiveSpanVisitor = new TagHelperDirectiveSpanVisitor(resolver, new ParserErrorSink());
+            var tagHelperDirectiveSpanVisitor = new TagHelperDirectiveSpanVisitor(resolver, new ErrorSink());
             var document = new MarkupBlock(
                 new DirectiveBlock(
                     Factory.CodeTransition(),
@@ -149,7 +149,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         {
             // Arrange
             var resolver = new TestTagHelperDescriptorResolver();
-            var tagHelperDirectiveSpanVisitor = new TagHelperDirectiveSpanVisitor(resolver, new ParserErrorSink());
+            var tagHelperDirectiveSpanVisitor = new TagHelperDirectiveSpanVisitor(resolver, new ErrorSink());
             var document = new MarkupBlock(
                 new DirectiveBlock(
                     Factory.CodeTransition(),
@@ -173,7 +173,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         {
             // Arrange
             var resolver = new TestTagHelperDescriptorResolver();
-            var tagHelperDirectiveSpanVisitor = new TagHelperDirectiveSpanVisitor(resolver, new ParserErrorSink());
+            var tagHelperDirectiveSpanVisitor = new TagHelperDirectiveSpanVisitor(resolver, new ErrorSink());
             var document = new MarkupBlock(
                 new DirectiveBlock(
                     Factory.CodeTransition(),
@@ -199,7 +199,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             var tagHelperDirectiveSpanVisitor =
                 new TagHelperDirectiveSpanVisitor(
                     new TestTagHelperDescriptorResolver(),
-                    new ParserErrorSink());
+                    new ErrorSink());
             var document = new MarkupBlock(Factory.Markup("Hello World"));
 
             // Act
@@ -256,22 +256,22 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         private class CustomTagHelperDirectiveSpanVisitor : TagHelperDirectiveSpanVisitor
         {
             private Func<IEnumerable<TagHelperDirectiveDescriptor>, 
-                         ParserErrorSink,
+                         ErrorSink,
                          TagHelperDescriptorResolutionContext> _replacer;
 
             public CustomTagHelperDirectiveSpanVisitor(
                 ITagHelperDescriptorResolver descriptorResolver,
                 Func<IEnumerable<TagHelperDirectiveDescriptor>, 
-                     ParserErrorSink, 
+                     ErrorSink, 
                      TagHelperDescriptorResolutionContext> replacer)
-                : base(descriptorResolver, new ParserErrorSink())
+                : base(descriptorResolver, new ErrorSink())
             {
                 _replacer = replacer;
             }
 
             protected override TagHelperDescriptorResolutionContext GetTagHelperDescriptorResolutionContext(
                 IEnumerable<TagHelperDirectiveDescriptor> descriptors,
-                ParserErrorSink errorSink)
+                ErrorSink errorSink)
             {
                 return _replacer(descriptors, errorSink);
             }

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -4894,7 +4894,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
         public override ParserContext CreateParserContext(ITextDocument input,
                                                           ParserBase codeParser,
                                                           ParserBase markupParser,
-                                                          ParserErrorSink errorSink)
+                                                          ErrorSink errorSink)
         {
             return base.CreateParserContext(input, codeParser, markupParser, errorSink);
         }
@@ -4904,7 +4904,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                   MarkupBlock expectedOutput,
                                   IEnumerable<RazorError> expectedErrors)
         {
-            var errorSink = new ParserErrorSink();
+            var errorSink = new ErrorSink();
             var results = ParseDocument(documentContent, errorSink);
             var rewritingContext = new RewritingContext(results.Document, errorSink);
             new TagHelperParseTreeRewriter(provider).Rewrite(rewritingContext);


### PR DESCRIPTION
- #320
- `ParserErrorSink` -> `ErrorSink`
- move `ErrorSink`, `RazorError`, and `SourceLocation` to root namespace
- move `RazorErrorTest` and `SourceLocationTest` to root namespace

in separate commit, remove and sort `using`s