### PR TITLE
Improve `GetHashCode()` implementations and their consistency with `Equals()`

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 {

--- a/src/Microsoft.AspNet.Razor/Editor/AutoCompleteEditHandler.cs
+++ b/src/Microsoft.AspNet.Razor/Editor/AutoCompleteEditHandler.cs
@@ -7,12 +7,13 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
-using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 {
     public class AutoCompleteEditHandler : SpanEditHandler
     {
+        private static readonly int TypeHashCode = typeof(AutoCompleteEditHandler).GetHashCode();
+
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Func<T> is the recommended delegate type and requires this level of nesting.")]
         public AutoCompleteEditHandler(Func<string, IEnumerable<ISymbol>> tokenizer)
             : base(tokenizer)
@@ -48,18 +49,15 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         public override bool Equals(object obj)
         {
             var other = obj as AutoCompleteEditHandler;
-            return base.Equals(obj) &&
-                   other != null &&
-                   string.Equals(other.AutoCompleteString, AutoCompleteString, StringComparison.Ordinal) &&
-                   AutoCompleteAtEndOfSpan == other.AutoCompleteAtEndOfSpan;
+            return base.Equals(other) &&
+                string.Equals(other.AutoCompleteString, AutoCompleteString, StringComparison.Ordinal) &&
+                AutoCompleteAtEndOfSpan == other.AutoCompleteAtEndOfSpan;
         }
 
         public override int GetHashCode()
         {
-            return HashCodeCombiner.Start()
-                .Add(base.GetHashCode())
-                .Add(AutoCompleteString)
-                .CombinedHash;
+            // Hash code should include only immutable properties but Equals also checks the type.
+            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Editor/AutoCompleteEditHandler.cs
+++ b/src/Microsoft.AspNet.Razor/Editor/AutoCompleteEditHandler.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
+using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 {
@@ -20,13 +21,20 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         {
         }
 
+        public AutoCompleteEditHandler(Func<string, IEnumerable<ISymbol>> tokenizer, bool autoCompleteAtEndOfSpan)
+            : this(tokenizer)
+        {
+            AutoCompleteAtEndOfSpan = autoCompleteAtEndOfSpan;
+        }
+
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Func<T> is the recommended delegate type and requires this level of nesting.")]
         public AutoCompleteEditHandler(Func<string, IEnumerable<ISymbol>> tokenizer, AcceptedCharacters accepted)
             : base(tokenizer, accepted)
         {
         }
 
-        public bool AutoCompleteAtEndOfSpan { get; set; }
+        public bool AutoCompleteAtEndOfSpan { get; }
+
         public string AutoCompleteString { get; set; }
 
         protected override PartialParseResult CanAcceptChange(Span target, TextChange normalizedChange)
@@ -57,7 +65,10 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         public override int GetHashCode()
         {
             // Hash code should include only immutable properties but Equals also checks the type.
-            return TypeHashCode;
+            return HashCodeCombiner.Start()
+                .Add(TypeHashCode)
+                .Add(AutoCompleteAtEndOfSpan)
+                .CombinedHash;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Editor/ImplicitExpressionEditHandler.cs
+++ b/src/Microsoft.AspNet.Razor/Editor/ImplicitExpressionEditHandler.cs
@@ -19,12 +19,18 @@ namespace Microsoft.AspNet.Razor.Editor
     public class ImplicitExpressionEditHandler : SpanEditHandler
     {
         private readonly ISet<string> _keywords;
+        private readonly IReadOnlyCollection<string> _readOnlyKeywords;
 
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Func<T> is the recommended delegate type and requires this level of nesting.")]
         public ImplicitExpressionEditHandler(Func<string, IEnumerable<ISymbol>> tokenizer, ISet<string> keywords, bool acceptTrailingDot)
             : base(tokenizer)
         {
             _keywords = keywords ?? new HashSet<string>();
+
+            // HashSet<T> implements IReadOnlyCollection<T> as of 4.6, but does not for 4.5.1. If the runtime cast
+            // succeeds, avoid creating a new collection.
+            _readOnlyKeywords = (_keywords as IReadOnlyCollection<string>) ?? _keywords.ToArray();
+
             AcceptTrailingDot = acceptTrailingDot;
         }
 
@@ -34,7 +40,7 @@ namespace Microsoft.AspNet.Razor.Editor
         {
             get
             {
-                return (IReadOnlyCollection<string>)_keywords;
+                return _readOnlyKeywords;
             }
         }
 

--- a/src/Microsoft.AspNet.Razor/Editor/ImplicitExpressionEditHandler.cs
+++ b/src/Microsoft.AspNet.Razor/Editor/ImplicitExpressionEditHandler.cs
@@ -18,18 +18,25 @@ namespace Microsoft.AspNet.Razor.Editor
 {
     public class ImplicitExpressionEditHandler : SpanEditHandler
     {
-        private static readonly int TypeHashCode = typeof(ImplicitExpressionEditHandler).GetHashCode();
+        private readonly ISet<string> _keywords;
 
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Func<T> is the recommended delegate type and requires this level of nesting.")]
         public ImplicitExpressionEditHandler(Func<string, IEnumerable<ISymbol>> tokenizer, ISet<string> keywords, bool acceptTrailingDot)
             : base(tokenizer)
         {
-            Keywords = keywords ?? new HashSet<string>();
+            _keywords = keywords ?? new HashSet<string>();
             AcceptTrailingDot = acceptTrailingDot;
         }
 
         public bool AcceptTrailingDot { get; }
-        public ISet<string> Keywords { get; }
+
+        public IReadOnlyCollection<string> Keywords
+        {
+            get
+            {
+                return (IReadOnlyCollection<string>)_keywords;
+            }
+        }
 
         public override string ToString()
         {
@@ -40,15 +47,15 @@ namespace Microsoft.AspNet.Razor.Editor
         {
             var other = obj as ImplicitExpressionEditHandler;
             return base.Equals(other) &&
-                Keywords.SetEquals(other.Keywords) &&
+                _keywords.SetEquals(other._keywords) &&
                 AcceptTrailingDot == other.AcceptTrailingDot;
         }
 
         public override int GetHashCode()
         {
-            // Hash code should include only immutable properties but Equals also checks the type.
+            // Hash code should include only immutable properties and base has none.
             return HashCodeCombiner.Start()
-                .Add(TypeHashCode)
+                .Add(Keywords)
                 .Add(AcceptTrailingDot)
                 .CombinedHash;
         }
@@ -306,7 +313,7 @@ namespace Microsoft.AspNet.Razor.Editor
         {
             using (var reader = new StringReader(newContent))
             {
-                return Keywords.Contains(reader.ReadWhile(ParserHelpers.IsIdentifierPart));
+                return _keywords.Contains(reader.ReadWhile(ParserHelpers.IsIdentifierPart));
             }
         }
     }

--- a/src/Microsoft.AspNet.Razor/Editor/ImplicitExpressionEditHandler.cs
+++ b/src/Microsoft.AspNet.Razor/Editor/ImplicitExpressionEditHandler.cs
@@ -18,15 +18,18 @@ namespace Microsoft.AspNet.Razor.Editor
 {
     public class ImplicitExpressionEditHandler : SpanEditHandler
     {
+        private static readonly int TypeHashCode = typeof(ImplicitExpressionEditHandler).GetHashCode();
+
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Func<T> is the recommended delegate type and requires this level of nesting.")]
         public ImplicitExpressionEditHandler(Func<string, IEnumerable<ISymbol>> tokenizer, ISet<string> keywords, bool acceptTrailingDot)
             : base(tokenizer)
         {
-            Initialize(keywords, acceptTrailingDot);
+            Keywords = keywords ?? new HashSet<string>();
+            AcceptTrailingDot = acceptTrailingDot;
         }
 
-        public bool AcceptTrailingDot { get; private set; }
-        public ISet<string> Keywords { get; private set; }
+        public bool AcceptTrailingDot { get; }
+        public ISet<string> Keywords { get; }
 
         public override string ToString()
         {
@@ -36,18 +39,17 @@ namespace Microsoft.AspNet.Razor.Editor
         public override bool Equals(object obj)
         {
             var other = obj as ImplicitExpressionEditHandler;
-            return other != null &&
-                   base.Equals(other) &&
-                   Keywords.SetEquals(other.Keywords) &&
-                   AcceptTrailingDot == other.AcceptTrailingDot;
+            return base.Equals(other) &&
+                Keywords.SetEquals(other.Keywords) &&
+                AcceptTrailingDot == other.AcceptTrailingDot;
         }
 
         public override int GetHashCode()
         {
+            // Hash code should include only immutable properties but Equals also checks the type.
             return HashCodeCombiner.Start()
-                .Add(base.GetHashCode())
+                .Add(TypeHashCode)
                 .Add(AcceptTrailingDot)
-                .Add(Keywords)
                 .CombinedHash;
         }
 
@@ -102,12 +104,6 @@ namespace Microsoft.AspNet.Razor.Editor
             }
 
             return PartialParseResult.Rejected;
-        }
-
-        private void Initialize(ISet<string> keywords, bool acceptTrailingDot)
-        {
-            Keywords = keywords ?? new HashSet<string>();
-            AcceptTrailingDot = acceptTrailingDot;
         }
 
         // A dotless commit is the process of inserting a '.' with an intellisense selection.

--- a/src/Microsoft.AspNet.Razor/Editor/SpanEditHandler.cs
+++ b/src/Microsoft.AspNet.Razor/Editor/SpanEditHandler.cs
@@ -170,8 +170,8 @@ namespace Microsoft.AspNet.Razor.Editor
         public override bool Equals(object obj)
         {
             var other = obj as SpanEditHandler;
-            return obj != null &&
-                GetType() == obj.GetType() &&
+            return other != null &&
+                GetType() == other.GetType() &&
                 AcceptedCharacters == other.AcceptedCharacters &&
                 EditorHints == other.EditorHints;
         }

--- a/src/Microsoft.AspNet.Razor/Editor/SpanEditHandler.cs
+++ b/src/Microsoft.AspNet.Razor/Editor/SpanEditHandler.cs
@@ -170,9 +170,10 @@ namespace Microsoft.AspNet.Razor.Editor
         public override bool Equals(object obj)
         {
             var other = obj as SpanEditHandler;
-            return other != null &&
-                   AcceptedCharacters == other.AcceptedCharacters &&
-                   EditorHints == other.EditorHints;
+            return obj != null &&
+                GetType() == obj.GetType() &&
+                AcceptedCharacters == other.AcceptedCharacters &&
+                EditorHints == other.EditorHints;
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Editor/SpanEditHandler.cs
+++ b/src/Microsoft.AspNet.Razor/Editor/SpanEditHandler.cs
@@ -8,13 +8,14 @@ using System.Linq;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
-using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Editor
 {
     // Manages edits to a span
     public class SpanEditHandler
     {
+        private static readonly int TypeHashCode = typeof(SpanEditHandler).GetHashCode();
+
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Func<T> is the recommended delegate type and requires this level of nesting.")]
         public SpanEditHandler(Func<string, IEnumerable<ISymbol>> tokenizer)
             : this(tokenizer, AcceptedCharacters.Any)
@@ -176,10 +177,8 @@ namespace Microsoft.AspNet.Razor.Editor
 
         public override int GetHashCode()
         {
-            return HashCodeCombiner.Start()
-                .Add(AcceptedCharacters)
-                .Add(EditorHints)
-                .CombinedHash;
+            // Hash code should include only immutable properties but Equals also checks the type.
+            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/AddImportCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/AddImportCodeGenerator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Generator
 {
@@ -15,7 +14,7 @@ namespace Microsoft.AspNet.Razor.Generator
             NamespaceKeywordLength = namespaceKeywordLength;
         }
 
-        public string Namespace { get; private set; }
+        public string Namespace { get; }
         public int NamespaceKeywordLength { get; set; }
 
         public override void GenerateCode(Span target, CodeGeneratorContext context)
@@ -45,10 +44,8 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override int GetHashCode()
         {
-            return HashCodeCombiner.Start()
-                .Add(Namespace)
-                .Add(NamespaceKeywordLength)
-                .CombinedHash;
+            // Hash code should include only immutable properties.
+            return Namespace == null ? 0 : StringComparer.Ordinal.GetHashCode(Namespace);
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/AddImportCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/AddImportCodeGenerator.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNet.Razor.Generator
         }
 
         public string Namespace { get; }
+
         public int NamespaceKeywordLength { get; set; }
 
         public override void GenerateCode(Span target, CodeGeneratorContext context)
@@ -38,8 +39,8 @@ namespace Microsoft.AspNet.Razor.Generator
         {
             var other = obj as AddImportCodeGenerator;
             return other != null &&
-                   string.Equals(Namespace, other.Namespace, StringComparison.Ordinal) &&
-                   NamespaceKeywordLength == other.NamespaceKeywordLength;
+                string.Equals(Namespace, other.Namespace, StringComparison.Ordinal) &&
+                NamespaceKeywordLength == other.NamespaceKeywordLength;
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/AttributeBlockCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/AttributeBlockCodeGenerator.cs
@@ -19,9 +19,9 @@ namespace Microsoft.AspNet.Razor.Generator
             Suffix = suffix;
         }
 
-        public string Name { get; private set; }
-        public LocationTagged<string> Prefix { get; private set; }
-        public LocationTagged<string> Suffix { get; private set; }
+        public string Name { get; }
+        public LocationTagged<string> Prefix { get; }
+        public LocationTagged<string> Suffix { get; }
 
         public override void GenerateStartBlockCode(Block target, CodeGeneratorContext context)
         {
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.Razor.Generator
         public override int GetHashCode()
         {
             return HashCodeCombiner.Start()
-                .Add(Name)
+                .Add(Name, StringComparer.Ordinal)
                 .Add(Prefix)
                 .Add(Suffix)
                 .CombinedHash;

--- a/src/Microsoft.AspNet.Razor/Generator/AttributeBlockCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/AttributeBlockCodeGenerator.cs
@@ -20,7 +20,9 @@ namespace Microsoft.AspNet.Razor.Generator
         }
 
         public string Name { get; }
+
         public LocationTagged<string> Prefix { get; }
+
         public LocationTagged<string> Suffix { get; }
 
         public override void GenerateStartBlockCode(Block target, CodeGeneratorContext context)
@@ -46,9 +48,9 @@ namespace Microsoft.AspNet.Razor.Generator
         {
             var other = obj as AttributeBlockCodeGenerator;
             return other != null &&
-                   string.Equals(other.Name, Name, StringComparison.Ordinal) &&
-                   Equals(other.Prefix, Prefix) &&
-                   Equals(other.Suffix, Suffix);
+                string.Equals(other.Name, Name, StringComparison.Ordinal) &&
+                Equals(other.Prefix, Prefix) &&
+                Equals(other.Suffix, Suffix);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/BlockCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/BlockCodeGenerator.cs
@@ -23,7 +23,8 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override bool Equals(object obj)
         {
-            return obj is IBlockCodeGenerator;
+            return obj != null &&
+                GetType() == obj.GetType();
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/BlockCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/BlockCodeGenerator.cs
@@ -8,6 +8,8 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public abstract class BlockCodeGenerator : IBlockCodeGenerator
     {
+        private static readonly int TypeHashCode = typeof(BlockCodeGenerator).GetHashCode();
+
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "This class has no instance state")]
         public static readonly IBlockCodeGenerator Null = new NullBlockCodeGenerator();
 
@@ -21,12 +23,12 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override bool Equals(object obj)
         {
-            return (obj as IBlockCodeGenerator) != null;
+            return obj is IBlockCodeGenerator;
         }
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return TypeHashCode;
         }
 
         private class NullBlockCodeGenerator : IBlockCodeGenerator

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/LineMapping.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/LineMapping.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
 {
     public class LineMapping
     {
+        private static readonly int TypeHashCode = typeof(LineMapping).GetHashCode();
+
         public LineMapping()
             : this(documentLocation: null, generatedLocation: null)
         {
@@ -24,22 +26,50 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
         public override bool Equals(object obj)
         {
             var other = obj as LineMapping;
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+
             return DocumentLocation.Equals(other.DocumentLocation) &&
-                   GeneratedLocation.Equals(other.GeneratedLocation);
+                GeneratedLocation.Equals(other.GeneratedLocation);
         }
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            // Hash code should include only immutable properties but Equals also checks the type.
+            return TypeHashCode;
         }
 
         public static bool operator ==(LineMapping left, LineMapping right)
         {
+            if (ReferenceEquals(left, right))
+            {
+                // Exact equality e.g. both objects are null.
+                return true;
+            }
+
+            if (ReferenceEquals(left, null))
+            {
+                return false;
+            }
+
             return left.Equals(right);
         }
 
         public static bool operator !=(LineMapping left, LineMapping right)
         {
+            if (ReferenceEquals(left, right))
+            {
+                // Exact equality e.g. both objects are null.
+                return false;
+            }
+
+            if (ReferenceEquals(left, null))
+            {
+                return true;
+            }
+
             return !left.Equals(right);
         }
 

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/LineMapping.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/LineMapping.cs
@@ -2,26 +2,21 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Globalization;
+using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler
 {
     public class LineMapping
     {
-        private static readonly int TypeHashCode = typeof(LineMapping).GetHashCode();
-
-        public LineMapping()
-            : this(documentLocation: null, generatedLocation: null)
-        {
-        }
-
         public LineMapping(MappingLocation documentLocation, MappingLocation generatedLocation)
         {
             DocumentLocation = documentLocation;
             GeneratedLocation = generatedLocation;
         }
 
-        public MappingLocation DocumentLocation { get; set; }
-        public MappingLocation GeneratedLocation { get; set; }
+        public MappingLocation DocumentLocation { get; }
+
+        public MappingLocation GeneratedLocation { get; }
 
         public override bool Equals(object obj)
         {
@@ -37,8 +32,10 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
 
         public override int GetHashCode()
         {
-            // Hash code should include only immutable properties but Equals also checks the type.
-            return TypeHashCode;
+            return HashCodeCombiner.Start()
+                .Add(DocumentLocation)
+                .Add(GeneratedLocation)
+                .CombinedHash;
         }
 
         public static bool operator ==(LineMapping left, LineMapping right)

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/LineMappingManager.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/LineMappingManager.cs
@@ -12,15 +12,11 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
             Mappings = new List<LineMapping>();
         }
 
-        public List<LineMapping> Mappings { get; private set; }
+        public List<LineMapping> Mappings { get; }
 
         public void AddMapping(MappingLocation documentLocation, MappingLocation generatedLocation)
         {
-            Mappings.Add(new LineMapping
-            {
-                DocumentLocation = documentLocation,
-                GeneratedLocation = generatedLocation
-            });
+            Mappings.Add(new LineMapping(documentLocation, generatedLocation));
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/MappingLocation.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/MappingLocation.cs
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Globalization;
+using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Generator.Compiler
 {
     public class MappingLocation
     {
-        private static readonly int TypeHashCode = typeof(MappingLocation).GetHashCode();
-
         public MappingLocation()
         {
         }
@@ -21,10 +20,13 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
             CharacterIndex = location.CharacterIndex;
         }
 
-        public int ContentLength { get; set; }
-        public int AbsoluteIndex { get; set; }
-        public int LineIndex { get; set; }
-        public int CharacterIndex { get; set; }
+        public int ContentLength { get; }
+
+        public int AbsoluteIndex { get; }
+
+        public int LineIndex { get; }
+
+        public int CharacterIndex { get; }
 
         public override bool Equals(object obj)
         {
@@ -42,8 +44,12 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
 
         public override int GetHashCode()
         {
-            // Hash code should include only immutable properties but Equals also checks the type.
-            return TypeHashCode;
+            return HashCodeCombiner.Start()
+                .Add(AbsoluteIndex)
+                .Add(ContentLength)
+                .Add(LineIndex)
+                .Add(CharacterIndex)
+                .CombinedHash;
         }
 
         public override string ToString()

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/MappingLocation.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/LineMappings/MappingLocation.cs
@@ -7,7 +7,11 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
 {
     public class MappingLocation
     {
-        public MappingLocation() : base() { }
+        private static readonly int TypeHashCode = typeof(MappingLocation).GetHashCode();
+
+        public MappingLocation()
+        {
+        }
 
         public MappingLocation(SourceLocation location, int contentLength)
         {
@@ -25,16 +29,21 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
         public override bool Equals(object obj)
         {
             var other = obj as MappingLocation;
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
 
             return AbsoluteIndex == other.AbsoluteIndex &&
-                   ContentLength == other.ContentLength &&
-                   LineIndex == other.LineIndex &&
-                   CharacterIndex == other.CharacterIndex;
+                ContentLength == other.ContentLength &&
+                LineIndex == other.LineIndex &&
+                CharacterIndex == other.CharacterIndex;
         }
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            // Hash code should include only immutable properties but Equals also checks the type.
+            return TypeHashCode;
         }
 
         public override string ToString()
@@ -49,11 +58,33 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler
 
         public static bool operator ==(MappingLocation left, MappingLocation right)
         {
+            if (ReferenceEquals(left, right))
+            {
+                // Exact equality e.g. both objects are null.
+                return true;
+            }
+
+            if (ReferenceEquals(left, null))
+            {
+                return false;
+            }
+
             return left.Equals(right);
         }
 
         public static bool operator !=(MappingLocation left, MappingLocation right)
         {
+            if (ReferenceEquals(left, right))
+            {
+                // Exact equality e.g. both objects are null.
+                return false;
+            }
+
+            if (ReferenceEquals(left, null))
+            {
+                return true;
+            }
+
             return !left.Equals(right);
         }
     }

--- a/src/Microsoft.AspNet.Razor/Generator/DynamicAttributeBlockCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/DynamicAttributeBlockCodeGenerator.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNet.Razor.Generator
         }
 
         public LocationTagged<string> Prefix { get; }
+
         public SourceLocation ValueStart { get; }
 
         public override void GenerateStartBlockCode(Block target, CodeGeneratorContext context)
@@ -45,7 +46,7 @@ namespace Microsoft.AspNet.Razor.Generator
         {
             var other = obj as DynamicAttributeBlockCodeGenerator;
             return other != null &&
-                   Equals(other.Prefix, Prefix);
+                Equals(other.Prefix, Prefix);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/DynamicAttributeBlockCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/DynamicAttributeBlockCodeGenerator.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Globalization;
 using Microsoft.AspNet.Razor.Generator.Compiler;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
-using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Generator
 {
@@ -23,8 +21,8 @@ namespace Microsoft.AspNet.Razor.Generator
             ValueStart = valueStart;
         }
 
-        public LocationTagged<string> Prefix { get; private set; }
-        public SourceLocation ValueStart { get; private set; }
+        public LocationTagged<string> Prefix { get; }
+        public SourceLocation ValueStart { get; }
 
         public override void GenerateStartBlockCode(Block target, CodeGeneratorContext context)
         {
@@ -52,9 +50,7 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override int GetHashCode()
         {
-            return HashCodeCombiner.Start()
-                .Add(Prefix)
-                .CombinedHash;
+            return Prefix == null ? 0 : Prefix.GetHashCode();
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/ExpressionCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/ExpressionCodeGenerator.cs
@@ -32,7 +32,8 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override bool Equals(object obj)
         {
-            return obj is ExpressionCodeGenerator;
+            return obj != null &&
+                GetType() == obj.GetType();
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/ExpressionCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/ExpressionCodeGenerator.cs
@@ -8,6 +8,8 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public class ExpressionCodeGenerator : HybridCodeGenerator
     {
+        private static readonly int TypeHashCode = typeof(ExpressionCodeGenerator).GetHashCode();
+
         public override void GenerateStartBlockCode(Block target, CodeGeneratorContext context)
         {
             context.CodeTreeBuilder.StartChunkBlock<ExpressionBlockChunk>(target);
@@ -35,7 +37,7 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/GeneratedClassContext.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/GeneratedClassContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Framework.Internal;
+using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Generator
 {
@@ -121,12 +122,12 @@ namespace Microsoft.AspNet.Razor.Generator
         }
 
         // Required Items
-        public string WriteMethodName { get; private set; }
-        public string WriteLiteralMethodName { get; private set; }
-        public string WriteToMethodName { get; private set; }
-        public string WriteLiteralToMethodName { get; private set; }
-        public string ExecuteMethodName { get; private set; }
-        public GeneratedTagHelperContext GeneratedTagHelperContext { get; private set; }
+        public string WriteMethodName { get; }
+        public string WriteLiteralMethodName { get; }
+        public string WriteToMethodName { get; }
+        public string WriteLiteralToMethodName { get; }
+        public string ExecuteMethodName { get; }
+        public GeneratedTagHelperContext GeneratedTagHelperContext { get; }
 
         // Optional Items
         public string BeginContextMethodName { get; set; }
@@ -174,16 +175,14 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override int GetHashCode()
         {
-            // TODO: Use HashCodeCombiner
-            return DefineSectionMethodName.GetHashCode() ^
-                   WriteMethodName.GetHashCode() ^
-                   WriteLiteralMethodName.GetHashCode() ^
-                   WriteToMethodName.GetHashCode() ^
-                   WriteLiteralToMethodName.GetHashCode() ^
-                   ExecuteMethodName.GetHashCode() ^
-                   TemplateTypeName.GetHashCode() ^
-                   BeginContextMethodName.GetHashCode() ^
-                   EndContextMethodName.GetHashCode();
+            // Hash code should include only immutable properties.
+            return HashCodeCombiner.Start()
+                .Add(WriteMethodName, StringComparer.Ordinal)
+                .Add(WriteLiteralMethodName, StringComparer.Ordinal)
+                .Add(WriteToMethodName, StringComparer.Ordinal)
+                .Add(WriteLiteralToMethodName, StringComparer.Ordinal)
+                .Add(ExecuteMethodName, StringComparer.Ordinal)
+                .CombinedHash;
         }
 
         public static bool operator ==(GeneratedClassContext left, GeneratedClassContext right)

--- a/src/Microsoft.AspNet.Razor/Generator/GeneratedClassContext.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/GeneratedClassContext.cs
@@ -161,16 +161,17 @@ namespace Microsoft.AspNet.Razor.Generator
             {
                 return false;
             }
+
             var other = (GeneratedClassContext)obj;
             return string.Equals(DefineSectionMethodName, other.DefineSectionMethodName, StringComparison.Ordinal) &&
-                   string.Equals(WriteMethodName, other.WriteMethodName, StringComparison.Ordinal) &&
-                   string.Equals(WriteLiteralMethodName, other.WriteLiteralMethodName, StringComparison.Ordinal) &&
-                   string.Equals(WriteToMethodName, other.WriteToMethodName, StringComparison.Ordinal) &&
-                   string.Equals(WriteLiteralToMethodName, other.WriteLiteralToMethodName, StringComparison.Ordinal) &&
-                   string.Equals(ExecuteMethodName, other.ExecuteMethodName, StringComparison.Ordinal) &&
-                   string.Equals(TemplateTypeName, other.TemplateTypeName, StringComparison.Ordinal) &&
-                   string.Equals(BeginContextMethodName, other.BeginContextMethodName, StringComparison.Ordinal) &&
-                   string.Equals(EndContextMethodName, other.EndContextMethodName, StringComparison.Ordinal);
+                string.Equals(WriteMethodName, other.WriteMethodName, StringComparison.Ordinal) &&
+                string.Equals(WriteLiteralMethodName, other.WriteLiteralMethodName, StringComparison.Ordinal) &&
+                string.Equals(WriteToMethodName, other.WriteToMethodName, StringComparison.Ordinal) &&
+                string.Equals(WriteLiteralToMethodName, other.WriteLiteralToMethodName, StringComparison.Ordinal) &&
+                string.Equals(ExecuteMethodName, other.ExecuteMethodName, StringComparison.Ordinal) &&
+                string.Equals(TemplateTypeName, other.TemplateTypeName, StringComparison.Ordinal) &&
+                string.Equals(BeginContextMethodName, other.BeginContextMethodName, StringComparison.Ordinal) &&
+                string.Equals(EndContextMethodName, other.EndContextMethodName, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/LiteralAttributeCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/LiteralAttributeCodeGenerator.cs
@@ -24,7 +24,9 @@ namespace Microsoft.AspNet.Razor.Generator
         }
 
         public LocationTagged<string> Prefix { get; }
+
         public LocationTagged<string> Value { get; }
+
         public LocationTagged<SpanCodeGenerator> ValueGenerator { get; }
 
         public override void GenerateCode(Span target, CodeGeneratorContext context)
@@ -61,9 +63,9 @@ namespace Microsoft.AspNet.Razor.Generator
         {
             var other = obj as LiteralAttributeCodeGenerator;
             return other != null &&
-                   Equals(other.Prefix, Prefix) &&
-                   Equals(other.Value, Value) &&
-                   Equals(other.ValueGenerator, ValueGenerator);
+                Equals(other.Prefix, Prefix) &&
+                Equals(other.Value, Value) &&
+                Equals(other.ValueGenerator, ValueGenerator);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/LiteralAttributeCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/LiteralAttributeCodeGenerator.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Globalization;
 using Microsoft.AspNet.Razor.Generator.Compiler;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
@@ -24,9 +23,9 @@ namespace Microsoft.AspNet.Razor.Generator
             Value = value;
         }
 
-        public LocationTagged<string> Prefix { get; private set; }
-        public LocationTagged<string> Value { get; private set; }
-        public LocationTagged<SpanCodeGenerator> ValueGenerator { get; private set; }
+        public LocationTagged<string> Prefix { get; }
+        public LocationTagged<string> Value { get; }
+        public LocationTagged<SpanCodeGenerator> ValueGenerator { get; }
 
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {

--- a/src/Microsoft.AspNet.Razor/Generator/MarkupCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/MarkupCodeGenerator.cs
@@ -7,8 +7,6 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public class MarkupCodeGenerator : SpanCodeGenerator
     {
-        private static readonly int TypeHashCode = typeof(MarkupCodeGenerator).GetHashCode();
-
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {
             context.CodeTreeBuilder.AddLiteralChunk(target.Content, target);
@@ -17,16 +15,6 @@ namespace Microsoft.AspNet.Razor.Generator
         public override string ToString()
         {
             return "Markup";
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is MarkupCodeGenerator;
-        }
-
-        public override int GetHashCode()
-        {
-            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/MarkupCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/MarkupCodeGenerator.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public class MarkupCodeGenerator : SpanCodeGenerator
     {
+        private static readonly int TypeHashCode = typeof(MarkupCodeGenerator).GetHashCode();
+
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {
             context.CodeTreeBuilder.AddLiteralChunk(target.Content, target);
@@ -24,7 +26,7 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/ResolveUrlCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/ResolveUrlCodeGenerator.cs
@@ -7,8 +7,6 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public class ResolveUrlCodeGenerator : SpanCodeGenerator
     {
-        private static readonly int TypeHashCode = typeof(ResolveUrlCodeGenerator).GetHashCode();
-
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {
             // Check if the host supports it
@@ -25,16 +23,6 @@ namespace Microsoft.AspNet.Razor.Generator
         public override string ToString()
         {
             return "VirtualPath";
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is ResolveUrlCodeGenerator;
-        }
-
-        public override int GetHashCode()
-        {
-            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/ResolveUrlCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/ResolveUrlCodeGenerator.cs
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 
 namespace Microsoft.AspNet.Razor.Generator
 {
     public class ResolveUrlCodeGenerator : SpanCodeGenerator
     {
+        private static readonly int TypeHashCode = typeof(ResolveUrlCodeGenerator).GetHashCode();
+
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {
             // Check if the host supports it
@@ -33,7 +34,7 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/SectionCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/SectionCodeGenerator.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.AspNet.Razor.Generator.Compiler;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
-using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Generator
 {
@@ -15,7 +14,7 @@ namespace Microsoft.AspNet.Razor.Generator
             SectionName = sectionName;
         }
 
-        public string SectionName { get; private set; }
+        public string SectionName { get; }
 
         public override void GenerateStartBlockCode(Block target, CodeGeneratorContext context)
         {
@@ -32,17 +31,13 @@ namespace Microsoft.AspNet.Razor.Generator
         public override bool Equals(object obj)
         {
             var other = obj as SectionCodeGenerator;
-            return other != null &&
-                   base.Equals(other) &&
+            return base.Equals(other) &&
                    string.Equals(SectionName, other.SectionName, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()
         {
-            return HashCodeCombiner.Start()
-                .Add(base.GetHashCode())
-                .Add(SectionName)
-                .CombinedHash;
+            return SectionName == null ? 0 : StringComparer.Ordinal.GetHashCode(SectionName);
         }
 
         public override string ToString()

--- a/src/Microsoft.AspNet.Razor/Generator/SectionCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/SectionCodeGenerator.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Razor.Generator
         {
             var other = obj as SectionCodeGenerator;
             return base.Equals(other) &&
-                   string.Equals(SectionName, other.SectionName, StringComparison.Ordinal);
+                string.Equals(SectionName, other.SectionName, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/SetBaseTypeCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/SetBaseTypeCodeGenerator.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Razor.Generator
             BaseType = baseType;
         }
 
-        public string BaseType { get; private set; }
+        public string BaseType { get; }
 
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {

--- a/src/Microsoft.AspNet.Razor/Generator/SetBaseTypeCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/SetBaseTypeCodeGenerator.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.Razor.Generator
         {
             var other = obj as SetBaseTypeCodeGenerator;
             return other != null &&
-                   string.Equals(BaseType, other.BaseType, StringComparison.Ordinal);
+                string.Equals(BaseType, other.BaseType, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/SpanCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/SpanCodeGenerator.cs
@@ -19,7 +19,8 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override bool Equals(object obj)
         {
-            return obj is ISpanCodeGenerator;
+            return obj != null &&
+                GetType() == obj.GetType();
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Generator/SpanCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/SpanCodeGenerator.cs
@@ -8,6 +8,8 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public abstract class SpanCodeGenerator : ISpanCodeGenerator
     {
+        private static readonly int TypeHashCode = typeof(SpanCodeGenerator).GetHashCode();
+
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "This class has no instance state")]
         public static readonly ISpanCodeGenerator Null = new NullSpanCodeGenerator();
 
@@ -17,12 +19,12 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override bool Equals(object obj)
         {
-            return (obj as ISpanCodeGenerator) != null;
+            return obj is ISpanCodeGenerator;
         }
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return TypeHashCode;
         }
 
         private class NullSpanCodeGenerator : ISpanCodeGenerator

--- a/src/Microsoft.AspNet.Razor/Generator/StatementCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/StatementCodeGenerator.cs
@@ -7,8 +7,6 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public class StatementCodeGenerator : SpanCodeGenerator
     {
-        private static readonly int TypeHashCode = typeof(StatementCodeGenerator).GetHashCode();
-
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {
             context.CodeTreeBuilder.AddStatementChunk(target.Content, target);
@@ -17,16 +15,6 @@ namespace Microsoft.AspNet.Razor.Generator
         public override string ToString()
         {
             return "Stmt";
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is StatementCodeGenerator;
-        }
-
-        public override int GetHashCode()
-        {
-            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/StatementCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/StatementCodeGenerator.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public class StatementCodeGenerator : SpanCodeGenerator
     {
+        private static readonly int TypeHashCode = typeof(StatementCodeGenerator).GetHashCode();
+
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {
             context.CodeTreeBuilder.AddStatementChunk(target.Content, target);
@@ -24,7 +26,7 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/TagHelpers/TagHelperPrefixDirectiveCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/TagHelpers/TagHelperPrefixDirectiveCodeGenerator.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 namespace Microsoft.AspNet.Razor.Generator
 {
     /// <summary>
-    /// A <see cref="SpanCodeGenerator"/> responsible for generating 
+    /// A <see cref="SpanCodeGenerator"/> responsible for generating
     /// <see cref="Compiler.TagHelperPrefixDirectiveChunk"/>s.
     /// </summary>
     public class TagHelperPrefixDirectiveCodeGenerator : SpanCodeGenerator

--- a/src/Microsoft.AspNet.Razor/Generator/TypeMemberCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/TypeMemberCodeGenerator.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public class TypeMemberCodeGenerator : SpanCodeGenerator
     {
+        private static readonly int TypeHashCode = typeof(TypeMemberCodeGenerator).GetHashCode();
+
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {
             context.CodeTreeBuilder.AddTypeMemberChunk(target.Content, target);
@@ -25,7 +27,7 @@ namespace Microsoft.AspNet.Razor.Generator
         // C# complains at us if we don't provide an implementation, even one like this
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Generator/TypeMemberCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/TypeMemberCodeGenerator.cs
@@ -7,8 +7,6 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public class TypeMemberCodeGenerator : SpanCodeGenerator
     {
-        private static readonly int TypeHashCode = typeof(TypeMemberCodeGenerator).GetHashCode();
-
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {
             context.CodeTreeBuilder.AddTypeMemberChunk(target.Content, target);
@@ -17,17 +15,6 @@ namespace Microsoft.AspNet.Razor.Generator
         public override string ToString()
         {
             return "TypeMember";
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is TypeMemberCodeGenerator;
-        }
-
-        // C# complains at us if we don't provide an implementation, even one like this
-        public override int GetHashCode()
-        {
-            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNet.Razor.Parser
             }
 
             // Set up edit handler
-            var editHandler = new AutoCompleteEditHandler(Language.TokenizeString) { AutoCompleteAtEndOfSpan = true };
+            var editHandler = new AutoCompleteEditHandler(Language.TokenizeString, autoCompleteAtEndOfSpan: true);
 
             Span.EditHandler = editHandler;
             Span.Accept(CurrentSymbol);

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/Block.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/Block.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Text;
+using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 {
@@ -45,11 +46,11 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "Type is the most appropriate name for this property and there is little chance of confusion with GetType")]
-        public BlockType Type { get; private set; }
+        public BlockType Type { get; }
 
-        public IEnumerable<SyntaxTreeNode> Children { get; private set; }
+        public IEnumerable<SyntaxTreeNode> Children { get; }
 
-        public IBlockCodeGenerator CodeGenerator { get; private set; }
+        public IBlockCodeGenerator CodeGenerator { get; }
 
         public override bool IsBlock
         {
@@ -118,7 +119,11 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 
         public override int GetHashCode()
         {
-            return (int)Type;
+            return HashCodeCombiner.Start()
+                .Add(Type)
+                .Add(CodeGenerator)
+                .Add(Children)
+                .CombinedHash;
         }
 
         public IEnumerable<Span> Flatten()
@@ -201,7 +206,19 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
             {
                 return false;
             }
+
             return Enumerable.SequenceEqual(Children, other.Children, new EquivalenceComparer());
+        }
+
+        public override int GetEquivalenceHash()
+        {
+            var combiner = HashCodeCombiner.Start().Add(Type);
+            foreach (var child in Children)
+            {
+                combiner.Add(child.GetEquivalenceHash());
+            }
+
+            return combiner.CombinedHash;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/Block.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/Block.cs
@@ -112,9 +112,9 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         {
             var other = obj as Block;
             return other != null &&
-                   Type == other.Type &&
-                   Equals(CodeGenerator, other.CodeGenerator) &&
-                   ChildrenEqual(Children, other.Children);
+                Type == other.Type &&
+                Equals(CodeGenerator, other.CodeGenerator) &&
+                ChildrenEqual(Children, other.Children);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/EquivalenceComparer.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/EquivalenceComparer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 
         public int GetHashCode(SyntaxTreeNode obj)
         {
-            return obj.GetHashCode();
+            return obj.GetEquivalenceHash();
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/Span.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/Span.cs
@@ -126,10 +126,10 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         {
             var other = node as Span;
             return other != null &&
-                   Kind.Equals(other.Kind) &&
-                   Start.Equals(other.Start) &&
-                   EditHandler.Equals(other.EditHandler) &&
-                   string.Equals(other.Content, Content, StringComparison.Ordinal);
+                Kind.Equals(other.Kind) &&
+                Start.Equals(other.Start) &&
+                EditHandler.Equals(other.EditHandler) &&
+                string.Equals(other.Content, Content, StringComparison.Ordinal);
         }
 
         public override int GetEquivalenceHash()
@@ -142,10 +142,10 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         {
             var other = obj as Span;
             return other != null &&
-                   Kind.Equals(other.Kind) &&
-                   EditHandler.Equals(other.EditHandler) &&
-                   CodeGenerator.Equals(other.CodeGenerator) &&
-                   Symbols.SequenceEqual(other.Symbols);
+                Kind.Equals(other.Kind) &&
+                EditHandler.Equals(other.EditHandler) &&
+                CodeGenerator.Equals(other.CodeGenerator) &&
+                Symbols.SequenceEqual(other.Symbols);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/Span.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/Span.cs
@@ -10,12 +10,12 @@ using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Generator;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
-using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 {
     public class Span : SyntaxTreeNode
     {
+        private static readonly int TypeHashCode = typeof(Span).GetHashCode();
         private SourceLocation _start;
 
         public Span(SpanBuilder builder)
@@ -132,6 +132,12 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                    string.Equals(other.Content, Content, StringComparison.Ordinal);
         }
 
+        public override int GetEquivalenceHash()
+        {
+            // Hash code should include only immutable properties but EquivalentTo also checks the type.
+            return TypeHashCode;
+        }
+
         public override bool Equals(object obj)
         {
             var other = obj as Span;
@@ -144,11 +150,8 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 
         public override int GetHashCode()
         {
-            return HashCodeCombiner.Start()
-                .Add((int)Kind)
-                .Add(Start)
-                .Add(Content)
-                .CombinedHash;
+            // Hash code should include only immutable properties but Equals also checks the type.
+            return TypeHashCode;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/SyntaxTreeNode.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/SyntaxTree/SyntaxTreeNode.cs
@@ -37,5 +37,15 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
         /// symbols may be different.
         /// </returns>
         public abstract bool EquivalentTo(SyntaxTreeNode node);
+
+        /// <summary>
+        /// Determines a hash code for the <see cref="SyntaxTreeNode"/> using only information relevant in
+        /// <see cref="EquivalentTo"/> comparisons.
+        /// </summary>
+        /// <returns>
+        /// A hash code for the <see cref="SyntaxTreeNode"/> using only information relevant in
+        /// <see cref="EquivalentTo"/> comparisons.
+        /// </returns>
+        public abstract int GetEquivalenceHash();
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// <summary>
         /// The HTML tag name.
         /// </summary>
-        public string TagName { get; private set; }
+        public string TagName { get; }
 
         public override int Length
         {

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
@@ -116,9 +116,9 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         public bool Equals(TagHelperBlock other)
         {
             return other != null &&
-                   TagName == other.TagName &&
-                   Attributes.SequenceEqual(other.Attributes) &&
-                   base.Equals(other);
+                TagName == other.TagName &&
+                Attributes.SequenceEqual(other.Attributes) &&
+                base.Equals(other);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlock.cs
@@ -115,20 +115,18 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
         /// </returns>
         public bool Equals(TagHelperBlock other)
         {
-            return other != null &&
-                TagName == other.TagName &&
-                Attributes.SequenceEqual(other.Attributes) &&
-                base.Equals(other);
+            return base.Equals(other) &&
+                string.Equals(TagName, other.TagName, StringComparison.OrdinalIgnoreCase) &&
+                Attributes.SequenceEqual(other.Attributes);
         }
 
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return HashCodeCombiner
-                .Start()
-                .Add(TagName)
-                .Add(Attributes)
+            return HashCodeCombiner.Start()
                 .Add(base.GetHashCode())
+                .Add(TagName, StringComparer.OrdinalIgnoreCase)
+                .Add(Attributes)
                 .CombinedHash;
         }
     }

--- a/src/Microsoft.AspNet.Razor/RazorError.cs
+++ b/src/Microsoft.AspNet.Razor/RazorError.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Globalization;
+using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor
 {
     public class RazorError : IEquatable<RazorError>
     {
-        private static readonly int TypeHashCode = typeof(RazorError).GetHashCode();
-
         public RazorError()
             : this(message: string.Empty, location: SourceLocation.Undefined)
         {
@@ -37,8 +36,22 @@ namespace Microsoft.AspNet.Razor
         {
         }
 
+        /// <summary>
+        /// Gets (or sets) the message describing the error.
+        /// </summary>
+        /// <remarks>Set property is only accessible for deserialization purposes.</remarks>
         public string Message { get; set; }
+
+        /// <summary>
+        /// Gets (or sets) the start position of the erroneous text.
+        /// </summary>
+        /// <remarks>Set property is only accessible for deserialization purposes.</remarks>
         public SourceLocation Location { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length of the erroneous text.
+        /// </summary>
+        /// <remarks>Set property is only accessible for deserialization purposes.</remarks>
         public int Length { get; set; }
 
         public override string ToString()
@@ -54,8 +67,10 @@ namespace Microsoft.AspNet.Razor
 
         public override int GetHashCode()
         {
-            // Hash code should include only immutable properties but Equals also checks the type.
-            return TypeHashCode;
+            return HashCodeCombiner.Start()
+                .Add(Message, StringComparer.Ordinal)
+                .Add(Location)
+                .CombinedHash;
         }
 
         public bool Equals(RazorError other)

--- a/src/Microsoft.AspNet.Razor/RazorError.cs
+++ b/src/Microsoft.AspNet.Razor/RazorError.cs
@@ -8,6 +8,8 @@ namespace Microsoft.AspNet.Razor
 {
     public class RazorError : IEquatable<RazorError>
     {
+        private static readonly int TypeHashCode = typeof(RazorError).GetHashCode();
+
         public RazorError()
             : this(message: string.Empty, location: SourceLocation.Undefined)
         {
@@ -46,19 +48,21 @@ namespace Microsoft.AspNet.Razor
 
         public override bool Equals(object obj)
         {
-            var err = obj as RazorError;
-            return (err != null) && Equals(err);
+            var error = obj as RazorError;
+            return Equals(error);
         }
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            // Hash code should include only immutable properties but Equals also checks the type.
+            return TypeHashCode;
         }
 
         public bool Equals(RazorError other)
         {
-            return string.Equals(other.Message, Message, StringComparison.Ordinal) &&
-                   Location.Equals(other.Location);
+            return other != null &&
+                string.Equals(other.Message, Message, StringComparison.Ordinal) &&
+                Location.Equals(other.Location);
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/SourceLocation.cs
+++ b/src/Microsoft.AspNet.Razor/SourceLocation.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNet.Razor
         public override int GetHashCode()
         {
             return HashCodeCombiner.Start()
-                .Add(FilePath)
+                .Add(FilePath, StringComparer.Ordinal)
                 .Add(AbsoluteIndex)
                 .CombinedHash;
         }

--- a/src/Microsoft.AspNet.Razor/SourceLocation.cs
+++ b/src/Microsoft.AspNet.Razor/SourceLocation.cs
@@ -5,7 +5,6 @@ using System;
 using System.Globalization;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.Framework.Internal;
-using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor
 {
@@ -18,6 +17,8 @@ namespace Microsoft.AspNet.Razor
 #endif
     public struct SourceLocation : IEquatable<SourceLocation>, IComparable<SourceLocation>
     {
+        private static readonly int TypeHashCode = typeof(SourceLocation).GetHashCode();
+
         /// <summary>
         /// An undefined <see cref="SourceLocation"/>.
         /// </summary>
@@ -96,20 +97,15 @@ namespace Microsoft.AspNet.Razor
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            // LineIndex and CharacterIndex can be calculated from AbsoluteIndex and the document content.
-            return HashCodeCombiner.Start()
-                .Add(FilePath, StringComparer.Ordinal)
-                .Add(AbsoluteIndex)
-                .CombinedHash;
+            // Hash code should include only immutable properties but Equals also checks the type.
+            return TypeHashCode;
         }
 
         /// <inheritdoc />
         public bool Equals(SourceLocation other)
         {
-            return string.Equals(FilePath, other.FilePath, StringComparison.Ordinal) &&
-                AbsoluteIndex == other.AbsoluteIndex &&
-                LineIndex == other.LineIndex &&
-                CharacterIndex == other.CharacterIndex;
+            // LineIndex and CharacterIndex can be calculated from AbsoluteIndex and the document content.
+            return CompareTo(other) == 0;
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNet.Razor/SourceLocation.cs
+++ b/src/Microsoft.AspNet.Razor/SourceLocation.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.Framework.Internal;
+using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor
 {
@@ -17,8 +18,6 @@ namespace Microsoft.AspNet.Razor
 #endif
     public struct SourceLocation : IEquatable<SourceLocation>, IComparable<SourceLocation>
     {
-        private static readonly int TypeHashCode = typeof(SourceLocation).GetHashCode();
-
         /// <summary>
         /// An undefined <see cref="SourceLocation"/>.
         /// </summary>
@@ -91,14 +90,17 @@ namespace Microsoft.AspNet.Razor
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            return (obj is SourceLocation) && Equals((SourceLocation)obj);
+            return obj is SourceLocation &&
+                Equals((SourceLocation)obj);
         }
 
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            // Hash code should include only immutable properties but Equals also checks the type.
-            return TypeHashCode;
+            return HashCodeCombiner.Start()
+                .Add(FilePath)
+                .Add(AbsoluteIndex)
+                .CombinedHash;
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptor.cs
@@ -38,17 +38,17 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <summary>
         /// The HTML attribute name.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The name of the CLR property name that corresponds to the HTML attribute name.
         /// </summary>
-        public string PropertyName { get; private set; }
+        public string PropertyName { get; }
 
         /// <summary>
         /// The full name of the named (see <see name="PropertyName"/>) property's
         /// <see cref="System.Type"/>.
         /// </summary>
-        public string TypeName { get; private set; }
+        public string TypeName { get; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptor.cs
@@ -38,17 +38,17 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <summary>
         /// The HTML attribute name.
         /// </summary>
-        public string Name { get; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// The name of the CLR property name that corresponds to the HTML attribute name.
         /// </summary>
-        public string PropertyName { get; }
+        public string PropertyName { get; private set; }
 
         /// <summary>
         /// The full name of the named (see <see name="PropertyName"/>) property's
         /// <see cref="System.Type"/>.
         /// </summary>
-        public string TypeName { get; }
+        public string TypeName { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
@@ -102,37 +102,37 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available
         /// tag helpers.
         /// </summary>
-        public string Prefix { get; }
+        public string Prefix { get; private set; }
 
         /// <summary>
         /// The tag name that the tag helper should target.
         /// </summary>
-        public string TagName { get; }
+        public string TagName { get; private set; }
 
         /// <summary>
         /// The full tag name that is required for the tag helper to target an HTML element.
         /// </summary>
         /// <remarks>This is equivalent to <see cref="Prefix"/> and <see cref="TagName"/> concatenated.</remarks>
-        public string FullTagName { get; }
+        public string FullTagName { get; private set; }
 
         /// <summary>
         /// The full name of the tag helper class.
         /// </summary>
-        public string TypeName { get; }
+        public string TypeName { get; private set; }
 
         /// <summary>
         /// The name of the assembly containing the tag helper class.
         /// </summary>
-        public string AssemblyName { get; }
+        public string AssemblyName { get; private set; }
 
         /// <summary>
         /// The list of attributes the tag helper expects.
         /// </summary>
-        public IReadOnlyList<TagHelperAttributeDescriptor> Attributes { get; }
+        public IReadOnlyList<TagHelperAttributeDescriptor> Attributes { get; private set; }
 
         /// <summary>
         /// The list of required attribute names the tag helper expects to target an element.
         /// </summary>
-        public IReadOnlyList<string> RequiredAttributes { get; }
+        public IReadOnlyList<string> RequiredAttributes { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <paramref name="attributes"/>.
         /// </summary>
         /// <param name="prefix">
-        /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available 
+        /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available
         /// tag helpers.
         /// </param>
         /// <param name="tagName">The tag name that the tag helper targets. '*' indicates a catch-all
@@ -99,40 +99,40 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         }
 
         /// <summary>
-        /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available 
+        /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available
         /// tag helpers.
         /// </summary>
-        public string Prefix { get; private set; }
+        public string Prefix { get; }
 
         /// <summary>
         /// The tag name that the tag helper should target.
         /// </summary>
-        public string TagName { get; private set; }
+        public string TagName { get; }
 
         /// <summary>
         /// The full tag name that is required for the tag helper to target an HTML element.
         /// </summary>
         /// <remarks>This is equivalent to <see cref="Prefix"/> and <see cref="TagName"/> concatenated.</remarks>
-        public string FullTagName { get; private set; }
+        public string FullTagName { get; }
 
         /// <summary>
         /// The full name of the tag helper class.
         /// </summary>
-        public string TypeName { get; private set; }
+        public string TypeName { get; }
 
         /// <summary>
         /// The name of the assembly containing the tag helper class.
         /// </summary>
-        public string AssemblyName { get; private set; }
+        public string AssemblyName { get; }
 
         /// <summary>
         /// The list of attributes the tag helper expects.
         /// </summary>
-        public IList<TagHelperAttributeDescriptor> Attributes { get; private set; }
+        public IReadOnlyList<TagHelperAttributeDescriptor> Attributes { get; }
 
         /// <summary>
         /// The list of required attribute names the tag helper expects to target an element.
         /// </summary>
-        public IList<string> RequiredAttributes { get; private set; }
+        public IReadOnlyList<string> RequiredAttributes { get; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
@@ -40,10 +40,10 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                    string.Equals(descriptorX.AssemblyName, descriptorY.AssemblyName, StringComparison.Ordinal) &&
                    Enumerable.SequenceEqual(
                        descriptorX.RequiredAttributes.OrderBy(
-                           attribute => attribute, 
+                           attribute => attribute,
                            StringComparer.OrdinalIgnoreCase),
                        descriptorY.RequiredAttributes.OrderBy(
-                           attribute => attribute, 
+                           attribute => attribute,
                            StringComparer.OrdinalIgnoreCase),
                        StringComparer.OrdinalIgnoreCase);
         }
@@ -62,12 +62,11 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 .Add(descriptor.AssemblyName, StringComparer.Ordinal);
 
             var attributes = descriptor.RequiredAttributes.OrderBy(
-                attribute => attribute, 
+                attribute => attribute,
                 StringComparer.OrdinalIgnoreCase);
-
             foreach (var attribute in attributes)
             {
-                hashCodeCombiner.Add(attributes);
+                hashCodeCombiner.Add(attribute, StringComparer.OrdinalIgnoreCase);
             }
 
             return hashCodeCombiner.CombinedHash;

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDirectiveDescriptor.cs
@@ -36,16 +36,16 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <summary>
         /// A <see cref="string"/> used to find tag helper <see cref="System.Type"/>s.
         /// </summary>
-        public string DirectiveText { get; private set; }
+        public string DirectiveText { get; }
 
         /// <summary>
         /// The <see cref="TagHelperDirectiveType"/> of this directive.
         /// </summary>
-        public TagHelperDirectiveType DirectiveType { get; private set; }
+        public TagHelperDirectiveType DirectiveType { get; }
 
         /// <summary>
         /// The <see cref="SourceLocation"/> of the directive.
         /// </summary>
-        public SourceLocation Location { get; private set; }
+        public SourceLocation Location { get; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Text/LocationTagged.cs
+++ b/src/Microsoft.AspNet.Razor/Text/LocationTagged.cs
@@ -33,15 +33,19 @@ namespace Microsoft.AspNet.Razor.Text
             Value = value;
         }
 
-        public SourceLocation Location { get; private set; }
-        public T Value { get; private set; }
+        public SourceLocation Location { get; }
+        public T Value { get; }
 
         public override bool Equals(object obj)
         {
             LocationTagged<T> other = obj as LocationTagged<T>;
-            return other != null &&
-                   Equals(other.Location, Location) &&
-                   Equals(other.Value, Value);
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+
+            return Equals(other.Location, Location) &&
+                Equals(other.Value, Value);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Text/LocationTagged.cs
+++ b/src/Microsoft.AspNet.Razor/Text/LocationTagged.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNet.Razor.Text
         }
 
         public SourceLocation Location { get; }
+
         public T Value { get; }
 
         public override bool Equals(object obj)

--- a/src/Microsoft.AspNet.Razor/Text/TextChange.cs
+++ b/src/Microsoft.AspNet.Razor/Text/TextChange.cs
@@ -60,10 +60,15 @@ namespace Microsoft.AspNet.Razor.Text
         }
 
         public int OldPosition { get; }
+
         public int NewPosition { get; }
+
         public int OldLength { get; }
+
         public int NewLength { get; }
+
         public ITextBuffer NewBuffer { get; }
+
         public ITextBuffer OldBuffer { get; }
 
         /// <remark>
@@ -121,13 +126,14 @@ namespace Microsoft.AspNet.Razor.Text
             {
                 return false;
             }
+
             var change = (TextChange)obj;
-            return (change.OldPosition == OldPosition) &&
-                   (change.NewPosition == NewPosition) &&
-                   (change.OldLength == OldLength) &&
-                   (change.NewLength == NewLength) &&
-                   OldBuffer.Equals(change.OldBuffer) &&
-                   NewBuffer.Equals(change.NewBuffer);
+            return change.OldPosition == OldPosition &&
+                change.NewPosition == NewPosition &&
+                change.OldLength == OldLength &&
+                change.NewLength == NewLength &&
+                OldBuffer.Equals(change.OldBuffer) &&
+                NewBuffer.Equals(change.NewBuffer);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Text/TextChange.cs
+++ b/src/Microsoft.AspNet.Razor/Text/TextChange.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Text
 {
@@ -58,12 +59,12 @@ namespace Microsoft.AspNet.Razor.Text
             OldBuffer = oldBuffer;
         }
 
-        public int OldPosition { get; private set; }
-        public int NewPosition { get; private set; }
-        public int OldLength { get; private set; }
-        public int NewLength { get; private set; }
-        public ITextBuffer NewBuffer { get; private set; }
-        public ITextBuffer OldBuffer { get; private set; }
+        public int OldPosition { get; }
+        public int NewPosition { get; }
+        public int OldLength { get; }
+        public int NewLength { get; }
+        public ITextBuffer NewBuffer { get; }
+        public ITextBuffer OldBuffer { get; }
 
         /// <remark>
         /// Note: This property is not thread safe, and will move position on the textbuffer while being read.
@@ -129,6 +130,18 @@ namespace Microsoft.AspNet.Razor.Text
                    NewBuffer.Equals(change.NewBuffer);
         }
 
+        public override int GetHashCode()
+        {
+            return HashCodeCombiner.Start()
+                .Add(OldPosition)
+                .Add(NewPosition)
+                .Add(OldLength)
+                .Add(NewLength)
+                .Add(OldBuffer)
+                .Add(NewBuffer)
+                .CombinedHash;
+        }
+
         public string ApplyChange(string content, int changeOffset)
         {
             var changeRelativePosition = OldPosition - changeOffset;
@@ -145,11 +158,6 @@ namespace Microsoft.AspNet.Razor.Text
         public string ApplyChange(Span span)
         {
             return ApplyChange(span.Content, span.Start.AbsoluteIndex);
-        }
-
-        public override int GetHashCode()
-        {
-            return OldPosition ^ NewPosition ^ OldLength ^ NewLength ^ NewBuffer.GetHashCode() ^ OldBuffer.GetHashCode();
         }
 
         public override string ToString()

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/CSharpSymbol.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/CSharpSymbol.cs
@@ -35,12 +35,13 @@ namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
         public override bool Equals(object obj)
         {
             var other = obj as CSharpSymbol;
-            return base.Equals(obj) && other.Keyword == Keyword;
+            return base.Equals(other) && other.Keyword == Keyword;
         }
 
         public override int GetHashCode()
         {
-            return base.GetHashCode() ^ Keyword.GetHashCode();
+            // Hash code should include only immutable properties.
+            return base.GetHashCode();
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/SymbolBase.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/SymbolBase.cs
@@ -29,7 +29,9 @@ namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
         }
 
         public SourceLocation Start { get; private set; }
+
         public string Content { get; }
+
         public IEnumerable<RazorError> Errors { get; }
 
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "This is the most appropriate name for this property and conflicts are unlikely")]
@@ -39,9 +41,9 @@ namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
         {
             SymbolBase<TType> other = obj as SymbolBase<TType>;
             return other != null &&
-                   Start.Equals(other.Start) &&
-                   string.Equals(Content, other.Content, StringComparison.Ordinal) &&
-                   Type.Equals(other.Type);
+                Start.Equals(other.Start) &&
+                string.Equals(Content, other.Content, StringComparison.Ordinal) &&
+                Type.Equals(other.Type);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/SymbolBase.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/SymbolBase.cs
@@ -29,11 +29,11 @@ namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
         }
 
         public SourceLocation Start { get; private set; }
-        public string Content { get; private set; }
-        public IEnumerable<RazorError> Errors { get; private set; }
+        public string Content { get; }
+        public IEnumerable<RazorError> Errors { get; }
 
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "This is the most appropriate name for this property and conflicts are unlikely")]
-        public TType Type { get; private set; }
+        public TType Type { get; }
 
         public override bool Equals(object obj)
         {
@@ -46,9 +46,9 @@ namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
 
         public override int GetHashCode()
         {
+            // Hash code should include only immutable properties.
             return HashCodeCombiner.Start()
-                .Add(Start)
-                .Add(Content)
+                .Add(Content, StringComparer.Ordinal)
                 .Add(Type)
                 .CombinedHash;
         }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperDescriptorComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperDescriptorComparer.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             var hashCodeCombiner = HashCodeCombiner
                 .Start()
-                .Add(base.GetHashCode())
+                .Add(base.GetHashCode(descriptor))
                 .Add(descriptor.TagName, StringComparer.Ordinal)
                 .Add(descriptor.Prefix);
 

--- a/test/Microsoft.AspNet.Razor.Test/Editor/AutoCompleteEditHandlerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Editor/AutoCompleteEditHandlerTest.cs
@@ -21,13 +21,13 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
                             AutoCompleteString = "one string",
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         },
                         new AutoCompleteEditHandler(tokenizer: null, autoCompleteAtEndOfSpan: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
                             AutoCompleteString = "one string",
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         }
                     },
                     {
@@ -115,13 +115,13 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                         {
                             AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
                             AutoCompleteString = "four string",
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.None,
                         },
                         new AutoCompleteEditHandler(tokenizer: null, autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
                             AutoCompleteString = "four string",
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.None,
                         }
                     },
                     {
@@ -166,7 +166,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                         {
                             AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
                             AutoCompleteString = "five string",
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         },
                         new AutoCompleteEditHandler(
                             tokenizer: _ => Enumerable.Empty<ISymbol>(),

--- a/test/Microsoft.AspNet.Razor.Test/Editor/AutoCompleteEditHandlerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Editor/AutoCompleteEditHandlerTest.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.AspNet.Razor.Editor;
+using Microsoft.AspNet.Razor.Tokenizer.Symbols;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
+{
+    public class AutoCompleteEditHandlerTest
+    {
+        public static TheoryData<AutoCompleteEditHandler, AutoCompleteEditHandler> MatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<AutoCompleteEditHandler, AutoCompleteEditHandler>
+                {
+                    {
+                        new AutoCompleteEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "one string",
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new AutoCompleteEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "one string",
+                            EditorHints = EditorHints.LayoutPage,
+                        }
+                    },
+                    {
+                        // Tokenizer not involved in equality check or hash code calculation.
+                        new AutoCompleteEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            AutoCompleteAtEndOfSpan = true,
+                            AutoCompleteString = "two string",
+                            EditorHints = EditorHints.None,
+                        },
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            AutoCompleteAtEndOfSpan = true,
+                            AutoCompleteString = "two string",
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                };
+            }
+        }
+
+        public static TheoryData<AutoCompleteEditHandler, object> NonMatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<AutoCompleteEditHandler, object>
+                {
+                    {
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "three string",
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        null
+                    },
+                    {
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "three string",
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new object()
+                    },
+                    {
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "three string",
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                    },
+                    {
+                        // Different AcceptedCharacters.
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "three string",
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "three string",
+                            EditorHints = EditorHints.VirtualPath,
+                        }
+                    },
+                    {
+                        // Different AutoCompleteAtEndOfSpan.
+                        new AutoCompleteEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "four string",
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new AutoCompleteEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            AutoCompleteAtEndOfSpan = true,
+                            AutoCompleteString = "four string",
+                            EditorHints = EditorHints.LayoutPage,
+                        }
+                    },
+                    {
+                        // Different AutoCompleteString.
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NewLine,
+                            AutoCompleteAtEndOfSpan = true,
+                            AutoCompleteString = "some string",
+                            EditorHints = EditorHints.None,
+                        },
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NewLine,
+                            AutoCompleteAtEndOfSpan = true,
+                            AutoCompleteString = "different string",
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                    {
+                        // Different AutoCompleteString (case sensitive).
+                        new AutoCompleteEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.None,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "some string",
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new AutoCompleteEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.None,
+                            AutoCompleteAtEndOfSpan = false,
+                            AutoCompleteString = "Some String",
+                            EditorHints = EditorHints.VirtualPath,
+                        }
+                    },
+                    {
+                        // Different EditorHints.
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
+                            AutoCompleteAtEndOfSpan = true,
+                            AutoCompleteString = "five string",
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
+                            AutoCompleteAtEndOfSpan = true,
+                            AutoCompleteString = "five string",
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void Equals_True_WhenExpected(AutoCompleteEditHandler leftObject, AutoCompleteEditHandler rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonMatchingTestDataSet))]
+        public void Equals_False_WhenExpected(AutoCompleteEditHandler leftObject, object rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void GetHashCode_ReturnsSameValue_WhenEqual(
+            AutoCompleteEditHandler leftObject,
+            AutoCompleteEditHandler rightObject)
+        {
+            // Arrange & Act
+            var leftResult = leftObject.GetHashCode();
+            var rightResult = rightObject.GetHashCode();
+
+            // Assert
+            Assert.Equal(leftResult, rightResult);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/Editor/AutoCompleteEditHandlerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Editor/AutoCompleteEditHandlerTest.cs
@@ -17,34 +17,32 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                 return new TheoryData<AutoCompleteEditHandler, AutoCompleteEditHandler>
                 {
                     {
-                        new AutoCompleteEditHandler(tokenizer: null)
+                        new AutoCompleteEditHandler(tokenizer: null, autoCompleteAtEndOfSpan: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "one string",
                             EditorHints = EditorHints.LayoutPage,
                         },
-                        new AutoCompleteEditHandler(tokenizer: null)
+                        new AutoCompleteEditHandler(tokenizer: null, autoCompleteAtEndOfSpan: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "one string",
                             EditorHints = EditorHints.LayoutPage,
                         }
                     },
                     {
                         // Tokenizer not involved in equality check or hash code calculation.
-                        new AutoCompleteEditHandler(tokenizer: null)
+                        new AutoCompleteEditHandler(tokenizer: null, autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.Any,
-                            AutoCompleteAtEndOfSpan = true,
                             AutoCompleteString = "two string",
                             EditorHints = EditorHints.None,
                         },
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.Any,
-                            AutoCompleteAtEndOfSpan = true,
                             AutoCompleteString = "two string",
                             EditorHints = EditorHints.None,
                         }
@@ -60,30 +58,33 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                 return new TheoryData<AutoCompleteEditHandler, object>
                 {
                     {
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "three string",
                             EditorHints = EditorHints.VirtualPath,
                         },
                         null
                     },
                     {
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "three string",
                             EditorHints = EditorHints.VirtualPath,
                         },
                         new object()
                     },
                     {
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "three string",
                             EditorHints = EditorHints.VirtualPath,
                         },
@@ -91,85 +92,87 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                     },
                     {
                         // Different AcceptedCharacters.
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "three string",
                             EditorHints = EditorHints.VirtualPath,
                         },
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "three string",
                             EditorHints = EditorHints.VirtualPath,
                         }
                     },
                     {
                         // Different AutoCompleteAtEndOfSpan.
-                        new AutoCompleteEditHandler(tokenizer: null)
+                        new AutoCompleteEditHandler(tokenizer: null, autoCompleteAtEndOfSpan: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "four string",
                             EditorHints = EditorHints.LayoutPage,
                         },
-                        new AutoCompleteEditHandler(tokenizer: null)
+                        new AutoCompleteEditHandler(tokenizer: null, autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
-                            AutoCompleteAtEndOfSpan = true,
                             AutoCompleteString = "four string",
                             EditorHints = EditorHints.LayoutPage,
                         }
                     },
                     {
                         // Different AutoCompleteString.
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.NewLine,
-                            AutoCompleteAtEndOfSpan = true,
                             AutoCompleteString = "some string",
                             EditorHints = EditorHints.None,
                         },
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.NewLine,
-                            AutoCompleteAtEndOfSpan = true,
                             AutoCompleteString = "different string",
                             EditorHints = EditorHints.None,
                         }
                     },
                     {
                         // Different AutoCompleteString (case sensitive).
-                        new AutoCompleteEditHandler(tokenizer: null)
+                        new AutoCompleteEditHandler(tokenizer: null, autoCompleteAtEndOfSpan: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.None,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "some string",
                             EditorHints = EditorHints.VirtualPath,
                         },
-                        new AutoCompleteEditHandler(tokenizer: null)
+                        new AutoCompleteEditHandler(tokenizer: null, autoCompleteAtEndOfSpan: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.None,
-                            AutoCompleteAtEndOfSpan = false,
                             AutoCompleteString = "Some String",
                             EditorHints = EditorHints.VirtualPath,
                         }
                     },
                     {
                         // Different EditorHints.
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
-                            AutoCompleteAtEndOfSpan = true,
                             AutoCompleteString = "five string",
                             EditorHints = EditorHints.LayoutPage,
                         },
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
-                            AutoCompleteAtEndOfSpan = true,
                             AutoCompleteString = "five string",
                             EditorHints = EditorHints.None,
                         }

--- a/test/Microsoft.AspNet.Razor.Test/Editor/ImplicitExpressionEditHandlerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Editor/ImplicitExpressionEditHandlerTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         },
                         new ImplicitExpressionEditHandler(
                             tokenizer: null,
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         }
                     },
                     {
@@ -91,7 +91,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.WhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         },
                         null
                     },
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.WhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         },
                         new object()
                     },
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.WhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.None,
                         },
                         new SpanEditHandler( tokenizer: _ => null)
                     },
@@ -144,7 +144,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: false)
                         {
                             AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         },
                         new ImplicitExpressionEditHandler(
                             tokenizer: _ => null,
@@ -152,7 +152,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         }
                     },
                     {
@@ -201,7 +201,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.None,
                         },
                         new ImplicitExpressionEditHandler(
                             tokenizer: _ => Enumerable.Empty<ISymbol>(),
@@ -209,7 +209,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.None,
                         }
                     },
                     {
@@ -239,7 +239,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             acceptTrailingDot: true)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         },
                         new ImplicitExpressionEditHandler(
                             tokenizer: _ => Enumerable.Empty<ISymbol>(),

--- a/test/Microsoft.AspNet.Razor.Test/Editor/ImplicitExpressionEditHandlerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Editor/ImplicitExpressionEditHandlerTest.cs
@@ -1,0 +1,295 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNet.Razor.Editor;
+using Microsoft.AspNet.Razor.Tokenizer.Symbols;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
+{
+    public class ImplicitExpressionEditHandlerTest
+    {
+        public static TheoryData<ImplicitExpressionEditHandler, ImplicitExpressionEditHandler> MatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<ImplicitExpressionEditHandler, ImplicitExpressionEditHandler>
+                {
+                    {
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: null,
+                            keywords: new HashSet<string>(),
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: null,
+                            keywords: new HashSet<string>(),
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        }
+                    },
+                    {
+                        // Tokenizer not involved in equality check or hash code calculation.
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: null,
+                            keywords: new HashSet<string> { "keyword 1" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            EditorHints = EditorHints.None,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 1" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                    {
+                        // Only comparers are different (HashSet's comparer does not affect GetHashCode of entries).
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 2", "keyword 3" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            EditorHints = EditorHints.None,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "keyword 2", "keyword 3" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                };
+            }
+        }
+
+        public static TheoryData<ImplicitExpressionEditHandler, object> NonMatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<ImplicitExpressionEditHandler, object>
+                {
+                    {
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => null,
+                            keywords: new HashSet<string> { "keyword 4" },
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.WhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        null
+                    },
+                    {
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => null,
+                            keywords: new HashSet<string> { "keyword 4" },
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.WhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new object()
+                    },
+                    {
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => null,
+                            keywords: new HashSet<string> { "keyword 4" },
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.WhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new SpanEditHandler( tokenizer: _ => null)
+                    },
+                    {
+                        // Different AcceptedCharacters.
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 5" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 5" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            EditorHints = EditorHints.VirtualPath,
+                        }
+                    },
+                    {
+                        // Different AcceptTrailingDot.
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => null,
+                            keywords: new HashSet<string> { "keyword 6" },
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => null,
+                            keywords: new HashSet<string> { "keyword 6" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            EditorHints = EditorHints.LayoutPage,
+                        }
+                    },
+                    {
+                        // Different Keywords.
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 7" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NewLine,
+                            EditorHints = EditorHints.None,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 8" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NewLine,
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                    {
+                        // Different Keywords comparers (Equals uses left comparer).
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => null,
+                            keywords: new HashSet<string> { "keyword 9" },
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.None,
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => null,
+                            keywords: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "KEYWORD 9" },
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.None,
+                            EditorHints = EditorHints.VirtualPath,
+                        }
+                    },
+                    {
+                        // Different Keywords (count).
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 10" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 10", "keyword 11" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        }
+                    },
+                    {
+                        // Different Keywords (count).
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: null,
+                            keywords: new HashSet<string> { "keyword 12" },
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.WhiteSpace,
+                            EditorHints = EditorHints.None,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: null,
+                            keywords: new HashSet<string>(),
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.WhiteSpace,
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                    {
+                        // Different EditorHints.
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 13" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            keywords: new HashSet<string> { "keyword 13" },
+                            acceptTrailingDot: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void Equals_True_WhenExpected(
+            ImplicitExpressionEditHandler leftObject,
+            ImplicitExpressionEditHandler rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonMatchingTestDataSet))]
+        public void Equals_False_WhenExpected(ImplicitExpressionEditHandler leftObject, object rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void GetHashCode_ReturnsSameValue_WhenEqual(
+            ImplicitExpressionEditHandler leftObject,
+            ImplicitExpressionEditHandler rightObject)
+        {
+            // Arrange & Act
+            var leftResult = leftObject.GetHashCode();
+            var rightResult = rightObject.GetHashCode();
+
+            // Assert
+            Assert.Equal(leftResult, rightResult);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/Editor/SpanEditHandlerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Editor/SpanEditHandlerTest.cs
@@ -46,47 +46,6 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
             }
         }
 
-        // Following cases involve other SpanEditHandler that SpanEditHandler thinks are equal. But they have
-        // their own Equals() and GetHashCode() implementations, leading to X==Y but Y!=X and different hash codes.
-        public static TheoryData<SpanEditHandler, SpanEditHandler> SlightlyMatchingTestDataSet
-        {
-            get
-            {
-                return new TheoryData<SpanEditHandler, SpanEditHandler>
-                {
-                    {
-                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
-                        {
-                            AcceptedCharacters = AcceptedCharacters.Any,
-                            EditorHints = EditorHints.None,
-                        },
-                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
-                        {
-                            AcceptedCharacters = AcceptedCharacters.Any,
-                            AutoCompleteAtEndOfSpan = true,
-                            AutoCompleteString = "two string",
-                            EditorHints = EditorHints.None,
-                        }
-                    },
-                    {
-                        new SpanEditHandler(tokenizer: null)
-                        {
-                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
-                            EditorHints = EditorHints.VirtualPath,
-                        },
-                        new ImplicitExpressionEditHandler(
-                            tokenizer: null,
-                            keywords: new HashSet<string>(),
-                            acceptTrailingDot: false)
-                        {
-                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
-                            EditorHints = EditorHints.VirtualPath,
-                        }
-                    },
-                };
-            }
-        }
-
         public static TheoryData<SpanEditHandler, object> NonMatchingTestDataSet
         {
             get
@@ -108,6 +67,36 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                             EditorHints = EditorHints.VirtualPath,
                         },
                         new object()
+                    },
+                    {
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            EditorHints = EditorHints.None,
+                        },
+                        new AutoCompleteEditHandler(
+                            tokenizer: _ => Enumerable.Empty<ISymbol>(),
+                            autoCompleteAtEndOfSpan: true)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            AutoCompleteString = "two string",
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                    {
+                        new SpanEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: null,
+                            keywords: new HashSet<string>(),
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            EditorHints = EditorHints.VirtualPath,
+                        }
                     },
                     {
                         // Different AcceptedCharacters.
@@ -141,7 +130,6 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 
         [Theory]
         [MemberData(nameof(MatchingTestDataSet))]
-        [MemberData(nameof(SlightlyMatchingTestDataSet))]
         public void Equals_True_WhenExpected(SpanEditHandler leftObject, SpanEditHandler rightObject)
         {
             // Arrange & Act
@@ -149,28 +137,6 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 
             // Assert
             Assert.True(result);
-        }
-
-        [Theory]
-        [MemberData(nameof(MatchingTestDataSet))]
-        public void Equals_True_Symmetric(SpanEditHandler leftObject, SpanEditHandler rightObject)
-        {
-            // Arrange & Act
-            var result = rightObject.Equals(leftObject);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Theory]
-        [MemberData(nameof(SlightlyMatchingTestDataSet))]
-        public void Equals_False_NotSymmetric(SpanEditHandler leftObject, SpanEditHandler rightObject)
-        {
-            // Arrange & Act
-            var result = rightObject.Equals(leftObject);
-
-            // Assert
-            Assert.False(result);
         }
 
         [Theory]
@@ -194,20 +160,6 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
 
             // Assert
             Assert.Equal(leftResult, rightResult);
-        }
-
-        [Theory]
-        [MemberData(nameof(SlightlyMatchingTestDataSet))]
-        public void GetHashCode_ReturnsDifferentValues_NotSymmetric(
-            SpanEditHandler leftObject,
-            SpanEditHandler rightObject)
-        {
-            // Arrange & Act
-            var leftResult = leftObject.GetHashCode();
-            var rightResult = rightObject.GetHashCode();
-
-            // Assert
-            Assert.NotEqual(leftResult, rightResult);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Editor/SpanEditHandlerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Editor/SpanEditHandlerTest.cs
@@ -21,12 +21,12 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                         new SpanEditHandler(tokenizer: null)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         },
                         new SpanEditHandler(tokenizer: null)
                         {
                             AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         }
                     },
                     {
@@ -116,7 +116,7 @@ namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
                         new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
                         {
                             AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
-                            EditorHints = EditorHints.LayoutPage,
+                            EditorHints = EditorHints.VirtualPath,
                         },
                         new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
                         {

--- a/test/Microsoft.AspNet.Razor.Test/Editor/SpanEditHandlerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Editor/SpanEditHandlerTest.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNet.Razor.Editor;
+using Microsoft.AspNet.Razor.Tokenizer.Symbols;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Parser.SyntaxTree
+{
+    public class SpanEditHandlerTest
+    {
+        public static TheoryData<SpanEditHandler, SpanEditHandler> MatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<SpanEditHandler, SpanEditHandler>
+                {
+                    {
+                        new SpanEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new SpanEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        }
+                    },
+                    {
+                        // Tokenizer not involved in equality check or hash code calculation.
+                        new SpanEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            EditorHints = EditorHints.None,
+                        },
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                };
+            }
+        }
+
+        // Following cases involve other SpanEditHandler that SpanEditHandler thinks are equal. But they have
+        // their own Equals() and GetHashCode() implementations, leading to X==Y but Y!=X and different hash codes.
+        public static TheoryData<SpanEditHandler, SpanEditHandler> SlightlyMatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<SpanEditHandler, SpanEditHandler>
+                {
+                    {
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            EditorHints = EditorHints.None,
+                        },
+                        new AutoCompleteEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.Any,
+                            AutoCompleteAtEndOfSpan = true,
+                            AutoCompleteString = "two string",
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                    {
+                        new SpanEditHandler(tokenizer: null)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new ImplicitExpressionEditHandler(
+                            tokenizer: null,
+                            keywords: new HashSet<string>(),
+                            acceptTrailingDot: false)
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            EditorHints = EditorHints.VirtualPath,
+                        }
+                    },
+                };
+            }
+        }
+
+        public static TheoryData<SpanEditHandler, object> NonMatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<SpanEditHandler, object>
+                {
+                    {
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        null
+                    },
+                    {
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new object()
+                    },
+                    {
+                        // Different AcceptedCharacters.
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AllWhiteSpace,
+                            EditorHints = EditorHints.VirtualPath,
+                        },
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.AnyExceptNewline,
+                            EditorHints = EditorHints.VirtualPath,
+                        }
+                    },
+                    {
+                        // Different EditorHints.
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
+                            EditorHints = EditorHints.LayoutPage,
+                        },
+                        new SpanEditHandler(tokenizer: _ => Enumerable.Empty<ISymbol>())
+                        {
+                            AcceptedCharacters = AcceptedCharacters.NonWhiteSpace,
+                            EditorHints = EditorHints.None,
+                        }
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        [MemberData(nameof(SlightlyMatchingTestDataSet))]
+        public void Equals_True_WhenExpected(SpanEditHandler leftObject, SpanEditHandler rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void Equals_True_Symmetric(SpanEditHandler leftObject, SpanEditHandler rightObject)
+        {
+            // Arrange & Act
+            var result = rightObject.Equals(leftObject);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(SlightlyMatchingTestDataSet))]
+        public void Equals_False_NotSymmetric(SpanEditHandler leftObject, SpanEditHandler rightObject)
+        {
+            // Arrange & Act
+            var result = rightObject.Equals(leftObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonMatchingTestDataSet))]
+        public void Equals_False_WhenExpected(SpanEditHandler leftObject, object rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void GetHashCode_ReturnsSameValue_WhenEqual(SpanEditHandler leftObject, SpanEditHandler rightObject)
+        {
+            // Arrange & Act
+            var leftResult = leftObject.GetHashCode();
+            var rightResult = rightObject.GetHashCode();
+
+            // Assert
+            Assert.Equal(leftResult, rightResult);
+        }
+
+        [Theory]
+        [MemberData(nameof(SlightlyMatchingTestDataSet))]
+        public void GetHashCode_ReturnsDifferentValues_NotSymmetric(
+            SpanEditHandler leftObject,
+            SpanEditHandler rightObject)
+        {
+            // Arrange & Act
+            var leftResult = leftObject.GetHashCode();
+            var rightResult = rightObject.GetHashCode();
+
+            // Assert
+            Assert.NotEqual(leftResult, rightResult);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/Framework/RawTextSymbol.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/RawTextSymbol.cs
@@ -6,14 +6,13 @@ using System.Globalization;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
-using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Test.Framework
 {
     internal class RawTextSymbol : ISymbol
     {
         public SourceLocation Start { get; private set; }
-        public string Content { get; private set; }
+        public string Content { get; }
 
         public RawTextSymbol(SourceLocation start, string content)
         {
@@ -39,10 +38,8 @@ namespace Microsoft.AspNet.Razor.Test.Framework
 
         public override int GetHashCode()
         {
-            return HashCodeCombiner.Start()
-                .Add(Start)
-                .Add(Content)
-                .CombinedHash;
+            // Hash code should include only immutable properties.
+            return Content == null ? 0 : Content.GetHashCode();
         }
 
         public void OffsetStart(SourceLocation documentStart)

--- a/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
@@ -243,7 +243,12 @@ namespace Microsoft.AspNet.Razor.Test.Framework
 
         public static SpanConstructor AutoCompleteWith(this SpanConstructor self, string autoCompleteString, bool atEndOfSpan)
         {
-            return self.With(new AutoCompleteEditHandler(SpanConstructor.TestTokenizer) { AutoCompleteString = autoCompleteString, AutoCompleteAtEndOfSpan = atEndOfSpan });
+            return self.With(new AutoCompleteEditHandler(
+                SpanConstructor.TestTokenizer,
+                autoCompleteAtEndOfSpan: atEndOfSpan)
+            {
+                AutoCompleteString = autoCompleteString
+            });
         }
 
         public static SpanConstructor WithEditorHints(this SpanConstructor self, EditorHints hints)

--- a/test/Microsoft.AspNet.Razor.Test/Generator/AddImportCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/AddImportCodeGeneratorTest.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Generator
+{
+    public class AddImportCodeGeneratorTest
+    {
+        public static TheoryData<AddImportCodeGenerator, AddImportCodeGenerator> MatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<AddImportCodeGenerator, AddImportCodeGenerator>
+                {
+                    {
+                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 3),
+                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 3)
+                    },
+                    {
+                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
+                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23)
+                    },
+                };
+            }
+        }
+
+        public static TheoryData<AddImportCodeGenerator, object> NonMatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<AddImportCodeGenerator, object>
+                {
+                    {
+                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 0),
+                        null
+                    },
+                    {
+                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
+                        null
+                    },
+                    {
+                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
+                        new object()
+                    },
+                    {
+                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
+                        SpanCodeGenerator.Null
+                    },
+                    {
+                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
+                        new StatementCodeGenerator()
+                    },
+                    {
+                        // Different Namespace.
+                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 3),
+                        new AddImportCodeGenerator(ns: "Ginger", namespaceKeywordLength: 3)
+                    },
+                    {
+                        // Different Namespace (case sensitive).
+                        new AddImportCodeGenerator(ns: "fred", namespaceKeywordLength: 9),
+                        new AddImportCodeGenerator(ns: "FRED", namespaceKeywordLength: 9)
+                    },
+                    {
+                        // Different NamespaceKeywordLength.
+                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 0),
+                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 23)
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void Equals_True_WhenExpected(AddImportCodeGenerator leftObject, AddImportCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonMatchingTestDataSet))]
+        public void Equals_False_WhenExpected(AddImportCodeGenerator leftObject, object rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void GetHashCode_ReturnsSameValue_WhenEqual(
+            AddImportCodeGenerator leftObject,
+            AddImportCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var leftResult = leftObject.GetHashCode();
+            var rightResult = rightObject.GetHashCode();
+
+            // Assert
+            Assert.Equal(leftResult, rightResult);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/Generator/AttributeBlockCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/AttributeBlockCodeGeneratorTest.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Razor.Text;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Generator
+{
+    public class AttributeBlockCodeGeneratorTest
+    {
+        public static TheoryData<AttributeBlockCodeGenerator, AttributeBlockCodeGenerator> MatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<AttributeBlockCodeGenerator, AttributeBlockCodeGenerator>
+                {
+                    {
+                        new AttributeBlockCodeGenerator(name: null, prefix: null, suffix: null),
+                        new AttributeBlockCodeGenerator(name: null, prefix: null, suffix: null)
+                    },
+                    {
+                        new AttributeBlockCodeGenerator(
+                            name: "Fred",
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 0, line: 0, col: 0),
+                            suffix: new LocationTagged<string>(value: "George", offset: 0, line: 0, col: 0)),
+                        new AttributeBlockCodeGenerator(
+                            name: "Fred",
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 0, line: 0, col: 0),
+                            suffix: new LocationTagged<string>(value: "George", offset: 0, line: 0, col: 0))
+                    },
+                    {
+                        new AttributeBlockCodeGenerator(
+                            name: "Fred",
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            suffix: new LocationTagged<string>(value: "George", offset: 13, line: 14, col: 15)),
+                        new AttributeBlockCodeGenerator(
+                            name: "Fred",
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            suffix: new LocationTagged<string>(value: "George", offset: 13, line: 14, col: 15))
+                    },
+                };
+            }
+        }
+
+        public static TheoryData<AttributeBlockCodeGenerator, object> NonMatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<AttributeBlockCodeGenerator, object>
+                {
+                    {
+                        new AttributeBlockCodeGenerator(name: null, prefix: null, suffix: null),
+                        null
+                    },
+                    {
+                        new AttributeBlockCodeGenerator(
+                            name: "Fred",
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 0, line: 0, col: 0),
+                            suffix: new LocationTagged<string>(value: "George", offset: 0, line: 0, col: 0)),
+                        null
+                    },
+                    {
+                        new AttributeBlockCodeGenerator(
+                            name: "Fred",
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            suffix: new LocationTagged<string>(value: "George", offset: 13, line: 14, col: 15)),
+                        null
+                    },
+                    {
+                        new AttributeBlockCodeGenerator(
+                            name: "Fred",
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            suffix: new LocationTagged<string>(value: "George", offset: 13, line: 14, col: 15)),
+                        new object()
+                    },
+                    {
+                        new AttributeBlockCodeGenerator(
+                            name: "Fred",
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            suffix: new LocationTagged<string>(value: "George", offset: 13, line: 14, col: 15)),
+                        new RazorCommentCodeGenerator()
+                    },
+                    {
+                        // Different Name.
+                        new AttributeBlockCodeGenerator(name: "Fred", prefix: null, suffix: null),
+                        new AttributeBlockCodeGenerator(name: "Ginger", prefix: null, suffix: null)
+                    },
+                    {
+                        // Different Name (case sensitive).
+                        new AttributeBlockCodeGenerator(name: "fred", prefix: null, suffix: null),
+                        new AttributeBlockCodeGenerator(name: "FRED", prefix: null, suffix: null)
+                    },
+                    {
+                        // Different Prefix.
+                        new AttributeBlockCodeGenerator(
+                            name: null,
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            suffix: null),
+                        new AttributeBlockCodeGenerator(
+                            name: null,
+                            prefix: new LocationTagged<string>(value: "George", offset: 10, line: 11, col: 12),
+                            suffix: null)
+                    },
+                    {
+                        // Different Suffix.
+                        new AttributeBlockCodeGenerator(
+                            name: null,
+                            prefix: null,
+                            suffix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12)),
+                        new AttributeBlockCodeGenerator(
+                            name: null,
+                            prefix: null,
+                            suffix: new LocationTagged<string>(value: "George", offset: 10, line: 11, col: 12))
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void Equals_True_WhenExpected(
+            AttributeBlockCodeGenerator leftObject,
+            AttributeBlockCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonMatchingTestDataSet))]
+        public void Equals_False_WhenExpected(AttributeBlockCodeGenerator leftObject, object rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void GetHashCode_ReturnsSameValue_WhenEqual(
+            AttributeBlockCodeGenerator leftObject,
+            AttributeBlockCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var leftResult = leftObject.GetHashCode();
+            var rightResult = rightObject.GetHashCode();
+
+            // Assert
+            Assert.Equal(leftResult, rightResult);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/Generator/DynamicAttributeBlockCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/DynamicAttributeBlockCodeGeneratorTest.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Razor.Text;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Generator
+{
+    public class DynamicAttributeBlockCodeGeneratorTest
+    {
+        public static TheoryData<DynamicAttributeBlockCodeGenerator, DynamicAttributeBlockCodeGenerator> MatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<DynamicAttributeBlockCodeGenerator, DynamicAttributeBlockCodeGenerator>
+                {
+                    {
+                        new DynamicAttributeBlockCodeGenerator(prefix: null, offset: 0, line: 0, col: 0),
+                        new DynamicAttributeBlockCodeGenerator(prefix: null, offset: 0, line: 0, col: 0)
+                    },
+                    {
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "Fred", offset: 0, line: 0, col: 0),
+                            offset: 10,
+                            line: 11,
+                            col: 12),
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "Fred", offset: 0, line: 0, col: 0),
+                            offset: 10,
+                            line: 11,
+                            col: 12)
+                    },
+                    // ValueStart not involved in equality check or hash code calculation.
+                    {
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            offset: 10,
+                            line: 11,
+                            col: 12),
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            offset: 100,
+                            line: 11,
+                            col: 12)
+                    },
+                    {
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "George", offset: 10, line: 11, col: 12),
+                            offset: 10,
+                            line: 11,
+                            col: 12),
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "George", offset: 10, line: 11, col: 12),
+                            offset: 10,
+                            line: 110,
+                            col: 12)
+                    },
+                    {
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "Dean", offset: 10, line: 11, col: 12),
+                            offset: 10,
+                            line: 11,
+                            col: 12),
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "Dean", offset: 10, line: 11, col: 12),
+                            offset: 10,
+                            line: 11,
+                            col: 120)
+                    },
+                };
+            }
+        }
+
+        public static TheoryData<DynamicAttributeBlockCodeGenerator, object> NonMatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<DynamicAttributeBlockCodeGenerator, object>
+                {
+                    {
+                        new DynamicAttributeBlockCodeGenerator(prefix: null, offset: 0, line: 0, col: 0),
+                        null
+                    },
+                    {
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 0, line: 0, col: 0),
+                            offset: 10,
+                            line: 11,
+                            col: 12),
+                        null
+                    },
+                    {
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            offset: 10,
+                            line: 11,
+                            col: 12),
+                        new object()
+                    },
+                    {
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "George", offset: 10, line: 11, col: 12),
+                            offset: 10,
+                            line: 11,
+                            col: 12),
+                        new AttributeBlockCodeGenerator(
+                            name: "Fred",
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            suffix: new LocationTagged<string>(value: "George", offset: 13, line: 14, col: 15))
+                    },
+                    {
+                        // Different Prefix.
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "Ginger", offset: 10, line: 11, col: 12),
+                            offset: 10,
+                            line: 11,
+                            col: 12),
+                        new DynamicAttributeBlockCodeGenerator(
+                            prefix: new LocationTagged<string>(value: "George", offset: 10, line: 11, col: 12),
+                            offset: 10,
+                            line: 11,
+                            col: 12)
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void Equals_True_WhenExpected(
+            DynamicAttributeBlockCodeGenerator leftObject,
+            DynamicAttributeBlockCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonMatchingTestDataSet))]
+        public void Equals_False_WhenExpected(DynamicAttributeBlockCodeGenerator leftObject, object rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void GetHashCode_ReturnsSameValue_WhenEqual(
+            DynamicAttributeBlockCodeGenerator leftObject,
+            DynamicAttributeBlockCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var leftResult = leftObject.GetHashCode();
+            var rightResult = rightObject.GetHashCode();
+
+            // Assert
+            Assert.Equal(leftResult, rightResult);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/Generator/RazorCommentCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/RazorCommentCodeGeneratorTest.cs
@@ -17,36 +17,6 @@ namespace Microsoft.AspNet.Razor.Generator
                 return new TheoryData<RazorCommentCodeGenerator, IBlockCodeGenerator>
                 {
                     { new RazorCommentCodeGenerator(), new RazorCommentCodeGenerator() },
-
-                    // BlockCodeGenerator.Equals() only checks whether (other is IBlockCodeGenerator).
-                    {
-                        new RazorCommentCodeGenerator(),
-                        new TagHelperCodeGenerator(Enumerable.Empty<TagHelperDescriptor>())
-                    },
-                    { new RazorCommentCodeGenerator(), new TemplateBlockCodeGenerator() },
-                };
-            }
-        }
-
-        // Following cases involve other IBlockCodeGenerator that BlockCodeGenerator thinks are equal. But they have
-        // their own Equals() and GetHashCode() implementations, leading to X==Y but Y!=X and different hash codes.
-        public static TheoryData<RazorCommentCodeGenerator, IBlockCodeGenerator> SlightlyMatchingTestDataSet
-        {
-            get
-            {
-                return new TheoryData<RazorCommentCodeGenerator, IBlockCodeGenerator>
-                {
-                    { new RazorCommentCodeGenerator(), BlockCodeGenerator.Null },
-                    {
-                        new RazorCommentCodeGenerator(),
-                        new AttributeBlockCodeGenerator(name: null, prefix: null, suffix: null)
-                    },
-                    {
-                        new RazorCommentCodeGenerator(),
-                        new DynamicAttributeBlockCodeGenerator(prefix: null, offset: 0, line: 0, col: 0)
-                    },
-                    { new RazorCommentCodeGenerator(), new ExpressionCodeGenerator() },
-                    { new RazorCommentCodeGenerator(), new SectionCodeGenerator(sectionName: null) },
                 };
             }
         }
@@ -58,18 +28,33 @@ namespace Microsoft.AspNet.Razor.Generator
                 return new TheoryData<IBlockCodeGenerator, object>
                 {
                     { new RazorCommentCodeGenerator(), null },
+                    { new RazorCommentCodeGenerator(), new object() },
+                    { new RazorCommentCodeGenerator(), BlockCodeGenerator.Null },
+                    {
+                        new RazorCommentCodeGenerator(),
+                        new AttributeBlockCodeGenerator(name: null, prefix: null, suffix: null)
+                    },
+                    {
+                        new RazorCommentCodeGenerator(),
+                        new DynamicAttributeBlockCodeGenerator(prefix: null, offset: 0, line: 0, col: 0)
+                    },
+                    { new RazorCommentCodeGenerator(), new ExpressionCodeGenerator() },
+                    { new RazorCommentCodeGenerator(), new SectionCodeGenerator(sectionName: null) },
+                    {
+                        new RazorCommentCodeGenerator(),
+                        new TagHelperCodeGenerator(Enumerable.Empty<TagHelperDescriptor>())
+                    },
+                    { new RazorCommentCodeGenerator(), new TemplateBlockCodeGenerator() },
                     {
                         new RazorCommentCodeGenerator(),
                         new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 0)
                     },
-                    { BlockCodeGenerator.Null, new object() },
                 };
             }
         }
 
         [Theory]
         [MemberData(nameof(MatchingTestDataSet))]
-        [MemberData(nameof(SlightlyMatchingTestDataSet))]
         public void Equals_True_WhenExpected(RazorCommentCodeGenerator leftObject, IBlockCodeGenerator rightObject)
         {
             // Arrange & Act
@@ -77,28 +62,6 @@ namespace Microsoft.AspNet.Razor.Generator
 
             // Assert
             Assert.True(result);
-        }
-
-        [Theory]
-        [MemberData(nameof(MatchingTestDataSet))]
-        public void Equals_True_Symmetric(RazorCommentCodeGenerator leftObject, IBlockCodeGenerator rightObject)
-        {
-            // Arrange & Act
-            var result = rightObject.Equals(leftObject);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Theory]
-        [MemberData(nameof(SlightlyMatchingTestDataSet))]
-        public void Equals_False_NotSymmetric(RazorCommentCodeGenerator leftObject, IBlockCodeGenerator rightObject)
-        {
-            // Arrange & Act
-            var result = rightObject.Equals(leftObject);
-
-            // Assert
-            Assert.False(result);
         }
 
         [Theory]
@@ -124,20 +87,6 @@ namespace Microsoft.AspNet.Razor.Generator
 
             // Assert
             Assert.Equal(leftResult, rightResult);
-        }
-
-        [Theory]
-        [MemberData(nameof(SlightlyMatchingTestDataSet))]
-        public void GetHashCode_ReturnsDifferentValues_NotSymmetric(
-            RazorCommentCodeGenerator leftObject,
-            IBlockCodeGenerator rightObject)
-        {
-            // Arrange & Act
-            var leftResult = leftObject.GetHashCode();
-            var rightResult = rightObject.GetHashCode();
-
-            // Assert
-            Assert.NotEqual(leftResult, rightResult);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Generator/RazorCommentCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/RazorCommentCodeGeneratorTest.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.AspNet.Razor.TagHelpers;
+using Xunit;
+
+namespace Microsoft.AspNet.Razor.Generator
+{
+    // Really tests underlying BlockCodeGenerator
+    public class RazorCommentCodeGeneratorTest
+    {
+        public static TheoryData<RazorCommentCodeGenerator, IBlockCodeGenerator> MatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<RazorCommentCodeGenerator, IBlockCodeGenerator>
+                {
+                    { new RazorCommentCodeGenerator(), new RazorCommentCodeGenerator() },
+
+                    // BlockCodeGenerator.Equals() only checks whether (other is IBlockCodeGenerator).
+                    {
+                        new RazorCommentCodeGenerator(),
+                        new TagHelperCodeGenerator(Enumerable.Empty<TagHelperDescriptor>())
+                    },
+                    { new RazorCommentCodeGenerator(), new TemplateBlockCodeGenerator() },
+                };
+            }
+        }
+
+        // Following cases involve other IBlockCodeGenerator that BlockCodeGenerator thinks are equal. But they have
+        // their own Equals() and GetHashCode() implementations, leading to X==Y but Y!=X and different hash codes.
+        public static TheoryData<RazorCommentCodeGenerator, IBlockCodeGenerator> SlightlyMatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<RazorCommentCodeGenerator, IBlockCodeGenerator>
+                {
+                    { new RazorCommentCodeGenerator(), BlockCodeGenerator.Null },
+                    {
+                        new RazorCommentCodeGenerator(),
+                        new AttributeBlockCodeGenerator(name: null, prefix: null, suffix: null)
+                    },
+                    {
+                        new RazorCommentCodeGenerator(),
+                        new DynamicAttributeBlockCodeGenerator(prefix: null, offset: 0, line: 0, col: 0)
+                    },
+                    { new RazorCommentCodeGenerator(), new ExpressionCodeGenerator() },
+                    { new RazorCommentCodeGenerator(), new SectionCodeGenerator(sectionName: null) },
+                };
+            }
+        }
+
+        public static TheoryData<IBlockCodeGenerator, object> NonMatchingTestDataSet
+        {
+            get
+            {
+                return new TheoryData<IBlockCodeGenerator, object>
+                {
+                    { new RazorCommentCodeGenerator(), null },
+                    {
+                        new RazorCommentCodeGenerator(),
+                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 0)
+                    },
+                    { BlockCodeGenerator.Null, new object() },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        [MemberData(nameof(SlightlyMatchingTestDataSet))]
+        public void Equals_True_WhenExpected(RazorCommentCodeGenerator leftObject, IBlockCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void Equals_True_Symmetric(RazorCommentCodeGenerator leftObject, IBlockCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var result = rightObject.Equals(leftObject);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(SlightlyMatchingTestDataSet))]
+        public void Equals_False_NotSymmetric(RazorCommentCodeGenerator leftObject, IBlockCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var result = rightObject.Equals(leftObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonMatchingTestDataSet))]
+        public void Equals_False_WhenExpected(IBlockCodeGenerator leftObject, object rightObject)
+        {
+            // Arrange & Act
+            var result = leftObject.Equals(rightObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingTestDataSet))]
+        public void GetHashCode_ReturnsSameValue_WhenEqual(
+            RazorCommentCodeGenerator leftObject,
+            IBlockCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var leftResult = leftObject.GetHashCode();
+            var rightResult = rightObject.GetHashCode();
+
+            // Assert
+            Assert.Equal(leftResult, rightResult);
+        }
+
+        [Theory]
+        [MemberData(nameof(SlightlyMatchingTestDataSet))]
+        public void GetHashCode_ReturnsDifferentValues_NotSymmetric(
+            RazorCommentCodeGenerator leftObject,
+            IBlockCodeGenerator rightObject)
+        {
+            // Arrange & Act
+            var leftResult = leftObject.GetHashCode();
+            var rightResult = rightObject.GetHashCode();
+
+            // Assert
+            Assert.NotEqual(leftResult, rightResult);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/Generator/TestSpan.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/TestSpan.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
+using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.Test.Generator
 {
@@ -28,9 +28,9 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         {
         }
 
-        public SpanKind Kind { get; private set; }
-        public int Start { get; private set; }
-        public int End { get; private set; }
+        public SpanKind Kind { get; }
+        public int Start { get; }
+        public int End { get; }
 
         public override string ToString()
         {
@@ -53,7 +53,11 @@ namespace Microsoft.AspNet.Razor.Test.Generator
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return HashCodeCombiner.Start()
+                .Add(Kind)
+                .Add(Start)
+                .Add(End)
+                .CombinedHash;
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Generator/TestSpan.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/TestSpan.cs
@@ -29,7 +29,9 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         }
 
         public SpanKind Kind { get; }
+
         public int Start { get; }
+
         public int End { get; }
 
         public override string ToString()
@@ -40,15 +42,10 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         public override bool Equals(object obj)
         {
             var other = obj as TestSpan;
-
-            if (other != null)
-            {
-                return (Kind == other.Kind) &&
-                       (Start == other.Start) &&
-                       (End == other.End);
-            }
-
-            return false;
+            return other != null &&
+                Kind == other.Kind &&
+                Start == other.Start &&
+                End == other.End;
         }
 
         public override int GetHashCode()

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
@@ -20,7 +20,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharacters.None),
-                    Factory.Code("\"\"").AsTagHelperPrefixDirective("")));
+                    Factory.Code("\"\"")
+                        .AsTagHelperPrefixDirective(string.Empty)));
         }
 
         [Fact]
@@ -32,7 +33,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharacters.None),
-                    Factory.Code("\"Foo\"").AsTagHelperPrefixDirective("Foo")));
+                    Factory.Code("\"Foo\"")
+                        .AsTagHelperPrefixDirective("Foo")));
         }
 
         [Fact]
@@ -44,7 +46,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharacters.None),
-                    Factory.EmptyCSharp().AsTagHelperPrefixDirective(string.Empty)),
+                    Factory.EmptyCSharp()
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                     RazorResources.FormatParseError_DirectiveMustHaveValue(
                         SyntaxConstants.CSharp.TagHelperPrefixKeyword),
@@ -60,12 +64,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharacters.None),
-                    Factory.Code("\"Foo").AsTagHelperPrefixDirective("Foo")),
-                 new RazorError(
-                     RazorResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
-                 new RazorError(
-                     RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
+                    Factory.Code("\"Foo")
+                        .AsTagHelperPrefixDirective("Foo")),
+                new RazorError(
+                    RazorResources.ParseError_Unterminated_String_Literal,
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
+                new RazorError(
+                    RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.TagHelperPrefixKeyword),
                         absoluteIndex: 17, lineIndex: 0, columnIndex: 17));
         }
@@ -79,7 +84,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharacters.None),
-                    Factory.Code("Foo\"").AsTagHelperPrefixDirective("Foo")),
+                    Factory.Code("Foo\"")
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
                      absoluteIndex: 20, lineIndex: 0, columnIndex: 20),
