### PR TITLE
Quick fix: Remove project.json warning

### DIFF
--- a/test/Microsoft.AspNet.Razor.Test/project.json
+++ b/test/Microsoft.AspNet.Razor.Test/project.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0",
-    "resources": "TestFiles/**/*",
+    "resource": "TestFiles/**/*",
     "dependencies": {
         "Moq": "4.2.1312.1622",
         "Microsoft.AspNet.Razor": "4.0.0-*",


### PR DESCRIPTION
- `resources` -> `resource`

Example warning during `dnu build --quiet`:
```
...\test\Microsoft.AspNet.Razor.Test\project.json(3,34): warning: Property "resources" is deprecated. It is replaced by "resource".
```
Primarily resulted in VS Error List noise. Above does not normally show up in
`build.cmd` runs because `dnx . test` does not show build warnings.