### PR TITLE
Add TagHelperOutput.Attributes and TagHelperContext.AllAttributes replacement.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -218,6 +218,38 @@ namespace Microsoft.AspNet.Razor.Runtime
             return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidBoundAttributeName"), p0, p1, p2);
         }
 
+        /// <summary>
+        /// Cannot add a '{0}' with a null '{1}'.
+        /// </summary>
+        internal static string TagHelperAttributeList_CannotAddWithNullName
+        {
+            get { return GetString("TagHelperAttributeList_CannotAddWithNullName"); }
+        }
+
+        /// <summary>
+        /// Cannot add a '{0}' with a null '{1}'.
+        /// </summary>
+        internal static string FormatTagHelperAttributeList_CannotAddWithNullName(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperAttributeList_CannotAddWithNullName"), p0, p1);
+        }
+
+        /// <summary>
+        /// Cannot add a {0} with inconsistent names. The {1} property '{2}' must match the location '{3}'.
+        /// </summary>
+        internal static string TagHelperAttributeList_CannotAddAttribute
+        {
+            get { return GetString("TagHelperAttributeList_CannotAddAttribute"); }
+        }
+
+        /// <summary>
+        /// Cannot add a {0} with inconsistent names. The {1} property '{2}' must match the location '{3}'.
+        /// </summary>
+        internal static string FormatTagHelperAttributeList_CannotAddAttribute(object p0, object p1, object p2, object p3)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperAttributeList_CannotAddAttribute"), p0, p1, p2, p3);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -156,4 +156,10 @@
   <data name="TagHelperDescriptorFactory_InvalidBoundAttributeName" xml:space="preserve">
     <value>Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes beginning with '{2}'.</value>
   </data>
