### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/ParserContext.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/ParserContext.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Razor.Parser
         {
             if (activeParser != codeParser && activeParser != markupParser)
             {
-                throw new ArgumentException(RazorResources.ActiveParser_Must_Be_Code_Or_Markup_Parser, "activeParser");
+                throw new ArgumentException(RazorResources.ActiveParser_Must_Be_Code_Or_Markup_Parser, nameof(activeParser));
             }
 
             CaptureOwnerTask();

--- a/src/Microsoft.AspNet.Razor/RazorEditorParser.cs
+++ b/src/Microsoft.AspNet.Razor/RazorEditorParser.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.Razor
         {
             if (string.IsNullOrEmpty(sourceFileName))
             {
-                throw new ArgumentException(CommonResources.Argument_Cannot_Be_Null_Or_Empty, "sourceFileName");
+                throw new ArgumentException(CommonResources.Argument_Cannot_Be_Null_Or_Empty, nameof(sourceFileName));
             }
 
             Host = host;

--- a/src/Microsoft.AspNet.Razor/Text/LineTrackingStringBuffer.cs
+++ b/src/Microsoft.AspNet.Razor/Text/LineTrackingStringBuffer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNet.Razor.Text
             var line = FindLine(absoluteIndex);
             if (line == null)
             {
-                throw new ArgumentOutOfRangeException("absoluteIndex");
+                throw new ArgumentOutOfRangeException(nameof(absoluteIndex));
             }
             var idx = absoluteIndex - line.Start;
             return new CharacterReference(line.Content[idx], new SourceLocation(absoluteIndex, line.Index, idx));

--- a/src/Microsoft.AspNet.Razor/Text/TextChange.cs
+++ b/src/Microsoft.AspNet.Razor/Text/TextChange.cs
@@ -35,19 +35,19 @@ namespace Microsoft.AspNet.Razor.Text
         {
             if (oldPosition < 0)
             {
-                throw new ArgumentOutOfRangeException("oldPosition", CommonResources.FormatArgument_Must_Be_GreaterThanOrEqualTo(0));
+                throw new ArgumentOutOfRangeException(nameof(oldPosition), CommonResources.FormatArgument_Must_Be_GreaterThanOrEqualTo(0));
             }
             if (newPosition < 0)
             {
-                throw new ArgumentOutOfRangeException("newPosition", CommonResources.FormatArgument_Must_Be_GreaterThanOrEqualTo(0));
+                throw new ArgumentOutOfRangeException(nameof(newPosition), CommonResources.FormatArgument_Must_Be_GreaterThanOrEqualTo(0));
             }
             if (oldLength < 0)
             {
-                throw new ArgumentOutOfRangeException("oldLength", CommonResources.FormatArgument_Must_Be_GreaterThanOrEqualTo(0));
+                throw new ArgumentOutOfRangeException(nameof(oldLength), CommonResources.FormatArgument_Must_Be_GreaterThanOrEqualTo(0));
             }
             if (newLength < 0)
             {
-                throw new ArgumentOutOfRangeException("newLength", CommonResources.FormatArgument_Must_Be_GreaterThanOrEqualTo(0));
+                throw new ArgumentOutOfRangeException(nameof(newLength), CommonResources.FormatArgument_Must_Be_GreaterThanOrEqualTo(0));
             }
 
             OldPosition = oldPosition;


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason