### PR TITLE
Update Razor directives to format correctly when entering newline.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNet.Razor.Parser
             Span.EditHandler.EditorHints = EditorHints.LayoutPage | EditorHints.VirtualPath;
             var foundNewline = Optional(CSharpSymbolType.NewLine);
             AddMarkerSymbolIfNecessary();
-            Output(SpanKind.MetaCode, foundNewline ? AcceptedCharacters.None : AcceptedCharacters.Any);
+            Output(SpanKind.MetaCode, foundNewline ? AcceptedCharacters.None : AcceptedCharacters.AnyExceptNewline);
         }
 
         protected virtual void SectionDirective()
@@ -286,7 +286,7 @@ namespace Microsoft.AspNet.Razor.Parser
 
             // Output the span and finish the block
             CompleteBlock();
-            Output(SpanKind.Code);
+            Output(SpanKind.Code, AcceptedCharacters.AnyExceptNewline);
         }
 
         private void TagHelperDirective(string keyword, Func<string, ISpanCodeGenerator> buildCodeGenerator)
@@ -304,7 +304,7 @@ namespace Microsoft.AspNet.Razor.Parser
 
             // If we found whitespace then any content placed within the whitespace MAY cause a destructive change
             // to the document.  We can't accept it.
-            Output(SpanKind.MetaCode, foundWhitespace ? AcceptedCharacters.None : AcceptedCharacters.Any);
+            Output(SpanKind.MetaCode, foundWhitespace ? AcceptedCharacters.None : AcceptedCharacters.AnyExceptNewline);
 
             if (EndOfFile || At(CSharpSymbolType.NewLine))
             {
@@ -346,7 +346,7 @@ namespace Microsoft.AspNet.Razor.Parser
 
             // Output the span and finish the block
             CompleteBlock();
-            Output(SpanKind.Code);
+            Output(SpanKind.Code, AcceptedCharacters.AnyExceptNewline);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
@@ -305,24 +305,31 @@ namespace Microsoft.AspNet.Razor.Test.Framework
 
         public SpanConstructor AsBaseType(string baseType)
         {
-            return _self.With(new SetBaseTypeCodeGenerator(baseType));
+            return _self
+                .With(new SetBaseTypeCodeGenerator(baseType))
+                .Accepts(AcceptedCharacters.AnyExceptNewline);
         }
 
         public SpanConstructor AsAddTagHelper(string lookupText)
         {
-            return _self.With(
-                new AddOrRemoveTagHelperCodeGenerator(removeTagHelperDescriptors: false, lookupText: lookupText));
+            return _self
+                .With(
+                    new AddOrRemoveTagHelperCodeGenerator(removeTagHelperDescriptors: false, lookupText: lookupText))
+                .Accepts(AcceptedCharacters.AnyExceptNewline);
         }
 
         public SpanConstructor AsRemoveTagHelper(string lookupText)
         {
-            return _self.With(
-                new AddOrRemoveTagHelperCodeGenerator(removeTagHelperDescriptors: true, lookupText: lookupText));
+            return _self
+                .With(new AddOrRemoveTagHelperCodeGenerator(removeTagHelperDescriptors: true, lookupText: lookupText))
+                .Accepts(AcceptedCharacters.AnyExceptNewline);
         }
 
         public SpanConstructor AsTagHelperPrefixDirective(string prefix)
         {
-            return _self.With(new TagHelperPrefixDirectiveCodeGenerator(prefix));
+            return _self
+                .With(new TagHelperPrefixDirectiveCodeGenerator(prefix))
+                .Accepts(AcceptedCharacters.AnyExceptNewline);
         }
 
         public SpanConstructor As(ISpanCodeGenerator codeGenerator)

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpLayoutDirectiveTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpLayoutDirectiveTest.cs
@@ -37,6 +37,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.MetaCode("layout ").Accepts(AcceptedCharacters.None),
                     Factory.MetaCode("Foo Bar Baz")
                            .With(new SetLayoutCodeGenerator("Foo Bar Baz"))
+                           .Accepts(AcceptedCharacters.AnyExceptNewline)
                            .WithEditorHints(EditorHints.VirtualPath | EditorHints.LayoutPage)
                 )
             );
@@ -63,6 +64,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.EmptyCSharp()
                            .AsMetaCode()
                            .With(new SetLayoutCodeGenerator(string.Empty))
+                           .Accepts(AcceptedCharacters.AnyExceptNewline)
                            .WithEditorHints(EditorHints.VirtualPath | EditorHints.LayoutPage)
                 )
             );


### PR DESCRIPTION
- Existing Razor directives `@layout`, `@inherits`, `@addTagHelper`, `@tagHelperPrefix` and `@removeTagHelper` should only ever span a single line and need to cause a re-parse when a newline is entered during design time. To do this modified their `AcceptedCharacters` to accept anything other than newline rather than anything.
- Updated existing tests to now expect `AcceptedCharacters.AnyExceptNewline` when directives are present.

**Note:** Manually tested this in my own VS' editor and all worked.

#332

**Mvc react PR:** https://github.com/aspnet/Mvc/pull/2385