+  <data name="TagHelperAttributeList_CannotAddWithNullName" xml:space="preserve">
+    <value>Cannot add a '{0}' with a null '{1}'.</value>
+  </data>
+  <data name="TagHelperAttributeList_CannotAddAttribute" xml:space="preserve">
+    <value>Cannot add a {0} with inconsistent names. The {1} property '{2}' must match the location '{3}'.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/IReadOnlyTagHelperAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/IReadOnlyTagHelperAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// A read-only HTML tag helper attribute.
+    /// </summary>
+    public interface IReadOnlyTagHelperAttribute : IEquatable<IReadOnlyTagHelperAttribute>
+    {
+        /// <summary>
+        /// Gets the name of the attribute.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets the value of the attribute.
+        /// </summary>
+        object Value { get; }
+    }
+}

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/ReadOnlyTagHelperAttributeList.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/ReadOnlyTagHelperAttributeList.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// A read-only collection of <typeparamref name="TAttribute"/>s.
+    /// </summary>
+    /// <typeparam name="TAttribute">
+    /// The type of <see cref="IReadOnlyTagHelperAttribute"/>s in the collection.
+    /// </typeparam>
+    public class ReadOnlyTagHelperAttributeList<TAttribute> : IReadOnlyList<TAttribute>
+        where TAttribute : IReadOnlyTagHelperAttribute
+    {
+        /// <summary>
+        /// Instantiates a new instance of <see cref="ReadOnlyTagHelperAttributeList{TAttribute}"/> with an empty
+        /// collection.
+        /// </summary>
+        protected ReadOnlyTagHelperAttributeList()
+        {
+            Attributes = new List<TAttribute>();
+        }
+
+        /// <summary>
+        /// Instantiates a new instance of <see cref="ReadOnlyTagHelperAttributeList{TAttribute}"/> with the specified
+        /// <paramref name="attributes"/>.
+        /// </summary>
+        /// <param name="attributes">The collection to wrap.</param>
+        public ReadOnlyTagHelperAttributeList([NotNull] IEnumerable<TAttribute> attributes)
+        {
+            Attributes = new List<TAttribute>(attributes);
+        }
+
+        /// <summary>
+        /// The underlying collection of <typeparamref name="TAttribute"/>s.
+        /// </summary>
+        /// <remarks>Intended for use in a non-read-only subclass. Changes to this <see cref="List{TAttribute}"/> will
+        /// affect all getters that <see cref="ReadOnlyTagHelperAttributeList{TAttribute}"/> provides.</remarks>
+        protected List<TAttribute> Attributes { get; }
+
+        /// <inheritdoc />
+        public TAttribute this[int index]
+        {
+            get
+            {
+                return Attributes[index];
+            }
+        }
+
+        /// <summary>
+        /// Gets the first <typeparamref name="TAttribute"/> with <see cref="IReadOnlyTagHelperAttribute.Name"/>
+        /// matching <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">
+        /// The <see cref="IReadOnlyTagHelperAttribute.Name"/> of the <typeparamref name="TAttribute"/> to get.
+        /// </param>
+        /// <returns>The first <typeparamref name="TAttribute"/> with <see cref="IReadOnlyTagHelperAttribute.Name"/>
+        /// matching <paramref name="name"/>.
+        /// </returns>
+        /// <remarks><paramref name="name"/> is compared case-insensitively.</remarks>
+        public TAttribute this[[NotNull] string name]
+        {
+            get
+            {
+                return Attributes.FirstOrDefault(attribute => NameEquals(name, attribute));
+            }
+        }
+
+        /// <inheritdoc />
+        public int Count
+        {
+            get
+            {
+                return Attributes.Count;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether a <typeparamref name="TAttribute"/> matching <paramref name="item"/> exists in the
+        /// collection.
+        /// </summary>
+        /// <param name="item">The <typeparamref name="TAttribute"/> to locate.</param>
+        /// <returns>
+        /// <c>true</c> if an <typeparamref name="TAttribute"/> matching <paramref name="item"/> exists in the
+        /// collection; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// <paramref name="item"/>s <see cref="IReadOnlyTagHelperAttribute.Name"/> is compared case-insensitively.
+        /// </remarks>
+        public bool Contains([NotNull] TAttribute item)
+        {
+            return Attributes.Contains(item);
+        }
+
+        /// <summary>
+        /// Determines whether a <typeparamref name="TAttribute"/> with the same
+        /// <see cref="IReadOnlyTagHelperAttribute.Name"/> exists in the collection.
+        /// </summary>
+        /// <param name="name">The <see cref="IReadOnlyTagHelperAttribute.Name"/> of the
+        /// <typeparamref name="TAttribute"/> to get.</param>
+        /// <returns>
+        /// <c>true</c> if a <typeparamref name="TAttribute"/> with the same
+        /// <see cref="IReadOnlyTagHelperAttribute.Name"/> exists in the collection; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks><paramref name="name"/> is compared case-insensitively.</remarks>
+        public bool ContainsName([NotNull] string name)
+        {
+            return Attributes.Any(attribute => NameEquals(name, attribute));
+        }
+
+        /// <summary>
+        /// Searches for a <typeparamref name="TAttribute"/> matching <paramref name="item"/> in the collection and
+        /// returns the zero-based index of the first occurrence.
+        /// </summary>
+        /// <param name="item">The <typeparamref name="TAttribute"/> to locate.</param>
+        /// <returns>The zero-based index of the first occurrence of a <typeparamref name="TAttribute"/> matching
+        /// <paramref name="item"/> in the collection, if found; otherwise, –1.</returns>
+        /// <remarks>
+        /// <paramref name="item"/>s <see cref="IReadOnlyTagHelperAttribute.Name"/> is compared case-insensitively.
+        /// </remarks>
+        public int IndexOf([NotNull] TAttribute item)
+        {
+            return Attributes.IndexOf(item);
+        }
+
+        /// <summary>
+        /// Retrieves the first <typeparamref name="TAttribute"/> with <see cref="IReadOnlyTagHelperAttribute.Name"/>
+        /// matching <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The <see cref="IReadOnlyTagHelperAttribute.Name"/> of the
+        /// <typeparamref name="TAttribute"/> to get.</param>
+        /// <param name="attribute">When this method returns, the first <typeparamref name="TAttribute"/> with
+        /// <see cref="IReadOnlyTagHelperAttribute.Name"/> matching <paramref name="name"/>, if found; otherwise,
+        /// <c>null</c>.</param>
+        /// <returns><c>true</c> if a <typeparamref name="TAttribute"/> with the same
+        /// <see cref="IReadOnlyTagHelperAttribute.Name"/> exists in the collection; otherwise, <c>false</c>.</returns>
+        /// <remarks><paramref name="name"/> is compared case-insensitively.</remarks>
+        public bool TryGetAttribute([NotNull] string name, out TAttribute attribute)
+        {
+            attribute = Attributes.FirstOrDefault(attr => NameEquals(name, attr));
+
+            return attribute != null;
+        }
+
+        /// <summary>
+        /// Retrieves <typeparamref name="TAttribute"/>s in the collection with
+        /// <see cref="IReadOnlyTagHelperAttribute.Name"/> matching <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The <see cref="IReadOnlyTagHelperAttribute.Name"/> of the
+        /// <typeparamref name="TAttribute"/>s to get.</param>
+        /// <param name="attributes">When this method returns, the <typeparamref name="TAttribute"/>s with
+        /// <see cref="IReadOnlyTagHelperAttribute.Name"/> matching <paramref name="name"/>, if at least one is
+        /// found; otherwise, <c>null</c>.</param>
+        /// <returns><c>true</c> if at least one <typeparamref name="TAttribute"/> with the same
+        /// <see cref="IReadOnlyTagHelperAttribute.Name"/> exists in the collection; otherwise, <c>false</c>.</returns>
+        /// <remarks><paramref name="name"/> is compared case-insensitively.</remarks>
+        public bool TryGetAttributes([NotNull] string name, out IEnumerable<TAttribute> attributes)
+        {
+            attributes = Attributes.Where(attribute => NameEquals(name, attribute));
+
+            return attributes.Any();
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<TAttribute> GetEnumerator()
+        {
+            return Attributes.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Determines if the specified <paramref name="attribute"/> has the same name as <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The value to compare against <paramref name="attribute"/>s
+        /// <see cref="TagHelperAttribute.Name"/>.</param>
+        /// <param name="attribute">The attribute to compare against.</param>
+        /// <returns><c>true</c> if <paramref name="name"/> case-insensitively matches <paramref name="attribute"/>s
+        /// <see cref="TagHelperAttribute.Name"/>.</returns>
+        protected static bool NameEquals(string name, [NotNull] TAttribute attribute)
+        {
+            return string.Equals(name, attribute.Name, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Internal.Web.Utils;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// An HTML tag helper attribute.
+    /// </summary>
+    public class TagHelperAttribute : IReadOnlyTagHelperAttribute
+    {
+        private static readonly int TypeHashCode = typeof(TagHelperAttribute).GetHashCode();
+
+        /// <summary>
+        /// Instantiates a new instance of <see cref="TagHelperAttribute"/>.
+        /// </summary>
+        public TagHelperAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new instance of <see cref="TagHelperAttribute"/> with the specified <paramref name="name"/>
+        /// and <paramref name="value"/>.
+        /// </summary>
+        /// <param name="name">The <see cref="Name"/> of the attribute.</param>
+        /// <param name="value">The <see cref="Value"/> of the attribute.</param>
+        public TagHelperAttribute(string name, object value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the attribute.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of the attribute.
+        /// </summary>
+        public object Value { get; set; }
+
+        /// <summary>
+        /// Converts the specified <paramref name="value"/> into a <see cref="TagHelperAttribute"/>.
+        /// </summary>
+        /// <param name="value">The <see cref="Value"/> of the created <see cref="TagHelperAttribute"/>.</param>
+        /// <remarks>Created <see cref="TagHelperAttribute"/>s <see cref="Name"/> is set to <c>null</c>.</remarks>
+        public static implicit operator TagHelperAttribute(string value)
+        {
+            return new TagHelperAttribute
+            {
+                Value = value
+            };
+        }
+
+        /// <inheritdoc />
+        /// <remarks><see cref="Name"/> is compared case-insensitively.</remarks>
+        public bool Equals(IReadOnlyTagHelperAttribute other)
+        {
+            return
+                other != null &&
+                string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) &&
+                Equals(Value, other.Value);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            var other = obj as IReadOnlyTagHelperAttribute;
+
+            return Equals(other);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return TypeHashCode;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttributeList.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttributeList.cs
@@ -1,0 +1,239 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// A collection of <see cref="TagHelperAttribute"/>s.
+    /// </summary>
+    public class TagHelperAttributeList : ReadOnlyTagHelperAttributeList<TagHelperAttribute>, IList<TagHelperAttribute>
+    {
+        /// <summary>
+        /// Instantiates a new instance of <see cref="TagHelperAttributeList"/> with an empty collection.
+        /// </summary>
+        public TagHelperAttributeList()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new instance of <see cref="TagHelperAttributeList"/> with the specified
+        /// <paramref name="attributes"/>.
+        /// </summary>
+        /// <param name="attributes">The collection to wrap.</param>
+        public TagHelperAttributeList([NotNull] IEnumerable<TagHelperAttribute> attributes)
+            : base(attributes)
+        {
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <paramref name="value"/>'s <see cref="TagHelperAttribute.Name"/> must not be <c>null</c>.
+        /// </remarks>
+        public new TagHelperAttribute this[int index]
+        {
+            get
+            {
+                return base[index];
+            }
+            [param: NotNull]
+            set
+            {
+                if (value.Name == null)
+                {
+                    throw new ArgumentException(
+                        Resources.FormatTagHelperAttributeList_CannotAddWithNullName(
+                            typeof(TagHelperAttribute).FullName,
+                            nameof(TagHelperAttribute.Name)),
+                        nameof(value));
+                }
+
+                Attributes[index] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the first <see cref="TagHelperAttribute"/> with <see cref="TagHelperAttribute.Name"/> matching
+        /// <paramref name="name"/>. When setting, replaces the first matching
+        /// <see cref="TagHelperAttribute"/> with the specified <paramref name="value"/> and removes any additional
+        /// matching <see cref="TagHelperAttribute"/>s. If a matching <see cref="TagHelperAttribute"/> is not found,
+        /// adds the specified <paramref name="value"/> to the end of the collection.
+        /// </summary>
+        /// <param name="name">
+        /// The <see cref="TagHelperAttribute.Name"/> of the <see cref="TagHelperAttribute"/> to get or set.
+        /// </param>
+        /// <returns>The first <see cref="TagHelperAttribute"/> with <see cref="TagHelperAttribute.Name"/> matching
+        /// <paramref name="name"/>.
+        /// </returns>
+        /// <remarks><paramref name="name"/> is compared case-insensitively. When setting,
+        /// <see cref="TagHelperAttribute"/>s <see cref="TagHelperAttribute.Name"/> must be <c>null</c> or
+        /// case-insensitively match the specified <paramref name="name"/>.</remarks>
+        /// <example>
+        /// <code>
+        /// var attributes = new TagHelperAttributeList();
+        ///
+        /// // Will "value" be converted to a TagHelperAttribute with a null Name
+        /// attributes["name"] = "value";
+        ///
+        /// // TagHelperAttribute.Name must match the specified name.
+        /// attributes["name"] = new TagHelperAttribute("name", "value");
+        /// </code>
+        /// </example>
+        public new TagHelperAttribute this[[NotNull] string name]
+        {
+            get
+            {
+                return base[name];
+            }
+            [param: NotNull]
+            set
+            {
+                // Name will be null if user attempts to set the attribute via an implicit conversion:
+                // output.Attributes["someName"] = "someValue"
+                if (value.Name == null)
+                {
+                    value.Name = name;
+                }
+                else if (!NameEquals(name, value))
+                {
+                    throw new ArgumentException(
+                        Resources.FormatTagHelperAttributeList_CannotAddAttribute(
+                            nameof(TagHelperAttribute),
+                            nameof(TagHelperAttribute.Name),
+                            value.Name,
+                            name),
+                        nameof(name));
+                }
+
+                var attributeReplaced = false;
+
+                for (var i = 0; i < Attributes.Count; i++)
+                {
+                    if (NameEquals(name, Attributes[i]))
+                    {
+                        // We replace the first attribute with the provided value, remove all the rest.
+                        if (!attributeReplaced)
+                        {
+                            // We replace the first attribute we find with the same name.
+                            Attributes[i] = value;
+                            attributeReplaced = true;
+                        }
+                        else
+                        {
+                            Attributes.RemoveAt(i--);
+                        }
+                    }
+                }
+
+                // If we didn't replace an attribute value we should add value to the end of the collection.
+                if (!attributeReplaced)
+                {
+                    Add(value);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        bool ICollection<TagHelperAttribute>.IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Adds a <see cref="TagHelperAttribute"/> to the end of the collection with the specified
+        /// <paramref name="name"/> and <paramref name="value"/>.
+        /// </summary>
+        /// <param name="name">The <see cref="TagHelperAttribute.Name"/> of the attribute to add.</param>
+        /// <param name="value">The <see cref="TagHelperAttribute.Value"/> of the attribute to add.</param>
+        public void Add([NotNull] string name, object value)
+        {
+            Attributes.Add(new TagHelperAttribute(name, value));
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <paramref name="attribute"/>'s <see cref="TagHelperAttribute.Name"/> must not be <c>null</c>.
+        /// </remarks>
+        public void Add([NotNull] TagHelperAttribute attribute)
+        {
+            if (attribute.Name == null)
+            {
+                throw new ArgumentException(
+                    Resources.FormatTagHelperAttributeList_CannotAddWithNullName(
+                        typeof(TagHelperAttribute).FullName,
+                        nameof(TagHelperAttribute.Name)),
+                    nameof(attribute));
+            }
+
+            Attributes.Add(attribute);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <paramref name="attribute"/>'s <see cref="TagHelperAttribute.Name"/> must not be <c>null</c>.
+        /// </remarks>
+        public void Insert(int index, [NotNull] TagHelperAttribute attribute)
+        {
+            if (attribute.Name == null)
+            {
+                throw new ArgumentException(
+                    Resources.FormatTagHelperAttributeList_CannotAddWithNullName(
+                        typeof(TagHelperAttribute).FullName,
+                        nameof(TagHelperAttribute.Name)),
+                    nameof(attribute));
+            }
+
+            Attributes.Insert(index, attribute);
+        }
+
+        /// <inheritdoc />
+        public void CopyTo([NotNull] TagHelperAttribute[] array, int index)
+        {
+            Attributes.CopyTo(array, index);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <paramref name="attribute"/>s <see cref="TagHelperAttribute.Name"/> is compared case-insensitively.
+        /// </remarks>
+        public bool Remove([NotNull] TagHelperAttribute attribute)
+        {
+            return Attributes.Remove(attribute);
+        }
+
+        /// <inheritdoc />
+        public void RemoveAt(int index)
+        {
+            Attributes.RemoveAt(index);
+        }
+
+        /// <summary>
+        /// Removes all <see cref="TagHelperAttribute"/>s with <see cref="TagHelperAttribute.Name"/> matching
+        /// <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">
+        /// The <see cref="TagHelperAttribute.Name"/> of <see cref="TagHelperAttribute"/>s to remove.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if at least 1 <see cref="TagHelperAttribute"/> was removed; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks><paramref name="name"/> is compared case-insensitively.</remarks>
+        public bool RemoveAll([NotNull] string name)
+        {
+            return Attributes.RemoveAll(attribute => NameEquals(name, attribute)) > 0;
+        }
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            Attributes.Clear();
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Framework.Internal;
 
@@ -25,12 +26,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="getChildContentAsync">A delegate used to execute and retrieve the rendered child content 
         /// asynchronously.</param>
         public TagHelperContext(
-            [NotNull] IDictionary<string, object> allAttributes,
+            [NotNull] IEnumerable<IReadOnlyTagHelperAttribute> allAttributes,
             [NotNull] IDictionary<object, object> items,
             [NotNull] string uniqueId,
             [NotNull] Func<Task<TagHelperContent>> getChildContentAsync)
         {
-            AllAttributes = allAttributes;
+            AllAttributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
+                allAttributes.Select(attribute => new TagHelperAttribute(attribute.Name, attribute.Value)));
             Items = items;
             UniqueId = uniqueId;
             _getChildContentAsync = getChildContentAsync;
@@ -39,7 +41,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Every attribute associated with the current HTML element.
         /// </summary>
-        public IDictionary<string, object> AllAttributes { get; }
+        public ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute> AllAttributes { get; }
 
         /// <summary>
         /// Gets the collection of items used to communicate with other <see cref="ITagHelper"/>s.

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -60,8 +60,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             _endTagHelperWritingScope = endTagHelperWritingScope;
 
             SelfClosing = selfClosing;
-            AllAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-            HTMLAttributes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            HTMLAttributes = new TagHelperAttributeList();
+            AllAttributes = new TagHelperAttributeList();
             TagName = tagName;
             Items = items;
             UniqueId = uniqueId;
@@ -91,12 +91,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// HTML attributes.
         /// </summary>
-        public IDictionary<string, object> HTMLAttributes { get; }
+        public TagHelperAttributeList HTMLAttributes { get; }
 
         /// <summary>
         /// <see cref="ITagHelper"/> bound attributes and HTML attributes.
         /// </summary>
-        public IDictionary<string, object> AllAttributes { get; }
+        public TagHelperAttributeList AllAttributes { get; }
 
         /// <summary>
         /// An identifier unique to the HTML element this context is for.

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     {
         // Internal for testing
         internal TagHelperOutput(string tagName)
-            : this(tagName, new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase))
+            : this(tagName, new TagHelperAttributeList())
         {
         }
 
@@ -25,10 +25,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="attributes">The HTML attributes.</param>
         public TagHelperOutput(
             string tagName,
-            [NotNull] IDictionary<string, object> attributes)
+            [NotNull] TagHelperAttributeList attributes)
         {
             TagName = tagName;
-            Attributes = new Dictionary<string, object>(attributes, StringComparer.OrdinalIgnoreCase);
+            Attributes = new TagHelperAttributeList(attributes);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// a <c>Microsoft.AspNet.Mvc.Rendering.HtmlString</c> instance. MVC converts most other types to a
         /// <see cref="string"/>, then HTML encodes the result.
         /// </remarks>
-        public IDictionary<string, object> Attributes { get; }
+        public TagHelperAttributeList Attributes { get; }
 
         /// <summary>
         /// Changes <see cref="TagHelperOutput"/> to generate nothing.

--- a/src/Microsoft.AspNet.Razor/Common/HashCodeCombiner.cs
+++ b/src/Microsoft.AspNet.Razor/Common/HashCodeCombiner.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Internal.Web.Utils
 {
-    internal class HashCodeCombiner
+    public class HashCodeCombiner
     {
         private long _combinedHash64 = 0x1505L;
 

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         {
             TagName = source.TagName;
             Descriptors = source.Descriptors;
-            Attributes = new Dictionary<string, SyntaxTreeNode>(source.Attributes);
+            Attributes = new List<KeyValuePair<string, SyntaxTreeNode>>(source.Attributes);
             _start = source.Start;
             SelfClosing = source.SelfClosing;
             SourceStartTag = source.SourceStartTag;
@@ -36,9 +36,9 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
 
             source.Reset();
 
-            foreach (var attributeChildren in Attributes.Values)
+            foreach (var attributeChildren in Attributes)
             {
-                attributeChildren.Parent = this;
+                attributeChildren.Value.Parent = this;
             }
         }
 
@@ -67,7 +67,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// <summary>
         /// The HTML attributes.
         /// </summary>
-        public IDictionary<string, SyntaxTreeNode> Attributes { get; private set; }
+        public IList<KeyValuePair<string, SyntaxTreeNode>> Attributes { get; }
 
         /// <inheritdoc />
         public override SourceLocation Start

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         {
             TagName = original.TagName;
             Descriptors = original.Descriptors;
-            Attributes = new Dictionary<string, SyntaxTreeNode>(original.Attributes);
+            Attributes = new List<KeyValuePair<string, SyntaxTreeNode>>(original.Attributes);
         }
 
         /// <summary>
@@ -39,26 +39,28 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// <param name="attributes">Attributes of the <see cref="TagHelperBlock"/>.</param>
         /// <param name="descriptors">The <see cref="TagHelperDescriptor"/>s associated with the current HTML
         /// tag.</param>
-        public TagHelperBlockBuilder(string tagName,
-                                     bool selfClosing,
-                                     SourceLocation start,
-                                     IDictionary<string, SyntaxTreeNode> attributes,
-                                     IEnumerable<TagHelperDescriptor> descriptors)
+        public TagHelperBlockBuilder(
+            string tagName,
+            bool selfClosing,
+            SourceLocation start,
+            IList<KeyValuePair<string, SyntaxTreeNode>> attributes,
+            IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;
             SelfClosing = selfClosing;
             Start = start;
             Descriptors = descriptors;
-            Attributes = new Dictionary<string, SyntaxTreeNode>(attributes);
+            Attributes = new List<KeyValuePair<string, SyntaxTreeNode>>(attributes);
             Type = BlockType.Tag;
             CodeGenerator = new TagHelperCodeGenerator(descriptors);
         }
 
         // Internal for testing
-        internal TagHelperBlockBuilder(string tagName,
-                                       bool selfClosing,
-                                       IDictionary<string, SyntaxTreeNode> attributes,
-                                       IEnumerable<SyntaxTreeNode> children)
+        internal TagHelperBlockBuilder(
+            string tagName,
+            bool selfClosing,
+            IList<KeyValuePair<string, SyntaxTreeNode>> attributes,
+            IEnumerable<SyntaxTreeNode> children)
         {
             TagName = tagName;
             SelfClosing = selfClosing;
@@ -98,7 +100,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// <summary>
         /// The HTML attributes.
         /// </summary>
-        public IDictionary<string, SyntaxTreeNode> Attributes { get; private set; }
+        public IList<KeyValuePair<string, SyntaxTreeNode>> Attributes { get; }
 
         /// <summary>
         /// The HTML tag name.

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
@@ -31,14 +31,14 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             return new TagHelperBlockBuilder(tagName, selfClosing, start, attributes, descriptors);
         }
 
-        private static IDictionary<string, SyntaxTreeNode> GetTagAttributes(
+        private static IList<KeyValuePair<string, SyntaxTreeNode>> GetTagAttributes(
             string tagName,
             bool validStructure,
             Block tagBlock,
             IEnumerable<TagHelperDescriptor> descriptors,
             ErrorSink errorSink)
         {
-            var attributes = new Dictionary<string, SyntaxTreeNode>(StringComparer.OrdinalIgnoreCase);
+            var attributes = new List<KeyValuePair<string, SyntaxTreeNode>>();
 
             // Build a dictionary so we can easily lookup expected attribute value lookups
             IReadOnlyDictionary<string, string> attributeValueTypes =
@@ -88,7 +88,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
                             attribute.Key.Length);
                     }
 
-                    attributes[attribute.Key] = attribute.Value;
+                    attributes.Add(new KeyValuePair<string, SyntaxTreeNode>(attribute.Key, attribute.Value));
                 }
             }
 
@@ -137,13 +137,13 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
 
                 if (afterEquals)
                 {
-                    // We've captured all leading whitespace, the attribute name, and an equals with an optional 
+                    // We've captured all leading whitespace, the attribute name, and an equals with an optional
                     // quote/double quote. We're now at: " asp-for='|...'" or " asp-for=|..."
-                    // The goal here is to capture all symbols until the end of the attribute. Note this will not 
+                    // The goal here is to capture all symbols until the end of the attribute. Note this will not
                     // consume an ending quote due to the symbolOffset.
 
-                    // When symbols are accepted into SpanBuilders, their locations get altered to be offset by the 
-                    // parent which is why we need to mark our start location prior to adding the symbol. 
+                    // When symbols are accepted into SpanBuilders, their locations get altered to be offset by the
+                    // parent which is why we need to mark our start location prior to adding the symbol.
                     // This is needed to know the location of the attribute value start within the document.
                     if (!capturedAttributeValueStart)
                     {
@@ -206,10 +206,10 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
                 }
                 else if (symbol.Type == HtmlSymbolType.WhiteSpace)
                 {
-                    // We're at the start of the attribute, this branch may be hit on the first iterations of 
+                    // We're at the start of the attribute, this branch may be hit on the first iterations of
                     // the loop since the parser separates attributes with their spaces included as symbols.
                     // We're at: "| asp-for='...'" or "| asp-for=..."
-                    // Note: This will not be hit even for situations like asp-for  ="..." because the core Razor 
+                    // Note: This will not be hit even for situations like asp-for  ="..." because the core Razor
                     // parser currently does not know how to handle attributes in that format. This will be addressed
                     // by https://github.com/aspnet/Razor/issues/123.
 
@@ -230,7 +230,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
                 {
                     errorSink.OnError(
                         span.Start,
-                        RazorResources.TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed,
+                        RazorResources.TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed,
                         span.Content.Length);
                 }
 
@@ -375,7 +375,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
                     else if (isDynamic && childSpan.CodeGenerator == SpanCodeGenerator.Null)
                     {
                         // Usually the dynamic code generator handles rendering the null code generators underneath
-                        // it. This doesn't make sense in terms of tag helpers though, we need to change null code 
+                        // it. This doesn't make sense in terms of tag helpers though, we need to change null code
                         // generators to markup code generators.
 
                         newCodeGenerator = new MarkupCodeGenerator();

--- a/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
@@ -1369,17 +1369,17 @@ namespace Microsoft.AspNet.Razor
         /// <summary>
         /// TagHelper attributes must be welformed.
         /// </summary>
-        internal static string TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed
+        internal static string TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed
         {
-            get { return GetString("TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed"); }
+            get { return GetString("TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed"); }
         }
 
         /// <summary>
         /// TagHelper attributes must be welformed.
         /// </summary>
-        internal static string FormatTagHelperBlockRewriter_TagHelperAttributesMustBeWelformed()
+        internal static string FormatTagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed()
         {
-            return GetString("TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed");
+            return GetString("TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed");
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Razor/RazorResources.resx
+++ b/src/Microsoft.AspNet.Razor/RazorResources.resx
@@ -390,7 +390,7 @@ Instead, wrap the contents of the block in "{{}}":
   <data name="TagHelpersParseTreeRewriter_MissingCloseAngle" xml:space="preserve">
     <value>Missing close angle for tag helper '{0}'.</value>
   </data>
-  <data name="TagHelperBlockRewriter_TagHelperAttributesMustBeWelformed" xml:space="preserve">
+  <data name="TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed" xml:space="preserve">
     <value>TagHelper attributes must be welformed.</value>
   </data>
   <data name="TagHelpers_AttributeExpressionRequired" xml:space="preserve">

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperAttributeComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperAttributeComparer.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Internal.Web.Utils;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    public class CaseSensitiveTagHelperAttributeComparer : IEqualityComparer<IReadOnlyTagHelperAttribute>
+    {
+        public readonly static CaseSensitiveTagHelperAttributeComparer Default =
+            new CaseSensitiveTagHelperAttributeComparer();
+
+        private CaseSensitiveTagHelperAttributeComparer()
+        {
+        }
+
+        public bool Equals(
+            [NotNull] IReadOnlyTagHelperAttribute attributeX,
+            [NotNull] IReadOnlyTagHelperAttribute attributeY)
+        {
+            return
+                attributeX == attributeY ||
+                // Normal comparer doesn't care about the Name case, in tests we do.
+                string.Equals(attributeX.Name, attributeY.Name, StringComparison.Ordinal) &&
+                Equals(attributeX.Value, attributeY.Value);
+        }
+
+        public int GetHashCode([NotNull] IReadOnlyTagHelperAttribute attribute)
+        {
+            return HashCodeCombiner
+                .Start()
+                .Add(attribute.Name, StringComparer.Ordinal)
+                .Add(attribute.Value)
+                .CombinedHash;
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/ReadOnlyTagHelperAttributeListTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/ReadOnlyTagHelperAttributeListTest.cs
@@ -1,0 +1,702 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    public class ReadOnlyTagHelperAttributeListTest
+    {
+        public static TheoryData IntIndexerData
+        {
+            get
+            {
+                var first = new TagHelperAttribute("First", "First Value");
+                var second = new TagHelperAttribute("Second", "Second Value");
+                var third = new TagHelperAttribute("Third", "Third Value");
+
+                return new TheoryData<
+                    IEnumerable<IReadOnlyTagHelperAttribute>, // initialAttributes
+                    int, // indexToLookup
+                    IReadOnlyTagHelperAttribute> // expectedAttribute
+                {
+                    { new[] { first }, 0, first },
+                    { new[] { first, second }, 0, first },
+                    { new[] { first, second }, 1, second },
+                    { new[] { first, second, third}, 1, second },
+                    { new[] { first, second, third }, 2, third },
+                    { new[] { first, first, second, third}, 1, first },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IntIndexerData))]
+        public void IntIndexer_ReturnsExpectedAttribute(
+            IEnumerable<IReadOnlyTagHelperAttribute> initialAttributes,
+            int indexToLookup,
+            IReadOnlyTagHelperAttribute expectedAttribute)
+        {
+            // Arrange
+            var attributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(initialAttributes);
+
+            // Act
+            var attribute = attributes[indexToLookup];
+
+            // Assert
+            Assert.Equal(expectedAttribute, attribute, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        public static TheoryData IntIndexerThrowData
+        {
+            get
+            {
+                return new TheoryData<int> { 2, -1, 20 };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IntIndexerThrowData))]
+        public void IntIndexer_ThrowsIfInvalidIndex(int index)
+        {
+            // Arrange
+            var attributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
+                new[]
+                {
+                    new TagHelperAttribute("a", "av"),
+                    new TagHelperAttribute("b", "bv")
+                });
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentOutOfRangeException>("index", () => attributes[index]);
+        }
+
+        public static TheoryData StringIndexerData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var A3 = new TagHelperAttribute("AName", "AName Third Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+                var C = new TagHelperAttribute("CName", "CName Value");
+
+                return new TheoryData<
+                    IEnumerable<IReadOnlyTagHelperAttribute>, // initialAttributes
+                    string, // nameToLookup
+                    IReadOnlyTagHelperAttribute> // expectedAttribute
+                {
+                    { new[] { A }, "AName", A },
+                    { new[] { A }, "AnAmE", A },
+                    { new[] { A, B }, "AName", A },
+                    { new[] { A, B }, "AnAmE", A },
+                    { new[] { A, B }, "BName", B },
+                    { new[] { A, B }, "BnAmE", B },
+                    { new[] { A, B, C }, "BName", B },
+                    { new[] { A, B, C }, "bname", B },
+                    { new[] { A, B, C }, "CName", C },
+                    { new[] { A, B, C }, "cnamE", C },
+
+                    // Multiple elements same name
+                    { new[] { A, B, A2, C }, "AName", A },
+                    { new[] { A, B, A2, C }, "aname", A },
+                    { new[] { B, A2, A }, "aname", A2 },
+                    { new[] { B, A2, A, C }, "AName", A2 },
+                    { new[] { A, A3 }, "AName", A },
+                    { new[] { A3, A }, "aname", A3 },
+                    { new[] { A, A2, A3 }, "AName", A },
+                    { new[] { C, B, A3, A }, "AName", A3 },
+
+                    // Null expected lookups
+                    { new[] { A }, "_AName_", null },
+                    { new[] { A }, "completely different", null },
+                    { new[] { A, B }, "_AName_", null },
+                    { new[] { A, B }, "completely different", null },
+                    { new[] { A, B, C }, "_BName_", null },
+                    { new[] { A, B, C }, "completely different", null },
+                    { new[] { A, A2, B, C }, "_cnamE_", null },
+                    { new[] { A, A2, B, C }, "completely different", null },
+                    { new[] { A, A2, A3, B, C }, "_cnamE_", null },
+                    { new[] { A, A2, A3, B, C }, "completely different", null },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(StringIndexerData))]
+        public void StringIndexer_ReturnsExpectedAttribute(
+            IEnumerable<IReadOnlyTagHelperAttribute> initialAttributes,
+            string nameToLookup,
+            IReadOnlyTagHelperAttribute expectedAttribute)
+        {
+            // Arrange
+            var attributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(initialAttributes);
+
+            // Act
+            var attribute = attributes[nameToLookup];
+
+            // Assert
+            Assert.Equal(expectedAttribute, attribute, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        [Fact]
+        public void Count_ReturnsNumberOfAttributes()
+        {
+            // Arrange
+            var attributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
+                new[]
+                {
+                    new TagHelperAttribute(),
+                    new TagHelperAttribute(),
+                    new TagHelperAttribute()
+                });
+
+            // Act
+            var count = attributes.Count;
+
+            // Assert
+            Assert.Equal(3, count);
+        }
+
+        public static TheoryData ContainsData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var A3 = new TagHelperAttribute("AName", "AName Third Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+                var C = new TagHelperAttribute("CName", "CName Value");
+
+                return new TheoryData<
+                    IEnumerable<IReadOnlyTagHelperAttribute>, // initialAttributes
+                    IReadOnlyTagHelperAttribute, // attributeToLookup
+                    bool> // expected
+                {
+                    { new[] { A }, A, true },
+                    { new[] { A }, new TagHelperAttribute(A.Name, A.Value), true },
+                    { new[] { A }, new TagHelperAttribute("aname", A.Value), true },
+                    { new[] { A, B }, A, true },
+                    { new[] { A, B }, new TagHelperAttribute(A.Name, A.Value), true },
+                    { new[] { A, B }, new TagHelperAttribute("AnaMe", A.Value), true },
+                    { new[] { A, B }, B, true },
+                    { new[] { A, B }, new TagHelperAttribute(B.Name, B.Value), true },
+                    { new[] { A, B }, new TagHelperAttribute("BNAME", B.Value), true },
+                    { new[] { A, B, C }, B, true },
+                    { new[] { A, B, C }, new TagHelperAttribute(B.Name, B.Value), true },
+                    { new[] { A, B, C }, new TagHelperAttribute("bname", B.Value), true },
+                    { new[] { A, B, C }, C, true },
+                    { new[] { A, B, C }, new TagHelperAttribute(C.Name, C.Value), true },
+                    { new[] { A, B, C }, new TagHelperAttribute("CNAme", C.Value), true },
+                    { new[] { A }, B, false },
+                    { new[] { A }, new TagHelperAttribute(A.Name, "different value"), false },
+                    { new[] { A }, new TagHelperAttribute("aname_not", "different value"), false },
+                    { new[] { A, B }, A2, false },
+                    { new[] { A, B }, new TagHelperAttribute(A.Name, "different value"), false },
+                    { new[] { A, B }, new TagHelperAttribute("AnaMe_not", "different value"), false },
+                    { new[] { A, B }, new TagHelperAttribute(B.Name, "different value"), false },
+                    { new[] { A, B }, new TagHelperAttribute("BNAME_not", "different value"), false },
+                    { new[] { A, B, C }, A2, false },
+                    { new[] { A, B, C }, new TagHelperAttribute(B.Name, "different value"), false },
+                    { new[] { A, B, C }, new TagHelperAttribute("bname_not", "different value"), false },
+                    { new[] { A, B, C }, new TagHelperAttribute(C.Name, "different value"), false },
+                    { new[] { A, B, C }, new TagHelperAttribute("CNAme_not", "different value"), false },
+
+                    // Multiple elements same name
+                    { new[] { A, B, A2, C }, A, true },
+                    { new[] { A, B, A2, C }, new TagHelperAttribute(A.Name, A.Value), true },
+                    { new[] { A, B, A2, C }, new TagHelperAttribute("aname", A.Value), true },
+                    { new[] { B, A2, A }, A2, true },
+                    { new[] { B, A2, A }, new TagHelperAttribute(A.Name, A.Value), true },
+                    { new[] { B, A2, A }, new TagHelperAttribute("AnAME", A2.Value), true },
+                    { new[] { B, A2, A, C }, A, true },
+                    { new[] { B, A2, A, C }, new TagHelperAttribute(A.Name, A.Value), true },
+                    { new[] { B, A2, A, C }, new TagHelperAttribute("ANAME", A.Value), true },
+                    { new[] { A, A3 }, A, true },
+                    { new[] { A, A3 }, new TagHelperAttribute(A.Name, A.Value), true },
+                    { new[] { A, A3 }, new TagHelperAttribute("ANamE", A.Value), true },
+                    { new[] { A3, A }, A3, true },
+                    { new[] { A3, A }, new TagHelperAttribute(A3.Name, A3.Value), true },
+                    { new[] { A3, A }, new TagHelperAttribute("anamE", A3.Value), true },
+                    { new[] { A, A2, A3 }, A, true },
+                    { new[] { A, A2, A3 }, new TagHelperAttribute(A.Name, A.Value), true },
+                    { new[] { A, A2, A3 }, new TagHelperAttribute("ANAme", A.Value), true },
+                    { new[] { C, B, A3, A }, A3, true },
+                    { new[] { C, B, A3, A }, new TagHelperAttribute(A3.Name, A3.Value), true },
+                    { new[] { C, B, A3, A }, new TagHelperAttribute("aname", A3.Value), true },
+                    { new[] { A, B, A2, C }, A3, false },
+                    { new[] { A, B, A2, C }, new TagHelperAttribute(A.Name, A3.Value), false },
+                    { new[] { A, B, A2, C }, new TagHelperAttribute("aname_not", "different value"), false },
+                    { new[] { B, A2, A }, A3, false },
+                    { new[] { B, A2, A }, new TagHelperAttribute(A.Name, A3.Value), false },
+                    { new[] { B, A2, A }, new TagHelperAttribute("AnAME_not", "different value"), false },
+                    { new[] { B, A2, A, C }, A3, false },
+                    { new[] { B, A2, A, C }, new TagHelperAttribute(A.Name, A3.Value), false },
+                    { new[] { B, A2, A, C }, new TagHelperAttribute("ANAME_not", "different value"), false },
+                    { new[] { A, A3 }, B, false },
+                    { new[] { A, A3 }, new TagHelperAttribute(A.Name, A2.Value), false },
+                    { new[] { A, A3 }, new TagHelperAttribute("ANamE_not", "different value"), false },
+                    { new[] { A3, A }, B, false },
+                    { new[] { A3, A }, new TagHelperAttribute(A3.Name, A2.Value), false },
+                    { new[] { A3, A }, new TagHelperAttribute("anamE_not", "different value"), false },
+                    { new[] { A, A2, A3 }, B, false },
+                    { new[] { A, A2, A3 }, new TagHelperAttribute(A.Name, B.Value), false },
+                    { new[] { A, A2, A3 }, new TagHelperAttribute("ANAme_not", "different value"), false },
+                    { new[] { C, B, A3, A }, A2, false },
+                    { new[] { C, B, A3, A }, new TagHelperAttribute(A3.Name, A2.Value), false },
+                    { new[] { C, B, A3, A }, new TagHelperAttribute("aname_not", "different value"), false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ContainsData))]
+        public void Contains_ReturnsExpectedResult(
+            IEnumerable<IReadOnlyTagHelperAttribute> initialAttributes,
+            IReadOnlyTagHelperAttribute attributeToLookup,
+            bool expected)
+        {
+            // Arrange
+            var attributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(initialAttributes);
+
+            // Act
+            var contains = attributes.Contains(attributeToLookup);
+
+            // Assert
+            Assert.Equal(expected, contains);
+        }
+
+        public static TheoryData ContainsNameData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var A3 = new TagHelperAttribute("AName", "AName Third Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+                var C = new TagHelperAttribute("CName", "CName Value");
+
+                return new TheoryData<
+                    IEnumerable<IReadOnlyTagHelperAttribute>, // initialAttributes
+                    string, // nameToLookup
+                    bool> // expected
+                {
+                    { new[] { A }, A.Name, true },
+                    { new[] { A }, "aname", true },
+                    { new[] { A, B }, A.Name, true },
+                    { new[] { A, B }, "AnaMe", true },
+                    { new[] { A, B }, B.Name, true },
+                    { new[] { A, B }, "BNAME", true },
+                    { new[] { A, B, C }, B.Name, true },
+                    { new[] { A, B, C }, "bname", true },
+                    { new[] { A, B, C }, C.Name, true },
+                    { new[] { A, B, C }, "CNAme", true },
+                    { new[] { A }, B.Name, false },
+                    { new[] { A, B }, C.Name, false },
+                    { new[] { A, B, C }, "different", false },
+
+                    // Multiple elements same name
+                    { new[] { A, B, A2, C }, A.Name, true },
+                    { new[] { A, B, A2, C }, "aname", true },
+                    { new[] { B, A2, A }, A2.Name, true },
+                    { new[] { B, A2, A }, "AnAME", true },
+                    { new[] { B, A2, A, C }, A.Name, true },
+                    { new[] { B, A2, A, C }, "ANAME", true },
+                    { new[] { A, A3 }, A.Name, true },
+                    { new[] { A, A3 }, "ANamE", true },
+                    { new[] { A, A2, A3 }, A.Name, true },
+                    { new[] { A, A2, A3 }, "ANAme", true },
+                    { new[] { C, B, A3, A }, A3.Name, true },
+                    { new[] { C, B, A3, A }, "aname", true },
+                    { new[] { A, B, A2, C }, "aname_not", false },
+                    { new[] { B, A2, A }, C.Name, false },
+                    { new[] { B, A2, A }, "AnAME_not", false },
+                    { new[] { B, A2, A, C }, "different", false },
+                    { new[] { B, A2, A, C }, "ANAME_not", false },
+                    { new[] { A, A3 }, B.Name, false },
+                    { new[] { A, A3 }, "ANamE_not", false },
+                    { new[] { A3, A }, B.Name, false },
+                    { new[] { A3, A }, "anamE_not", false },
+                    { new[] { A, A2, A3 }, B.Name, false },
+                    { new[] { A, A2, A3 }, "ANAme_not", false },
+                    { new[] { C, B, A3, A }, "different", false },
+                    { new[] { C, B, A3, A }, "aname_not", false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ContainsNameData))]
+        public void ContainsName_ReturnsExpectedResult(
+            IEnumerable<IReadOnlyTagHelperAttribute> initialAttributes,
+            string nameToLookup,
+            bool expected)
+        {
+            // Arrange
+            var attributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(initialAttributes);
+
+            // Act
+            var contains = attributes.ContainsName(nameToLookup);
+
+            // Assert
+            Assert.Equal(expected, contains);
+        }
+
+        public static TheoryData IndexOfData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var A3 = new TagHelperAttribute("AName", "AName Third Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+                var C = new TagHelperAttribute("CName", "CName Value");
+
+                return new TheoryData<
+                    IEnumerable<IReadOnlyTagHelperAttribute>, // initialAttributes
+                    IReadOnlyTagHelperAttribute, // attributeToLookup
+                    int> // expected
+                {
+                    { new[] { A }, A, 0 },
+                    { new[] { A }, new TagHelperAttribute(A.Name, A.Value), 0 },
+                    { new[] { A }, new TagHelperAttribute("aname", A.Value), 0 },
+                    { new[] { A, B }, A, 0 },
+                    { new[] { A, B }, new TagHelperAttribute(A.Name, A.Value), 0 },
+                    { new[] { A, B }, new TagHelperAttribute("AnaMe", A.Value), 0 },
+                    { new[] { A, B }, B, 1 },
+                    { new[] { A, B }, new TagHelperAttribute(B.Name, B.Value), 1 },
+                    { new[] { A, B }, new TagHelperAttribute("BNAME", B.Value), 1 },
+                    { new[] { A, B, C }, B, 1 },
+                    { new[] { A, B, C }, new TagHelperAttribute(B.Name, B.Value), 1 },
+                    { new[] { A, B, C }, new TagHelperAttribute("bname", B.Value), 1 },
+                    { new[] { A, B, C }, C, 2 },
+                    { new[] { A, B, C }, new TagHelperAttribute(C.Name, C.Value), 2 },
+                    { new[] { A, B, C }, new TagHelperAttribute("CNAme", C.Value), 2 },
+                    { new[] { A }, B, -1 },
+                    { new[] { A }, new TagHelperAttribute(A.Name, "different value"), -1 },
+                    { new[] { A }, new TagHelperAttribute("aname_not", "different value"), -1 },
+                    { new[] { A, B }, A2, -1 },
+                    { new[] { A, B }, new TagHelperAttribute(A.Name, "different value"), -1 },
+                    { new[] { A, B }, new TagHelperAttribute("AnaMe_not", "different value"), -1 },
+                    { new[] { A, B }, new TagHelperAttribute(B.Name, "different value"), -1 },
+                    { new[] { A, B }, new TagHelperAttribute("BNAME_not", "different value"), -1 },
+                    { new[] { A, B, C }, A2, -1 },
+                    { new[] { A, B, C }, new TagHelperAttribute(B.Name, "different value"), -1 },
+                    { new[] { A, B, C }, new TagHelperAttribute("bname_not", "different value"), -1 },
+                    { new[] { A, B, C }, new TagHelperAttribute(C.Name, "different value"), -1 },
+                    { new[] { A, B, C }, new TagHelperAttribute("CNAme_not", "different value"), -1 },
+
+                    // Multiple elements same name
+                    { new[] { A, B, A2, C }, A, 0 },
+                    { new[] { A, B, A2, C }, new TagHelperAttribute(A.Name, A.Value), 0 },
+                    { new[] { A, B, A2, C }, new TagHelperAttribute("aname", A.Value), 0 },
+                    { new[] { B, A2, A }, A2, 1 },
+                    { new[] { B, A2, A }, new TagHelperAttribute(A.Name, A.Value), 2 },
+                    { new[] { B, A2, A }, new TagHelperAttribute("AnAME", A2.Value), 1 },
+                    { new[] { B, A2, A, C }, A, 2 },
+                    { new[] { B, A2, A, C }, new TagHelperAttribute(A.Name, A.Value), 2 },
+                    { new[] { B, A2, A, C }, new TagHelperAttribute("ANAME", A.Value), 2 },
+                    { new[] { A, A3 }, A, 0 },
+                    { new[] { A, A3 }, new TagHelperAttribute(A.Name, A.Value), 0 },
+                    { new[] { A, A3 }, new TagHelperAttribute("ANamE", A.Value), 0 },
+                    { new[] { A3, A }, A3, 0 },
+                    { new[] { A3, A }, new TagHelperAttribute(A3.Name, A3.Value), 0 },
+                    { new[] { A3, A }, new TagHelperAttribute("anamE", A3.Value), 0 },
+                    { new[] { A, A2, A3 }, A, 0 },
+                    { new[] { A, A2, A3 }, new TagHelperAttribute(A.Name, A.Value), 0 },
+                    { new[] { A, A2, A3 }, new TagHelperAttribute("ANAme", A.Value), 0 },
+                    { new[] { C, B, A3, A }, A3, 2 },
+                    { new[] { C, B, A3, A }, new TagHelperAttribute(A3.Name, A3.Value), 2 },
+                    { new[] { C, B, A3, A }, new TagHelperAttribute("aname", A3.Value), 2 },
+                    { new[] { A, B, A2, C }, A3, -1 },
+                    { new[] { A, B, A2, C }, new TagHelperAttribute(A.Name, A3.Value), -1 },
+                    { new[] { A, B, A2, C }, new TagHelperAttribute("aname_not", "different value"), -1 },
+                    { new[] { B, A2, A }, A3, -1 },
+                    { new[] { B, A2, A }, new TagHelperAttribute(A.Name, A3.Value), -1 },
+                    { new[] { B, A2, A }, new TagHelperAttribute("AnAME_not", "different value"), -1 },
+                    { new[] { B, A2, A, C }, A3, -1 },
+                    { new[] { B, A2, A, C }, new TagHelperAttribute(A.Name, A3.Value), -1 },
+                    { new[] { B, A2, A, C }, new TagHelperAttribute("ANAME_not", "different value"), -1 },
+                    { new[] { A, A3 }, B, -1 },
+                    { new[] { A, A3 }, new TagHelperAttribute(A.Name, A2.Value), -1 },
+                    { new[] { A, A3 }, new TagHelperAttribute("ANamE_not", "different value"), -1 },
+                    { new[] { A3, A }, B, -1 },
+                    { new[] { A3, A }, new TagHelperAttribute(A3.Name, A2.Value), -1 },
+                    { new[] { A3, A }, new TagHelperAttribute("anamE_not", "different value"), -1 },
+                    { new[] { A, A2, A3 }, B, -1 },
+                    { new[] { A, A2, A3 }, new TagHelperAttribute(A.Name, B.Value), -1 },
+                    { new[] { A, A2, A3 }, new TagHelperAttribute("ANAme_not", "different value"), -1 },
+                    { new[] { C, B, A3, A }, A2, -1 },
+                    { new[] { C, B, A3, A }, new TagHelperAttribute(A3.Name, A2.Value), -1 },
+                    { new[] { C, B, A3, A }, new TagHelperAttribute("aname_not", "different value"), -1 },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IndexOfData))]
+        public void IndexOf_ReturnsExpectedResult(
+            IEnumerable<IReadOnlyTagHelperAttribute> initialAttributes,
+            IReadOnlyTagHelperAttribute attributeToLookup,
+            int expected)
+        {
+            // Arrange
+            var attributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(initialAttributes);
+
+            // Act
+            var index = attributes.IndexOf(attributeToLookup);
+
+            // Assert
+            Assert.Equal(expected, index);
+        }
+
+        public static TheoryData TryGetAttributeData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var A3 = new TagHelperAttribute("AName", "AName Third Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+                var C = new TagHelperAttribute("CName", "CName Value");
+
+                return new TheoryData<
+                    IEnumerable<IReadOnlyTagHelperAttribute>, // initialAttributes
+                    string, // nameToLookup
+                    IReadOnlyTagHelperAttribute, // expectedAttribute
+                    bool> // expectedResult
+                {
+                    { new[] { A }, "AName", A, true },
+                    { new[] { A }, "AnAmE", A, true },
+                    { new[] { A, B }, "AName", A, true },
+                    { new[] { A, B }, "AnAmE", A, true },
+                    { new[] { A, B }, "BName", B, true },
+                    { new[] { A, B }, "BnAmE", B, true },
+                    { new[] { A, B, C }, "BName", B, true },
+                    { new[] { A, B, C }, "bname", B, true },
+                    { new[] { A, B, C }, "CName", C, true },
+                    { new[] { A, B, C }, "cnamE", C, true },
+
+                    // Multiple elements same name
+                    { new[] { A, B, A2, C }, "AName", A, true },
+                    { new[] { A, B, A2, C }, "aname", A, true },
+                    { new[] { B, A2, A }, "aname", A2, true },
+                    { new[] { B, A2, A, C }, "AName", A2, true },
+                    { new[] { A, A3 }, "AName", A, true },
+                    { new[] { A3, A }, "aname", A3, true },
+                    { new[] { A, A2, A3 }, "AName", A, true },
+                    { new[] { C, B, A3, A }, "AName", A3, true },
+
+                    // Null expected lookups
+                    { new[] { A }, "_AName_", null, false },
+                    { new[] { A }, "completely different", null, false },
+                    { new[] { A, B }, "_AName_", null, false },
+                    { new[] { A, B }, "completely different", null, false },
+                    { new[] { A, B, C }, "_BName_", null, false },
+                    { new[] { A, B, C }, "completely different", null, false },
+                    { new[] { A, A2, B, C }, "_cnamE_", null, false },
+                    { new[] { A, A2, B, C }, "completely different", null, false },
+                    { new[] { A, A2, A3, B, C }, "_cnamE_", null, false },
+                    { new[] { A, A2, A3, B, C }, "completely different", null, false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TryGetAttributeData))]
+        public void TryGetAttribute_ReturnsExpectedValueAndAttribute(
+            IEnumerable<IReadOnlyTagHelperAttribute> initialAttributes,
+            string nameToLookup,
+            IReadOnlyTagHelperAttribute expectedAttribute,
+            bool expectedResult)
+        {
+            // Arrange
+            var attributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(initialAttributes);
+            IReadOnlyTagHelperAttribute attribute;
+
+            // Act
+            var result = attributes.TryGetAttribute(nameToLookup, out attribute);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedAttribute, attribute, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        public static TheoryData TryGetAttributesData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var A3 = new TagHelperAttribute("AName", "AName Third Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+                var C = new TagHelperAttribute("CName", "CName Value");
+
+                return new TheoryData<
+                    IEnumerable<IReadOnlyTagHelperAttribute>, // initialAttributes
+                    string, // nameToLookup
+                    IEnumerable<IReadOnlyTagHelperAttribute>, // expectedAttributes
+                    bool> // expectedResult
+                {
+                    { new[] { A }, "AName", new[] { A }, true },
+                    { new[] { A }, "AnAmE", new[] { A }, true },
+                    { new[] { A, B }, "AName", new[] { A }, true },
+                    { new[] { A, B }, "AnAmE", new[] { A }, true },
+                    { new[] { A, B }, "BName", new[] { B }, true },
+                    { new[] { A, B }, "BnAmE", new[] { B }, true },
+                    { new[] { A, B, C }, "BName", new[] { B }, true },
+                    { new[] { A, B, C }, "bname", new[] { B }, true },
+                    { new[] { A, B, C }, "CName", new[] { C }, true },
+                    { new[] { A, B, C }, "cnamE", new[] { C }, true },
+
+                    // Multiple elements same name
+                    { new[] { A, B, A2, C }, "AName", new[] { A, A2 }, true },
+                    { new[] { A, B, A2, C }, "aname", new[] { A, A2 }, true },
+                    { new[] { B, A2, A }, "aname", new[] { A2, A }, true },
+                    { new[] { B, A2, A, C }, "AName", new[] { A2, A }, true },
+                    { new[] { A, A3 }, "AName", new[] { A, A3 }, true },
+                    { new[] { A3, A }, "aname", new[] { A3, A }, true },
+                    { new[] { A, A2, A3 }, "AName", new[] { A, A2, A3 }, true },
+                    { new[] { C, B, A3, A }, "AName", new[] { A3, A }, true },
+
+                    // Null expected lookups
+                    { new[] { A }, "_AName_", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                    { new[] { A }, "completely different", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                    { new[] { A, B }, "_AName_", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                    { new[] { A, B }, "completely different", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                    { new[] { A, B, C }, "_BName_", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                    { new[] { A, B, C }, "way different", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                    { new[] { A, A2, B, C }, "_cnamE_", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                    { new[] { A, A2, B, C }, "way different", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                    { new[] { A, A2, A3, B, C }, "_cnamE_", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                    { new[] { A, A2, A3, B, C }, "different", Enumerable.Empty<IReadOnlyTagHelperAttribute>(), false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TryGetAttributesData))]
+        public void TryGetAttributes_ReturnsExpectedValueAndAttribute(
+            IEnumerable<IReadOnlyTagHelperAttribute> initialAttributes,
+            string nameToLookup,
+            IEnumerable<IReadOnlyTagHelperAttribute> expectedAttributes,
+            bool expectedResult)
+        {
+            // Arrange
+            var attributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(initialAttributes);
+            IEnumerable<IReadOnlyTagHelperAttribute> resolvedAttributes;
+
+            // Act
+            var result = attributes.TryGetAttributes(nameToLookup, out resolvedAttributes);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedAttributes, resolvedAttributes, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        [Fact]
+        public void Attributes_EqualsInitialAttributes()
+        {
+            // Arrange
+            var expectedAttributes = new[]
+            {
+                new TagHelperAttribute("A", "AV"),
+                new TagHelperAttribute("B", "BV")
+            };
+
+            // Act
+            var attributes = new TestableReadOnlyTagHelperAttributes(expectedAttributes);
+
+            // Assert
+            Assert.Equal(expectedAttributes, attributes.PublicAttributes);
+        }
+
+        [Fact]
+        public void GetEnumerator_ReturnsUnderlyingAttributesEnumerator()
+        {
+            // Arrange & Act
+            var attributes = new TestableReadOnlyTagHelperAttributes(new[]
+            {
+                new TagHelperAttribute("A", "AV"),
+                new TagHelperAttribute("B", "BV")
+            });
+
+            // Assert
+            Assert.Equal(attributes.GetEnumerator(), attributes.PublicAttributes.GetEnumerator());
+        }
+
+        [Fact]
+        public void ModifyingUnderlyingAttributes_AffectsExposedAttributes()
+        {
+            // Arrange
+            var attributes = new TestableReadOnlyTagHelperAttributes(Enumerable.Empty<IReadOnlyTagHelperAttribute>());
+            var expectedAttributes = new[]
+            {
+                new TagHelperAttribute("A", "AV"),
+                new TagHelperAttribute("B", "BV")
+            };
+
+            // Act
+            attributes.PublicAttributes.AddRange(expectedAttributes);
+
+            // Assert
+            Assert.Equal(attributes, expectedAttributes, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+
+        [Theory]
+        [MemberData(nameof(IntIndexerData))]
+        public void ModifyingUnderlyingAttributes_IntIndexer_ReturnsExpectedResult(
+            IEnumerable<IReadOnlyTagHelperAttribute> initialAttributes,
+            int indexToLookup,
+            IReadOnlyTagHelperAttribute expectedAttribute)
+        {
+            // Arrange
+            var attributes = new TestableReadOnlyTagHelperAttributes(Enumerable.Empty<IReadOnlyTagHelperAttribute>());
+            attributes.PublicAttributes.AddRange(initialAttributes);
+
+            // Act
+            var attribute = attributes[indexToLookup];
+
+            // Assert
+            Assert.Equal(expectedAttribute, attribute, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringIndexerData))]
+        public void ModifyingUnderlyingAttributes_StringIndexer_ReturnsExpectedResult(
+            IEnumerable<IReadOnlyTagHelperAttribute> initialAttributes,
+            string nameToLookup,
+            IReadOnlyTagHelperAttribute expectedAttribute)
+        {
+            // Arrange
+            var attributes = new TestableReadOnlyTagHelperAttributes(Enumerable.Empty<IReadOnlyTagHelperAttribute>());
+            attributes.PublicAttributes.AddRange(initialAttributes);
+
+            // Act
+            var attribute = attributes[nameToLookup];
+
+            // Assert
+            Assert.Equal(expectedAttribute, attribute, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        private class TestableReadOnlyTagHelperAttributes : ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>
+        {
+            public TestableReadOnlyTagHelperAttributes(IEnumerable<IReadOnlyTagHelperAttribute> attributes)
+                : base(attributes)
+            {
+            }
+
+            public List<IReadOnlyTagHelperAttribute> PublicAttributes
+            {
+                get
+                {
+                    return Attributes;
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperAttributeListTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperAttributeListTest.cs
@@ -1,0 +1,698 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    public class TagHelperAttributeListTest
+    {
+        [Theory]
+        [MemberData(
+            nameof(ReadOnlyTagHelperAttributeListTest.IntIndexerData),
+            MemberType = typeof(ReadOnlyTagHelperAttributeListTest))]
+        public void IntIndexer_GetsExpectedAttribute(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            int indexToLookup,
+            TagHelperAttribute expectedAttribute)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+
+            // Act
+            var attribute = attributes[indexToLookup];
+
+            // Assert
+            Assert.Equal(expectedAttribute, attribute, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        public static TheoryData IntIndexerSetData
+        {
+            get
+            {
+                var first = new TagHelperAttribute("First", "First Value");
+                var second = new TagHelperAttribute("Second", "Second Value");
+                var third = new TagHelperAttribute("Third", "Third Value");
+                var set = new TagHelperAttribute("Set", "Set Value");
+
+                return new TheoryData<
+                    IEnumerable<TagHelperAttribute>, // initialAttributes
+                    int, // indexToSet
+                    TagHelperAttribute, // setValue
+                    IEnumerable<TagHelperAttribute>> // expectedAttributes
+                {
+                    { new[] { first }, 0, set, new[] { set } },
+                    { new[] { first, second }, 0, set, new[] { set, second } },
+                    { new[] { first, second }, 1, set, new[] { first, set } },
+                    { new[] { first, second, third}, 1, set, new[] { first, set, third } },
+                    { new[] { first, second, third }, 2, set, new[] { first, second, set } },
+                    { new[] { first, first, second, third}, 1, set, new[] { first, set, second, third } },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(IntIndexerSetData))]
+        public void IntIndexer_SetsAttributeAtExpectedIndex(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            int indexToSet,
+            TagHelperAttribute setValue,
+            IEnumerable<TagHelperAttribute> expectedAttributes)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+
+            // Act
+            attributes[indexToSet] = setValue;
+
+            // Assert
+            Assert.Equal(expectedAttributes, attributes, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        [Theory]
+        [MemberData(
+            nameof(ReadOnlyTagHelperAttributeListTest.IntIndexerThrowData),
+            MemberType = typeof(ReadOnlyTagHelperAttributeListTest))]
+        public void IntIndexer_Getter_ThrowsIfIndexInvalid(int index)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(new[]
+                {
+                    new TagHelperAttribute("A", "AV"),
+                    new TagHelperAttribute("B", "BV")
+                });
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentOutOfRangeException>("index", () => attributes[index]);
+        }
+
+        [Theory]
+        [MemberData(
+            nameof(ReadOnlyTagHelperAttributeListTest.IntIndexerThrowData),
+            MemberType = typeof(ReadOnlyTagHelperAttributeListTest))]
+        public void IntIndexer_Setter_ThrowsIfIndexInvalid(int index)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(new[]
+            {
+                new TagHelperAttribute("A", "AV"),
+                new TagHelperAttribute("B", "BV")
+            });
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentOutOfRangeException>("index", () =>
+            {
+                attributes[index] = new TagHelperAttribute("C", "CV");
+            });
+        }
+
+        [Theory]
+        [MemberData(
+            nameof(ReadOnlyTagHelperAttributeListTest.StringIndexerData),
+            MemberType = typeof(ReadOnlyTagHelperAttributeListTest))]
+        public void StringIndexer_GetsExpectedAttribute(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            string nameToLookup,
+            TagHelperAttribute expectedAttribute)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+
+            // Act
+            var attribute = attributes[nameToLookup];
+
+            // Assert
+            Assert.Equal(expectedAttribute, attribute, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        public static TheoryData StringIndexerSetData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var ASet = new TagHelperAttribute("aname", "AName Set Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var A2Set = new TagHelperAttribute("aname", "AName Second Set Value");
+                var A3 = new TagHelperAttribute("AName", "AName Third Value");
+                var A3Set = new TagHelperAttribute("aname", "AName Third Set Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+                var BSet = new TagHelperAttribute("bname", "BName Set Value");
+                var C = new TagHelperAttribute("CName", "CName Value");
+                var CSet = new TagHelperAttribute("cname", "CName Set Value");
+                var set = new TagHelperAttribute("Set", "Set Value");
+
+                return new TheoryData<
+                    IEnumerable<TagHelperAttribute>, // initialAttributes
+                    string, // keyToSet
+                    TagHelperAttribute, // setValue
+                    IEnumerable<TagHelperAttribute>> // expectedAttributes
+                {
+                    { new[] { A }, "AName", ASet, new[] { ASet } },
+                    { new[] { A }, "AnAmE", ASet, new[] { ASet } },
+                    { new[] { A }, "AnAmE", "AV", new[] { new TagHelperAttribute("AnAmE", "AV") } },
+                    { new[] { A, B }, "AName", ASet, new[] { ASet, B } },
+                    { new[] { A, B }, "AnAmE", ASet, new[] { ASet, B } },
+                    { new[] { A, B }, "AnAmE", "AV", new[] { new TagHelperAttribute("AnAmE", "AV"), B } },
+                    { new[] { A, B }, "BName", BSet, new[] { A, BSet } },
+                    { new[] { A, B }, "BnAmE", BSet, new[] { A, BSet } },
+                    { new[] { A, B }, "BnAmE", "BV", new[] { A, new TagHelperAttribute("BnAmE", "BV") } },
+                    { new[] { A, B, C }, "BName", BSet, new[] { A, BSet, C } },
+                    { new[] { A, B, C }, "bname", BSet, new[] { A, BSet, C } },
+                    { new[] { A, B, C }, "bname", "BV", new[] { A, new TagHelperAttribute("bname", "BV"), C } },
+                    { new[] { A, B, C }, "CName", CSet, new[] { A, B, CSet } },
+                    { new[] { A, B, C }, "cnamE", CSet, new[] { A, B, CSet } },
+                    { new[] { A, B, C }, "cnamE", "CV", new[] { A, B, new TagHelperAttribute("cnamE", "CV") } },
+                    { Enumerable.Empty<TagHelperAttribute>(), "Set", set, new[] { set } },
+                    { new[] { B }, "Set", set, new[] { B, set } },
+                    { new[] { B }, "Set", "Set Value", new[] { B, set } },
+                    { new[] { A, B }, "Set", set, new[] { A, B, set } },
+                    { new[] { A, B }, "Set", "Set Value", new[] { A, B, set } },
+
+                    // Multiple elements same name
+                    { new[] { A, B, A2, C }, "AName", ASet, new[] { ASet, B, C } },
+                    { new[] { A, B, A2, C }, "aname", ASet, new[] { ASet, B, C } },
+                    { new[] { A, B, A2, C }, "aname", "av", new[] { new TagHelperAttribute("aname", "av"), B, C } },
+                    { new[] { B, A2, A }, "aname", A2Set, new[] { B, A2Set } },
+                    { new[] { B, A2, A }, "aname", "av", new[] { B, new TagHelperAttribute("aname", "av") } },
+                    { new[] { B, A2, A, C }, "AName", A2Set, new[] { B, A2Set, C } },
+                    { new[] { B, A2, A, C }, "AName", "av", new[] { B, new TagHelperAttribute("AName", "av"), C } },
+                    { new[] { A, A3 }, "AName", ASet, new[] { ASet } },
+                    { new[] { A, A3 }, "AName", "av", new[] { new TagHelperAttribute("AName", "av") } },
+                    { new[] { A3, A }, "aname", A3Set, new[] { A3Set } },
+                    { new[] { A3, A }, "aname", "av", new[] { new TagHelperAttribute("aname", "av") } },
+                    { new[] { A, A2, A3 }, "AName", ASet, new[] { ASet } },
+                    { new[] { A, A2, A3 }, "AName", "av", new[] { new TagHelperAttribute("AName", "av") } },
+                    { new[] { C, B, A3, A }, "AName", A3Set, new[] { C, B, A3Set } },
+                    { new[] { C, B, A3, A }, "AName", "av", new[] { C, B, new TagHelperAttribute("AName", "av") } },
+                    { new[] { A, A2, A3 }, "BNamE", BSet, new[] { A, A2, A3, BSet } },
+                    { new[] { A, A2, A3 }, "bname", "BName Set Value", new[] { A, A2, A3, BSet } },
+                    { new[] { A, A2, A3, B, C }, "Set", set, new[] { A, A2, A3, B, C, set } },
+                    { new[] { A, A2, A3, B, C }, "Set", "Set Value", new[] { A, A2, A3, B, C, set } },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(StringIndexerSetData))]
+        public void StringIndexer_SetsAttributeAtExpectedLocation(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            string keyToSet,
+            TagHelperAttribute setValue,
+            IEnumerable<TagHelperAttribute> expectedAttributes)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+
+            // Act
+            attributes[keyToSet] = setValue;
+
+            // Assert
+            Assert.Equal(expectedAttributes, attributes, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        [Fact]
+        public void StringIndexer_Setter_ThrowsIfIndexInvalid()
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(new[]
+            {
+                new TagHelperAttribute("A", "AV"),
+                new TagHelperAttribute("B", "BV")
+            });
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentOutOfRangeException>("index", () =>
+            {
+                attributes[2] = new TagHelperAttribute("C", "CV");
+            });
+        }
+
+        public static TheoryData StringIndexerSetterThrowData
+        {
+            get
+            {
+                // attributes
+                return new TheoryData<TagHelperAttributeList>
+                {
+                    { new TagHelperAttributeList() },
+                    { new TagHelperAttributeList { { "something", "a value" } } },
+                    { new TagHelperAttributeList { { "somethingelse", "a value" } } },
+                    { new TagHelperAttributeList { { "SomethingElse", "a value" } } },
+                    { new TagHelperAttributeList { { "something", "a value" }, { "somethingelse", "a value" } } },
+                    { new TagHelperAttributeList { { "SomethingElse", "a value" }, { "somethingelse", "a value" } } }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(StringIndexerSetterThrowData))]
+        public void StringIndexer_Setter_ThrowsIfUnmatchingKey(
+            TagHelperAttributeList attributes)
+        {
+            // Arrange
+            var expectedMessage = $"Cannot add a {nameof(TagHelperAttribute)} with inconsistent names. The " +
+                $"{nameof(TagHelperAttribute.Name)} property 'somethingelse' must match the location 'something'." +
+                $"{Environment.NewLine}Parameter name: name";
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>("name", () =>
+            {
+                attributes["something"] = new TagHelperAttribute("somethingelse", "value");
+            });
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+
+        [Fact]
+        public void ICollection_IsReadOnly_ReturnsFalse()
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList() as ICollection<TagHelperAttribute>;
+
+            // Act
+            var isReadOnly = attributes.IsReadOnly;
+
+            // Assert
+            Assert.False(isReadOnly);
+        }
+
+        public static TheoryData AddData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+
+                return new TheoryData<
+                    IEnumerable<TagHelperAttribute>, // initialAttributes
+                    TagHelperAttribute, // attributeToAdd
+                    IEnumerable<TagHelperAttribute>> // expectedAttributes
+                {
+                    { Enumerable.Empty<TagHelperAttribute>(), A, new[] { A } },
+                    { new[] { A }, B, new[] { A, B } },
+                    { new[] { A }, A2, new[] { A, A2 } },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AddData))]
+        public void Add_AppendsAttributes(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            TagHelperAttribute attributeToAdd,
+            IEnumerable<TagHelperAttribute> expectedAttributes)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+
+            // Act
+            attributes.Add(attributeToAdd);
+
+            // Assert
+            Assert.Equal(expectedAttributes, attributes, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        [Fact]
+        public void Add_ThrowsWhenNameAndValueAreNull()
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList();
+            var expectedMessage = $"Cannot add a '{typeof(TagHelperAttribute).FullName}' with a null " +
+                $"'{nameof(TagHelperAttribute.Name)}'.{Environment.NewLine}Parameter name: attribute";
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>("attribute",
+                () => attributes.Add(new TagHelperAttribute()));
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void Add_ThrowsWhenNameIsNull()
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList();
+            var expectedMessage = $"Cannot add a '{typeof(TagHelperAttribute).FullName}' with a null " +
+                $"'{nameof(TagHelperAttribute.Name)}'.{Environment.NewLine}Parameter name: attribute";
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>("attribute",
+                () => attributes.Add(new TagHelperAttribute
+                {
+                    Value = "Anything"
+                }));
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        public static TheoryData InsertData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+
+                return new TheoryData<
+                    IEnumerable<TagHelperAttribute>, // initialAttributes
+                    TagHelperAttribute, // attributeToAdd
+                    int, // locationToInsert
+                    IEnumerable<TagHelperAttribute>> // expectedAttributes
+                {
+                    { Enumerable.Empty<TagHelperAttribute>(), A, 0, new[] { A } },
+                    { new[] { A }, B, 1, new[] { A, B } },
+                    { new[] { A }, B, 0, new[] { B, A } },
+                    { new[] { A }, A2, 1, new[] { A, A2 } },
+                    { new[] { A }, A2, 0, new[] { A2, A } },
+                    { new[] { A, B }, A2, 0, new[] { A2, A, B } },
+                    { new[] { A, B }, A2, 1, new[] { A, A2, B } },
+                    { new[] { A, B }, A2, 2, new[] { A, B, A2 } },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InsertData))]
+        public void Insert_InsertsAttributes(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            TagHelperAttribute attributeToAdd,
+            int locationToInsert,
+            IEnumerable<TagHelperAttribute> expectedAttributes)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+
+            // Act
+            attributes.Insert(locationToInsert, attributeToAdd);
+
+            // Assert
+            Assert.Equal(expectedAttributes, attributes, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        [Fact]
+        public void Insert_ThrowsWhenNameIsNull()
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList();
+            var expectedMessage = $"Cannot add a '{typeof(TagHelperAttribute).FullName}' with a null " +
+                $"'{nameof(TagHelperAttribute.Name)}'.{Environment.NewLine}Parameter name: attribute";
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>("attribute",
+                () => attributes.Insert(0, new TagHelperAttribute
+                {
+                    Value = "Anything"
+                }));
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        [Fact]
+        public void Insert_ThrowsWhenIndexIsOutOfRange()
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(
+                new[]
+                {
+                    new TagHelperAttribute("a", "av"),
+                    new TagHelperAttribute("b", "bv"),
+                });
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentOutOfRangeException>("index",
+                () => attributes.Insert(3, new TagHelperAttribute("c", "cb")));
+        }
+
+        public static TheoryData CopyToData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+
+                return new TheoryData<
+                    IEnumerable<TagHelperAttribute>, // initialAttributes
+                    TagHelperAttribute[], // attributesToCopy
+                    int, // locationToCopy
+                    IEnumerable<TagHelperAttribute>> // expectedAttributes
+                {
+                    { Enumerable.Empty<TagHelperAttribute>(), new[] { A }, 0, new[] { A } },
+                    { Enumerable.Empty<TagHelperAttribute>(), new[] { A, B }, 0, new[] { A, B } },
+                    { new[] { A }, new[] { B }, 1, new[] { A, B } },
+                    { new[] { A }, new[] { B }, 0, new[] { B } },
+                    { new[] { A }, new[] { A2 }, 1, new[] { A, A2 } },
+                    { new[] { A }, new[] { A2 }, 0, new[] { A2 } },
+                    { new[] { A, B }, new[] { A2 }, 0, new[] { A2, B } },
+                    { new[] { A, B }, new[] { A2 }, 1, new[] { A, A2 } },
+                    { new[] { A, B }, new[] { A2 }, 2, new[] { A, B, A2 } },
+                    { new[] { A, B }, new[] { A2, A2 }, 0, new[] { A2, A2 } },
+                    { new[] { A, B, A2 }, new[] { A2, A2 }, 1, new[] { A, A2, A2 } },
+                    { new[] { A, B }, new[] { A2, A2 }, 2, new[] { A, B, A2, A2 } },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CopyToData))]
+        public void CopyTo_CopiesAttributes(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            TagHelperAttribute[] attributesToCopy,
+            int locationToCopy,
+            IEnumerable<TagHelperAttribute> expectedAttributes)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+            var attributeDestination = new TagHelperAttribute[expectedAttributes.Count()];
+            attributes.ToArray().CopyTo(attributeDestination, 0);
+
+            // Act
+            attributesToCopy.CopyTo(attributeDestination, locationToCopy);
+
+            // Assert
+            Assert.Equal(expectedAttributes, attributeDestination, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        public static TheoryData RemoveAllData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var A3 = new TagHelperAttribute("AName", "AName Third Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+                var C = new TagHelperAttribute("CName", "CName Value");
+
+                return new TheoryData<
+                    IEnumerable<TagHelperAttribute>, // initialAttributes
+                    string, // keyToRemove
+                    IEnumerable<TagHelperAttribute>, // expectedAttributes
+                    bool> // expectedRemoval
+                {
+                    { new[] { A }, "AName", Enumerable.Empty<TagHelperAttribute>(), true },
+                    { new[] { A }, "AnAmE", Enumerable.Empty<TagHelperAttribute>(), true },
+                    { new[] { A, B }, "AName", new[] { B }, true },
+                    { new[] { A, B }, "AnAmE", new[] { B }, true },
+                    { new[] { A, B }, "BName", new[] { A }, true },
+                    { new[] { A, B }, "BnAmE", new[] { A }, true },
+                    { new[] { A, B, C }, "BName", new[] { A, C }, true },
+                    { new[] { A, B, C }, "bname", new[] { A, C }, true },
+                    { new[] { A, B, C }, "CName", new[] { A, B }, true },
+                    { new[] { A, B, C }, "cnamE", new[] { A, B }, true },
+
+                    // Multiple elements same name
+                    { new[] { A, B, A2, C }, "AName", new[] { B, C }, true },
+                    { new[] { A, B, A2, C }, "aname", new[] { B, C }, true },
+                    { new[] { B, A2, A }, "aname", new[] { B }, true },
+                    { new[] { B, A2, A, C }, "AName", new[] { B, C }, true },
+                    { new[] { A, A3 }, "AName", Enumerable.Empty<TagHelperAttribute>(), true },
+                    { new[] { A3, A }, "aname", Enumerable.Empty<TagHelperAttribute>(), true },
+                    { new[] { A, A2, A3 }, "AName", Enumerable.Empty<TagHelperAttribute>(), true },
+                    { new[] { C, B, A3, A }, "AName", new[] { C, B }, true },
+
+                    // No removal expected lookups
+                    { Enumerable.Empty<TagHelperAttribute>(), "_0_", Enumerable.Empty<TagHelperAttribute>(), false },
+                    { new[] { A }, "_AName_", new[] { A }, false },
+                    { new[] { A }, "completely different", new[] { A }, false },
+                    { new[] { A, B }, "_AName_", new[] { A, B }, false },
+                    { new[] { A, B }, "completely different", new[] { A, B }, false },
+                    { new[] { A, B, C }, "_BName_", new[] { A, B, C }, false },
+                    { new[] { A, B, C }, "completely different", new[] { A, B, C }, false },
+                    { new[] { A, A2, B, C }, "_cnamE_", new[] { A, A2, B, C }, false },
+                    { new[] { A, A2, B, C }, "completely different", new[] { A, A2, B, C }, false },
+                    { new[] { A, A2, A3, B, C }, "_cnamE_", new[] { A, A2, A3, B, C }, false },
+                    { new[] { A, A2, A3, B, C }, "completely different", new[] { A, A2, A3, B, C }, false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RemoveAllData))]
+        public void RemoveAll_RemovesAllExpectedAttributes(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            string keyToRemove,
+            IEnumerable<TagHelperAttribute> expectedAttributes,
+            bool expectedRemoval)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+
+            // Act
+            var removed = attributes.RemoveAll(keyToRemove);
+
+            // Assert
+            Assert.Equal(expectedRemoval, removed);
+            Assert.Equal(expectedAttributes, attributes, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        public static TheoryData RemoveData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "av");
+                var A2 = new TagHelperAttribute("aname", "av");
+                var A3 = new TagHelperAttribute("AName", "av");
+                var B = new TagHelperAttribute("BName", "bv");
+                var C = new TagHelperAttribute("CName", "cv");
+                var empty = Enumerable.Empty<TagHelperAttribute>();
+
+                return new TheoryData<
+                    IEnumerable<TagHelperAttribute>, // initialAttributes
+                    TagHelperAttribute, // attributeToRemove
+                    IEnumerable<TagHelperAttribute>, // expectedAttributes
+                    bool> // expectedResult
+                {
+                    { new[] { A }, A, empty, true },
+                    { new[] { A }, new TagHelperAttribute("AnAmE", "av"), empty, true },
+                    { new[] { A, B }, A, new[] { B }, true },
+                    { new[] { A, B }, new TagHelperAttribute("AnAmE", "av"), new[] { B }, true },
+                    { new[] { A, B }, B, new[] { A }, true },
+                    { new[] { A, B }, new TagHelperAttribute("BnAmE", "bv"), new[] { A }, true },
+                    { new[] { A, B, C }, B, new[] { A, C }, true },
+                    { new[] { A, B, C }, new TagHelperAttribute("bname", "bv"), new[] { A, C }, true },
+                    { new[] { A, B, C }, C, new[] { A, B }, true },
+                    { new[] { A, B, C }, new TagHelperAttribute("cnamE", "cv"), new[] { A, B }, true },
+
+                    // Multiple elements same name
+                    { new[] { A, B, A2, C }, A, new[] { B, A2, C }, true },
+                    { new[] { A, B, A2, C }, new TagHelperAttribute("aname", "av"), new[] { B, A2, C }, true },
+                    { new[] { B, A2, A }, new TagHelperAttribute("aname", "av"), new[] { B, A }, true },
+                    { new[] { B, A2, A, C }, A, new[] { B, A, C }, true },
+                    { new[] { A, A3 }, A3, new[] { A3 }, true },
+                    { new[] { A3, A }, new TagHelperAttribute("aname", "av"), new[] { A }, true },
+                    { new[] { A, A2, A3 }, new TagHelperAttribute("AName", "av"), new[] { A2, A3 }, true },
+                    { new[] { C, B, A3, A }, new TagHelperAttribute("AName", "av"), new[] { C, B, A }, true },
+
+                    // Null expected lookups
+                    { Enumerable.Empty<TagHelperAttribute>(), "_0_", Enumerable.Empty<TagHelperAttribute>(), false },
+                    { new[] { A }, "_AName_", new[] { A }, false },
+                    { new[] { A }, "completely different", new[] { A }, false },
+                    { new[] { A, B }, "_AName_", new[] { A, B }, false },
+                    { new[] { A, B }, "completely different", new[] { A, B }, false },
+                    { new[] { A, B, C }, "_BName_", new[] { A, B, C }, false },
+                    { new[] { A, B, C }, "completely different", new[] { A, B, C }, false },
+                    { new[] { A, A2, B, C }, "_cnamE_", new[] { A, A2, B, C }, false },
+                    { new[] { A, A2, B, C }, "completely different", new[] { A, A2, B, C }, false },
+                    { new[] { A, A2, A3, B, C }, "_cnamE_", new[] { A, A2, A3, B, C }, false },
+                    { new[] { A, A2, A3, B, C }, "completely different", new[] { A, A2, A3, B, C }, false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RemoveData))]
+        public void Remove_ReturnsExpectedValueAndRemovesFirstAttribute(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            TagHelperAttribute attributeToRemove,
+            IEnumerable<TagHelperAttribute> expectedAttributes,
+            bool expectedResult)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+
+            // Act
+            var result = attributes.Remove(attributeToRemove);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(expectedAttributes, attributes, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        public static TheoryData RemoveAtData
+        {
+            get
+            {
+                var A = new TagHelperAttribute("AName", "AName Value");
+                var A2 = new TagHelperAttribute("aname", "AName Second Value");
+                var B = new TagHelperAttribute("BName", "BName Value");
+
+                return new TheoryData<
+                    IEnumerable<TagHelperAttribute>, // initialAttributes
+                    int, // locationToRemove
+                    IEnumerable<TagHelperAttribute>> // expectedAttributes
+                {
+                    { new[] { A }, 0, Enumerable.Empty<TagHelperAttribute>() },
+                    { new[] { A, B }, 0, new[] { B } },
+                    { new[] { A, B }, 1, new[] { A } },
+                    { new[] { A, A2 }, 0, new[] { A2 } },
+                    { new[] { A, A2 }, 1, new[] { A } },
+                    { new[] { A, B, A2 }, 0, new[] { B, A2 } },
+                    { new[] { A, B, A2 }, 1, new[] { A, A2 } },
+                    { new[] { A, B, A2 }, 2, new[] { A, B } },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RemoveAtData))]
+        public void RemoveAt_RemovesAttributeAtSpecifiedIndex(
+            IEnumerable<TagHelperAttribute> initialAttributes,
+            int locationToRemove,
+            IEnumerable<TagHelperAttribute> expectedAttributes)
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(initialAttributes);
+
+            // Act
+            attributes.RemoveAt(locationToRemove);
+
+            // Assert
+            Assert.Equal(expectedAttributes, attributes, CaseSensitiveTagHelperAttributeComparer.Default);
+        }
+
+        [Fact]
+        public void RemoveAt_ThrowsWhenIndexIsOutOfRange()
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(
+                new[]
+                {
+                    new TagHelperAttribute("a", "av"),
+                    new TagHelperAttribute("b", "bv"),
+                });
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentOutOfRangeException>("index",
+                () => attributes.RemoveAt(3));
+        }
+
+        [Fact]
+        public void Clear_RemovesAllAttributes()
+        {
+            // Arrange
+            var attributes = new TagHelperAttributeList(
+                new[]
+                {
+                    new TagHelperAttribute("a", "av"),
+                    new TagHelperAttribute("b", "bv"),
+                });
+
+            // Act
+            attributes.Clear();
+
+            // Assert
+            Assert.Empty(attributes);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperContextTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,7 +22,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Act
             var context = new TagHelperContext(
-                allAttributes: new Dictionary<string, object>(),
+                allAttributes: Enumerable.Empty<IReadOnlyTagHelperAttribute>(),
                 items: expectedItems,
                 uniqueId: string.Empty,
                 getChildContentAsync: () => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
@@ -148,6 +148,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             }
         }
 
+        [Theory]
         [MemberData(nameof(DictionaryCaseTestingData))]
         public void HtmlAttributes_IgnoresCase(string originalName, string updatedName)
         {
@@ -160,22 +161,23 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             var attribute = Assert.Single(executionContext.HTMLAttributes);
-            Assert.Equal(new KeyValuePair<string, object>(originalName, "something else"), attribute);
+            Assert.Equal(new TagHelperAttribute(originalName, "something else"), attribute);
         }
 
+        [Theory]
         [MemberData(nameof(DictionaryCaseTestingData))]
         public void AllAttributes_IgnoresCase(string originalName, string updatedName)
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
-            executionContext.AllAttributes[originalName] = false;
+            executionContext.AllAttributes.Add(originalName, value: false);
 
             // Act
-            executionContext.AllAttributes[updatedName] = true;
+            executionContext.AllAttributes[updatedName].Value = true;
 
             // Assert
             var attribute = Assert.Single(executionContext.AllAttributes);
-            Assert.Equal(new KeyValuePair<string, object>(originalName, true), attribute);
+            Assert.Equal(new TagHelperAttribute(originalName, true), attribute);
         }
 
         [Fact]
@@ -183,7 +185,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
-            var expectedAttributes = new Dictionary<string, object>
+            var expectedAttributes = new TagHelperAttributeList
             {
                 { "class", "btn" },
                 { "foo", "bar" }
@@ -194,7 +196,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             executionContext.AddHtmlAttribute("foo", "bar");
 
             // Assert
-            Assert.Equal(expectedAttributes, executionContext.HTMLAttributes);
+            Assert.Equal(
+                expectedAttributes,
+                executionContext.HTMLAttributes,
+                CaseSensitiveTagHelperAttributeComparer.Default);
         }
 
         [Fact]
@@ -202,7 +207,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("p", selfClosing: false);
-            var expectedAttributes = new Dictionary<string, object>
+            var expectedAttributes = new TagHelperAttributeList
             {
                 { "class", "btn" },
                 { "something", true },
@@ -215,7 +220,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             executionContext.AddHtmlAttribute("foo", "bar");
 
             // Assert
-            Assert.Equal(expectedAttributes, executionContext.AllAttributes);
+            Assert.Equal(
+                expectedAttributes,
+                executionContext.AllAttributes,
+                CaseSensitiveTagHelperAttributeComparer.Default);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
@@ -142,7 +141,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p",
-                attributes: new Dictionary<string, object>
+                new TagHelperAttributeList
                 {
                     { "class", "btn" },
                     { "something", "   spaced    " }
@@ -175,7 +174,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperOutput = new TagHelperOutput("p",
-                attributes: new Dictionary<string, object>
+                new TagHelperAttributeList
                 {
                     { originalName, "btn" },
                 });
@@ -185,7 +184,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             var attribute = Assert.Single(tagHelperOutput.Attributes);
-            Assert.Equal(new KeyValuePair<string, object>(originalName, "super button"), attribute);
+            Assert.Equal(
+                new TagHelperAttribute(updateName, "super button"),
+                attribute,
+                CaseSensitiveTagHelperAttributeComparer.Default);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperRunnerTest.cs
@@ -135,8 +135,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.Equal("foo", output.TagName);
-            Assert.Equal("somethingelse", output.Attributes["class"]);
-            Assert.Equal("world", output.Attributes["hello"]);
+            Assert.Equal("somethingelse", output.Attributes["class"].Value);
+            Assert.Equal("world", output.Attributes["hello"].Value);
             Assert.Equal(true, output.SelfClosing);
         }
 
@@ -154,7 +154,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var output = await runner.RunAsync(executionContext);
 
             // Assert
-            Assert.Equal("True", output.Attributes["foo"]);
+            Assert.Equal("True", output.Attributes["foo"].Value);
         }
 
         [Fact]
@@ -183,8 +183,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 Processed = true;
 
                 output.TagName = "foo";
-                output.Attributes["class"] = "somethingelse";
-                output.Attributes["hello"] = "world";
+
+                TagHelperAttribute classAttribute;
+                if (output.Attributes.TryGetAttribute("class", out classAttribute))
+                {
+                    classAttribute.Value = "somethingelse";
+                }
+
+                output.Attributes.Add("hello", "world");
                 output.SelfClosing = true;
             }
         }
@@ -203,7 +209,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             public override void Process(TagHelperContext context, TagHelperOutput output)
             {
-                output.Attributes["foo"] = context.AllAttributes["foo"].ToString();
+                output.Attributes.Add("foo", context.AllAttributes["foo"].Value.ToString());
             }
         }
 

--- a/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/BlockTypes.cs
@@ -153,24 +153,26 @@ namespace Microsoft.AspNet.Razor.Test.Framework
     public class MarkupTagHelperBlock : TagHelperBlock
     {
         public MarkupTagHelperBlock(string tagName)
-            : this(tagName, selfClosing: false, attributes: new Dictionary<string, SyntaxTreeNode>())
+            : this(tagName, selfClosing: false, attributes: new List<KeyValuePair<string, SyntaxTreeNode>>())
         {
         }
 
         public MarkupTagHelperBlock(string tagName, bool selfClosing)
-            : this(tagName, selfClosing, new Dictionary<string, SyntaxTreeNode>())
+            : this(tagName, selfClosing, new List<KeyValuePair<string, SyntaxTreeNode>>())
         {
         }
 
-        public MarkupTagHelperBlock(string tagName,
-                                    IDictionary<string, SyntaxTreeNode> attributes)
+        public MarkupTagHelperBlock(
+            string tagName,
+            IList<KeyValuePair<string, SyntaxTreeNode>> attributes)
             : this(tagName, selfClosing: false, attributes: attributes, children: new SyntaxTreeNode[0])
         {
         }
 
-        public MarkupTagHelperBlock(string tagName,
-                                    bool selfClosing,
-                                    IDictionary<string, SyntaxTreeNode> attributes)
+        public MarkupTagHelperBlock(
+            string tagName,
+            bool selfClosing,
+            IList<KeyValuePair<string, SyntaxTreeNode>> attributes)
             : this(tagName, selfClosing, attributes, new SyntaxTreeNode[0])
         {
         }
@@ -179,27 +181,29 @@ namespace Microsoft.AspNet.Razor.Test.Framework
             : this(
                   tagName,
                   selfClosing: false,
-                  attributes: new Dictionary<string, SyntaxTreeNode>(),
+                  attributes: new List<KeyValuePair<string, SyntaxTreeNode>>(),
                   children: children)
         {
         }
 
         public MarkupTagHelperBlock(string tagName, bool selfClosing, params SyntaxTreeNode[] children)
-            : this(tagName, selfClosing, new Dictionary<string, SyntaxTreeNode>(), children)
+            : this(tagName, selfClosing, new List<KeyValuePair<string, SyntaxTreeNode>>(), children)
         {
         }
 
-        public MarkupTagHelperBlock(string tagName,
-                                    IDictionary<string, SyntaxTreeNode> attributes,
-                                    params SyntaxTreeNode[] children)
+        public MarkupTagHelperBlock(
+            string tagName,
+            IList<KeyValuePair<string, SyntaxTreeNode>> attributes,
+            params SyntaxTreeNode[] children)
             : base(new TagHelperBlockBuilder(tagName, selfClosing: false, attributes: attributes, children: children))
         {
         }
-        
-        public MarkupTagHelperBlock(string tagName,
-                                    bool selfClosing,
-                                    IDictionary<string, SyntaxTreeNode> attributes,
-                                    params SyntaxTreeNode[] children)
+
+        public MarkupTagHelperBlock(
+            string tagName,
+            bool selfClosing,
+            IList<KeyValuePair<string, SyntaxTreeNode>> attributes,
+            params SyntaxTreeNode[] children)
             : base(new TagHelperBlockBuilder(tagName, selfClosing, attributes, children))
         {
         }

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -62,9 +62,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -73,9 +73,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = dateTimeNow
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow)
                                 }))
                     },
                     {
@@ -83,9 +83,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -94,9 +94,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = dateTimeNow
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow)
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -105,9 +105,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -124,9 +124,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "strong",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 }))
                     },
                     {
@@ -135,9 +135,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "strong",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["catchAll"] = dateTimeNow
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", dateTimeNow)
                                 }))
                     },
                     {
@@ -145,9 +145,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -156,9 +156,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["catchAll"] = dateTimeNow
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", dateTimeNow)
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -205,10 +205,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["notRequired"] = factory.Markup("a"),
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("a")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -217,10 +217,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["notRequired"] = dateTimeNow,
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", dateTimeNow),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -228,10 +228,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["notRequired"] = factory.Markup("a"),
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("a")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -241,10 +241,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "div",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["style"] = new MarkupBlock(),
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -253,10 +253,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "div",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["style"] = dateTimeNow,
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -264,10 +264,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["style"] = new MarkupBlock(),
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -276,10 +276,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["style"] = dateTimeNow,
-                                    ["class"] = dateTimeNow
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow)
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -288,10 +288,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["style"] = new MarkupBlock(),
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -308,10 +308,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn"),
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 }))
                     },
                     {
@@ -319,10 +319,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn"),
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -332,11 +332,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "div",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["style"] = new MarkupBlock(),
-                                    ["class"] = factory.Markup("btn"),
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 }))
                     },
                     {
@@ -344,11 +344,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["style"] = new MarkupBlock(),
-                                    ["class"] = factory.Markup("btn"),
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -358,11 +358,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["style"] = dateTimeNow,
-                                    ["class"] = dateTimeNow,
-                                    ["catchAll"] = dateTimeNow
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow),
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", dateTimeNow)
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -371,11 +371,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["style"] = new MarkupBlock(),
-                                    ["class"] = factory.Markup("btn"),
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -446,9 +446,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: new[]
                                 {
@@ -461,9 +461,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -476,9 +476,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: new[]
                                 {
@@ -493,9 +493,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -510,15 +510,15 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: new MarkupTagHelperBlock(
                                     "strong",
-                                    attributes: new Dictionary<string, SyntaxTreeNode>
+                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                     {
-                                        ["catchAll"] = factory.Markup("hi")
+                                        new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                     },
                                     children: new[]
                                     {
@@ -531,15 +531,15 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 },
                                 children: new MarkupTagHelperBlock(
                                     "p",
-                                    attributes: new Dictionary<string, SyntaxTreeNode>
+                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                     {
-                                        ["class"] = factory.Markup("btn")
+                                        new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                     },
                                     children: new[]
                                     {
@@ -552,15 +552,15 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: new MarkupTagHelperBlock(
                                     "p",
-                                    attributes: new Dictionary<string, SyntaxTreeNode>
+                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                     {
-                                        ["class"] = factory.Markup("btn")
+                                        new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                     },
                                     children: new[]
                                     {
@@ -573,15 +573,15 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 },
                                 children: new MarkupTagHelperBlock(
                                     "strong",
-                                    attributes: new Dictionary<string, SyntaxTreeNode>
+                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                     {
-                                        ["catchAll"] = factory.Markup("hi")
+                                        new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                     },
                                     children: new[]
                                     {
@@ -594,9 +594,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: new[]
                                 {
@@ -604,9 +604,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                     blockFactory.MarkupTagBlock("<p>"),
                                     new MarkupTagHelperBlock(
                                         "p",
-                                        attributes: new Dictionary<string, SyntaxTreeNode>
+                                        attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                         {
-                                            ["class"] = factory.Markup("btn")
+                                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                         },
                                         children: new[]
                                         {
@@ -623,9 +623,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["catchAll"] = factory.Markup("hi")
+                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                 },
                                 children: new[]
                                 {
@@ -633,9 +633,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                     blockFactory.MarkupTagBlock("<strong>"),
                                     new MarkupTagHelperBlock(
                                     "strong",
-                                    attributes: new Dictionary<string, SyntaxTreeNode>
+                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                     {
-                                        ["catchAll"] = factory.Markup("hi")
+                                        new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
                                     },
                                     children: new[]
                                     {
@@ -701,9 +701,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -720,10 +720,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["notRequired"] = factory.Markup("hi"),
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("hi")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -747,9 +747,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -763,10 +763,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["notRequired"] = factory.Markup("hi"),
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("hi")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -779,9 +779,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class=\"btn\" <p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: blockFactory.MarkupTagBlock("<p>"))),
                         new[]
@@ -798,10 +798,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p notRequired=\"hi\" class=\"btn\" <p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["notRequired"] = factory.Markup("hi"),
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("hi")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: blockFactory.MarkupTagBlock("<p>"))),
                         new[]
@@ -819,9 +819,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -838,10 +838,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    ["notRequired"] = factory.Markup("hi"),
-                                    ["class"] = factory.Markup("btn")
+                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("hi")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -1033,9 +1033,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "th:myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", factory.Markup("btn") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         availableDescriptorsColon
                     },
@@ -1045,9 +1045,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "PREFIXmyth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", factory.Markup("btn") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         availableDescriptorsText
                     },
@@ -1057,9 +1057,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "th:myth2",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", factory.Markup("btn") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         availableDescriptorsColon
                     },
@@ -1069,9 +1069,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "PREFIXmyth2",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", factory.Markup("btn") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         availableDescriptorsText
                     },
@@ -1080,9 +1080,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "th:myth",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", factory.Markup("btn") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces"))),
                         availableDescriptorsColon
@@ -1092,9 +1092,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "PREFIXmyth",
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", factory.Markup("btn") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces"))),
                         availableDescriptorsText
@@ -1105,17 +1105,19 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "th:myth2",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
                                     {
-                                        "bound",
-                                        new MarkupBlock(
+                                        new KeyValuePair<string, SyntaxTreeNode>(
+                                            "bound",
                                             new MarkupBlock(
-                                                new ExpressionBlock(
-                                                    factory.CodeTransition(),
-                                                    factory.Code("DateTime.Now")
-                                                        .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace)))) }
+                                                new MarkupBlock(
+                                                    new ExpressionBlock(
+                                                        factory.CodeTransition(),
+                                                        factory.Code("DateTime.Now")
+                                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                                            .Accepts(AcceptedCharacters.NonWhiteSpace)))))
+                                    }
                                 })),
                         availableDescriptorsColon
                     },
@@ -1125,17 +1127,19 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "PREFIXmyth2",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
                                     {
-                                        "bound",
-                                        new MarkupBlock(
+                                        new KeyValuePair<string, SyntaxTreeNode>(
+                                            "bound",
                                             new MarkupBlock(
-                                                new ExpressionBlock(
-                                                    factory.CodeTransition(),
-                                                    factory.Code("DateTime.Now")
-                                                        .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace)))) }
+                                                new MarkupBlock(
+                                                    new ExpressionBlock(
+                                                        factory.CodeTransition(),
+                                                        factory.Code("DateTime.Now")
+                                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                                            .Accepts(AcceptedCharacters.NonWhiteSpace)))))
+                                    }
                                 })),
                         availableDescriptorsText
                     },
@@ -1180,9 +1184,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bound", new MarkupBlock() }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", new MarkupBlock())
                                 })),
                         new[]
                         {
@@ -1197,9 +1201,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bound", factory.CodeMarkup("    true") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("    true"))
                                 })),
                         new RazorError[0]
                     },