@@ -98,7 +105,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharacters.None),
-                    Factory.Code("Foo").AsTagHelperPrefixDirective("Foo")),
+                    Factory.Code("Foo")
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.TagHelperPrefixKeyword),
@@ -113,7 +122,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("\"Foo\"").AsRemoveTagHelper("Foo")));
+                    Factory.Code("\"Foo\"")
+                        .AsRemoveTagHelper("Foo")));
         }
 
         [Fact]
@@ -124,7 +134,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + "   ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("\"  Foo,   Bar \"   ").AsRemoveTagHelper("  Foo,   Bar ")));
+                    Factory.Code("\"  Foo,   Bar \"   ")
+                        .AsRemoveTagHelper("Foo,   Bar")
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)));
         }
 
         [Fact]
@@ -135,7 +147,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.EmptyCSharp().AsRemoveTagHelper(string.Empty)),
+                    Factory.EmptyCSharp()
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                     RazorResources.FormatParseError_DirectiveMustHaveValue(
                         SyntaxConstants.CSharp.RemoveTagHelperKeyword),
@@ -150,7 +164,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("\"Foo").AsRemoveTagHelper("Foo")),
+                    Factory.Code("\"Foo")
+                        .AsRemoveTagHelper("Foo")),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
                      absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
@@ -168,7 +183,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("Foo\"").AsRemoveTagHelper("Foo")),
+                    Factory.Code("Foo\"")
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
                      absoluteIndex: 20, lineIndex: 0, columnIndex: 20),
