### PR TITLE
Add `HtmlAttributeNotBoundAttribute`

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlAttributeNameAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlAttributeNameAttribute.cs
@@ -28,6 +28,6 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// HTML attribute name of the associated property.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
     }
 }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlAttributeNotBoundAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlAttributeNotBoundAttribute.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// Indicates the associated <see cref="ITagHelper"/> property should not be bound to HTML attributes.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class HtmlAttributeNotBoundAttribute : Attribute
+    {
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="HtmlAttributeNotBoundAttribute"/> class.
+        /// </summary>
+        public HtmlAttributeNotBoundAttribute()
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -203,7 +203,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         private static IEnumerable<TagHelperAttributeDescriptor> GetAttributeDescriptors(
-            Type type, 
+            Type type,
             ErrorSink errorSink)
         {
             var accessibleProperties = type.GetRuntimeProperties().Where(IsAccessibleProperty);
@@ -226,12 +226,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Type parentType,
             ErrorSink errorSink)
         {
-            // data-* attributes are explicitly not implemented by user agents and are not intended for use on 
+            // data-* attributes are explicitly not implemented by user agents and are not intended for use on
             // the server; therefore it's invalid for TagHelpers to bind to them.
             if (attributeDescriptor.Name.StartsWith(DataDashPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 errorSink.OnError(
-                    SourceLocation.Zero, 
+                    SourceLocation.Zero,
                     Resources.FormatTagHelperDescriptorFactory_InvalidBoundAttributeName(
                         attributeDescriptor.PropertyName,
                         parentType.FullName,
@@ -255,10 +255,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         private static bool IsAccessibleProperty(PropertyInfo property)
         {
-            return property.GetMethod != null &&
-                   property.GetMethod.IsPublic &&
-                   property.SetMethod != null &&
-                   property.SetMethod.IsPublic;
+            // Accessible properties are those with public getters and setters and without [HtmlAttributeNotBound].
+            return property.GetMethod?.IsPublic == true &&
+                property.SetMethod?.IsPublic == true &&
+                property.GetCustomAttribute<HtmlAttributeNotBoundAttribute>(inherit: false) == null;
         }
 
         /// <summary>

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CommonTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CommonTagHelpers.cs
@@ -23,10 +23,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public string InvalidNoSetAttribute { get { return string.Empty; } }
     }
 
-    public class PrivateAccessorTagHelper : TagHelper
+    public class NonPublicAccessorTagHelper : TagHelper
     {
         public string ValidAttribute { get; set; }
         public string InvalidPrivateSetAttribute { get; private set; }
         public string InvalidPrivateGetAttribute { private get; set; }
+        protected string InvalidProtectedAttribute { get; set; }
+        internal string InvalidInternalAttribute { get; set; }
+        protected internal string InvalidProtectedInternalAttribute { get; set; }
     }
 }


### PR DESCRIPTION
- #182
- ignore otherwise-bound (i.e. `public`) properties in tag helpers

nits:
- add more `TagHelperDescriptorFactory` tests e.g. of `internal` properties
- remove `private` setter from `HtmlAttributeNameAttribute`
- use `null` propagation to shorten `IsAccessibleProperty` expression
- clean up some trailing whitespace