@@ -1209,9 +1213,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bound", factory.CodeMarkup("    ") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("    "))
                                 })),
                         new[]
                         {
@@ -1226,9 +1230,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bound", new MarkupBlock() }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", new MarkupBlock())
                                 })),
                         new[]
                         {
@@ -1246,9 +1251,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bound", factory.CodeMarkup("  ") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup(" ")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("  "))
                                 })),
                         new[]
                         {
@@ -1266,9 +1272,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("true")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null))
                                 })),
                         new[]
                         {
@@ -1283,10 +1290,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
-                                    { "name", new MarkupBlock() }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null)),
+                                    new KeyValuePair<string, SyntaxTreeNode>("name", new MarkupBlock())
                                 })),
                         new[]
                         {
@@ -1301,10 +1308,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
-                                    { "name", factory.Markup("  ") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null)),
+                                    new KeyValuePair<string, SyntaxTreeNode>("name", factory.Markup("  "))
                                 })),
                         new[]
                         {
@@ -1319,10 +1326,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
-                                    { "name", factory.Markup(string.Empty).With(SpanCodeGenerator.Null) }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("true")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("name", factory.Markup("john")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null)),
+                                    new KeyValuePair<string, SyntaxTreeNode>("name", factory.Markup(string.Empty).With(SpanCodeGenerator.Null))
                                 })),
                         new[]
                         {
@@ -1337,9 +1346,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "BouND", new MarkupBlock() }
+                                    new KeyValuePair<string, SyntaxTreeNode>("BouND", new MarkupBlock())
                                 })),
                         new[]
                         {
@@ -1354,9 +1363,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "BOUND", new MarkupBlock() }
+                                    new KeyValuePair<string, SyntaxTreeNode>("BOUND", new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>("bOUnd", new MarkupBlock())
                                 })),
                         new[]
                         {
@@ -1373,10 +1383,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "BOUND", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null) },
-                                    { "nAMe", factory.Markup("john") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("BOUND", factory.CodeMarkup(string.Empty).With(SpanCodeGenerator.Null)),
+                                    new KeyValuePair<string, SyntaxTreeNode>("nAMe", factory.Markup("john"))
                                 })),
                         new[]
                         {
@@ -1391,19 +1401,20 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
                                     {
-                                        "bound",
-                                        new MarkupBlock(
+                                        new KeyValuePair<string, SyntaxTreeNode>(
+                                            "bound",
                                             new MarkupBlock(
-                                            factory.Markup("    "),
-                                            new ExpressionBlock(
-                                                factory.CodeTransition(),
-                                                factory.Code("true")
-                                                    .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                    .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                                        factory.Markup("  "))
+                                                new MarkupBlock(
+                                                factory.Markup("    "),
+                                                new ExpressionBlock(
+                                                    factory.CodeTransition(),
+                                                    factory.Code("true")
+                                                        .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                                        .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                                factory.Markup("  ")))
                                     }
                                 })),
                         new RazorError[0]
@@ -1414,19 +1425,20 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
                                     {
-                                        "bound",
-                                        new MarkupBlock(
+                                        new KeyValuePair<string, SyntaxTreeNode>(
+                                            "bound",
                                             new MarkupBlock(
-                                            factory.Markup("    "),
-                                            new ExpressionBlock(
-                                                factory.CodeTransition(),
-                                                factory.MetaCode("(").Accepts(AcceptedCharacters.None),
-                                                factory.Code("true").AsExpression(),
-                                                factory.MetaCode(")").Accepts(AcceptedCharacters.None))),
-                                        factory.Markup("  "))
+                                                new MarkupBlock(
+                                                factory.Markup("    "),
+                                                new ExpressionBlock(
+                                                    factory.CodeTransition(),
+                                                    factory.MetaCode("(").Accepts(AcceptedCharacters.None),
+                                                    factory.Code("true").AsExpression(),
+                                                    factory.MetaCode(")").Accepts(AcceptedCharacters.None))),
+                                                factory.Markup("  ")))
                                     }
                                 })),
                         new RazorError[0]