@@ -186,7 +203,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("Foo").AsRemoveTagHelper("Foo")),
+                    Factory.Code("Foo")
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.RemoveTagHelperKeyword),
@@ -201,7 +220,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("\"Foo\"").AsAddTagHelper("Foo")));
+                    Factory.Code("\"Foo\"")
+                        .AsAddTagHelper("Foo")));
         }
 
         [Fact]
@@ -212,7 +232,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + "   ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("\"  Foo,   Bar \"   ").AsAddTagHelper("  Foo,   Bar ")));
+                    Factory.Code("\"  Foo,   Bar \"   ")
+                        .AsAddTagHelper("Foo,   Bar")));
         }
 
         [Fact]
@@ -223,7 +244,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.EmptyCSharp().AsAddTagHelper(string.Empty)),
+                    Factory.EmptyCSharp()
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                     RazorResources.FormatParseError_DirectiveMustHaveValue(SyntaxConstants.CSharp.AddTagHelperKeyword),
                     absoluteIndex: 14, lineIndex: 0, columnIndex: 14));
@@ -237,7 +260,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("\"Foo").AsAddTagHelper("Foo")),
+                    Factory.Code("\"Foo")
+                        .AsAddTagHelper("Foo")),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
                      absoluteIndex: 14, lineIndex: 0, columnIndex: 14),