@@ -3116,29 +3128,31 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class=\"\"></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class",  new MarkupBlock() }
+                                new KeyValuePair<string, SyntaxTreeNode>("class",  new MarkupBlock())
                             }))
                     },
                     {
                         "<p class=''></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class",  new MarkupBlock() }
+                                new KeyValuePair<string, SyntaxTreeNode>("class",  new MarkupBlock())
                             }))
                     },
                     {
                         "<p class=></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
                                 // We expected a markup node here because attribute values without quotes can only ever
                                 // be a single item, hence don't need to be enclosed by a block.
-                                { "class",  factory.Markup("").With(SpanCodeGenerator.Null) },
+                                new KeyValuePair<string, SyntaxTreeNode>(
+                                    "class",
+                                    factory.Markup("").With(SpanCodeGenerator.Null)),
                             }))
                     },
                     {
@@ -3146,11 +3160,13 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class1",  new MarkupBlock() },
-                                    { "class2",  factory.Markup("").With(SpanCodeGenerator.Null) },
-                                    { "class3",  new MarkupBlock() },
+                                    new KeyValuePair<string, SyntaxTreeNode>("class1", new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                        "class2",
+                                        factory.Markup("").With(SpanCodeGenerator.Null)),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class3", new MarkupBlock()),
                                 }))
                     },
                     {
@@ -3158,11 +3174,13 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class1",  new MarkupBlock() },
-                                    { "class2",  new MarkupBlock() },
-                                    { "class3",  factory.Markup("").With(SpanCodeGenerator.Null) },
+                                    new KeyValuePair<string, SyntaxTreeNode>("class1",  new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>("class2",  new MarkupBlock()),
+                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                        "class3",
+                                        factory.Markup("").With(SpanCodeGenerator.Null)),
                                 }))
                     },
                 };
@@ -3209,7 +3227,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p =\"false\"\" ></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>())),
+                                new List<KeyValuePair<string, SyntaxTreeNode>>())),
                         new []
                         {
                             new RazorError(
@@ -3221,9 +3239,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p bar=\"false\"\" <strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bar", factory.Markup("false") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("bar", factory.Markup("false"))
                                 })),
                         new []
                         {
@@ -3236,9 +3254,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p bar='false  <strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "bar", new MarkupBlock(factory.Markup("false"), factory.Markup("  <strong>")) }
+                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                        "bar",
+                                        new MarkupBlock(factory.Markup("false"), factory.Markup("  <strong>")))
                                 })),
                         new []
                         {
@@ -3272,9 +3292,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class=btn\" bar<strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", factory.Markup("btn") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         new []
                         {
@@ -3287,9 +3307,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class=btn\" bar=\"foo\"<strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", factory.Markup("btn") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
                                 })),
                         new []
                         {
@@ -3302,10 +3322,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class=\"btn bar=\"foo\"<strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", new MarkupBlock(factory.Markup("btn"), factory.Markup(" bar=")) },
-                                    { "foo", factory.Markup(string.Empty) }
+                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                        "class",
+                                        new MarkupBlock(factory.Markup("btn"), factory.Markup(" bar="))),
+                                    new KeyValuePair<string, SyntaxTreeNode>("foo", factory.Markup(string.Empty))
                                 },
                                 new MarkupTagHelperBlock("strong"))),
                         new []