@@ -255,7 +279,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("Foo\"").AsAddTagHelper("Foo")),
+                    Factory.Code("Foo\"")
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
                      absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
@@ -273,7 +299,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
-                    Factory.Code("Foo").AsAddTagHelper("Foo")),
+                    Factory.Code("Foo")
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.AddTagHelperKeyword),
@@ -349,7 +377,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.MetaCode(SyntaxConstants.CSharp.FunctionsKeyword + " {")
                            .Accepts(AcceptedCharacters.None),
                     Factory.Code(" foo(); bar(); ")
-                           .AsFunctionsBody(),
+                           .AsFunctionsBody()
+                           .AutoCompleteWith(autoCompleteString: null),
                     Factory.MetaCode("}")
                            .Accepts(AcceptedCharacters.None)));
         }
@@ -363,7 +392,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     Factory.MetaCode(SyntaxConstants.CSharp.FunctionsKeyword + " {")
                            .Accepts(AcceptedCharacters.None),
                     Factory.Code(" ")
-                           .AsFunctionsBody(),
+                        .AsFunctionsBody()
+                        .AutoCompleteWith(autoCompleteString: null),
                     Factory.MetaCode("}")
                            .Accepts(AcceptedCharacters.None)));
         }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpErrorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpErrorTest.cs