@@ -3325,9 +3347,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class=\"btn bar=\"foo\"></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", new MarkupBlock(factory.Markup("btn"), factory.Markup(" bar=")) },
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", new MarkupBlock(factory.Markup("btn"), factory.Markup(" bar="))),
                                 })),
                         new RazorError[0]
                     },
@@ -3357,9 +3379,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class=@DateTime.Now\"></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", dateTimeNow }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow)
                                 })),
                         new []
                         {
@@ -3372,9 +3394,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class=\"@do {",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", createInvalidDoBlock(string.Empty) }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", createInvalidDoBlock(string.Empty))
                                 })),
                         new []
                         {
@@ -3393,9 +3415,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p class=\"@do {\"></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", createInvalidDoBlock("\"></p>") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", createInvalidDoBlock("\"></p>"))
                                 })),
                         new []
                         {
@@ -3620,9 +3642,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "age", factory.CodeMarkup("12") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("age", factory.CodeMarkup("12"))
                                 }))
                     },
                     {
@@ -3630,9 +3652,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "birthday", factory.CodeMarkup("DateTime.Now") }
+                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                        "birthday",
+                                        factory.CodeMarkup("DateTime.Now"))
                                 }))
                     },
                     {
@@ -3640,9 +3664,9 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "name", factory.Markup("John") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("name", factory.Markup("John"))
                                 }))
                     },
                     {
@@ -3650,9 +3674,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "name", new MarkupBlock(factory.Markup("Time:"), dateTimeNow) }
+                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                        "name",
+                                        new MarkupBlock(factory.Markup("Time:"), dateTimeNow))
                                 }))
                     },
                     {
@@ -3660,11 +3686,15 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 selfClosing: true,
-                                attributes: new Dictionary<string, SyntaxTreeNode>
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "age", factory.CodeMarkup("12") },
-                                    { "birthday", factory.CodeMarkup("DateTime.Now") },
-                                    { "name", new MarkupBlock(factory.Markup("Time:"), dateTimeNow) }
+                                    new KeyValuePair<string, SyntaxTreeNode>("age", factory.CodeMarkup("12")),
+                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                        "birthday",
+                                        factory.CodeMarkup("DateTime.Now")),
+                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                        "name",
+                                        new MarkupBlock(factory.Markup("Time:"), dateTimeNow))
                                 }))
                     },
                 };