@@ -57,7 +57,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.EmptyCSharp().AsStatement(),
+                               Factory.EmptyCSharp()
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                ));
         }
@@ -82,7 +84,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(Environment.NewLine + "    ").AsStatement(),
+                               Factory.Code(Environment.NewLine + "    ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new ExpressionBlock(
                                    Factory.CodeTransition(),
                                    Factory.EmptyCSharp()
@@ -101,7 +105,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "    @",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(Environment.NewLine + "    ").AsStatement(),
+                               Factory.Code(Environment.NewLine + "    ")
+                                   .AsStatement()
+                                   .AutoCompleteWith("}"),
                                new ExpressionBlock(
                                    Factory.CodeTransition(),
                                    Factory.EmptyCSharp()
@@ -247,8 +253,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ var foo = bar; if(foo != null) { bar(); } ",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" var foo = bar; if(foo != null) { bar(); } ").AsStatement()
-                               ),
+                               Factory.Code(" var foo = bar; if(foo != null) { bar(); } ")
+                                   .AsStatement()
+                                   .AutoCompleteWith("}")),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, '}', '{'),
                                SourceLocation.Zero));
@@ -260,8 +267,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("functions { var foo = bar; if(foo != null) { bar(); } ",
                            new FunctionsBlock(
                                Factory.MetaCode("functions {").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" var foo = bar; if(foo != null) { bar(); } ").AsFunctionsBody()
-                               ),
+                               Factory.Code(" var foo = bar; if(foo != null) { bar(); } ")
+                                   .AsFunctionsBody()
+                                   .AutoCompleteWith("}")),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", '}', '{'),
                                SourceLocation.Zero));