@@ -3716,11 +3746,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now style=color:red;><strong></p></strong>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") },
-                                { "dynamic", new MarkupBlock(dateTimeNow) },
-                                { "style", factory.Markup("color:red;") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", new MarkupBlock(dateTimeNow)),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                             },
                             new MarkupTagHelperBlock("strong")),
                             blockFactory.MarkupTagBlock("</strong>")),
@@ -3773,15 +3803,15 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p class=\"foo\">Hello <p style=\"color:red;\">World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo"))
                             },
                             factory.Markup("Hello "),
                             new MarkupTagHelperBlock("p",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "style", factory.Markup("color:red;") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                                 },
                                 factory.Markup("World")))),
                     new RazorError[]
@@ -4125,34 +4155,34 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p      class=\"     foo\"    style=\"   color :  red  ;   \"    ></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new Dictionary<string, SyntaxTreeNode>
+                        new List<KeyValuePair<string, SyntaxTreeNode>>
                         {
-                            { "class", factory.Markup("     foo") },
-                            { "style",
+                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("     foo")),
+                            new KeyValuePair<string, SyntaxTreeNode>(
+                                "style",
                                 new MarkupBlock(
                                     factory.Markup("   color"),
                                     factory.Markup(" :"),
                                     factory.Markup("  red"),
                                     factory.Markup("  ;"),
-                                    factory.Markup("   "))
-                            }
+                                    factory.Markup("   ")))
                         }))
                 };
                 yield return new object[] {
                     "<p      class=\"     foo\"    style=\"   color :  red  ;   \"    >Hello World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("     foo") },
-                                { "style",
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("     foo")),
+                                new KeyValuePair<string, SyntaxTreeNode>(
+                                    "style",
                                     new MarkupBlock(
                                         factory.Markup("   color"),
                                         factory.Markup(" :"),
                                         factory.Markup("  red"),
                                         factory.Markup("  ;"),
-                                        factory.Markup("   "))
-                                }
+                                        factory.Markup("   ")))
                             },
                             factory.Markup("Hello World")))
                 };