@@ -592,7 +600,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                 new StatementBlock(
                     Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
                     Factory.Code("string.Format(")
-                           .AsStatement(),
+                        .AsStatement()
+                        .AutoCompleteWith(autoCompleteString: null),
                     new MarkupBlock(
                         BlockFactory.MarkupTagBlock("<html>", AcceptedCharacters.None),
                         BlockFactory.MarkupTagBlock("</html>", AcceptedCharacters.None)),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpRazorCommentsTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpRazorCommentsTest.cs
@@ -122,7 +122,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     new StatementBlock(
                         Factory.CodeTransition(),
                         Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                        Factory.Code(Environment.NewLine).AsStatement(),
+                        Factory.Code(Environment.NewLine)
+                            .AsStatement()
+                            .AutoCompleteWith("}"),
                         new MarkupBlock(
                             Factory.Markup("    "),
                             new MarkupTagBlock(
@@ -158,7 +160,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.CodeTransition(),
                         Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
                         Factory.EmptyCSharp()
-                               .AsStatement(),
+                            .AsStatement()
+                            .AutoCompleteWith("}"),
                         new CommentBlock(
                             Factory.CodeTransition(CSharpSymbolType.RazorCommentTransition)
                                    .Accepts(AcceptedCharacters.None),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSpecialBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSpecialBlockTest.cs
@@ -53,7 +53,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ using Foo.Bar.Baz; var foo = bar; }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" using Foo.Bar.Baz; var foo = bar; ").AsStatement(),
+                               Factory.Code(" using Foo.Bar.Baz; var foo = bar; ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                ),
                            new RazorError(
@@ -67,7 +69,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ using Foo = Bar.Baz; var foo = bar; }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" using Foo = Bar.Baz; var foo = bar; ").AsStatement(),
+                               Factory.Code(" using Foo = Bar.Baz; var foo = bar; ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                ),
                            new RazorError(
@@ -81,7 +85,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ functions Foo; }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" functions Foo; ").AsStatement(),
+                               Factory.Code(" functions Foo; ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                ));
         }
@@ -94,7 +100,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code($"{Environment.NewLine}    List<dynamic> photos = gallery.Photo.ToList();{Environment.NewLine}").AsStatement(),
+                               Factory.Code($"{Environment.NewLine}    List<dynamic> photos = gallery.Photo.ToList();{Environment.NewLine}")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                ));
         }