@@ -4160,16 +4190,20 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p     class=\"   foo  \" >Hello</p> <p    style=\"  color:red; \" >World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", new MarkupBlock(factory.Markup("   foo"), factory.Markup("  ")) }
+                                new KeyValuePair<string, SyntaxTreeNode>(
+                                    "class",
+                                    new MarkupBlock(factory.Markup("   foo"), factory.Markup("  ")))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "style", new MarkupBlock(factory.Markup("  color:red;"), factory.Markup(" ")) }
+                                new KeyValuePair<string, SyntaxTreeNode>(
+                                    "style",
+                                    new MarkupBlock(factory.Markup("  color:red;"), factory.Markup(" ")))
                             },
                             factory.Markup("World")))
                 };
@@ -4218,20 +4252,20 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     string.Format(currentFormattedString, dateTimeNowString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new Dictionary<string, SyntaxTreeNode>
+                        new List<KeyValuePair<string, SyntaxTreeNode>>
                         {
-                            { "class", new MarkupBlock(dateTimeNow) },
-                            { "style", new MarkupBlock(dateTimeNow) }
+                            new KeyValuePair<string, SyntaxTreeNode>("class", new MarkupBlock(dateTimeNow)),
+                            new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock(dateTimeNow))
                         }))
                 };
                 yield return new object[] {
                     string.Format(currentFormattedString, doWhileString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new Dictionary<string, SyntaxTreeNode>
+                        new List<KeyValuePair<string, SyntaxTreeNode>>
                         {
-                            { "class", new MarkupBlock(doWhile) },
-                            { "style", new MarkupBlock(doWhile) }
+                            new KeyValuePair<string, SyntaxTreeNode>("class", new MarkupBlock(doWhile)),
+                            new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock(doWhile))
                         }))
                 };
 
@@ -4240,10 +4274,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     string.Format(currentFormattedString, dateTimeNowString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", new MarkupBlock(dateTimeNow) },
-                                { "style", new MarkupBlock(dateTimeNow) }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", new MarkupBlock(dateTimeNow)),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock(dateTimeNow))
                             },
                             factory.Markup("Hello World")))
                 };
@@ -4251,10 +4285,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     string.Format(currentFormattedString, doWhileString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", new MarkupBlock(doWhile) },
-                                { "style", new MarkupBlock(doWhile) }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", new MarkupBlock(doWhile)),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock(doWhile))
                             },
                             factory.Markup("Hello World")))
                 };
@@ -4264,16 +4298,16 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     string.Format(currentFormattedString, dateTimeNowString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", new MarkupBlock(dateTimeNow) }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", new MarkupBlock(dateTimeNow))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "style", new MarkupBlock(dateTimeNow) }
+                                new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock(dateTimeNow))
                             },
                             factory.Markup("World")))
                 };
@@ -4281,16 +4315,16 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     string.Format(currentFormattedString, doWhileString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", new MarkupBlock(doWhile) }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", new MarkupBlock(doWhile))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "style", new MarkupBlock(doWhile) }
+                                new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock(doWhile))
                             },
                             factory.Markup("World")))
                 };
@@ -4301,10 +4335,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     string.Format(currentFormattedString, dateTimeNowString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", new MarkupBlock(dateTimeNow) },
-                                { "style", new MarkupBlock(dateTimeNow) }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", new MarkupBlock(dateTimeNow)),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock(dateTimeNow))
                             },
                             factory.Markup("Hello World "),
                             new MarkupTagBlock(
@@ -4482,10 +4516,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     new MarkupBlock(
                         new MarkupTagHelperBlock("script",
                             selfClosing: true,
-                            attributes: new Dictionary<string, SyntaxTreeNode>
+                            attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") },
-                                { "style", factory.Markup("color:red;") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                             }))
                 };
                 yield return new object[] {
@@ -4494,10 +4528,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupTagHelperBlock("p",
                             factory.Markup("Hello "),
                             new MarkupTagHelperBlock("script",
-                                new Dictionary<string, SyntaxTreeNode>
+                                new List<KeyValuePair<string, SyntaxTreeNode>>
                                 {
-                                    { "class", factory.Markup("foo") },
-                                    { "style", factory.Markup("color:red;") }
+                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                    new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                                 }),
                             factory.Markup(" World")))
                 };
@@ -4524,10 +4558,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
                             selfClosing: true,
-                            attributes:  new Dictionary<string, SyntaxTreeNode>
+                            attributes:  new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") },
-                                { "style", factory.Markup("color:red;") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                             }))
                 };
                 yield return new object[] {
@@ -4541,10 +4575,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 new MarkupTagHelperBlock(
                                     "p",
                                     selfClosing: true,
-                                    attributes: new Dictionary<string, SyntaxTreeNode>
+                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                                         {
-                                            { "class", factory.Markup("foo") },
-                                            { "style", factory.Markup("color:red;") }
+                                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                            new KeyValuePair<string, SyntaxTreeNode>(
+                                                "style",
+                                                factory.Markup("color:red;"))
                                         }),
                                 factory.Markup(" World")}))
                 };
@@ -4554,16 +4590,16 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         factory.Markup("Hello"),
                         new MarkupTagHelperBlock("p",
                             selfClosing: true,
-                            attributes: new Dictionary<string, SyntaxTreeNode>
+                            attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo"))
                             }),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
                             selfClosing: true,
-                            attributes: new Dictionary<string, SyntaxTreeNode>
+                            attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "style", factory.Markup("color:red;") }
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                             }),
                         factory.Markup("World"))
                 };
@@ -4596,22 +4632,22 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now style=color:red;></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new Dictionary<string, SyntaxTreeNode>
+                        new List<KeyValuePair<string, SyntaxTreeNode>>
                         {
-                            { "class", factory.Markup("foo") },
-                            { "dynamic", new MarkupBlock(dateTimeNow) },
-                            { "style", factory.Markup("color:red;") }
+                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                            new KeyValuePair<string, SyntaxTreeNode>("dynamic", new MarkupBlock(dateTimeNow)),
+                            new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                         }))
                 };
                 yield return new object[] {
                     "<p class=foo dynamic=@DateTime.Now style=color:red;>Hello World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") },
-                                { "dynamic", new MarkupBlock(dateTimeNow) },
-                                { "style", factory.Markup("color:red;") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", new MarkupBlock(dateTimeNow)),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("Hello World")))
                 };
@@ -4619,18 +4655,18 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now>Hello</p> <p style=color:red; dynamic=@DateTime.Now>World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") },
-                                { "dynamic", new MarkupBlock(dateTimeNow) }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", new MarkupBlock(dateTimeNow))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "style", factory.Markup("color:red;") },
-                                { "dynamic", new MarkupBlock(dateTimeNow) }
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;")),
+                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", new MarkupBlock(dateTimeNow))
                             },
                             factory.Markup("World")))
                 };
@@ -4638,11 +4674,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now style=color:red;>Hello World <strong class=\"foo\">inside of strong tag</strong></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") },
-                                { "dynamic", new MarkupBlock(dateTimeNow) },
-                                { "style", factory.Markup("color:red;") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", new MarkupBlock(dateTimeNow)),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("Hello World "),
                             new MarkupTagBlock(
@@ -4681,20 +4717,20 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p class=\"foo\" style=\"color:red;\"></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new Dictionary<string, SyntaxTreeNode>
+                        new List<KeyValuePair<string, SyntaxTreeNode>>
                         {
-                            { "class", factory.Markup("foo") },
-                            { "style", factory.Markup("color:red;") }
+                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                            new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                         }))
                 };
                 yield return new object[] {
                     "<p class=\"foo\" style=\"color:red;\">Hello World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") },
-                                { "style", factory.Markup("color:red;") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("Hello World")))
                 };
@@ -4702,16 +4738,16 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p class=\"foo\">Hello</p> <p style=\"color:red;\">World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo"))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "style", factory.Markup("color:red;") }
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("World")))
                 };
@@ -4719,10 +4755,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "<p class=\"foo\" style=\"color:red;\">Hello World <strong class=\"foo\">inside of strong tag</strong></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new Dictionary<string, SyntaxTreeNode>
+                            new List<KeyValuePair<string, SyntaxTreeNode>>
                             {
-                                { "class", factory.Markup("foo") },
-                                { "style", factory.Markup("color:red;") }
+                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
+                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("Hello World "),
                             new MarkupTagBlock(


### PR DESCRIPTION
- Added a TagHelperAttributes object that's used to hold 1=>many attributes. Is used for TagHelperOutput.Attributes.
- Added a ReadOnlyTagHelperAttributes object that holds 1=>many IReadOnlyTagHelperAttributes. Is used for TagHelperContext.AllAttributes.
- Added a TagHelperAttribute object which is used to represent attributes.
- Added a IReadOnlyTagHelperAttribute which is used to represent attributes which cannot be modified.

#279