@@ -109,7 +117,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{" + code + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(code).AsStatement(),
+                               Factory.Code(code)
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                ));
         }
@@ -136,7 +146,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("functions {" + code + "} zoop",
                            new FunctionsBlock(
                                Factory.MetaCode("functions {").Accepts(AcceptedCharacters.None),
-                               Factory.Code(code).AsFunctionsBody(),
+                               Factory.Code(code)
+                                   .AsFunctionsBody()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                ));
         }
@@ -147,7 +159,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("functions { { { { { } zoop",
                            new FunctionsBlock(
                                Factory.MetaCode("functions {").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" { { { { } zoop").AsFunctionsBody()
+                               Factory.Code(" { { { { } zoop")
+                                   .AsFunctionsBody()
+                                   .AutoCompleteWith("}")
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", "}", "{"),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpTemplateTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpTemplateTest.cs
@@ -82,7 +82,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "; }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" var foo = ").AsStatement(),
+                               Factory.Code(" var foo = ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new TemplateBlock(
                                    new MarkupBlock(
                                        Factory.MarkupTransition(),
@@ -104,7 +106,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code("i").AsStatement(),
+                               Factory.Code("i")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new TemplateBlock(
                                    new MarkupBlock(
                                        Factory.MarkupTransition(),
@@ -210,7 +214,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
         {
             ParseBlockTest("foreach(foo in Bar) { Html.ExecuteTemplate(foo," + TestNestedTemplateCode + "); }",
                            new StatementBlock(
-                               Factory.Code("foreach(foo in Bar) { Html.ExecuteTemplate(foo, ").AsStatement(),
+                               Factory.Code("foreach(foo in Bar) { Html.ExecuteTemplate(foo, ")
+                                   .AsStatement(),
                                TestNestedTemplate(),
                                Factory.Code("); }")
                                    .AsStatement()
@@ -225,7 +230,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ var foo = bar; Html.ExecuteTemplate(foo," + TestTemplateCode + "); }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" var foo = bar; Html.ExecuteTemplate(foo, ").AsStatement(),
+                               Factory.Code(" var foo = bar; Html.ExecuteTemplate(foo, ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                TestTemplate(),
                                Factory.Code("); ").AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
@@ -238,7 +245,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ var foo = bar; Html.ExecuteTemplate(foo," + TestTemplateCode + "," + TestTemplateCode + "); }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" var foo = bar; Html.ExecuteTemplate(foo, ").AsStatement(),
+                               Factory.Code(" var foo = bar; Html.ExecuteTemplate(foo, ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                TestTemplate(),
                                Factory.Code(", ").AsStatement(),
                                TestTemplate(),
@@ -253,7 +262,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ var foo = bar; Html.ExecuteTemplate(foo," + TestNestedTemplateCode + "); }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" var foo = bar; Html.ExecuteTemplate(foo, ").AsStatement(),
+                               Factory.Code(" var foo = bar; Html.ExecuteTemplate(foo, ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                TestNestedTemplate(),
                                Factory.Code("); ").AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpToMarkupSwitchTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpToMarkupSwitchTest.cs
@@ -19,7 +19,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ List< }",
                 new StatementBlock(
                     Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                    Factory.Code(" List< ").AsStatement(),
+                    Factory.Code(" List< ")
+                        .AsStatement()
+                        .AutoCompleteWith(autoCompleteString: null),
                     Factory.MetaCode("}").Accepts(AcceptedCharacters.None)));
         }
 
@@ -77,7 +79,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(Environment.NewLine + "    ").AsStatement(),
+                               Factory.Code(Environment.NewLine + "    ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new MarkupBlock(
                                         new MarkupTagBlock(
                                             Factory.Markup("<p>").Accepts(AcceptedCharacters.None)),
@@ -98,7 +102,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(Environment.NewLine + "    ").AsStatement(),
+                               Factory.Code(Environment.NewLine + "    ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new MarkupBlock(
                                    Factory.MarkupTransition(),
                                         new MarkupTagBlock(
@@ -122,7 +128,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(Environment.NewLine + "    ").AsStatement(),
+                               Factory.Code(Environment.NewLine + "    ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new MarkupBlock(
                                    Factory.MarkupTransition(),
                                    Factory.MetaMarkup(":", HtmlSymbolType.Colon),
@@ -152,13 +160,15 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                        new StatementBlock(
                                            Factory.CodeTransition(),
                                            Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                                           Factory.EmptyCSharp().AsStatement(),
+                                           Factory.EmptyCSharp()
+                                               .AsStatement()
+                                               .AutoCompleteWith(autoCompleteString: null),
                                            Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                            ),
                                        Factory.Markup(Environment.NewLine)
-                                           .With(new SingleLineMarkupEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString, AcceptedCharacters.None))
-                                       )
-                                   ),
+                                           .Accepts(AcceptedCharacters.None)
+                                   )
+                               ),
                                Factory.Code(")")
                                    .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                    .Accepts(AcceptedCharacters.NonWhiteSpace)
@@ -291,7 +301,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ if(foo) { <p>Bar</p> } else if(bar) { <p>Baz</p> } else { <p>Boz</p> } }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" if(foo) {").AsStatement(),
+                               Factory.Code(" if(foo) {")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new MarkupBlock(
                                    Factory.Markup(" "),
                                     new MarkupTagBlock(
@@ -421,7 +433,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "} }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code($" switch(foo) {{{Environment.NewLine}    case 0:{Environment.NewLine}").AsStatement(),
+                               Factory.Code($" switch(foo) {{{Environment.NewLine}    case 0:{Environment.NewLine}")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new MarkupBlock(
                                    Factory.Markup("        "),
                                    new MarkupTagBlock(
@@ -501,7 +515,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ for(int i = 0; i < 10; i++) { <p>Foo</p> } }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" for(int i = 0; i < 10; i++) {").AsStatement(),
+                               Factory.Code(" for(int i = 0; i < 10; i++) {")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new MarkupBlock(
                                     Factory.Markup(" "),
                                     new MarkupTagBlock(
@@ -541,12 +557,15 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "} } zoop",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" if(foo) {").AsStatement(),
+                               Factory.Code(" if(foo) {")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new MarkupBlock(
                                    Factory.Markup(" "),
                                    Factory.MarkupTransition(),
                                    Factory.MetaMarkup(":", HtmlSymbolType.Colon),
                                    Factory.Markup("Bar" + Environment.NewLine).Accepts(AcceptedCharacters.None)
+                                       .With(new SingleLineMarkupEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString, AcceptedCharacters.None))
                                    ),
                                Factory.Code("} ").AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)));
@@ -576,7 +595,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{ if (i > 0) { <text>;</text> } }",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(" if (i > 0) {").AsStatement(),
+                               Factory.Code(" if (i > 0) {")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new MarkupBlock(
                                    Factory.Markup(" "),
                                    new MarkupTagBlock(
@@ -606,7 +627,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code($"{Environment.NewLine}    if(true) {{{Environment.NewLine}").AsStatement(),
+                               Factory.Code($"{Environment.NewLine}    if(true) {{{Environment.NewLine}")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new MarkupBlock(
                                    Factory.Markup("        "),
                                    Factory.MarkupTransition(),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpVerbatimBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpVerbatimBlockTest.cs
@@ -21,7 +21,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.MetaCode("{")
                                    .Accepts(AcceptedCharacters.None),
                                Factory.Code(" foo(); ")
-                                   .AsStatement(),
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                Factory.MetaCode("}")
                                    .Accepts(AcceptedCharacters.None)
                                ));
@@ -33,7 +34,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{@}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.EmptyCSharp().AsStatement(),
+                               Factory.EmptyCSharp()
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new ExpressionBlock(
                                    Factory.CodeTransition(),
                                    Factory.EmptyCSharp().AsImplicitExpression(KeywordSet, acceptTrailingDot: true).Accepts(AcceptedCharacters.NonWhiteSpace)
@@ -53,7 +56,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
             ParseBlockTest("{@.}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.EmptyCSharp().AsStatement(),
+                               Factory.EmptyCSharp()
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new ExpressionBlock(
                                    Factory.CodeTransition(),
                                    Factory.EmptyCSharp().AsImplicitExpression(KeywordSet, acceptTrailingDot: true).Accepts(AcceptedCharacters.NonWhiteSpace)
@@ -75,7 +80,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.Code(Environment.NewLine + "    ").AsStatement(),
+                               Factory.Code(Environment.NewLine + "    ")
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new ExpressionBlock(
                                    Factory.CodeTransition(),
                                    Factory.EmptyCSharp().AsImplicitExpression(KeywordSet, acceptTrailingDot: true).Accepts(AcceptedCharacters.NonWhiteSpace)
@@ -94,7 +101,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.EmptyCSharp().AsStatement(),
+                               Factory.EmptyCSharp()
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new ExpressionBlock(
                                    Factory.CodeTransition(),
                                    Factory.Code("foo.").AsImplicitExpression(KeywordSet, acceptTrailingDot: true).Accepts(AcceptedCharacters.NonWhiteSpace)),
@@ -109,7 +118,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                          + "}",
                            new StatementBlock(
                                Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                               Factory.EmptyCSharp().AsStatement(),
+                               Factory.EmptyCSharp()
+                                   .AsStatement()
+                                   .AutoCompleteWith(autoCompleteString: null),
                                new ExpressionBlock(
                                    Factory.CodeTransition(),
                                    Factory.Code("foo.").AsImplicitExpression(KeywordSet, acceptTrailingDot: true).Accepts(AcceptedCharacters.NonWhiteSpace)),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpWhitespaceHandlingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpWhitespaceHandlingTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNet.Razor.Editor;
+using Microsoft.AspNet.Razor.Parser;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Test.Framework;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
@@ -20,7 +22,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.MarkupTransition()
                                    .Accepts(AcceptedCharacters.None),
                                Factory.MetaMarkup(":", HtmlSymbolType.Colon),
-                               Factory.Markup(" "),
+                               Factory.Markup(" ")
+                                   .With(new SingleLineMarkupEditHandler(
+                                       CSharpLanguageCharacteristics.Instance.TokenizeString,
+                                       AcceptedCharacters.Any)),
                                new StatementBlock(
                                    Factory.CodeTransition()
                                        .Accepts(AcceptedCharacters.None),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlBlockTest.cs
@@ -36,7 +36,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                     new StatementBlock(
                         Factory.CodeTransition(),
                         Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                        Factory.Code(Environment.NewLine).AsStatement(),
+                        Factory.Code(Environment.NewLine)
+                            .AsStatement()
+                            .AutoCompleteWith("}"),
                         new MarkupBlock(
                             new MarkupTagBlock(
                                 Factory.Markup("<"))))),
@@ -56,7 +58,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                     new StatementBlock(
                         Factory.CodeTransition(),
                         Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                        Factory.Code(Environment.NewLine).AsStatement(),
+                        Factory.Code(Environment.NewLine)
+                            .AsStatement()
+                            .AutoCompleteWith("}"),
                         new MarkupBlock(
                             new MarkupTagBlock(
                                 Factory.Markup("<" + Environment.NewLine))

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlDocumentTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlDocumentTest.cs
@@ -257,7 +257,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                     Factory.EmptyHtml(),
                     new SectionBlock(new SectionCodeGenerator("Foo"),
                         Factory.CodeTransition(),
-                        Factory.MetaCode("section Foo {"),
+                        Factory.MetaCode("section Foo {")
+                            .AutoCompleteWith(autoCompleteString: null, atEndOfSpan: true),
                         new MarkupBlock(
                             Factory.Markup(" "),
                             BlockFactory.MarkupTagBlock("<script>"),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlToCodeSwitchTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlToCodeSwitchTest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                                .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                .Accepts(AcceptedCharacters.NonWhiteSpace)),
                     Factory.Markup(" Baz" + Environment.NewLine)
-                           .With(new SingleLineMarkupEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString, AcceptedCharacters.None))));
+                        .Accepts(AcceptedCharacters.None)));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/PartialParsing/CSharpPartialParsingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/PartialParsing/CSharpPartialParsingTest.cs
@@ -50,7 +50,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.PartialParsing
                     new StatementBlock(
                         factory.CodeTransition(),
                         factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                        factory.Code(Environment.NewLine + "    ").AsStatement(),
+                        factory.Code(Environment.NewLine + "    ")
+                            .AsStatement()
+                            .AutoCompleteWith(autoCompleteString: null),
                         new ExpressionBlock(
                             factory.CodeTransition(),
                             factory.Code("DateTime..Now")
@@ -106,7 +108,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.PartialParsing
                         new StatementBlock(
                             factory.CodeTransition(),
                             factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                            factory.Code(Environment.NewLine + "    ").AsStatement(),
+                            factory.Code(Environment.NewLine + "    ")
+                                .AsStatement()
+                                .AutoCompleteWith(autoCompleteString: null),
                             new ExpressionBlock(
                                 factory.CodeTransition(),
                                 factory.Code(expectedCode)
@@ -166,7 +170,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.PartialParsing
                         new StatementBlock(
                             factory.CodeTransition(),
                             factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                            factory.Code(Environment.NewLine + "    ").AsStatement(),
+                            factory.Code(Environment.NewLine + "    ")
+                                .AsStatement()
+                                .AutoCompleteWith(autoCompleteString: null),
                             new ExpressionBlock(
                                 factory.CodeTransition(),
                                 factory.Code(expectedCode)
@@ -352,7 +358,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.PartialParsing
                     new StatementBlock(
                         factory.CodeTransition(),
                         factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                        factory.Code(Environment.NewLine + "    ").AsStatement(),
+                        factory.Code(Environment.NewLine + "    ")
+                            .AsStatement()
+                            .AutoCompleteWith(autoCompleteString: null),
                         new ExpressionBlock(
                             factory.CodeTransition(),
                             factory.Code("food")
@@ -379,7 +387,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.PartialParsing
                     new StatementBlock(
                         factory.CodeTransition(),
                         factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                        factory.Code(Environment.NewLine + "    ").AsStatement(),
+                        factory.Code(Environment.NewLine + "    ")
+                            .AsStatement()
+                            .AutoCompleteWith(autoCompleteString: null),
                         new ExpressionBlock(
                             factory.CodeTransition(),
                             factory.Code("foo.d")
@@ -406,7 +416,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.PartialParsing
                     new StatementBlock(
                         factory.CodeTransition(),
                         factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                        factory.Code(Environment.NewLine + "    ").AsStatement(),
+                        factory.Code(Environment.NewLine + "    ")
+                            .AsStatement()
+                            .AutoCompleteWith(autoCompleteString: null),
                         new ExpressionBlock(
                             factory.CodeTransition(),
                             factory.Code(@"foo.")
@@ -536,7 +548,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.PartialParsing
                     new StatementBlock(
                         factory.CodeTransition(),
                         factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                        factory.EmptyCSharp().AsStatement(),
+                        factory.EmptyCSharp()
+                            .AsStatement()
+                            .AutoCompleteWith(autoCompleteString: null),
                         new ExpressionBlock(
                             factory.CodeTransition(),
                             factory.Code("foo.b")
@@ -559,7 +573,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.PartialParsing
                     new StatementBlock(
                         factory.CodeTransition(),
                         factory.MetaCode("{").Accepts(AcceptedCharacters.None),
-                        factory.EmptyCSharp().AsStatement(),
+                        factory.EmptyCSharp()
+                            .AsStatement()
+                            .AutoCompleteWith(autoCompleteString: null),
                         new ExpressionBlock(
                             factory.CodeTransition(),
                             factory.Code("foo.")

--- a/test/Microsoft.AspNet.Razor.Test/SourceLocationTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/SourceLocationTest.cs
@@ -41,13 +41,15 @@ namespace Microsoft.AspNet.Razor
             Assert.Equal(characterIndex, sourceLocation.CharacterIndex);
         }
 
-        [Fact]
-        public void GetHashCode_ReturnsHashCode_UsingAbsoluteIndex()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("some-file")]
+        public void GetHashCode_ReturnsSameValue_WhenEqual(string path)
         {
             // Arrange
-            var sourceLocationA = new SourceLocation(10, 3, 4);
-            var sourceLocationB = new SourceLocation(10, 45, 8754);
-            var sourceLocationC = new SourceLocation(12, 45, 8754);
+            var sourceLocationA = new SourceLocation(path, 10, 3, 4);
+            var sourceLocationB = new SourceLocation(path, 10, 3, 4);
+            var sourceLocationC = new SourceLocation(path, 10, 45, 8754);
 
             // Act
             var hashCodeA = sourceLocationA.GetHashCode();
@@ -56,29 +58,11 @@ namespace Microsoft.AspNet.Razor
 
             // Assert
             Assert.Equal(hashCodeA, hashCodeB);
-            Assert.NotEqual(hashCodeA, hashCodeC);
+            Assert.Equal(hashCodeA, hashCodeC);
         }
 
         [Fact]
-        public void GetHashCode_ReturnsHashCode_UsingFilePathAndAbsoluteIndex_WhenFilePathIsNonNull()
-        {
-            // Arrange
-            var sourceLocationA = new SourceLocation("some-path", 3, 53, 94);
-            var sourceLocationB = new SourceLocation("some-path", 3, 43, 87);
-            var sourceLocationC = new SourceLocation(3, 53, 94);
-
-            // Act
-            var hashCodeA = sourceLocationA.GetHashCode();
-            var hashCodeB = sourceLocationB.GetHashCode();
-            var hashCodeC = sourceLocationC.GetHashCode();
-
-            // Assert
-            Assert.Equal(hashCodeA, hashCodeB);
-            Assert.NotEqual(hashCodeA, hashCodeC);
-        }
-
-        [Fact]
-        public void Equal_ReturnsFalse_IfIndexesDiffer()
+        public void Equals_ReturnsTrue_FilePathsNullAndAbsoluteIndicesMatch()
         {
             // Arrange
             var sourceLocationA = new SourceLocation(10, 3, 4);
@@ -88,11 +72,11 @@ namespace Microsoft.AspNet.Razor
             var result = sourceLocationA.Equals(sourceLocationB);
 
             // Assert
-            Assert.False(result);
+            Assert.True(result);
         }
 
         [Fact]
-        public void Equal_ReturnsFalse_IfFilePathIsDifferent()
+        public void Equals_ReturnsFalse_IfFilePathIsDifferent()
         {
             // Arrange
             var sourceLocationA = new SourceLocation(10, 3, 4);
@@ -108,7 +92,7 @@ namespace Microsoft.AspNet.Razor
         [Theory]
         [InlineData(null)]
         [InlineData("some-file")]
-        public void Equal_ReturnsTrue_IfFilePathAndIndexesAreSame(string path)
+        public void Equals_ReturnsTrue_IfFilePathAndIndexesAreSame(string path)
         {
             // Arrange
             var sourceLocationA = new SourceLocation(path, 10, 3, 4);


### PR DESCRIPTION
- #362 and more
- make `SourceLocation.Equals()` and `SourceLocation.CompareTo()` consistent
- use only immutable values in `GetHashCode()` calculations
 - avoid `object.GetHashCode()`; that calculates hash of reference
 - make a few more properties obviously immutable; remove `private` setters
 - BUT this leads to some static `GetHashCode()` values
- add `SyntaxTreeNode.GetEquivalenceHash()`
- correct important typo in `TagHelperDescriptorComparer`
- ensure `Equals()` does not `throw` an NRE e.g. in `LineMapping`

Add lots of tests
- not for all updated classes but enough to see impact of odd choices
 - assymetric `Equals()` implementations due to specificity in subclasses
 - some `Equals()` check for an `interface` implementation, not their `class`

nits:
- remove redundant null checks e.g. when also done in `base.Equals()`
- add `StringComparer.Ordinal` if `StringComparison.Ordinal` used in `Equals()`