### PR TITLE
[Design] Add `[HtmlAttributeName(..., DictionaryAttributePrefix="prefix")]`

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -187,6 +187,38 @@ namespace Microsoft.AspNet.Razor.Runtime
         }
 
         /// <summary>
+        /// name
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_Name
+        {
+            get { return GetString("TagHelperDescriptorFactory_Name"); }
+        }
+
+        /// <summary>
+        /// name
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_Name()
+        {
+            return GetString("TagHelperDescriptorFactory_Name");
+        }
+
+        /// <summary>
+        /// prefix
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_Prefix
+        {
+            get { return GetString("TagHelperDescriptorFactory_Prefix"); }
+        }
+
+        /// <summary>
+        /// prefix
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_Prefix()
+        {
+            return GetString("TagHelperDescriptorFactory_Prefix");
+        }
+
+        /// <summary>
         /// Tag
         /// </summary>
         internal static string TagHelperDescriptorFactory_Tag
@@ -203,7 +235,7 @@ namespace Microsoft.AspNet.Razor.Runtime
         }
 
         /// <summary>
-        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes beginning with '{2}'.
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} starts with '{4}'.
         /// </summary>
         internal static string TagHelperDescriptorFactory_InvalidBoundAttributeName
         {
@@ -211,11 +243,43 @@ namespace Microsoft.AspNet.Razor.Runtime
         }
 
         /// <summary>
-        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes beginning with '{2}'.
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} starts with '{4}'.
         /// </summary>
-        internal static string FormatTagHelperDescriptorFactory_InvalidBoundAttributeName(object p0, object p1, object p2)
+        internal static string FormatTagHelperDescriptorFactory_InvalidBoundAttributeName(object p0, object p1, object p2, object p3, object p4)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidBoundAttributeName"), p0, p1, p2);
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidBoundAttributeName"), p0, p1, p2, p3, p4);
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} contains a '{4}' character.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidBoundAttributeNameCharacter
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidBoundAttributeNameCharacter"); }
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} contains a '{4}' character.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidBoundAttributeNameCharacter(object p0, object p1, object p2, object p3, object p4)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidBoundAttributeNameCharacter"), p0, p1, p2, p3, p4);
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. '{2}.{3}' must be null unless property type implements '{4}'.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidBoundAttributePrefix
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidBoundAttributePrefix"); }
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. '{2}.{3}' must be null unless property type implements '{4}'.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidBoundAttributePrefix(object p0, object p1, object p2, object p3, object p4)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidBoundAttributePrefix"), p0, p1, p2, p3, p4);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -150,11 +150,23 @@
   <data name="TagHelperDescriptorFactory_Attribute" xml:space="preserve">
     <value>Attribute</value>
   </data>
+  <data name="TagHelperDescriptorFactory_Name" xml:space="preserve">
+    <value>name</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_Prefix" xml:space="preserve">
+    <value>prefix</value>
+  </data>
   <data name="TagHelperDescriptorFactory_Tag" xml:space="preserve">
     <value>Tag</value>
   </data>
   <data name="TagHelperDescriptorFactory_InvalidBoundAttributeName" xml:space="preserve">
-    <value>Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes beginning with '{2}'.</value>
+    <value>Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} starts with '{4}'.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_InvalidBoundAttributeNameCharacter" xml:space="preserve">
+    <value>Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} contains a '{4}' character.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_InvalidBoundAttributePrefix" xml:space="preserve">
+    <value>Invalid tag helper bound property '{0}.{1}'. '{2}.{3}' must be null unless property type implements '{4}'.</value>
   </data>
   <data name="TagHelperAttributeList_CannotAddWithNullName" xml:space="preserve">
     <value>Cannot add a '{0}' with a null '{1}'.</value>

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlAttributeNameAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlAttributeNameAttribute.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     public sealed class HtmlAttributeNameAttribute : Attribute
     {
+        private string _dictionaryAttributePrefix;
+
         /// <summary>
         /// Instantiates a new instance of the <see cref="HtmlAttributeNameAttribute"/> class.
         /// </summary>
@@ -29,5 +31,39 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// HTML attribute name of the associated property.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Gets or sets the prefix used to match HTML attribute names. Matching attributes are added to the
+        /// associated property (an <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/>).
+        /// </summary>
+        /// <remarks>
+        /// If non-<c>null</c> associated property must be compatible with
+        /// <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> where <c>TKey</c> is
+        /// <see cref="string"/>.
+        /// </remarks>
+        /// <value>
+        /// If associated property is compatible with
+        /// <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/>, default value is <c>Name + "-"</c>.
+        /// Otherwise default value is <c>null</c>.
+        /// </value>
+        public string DictionaryAttributePrefix
+        {
+            get
+            {
+                return _dictionaryAttributePrefix;
+            }
+            set
+            {
+                _dictionaryAttributePrefix = value;
+                DictionaryAttributePrefixSet = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets an indication whether <see cref="DictionaryAttributePrefix"/> has been set. Used to distinguish an
+        /// uninitialized <see cref="DictionaryAttributePrefix"/> value from an explicit <c>null</c> setting.
+        /// </summary>
+        /// <value><c>true</c> if <see cref="DictionaryAttributePrefix"/> was set. <c>false</c> otherwise.</value>
+        public bool DictionaryAttributePrefixSet { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Razor.Runtime/project.json
+++ b/src/Microsoft.AspNet.Razor.Runtime/project.json
@@ -5,7 +5,8 @@
         "Microsoft.AspNet.Razor": "4.0.0-*",
         "Microsoft.Framework.BufferEntryCollection.Sources": { "type": "build", "version": "1.0.0-*" },
         "Microsoft.Framework.CopyOnWriteDictionary.Sources": { "type": "build", "version": "1.0.0-*" },
-        "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" }
+        "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
+        "Microsoft.Framework.TypeNameHelper.Sources": { "type": "build", "version": "1.0.0-*" }
     },
     "frameworks": {
         "net45": { },

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptorComparer.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Framework.Internal;
+using Microsoft.Internal.Web.Utils;
+
+namespace Microsoft.AspNet.Razor.TagHelpers
+{
+    /// <summary>
+    /// An <see cref="IEqualityComparer{TagHelperAttributeDescriptor}"/> used to check equality between
+    /// two <see cref="TagHelperAttributeDescriptor"/>s.
+    /// </summary>
+    public class TagHelperAttributeDescriptorComparer : IEqualityComparer<TagHelperAttributeDescriptor>
+    {
+        /// <summary>
+        /// A default instance of the <see cref="TagHelperAttributeDescriptorComparer"/>.
+        /// </summary>
+        public static readonly TagHelperAttributeDescriptorComparer Default =
+            new TagHelperAttributeDescriptorComparer();
+
+        /// <summary>
+        /// Initializes a new <see cref="TagHelperAttributeDescriptorComparer"/> instance.
+        /// </summary>
+        private TagHelperAttributeDescriptorComparer()
+        {
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Determines equality based on <see cref="TagHelperAttributeDescriptor.Name"/>,
+        /// <see cref="TagHelperAttributeDescriptor.Prefix"/>, <see cref="TagHelperAttributeDescriptor.PropertyName"/>,
+        /// and <see cref="TagHelperAttributeDescriptor.TypeName"/>.
+        /// </remarks>
+        public bool Equals(TagHelperAttributeDescriptor descriptorX, TagHelperAttributeDescriptor descriptorY)
+        {
+            if (descriptorX == null || descriptorY == null)
+            {
+                return descriptorX == null && descriptorY == null;
+            }
+
+            // Other TagHelperAttributeDescriptor properties are determined from TypeName.
+            return string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(descriptorX.Prefix, descriptorY.Prefix, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(descriptorX.PropertyName, descriptorY.PropertyName, StringComparison.Ordinal) &&
+                string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal);
+        }
+
+        /// <inheritdoc />
+        public int GetHashCode([NotNull] TagHelperAttributeDescriptor descriptor)
+        {
+            return HashCodeCombiner.Start()
+                .Add(descriptor.Name, StringComparer.OrdinalIgnoreCase)
+                .Add(descriptor.Prefix, StringComparer.OrdinalIgnoreCase)
+                .Add(descriptor.PropertyName, StringComparer.Ordinal)
+                .Add(descriptor.TypeName, StringComparer.Ordinal)
+                .CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Framework.Internal;
 using Microsoft.Internal.Web.Utils;
 
 namespace Microsoft.AspNet.Razor.TagHelpers
@@ -20,14 +21,13 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         public static readonly TagHelperDescriptorComparer Default = new TagHelperDescriptorComparer();
 
         /// <summary>
-        /// Determines if the two given tag helpers are equal.
+        /// Initializes a new <see cref="TagHelperDescriptorComparer"/> instance.
         /// </summary>
-        /// <param name="descriptorX">A <see cref="TagHelperDescriptor"/> to compare with the given
-        /// <paramref name="descriptorY"/>.</param>
-        /// <param name="descriptorY">A <see cref="TagHelperDescriptor"/> to compare with the given
-        /// <paramref name="descriptorX"/>.</param>
-        /// <returns><c>true</c> if <paramref name="descriptorX"/> and <paramref name="descriptorY"/> are equal,
-        /// <c>false</c> otherwise.</returns>
+        protected TagHelperDescriptorComparer()
+        {
+        }
+
+        /// <inheritdoc />
         /// <remarks>
         /// Determines equality based on <see cref="TagHelperDescriptor.TypeName"/>,
         /// <see cref="TagHelperDescriptor.AssemblyName"/>, <see cref="TagHelperDescriptor.TagName"/>,
@@ -35,25 +35,22 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// </remarks>
         public bool Equals(TagHelperDescriptor descriptorX, TagHelperDescriptor descriptorY)
         {
+            if (descriptorX == null || descriptorY == null)
+            {
+                return descriptorX == null && descriptorY == null;
+            }
+
             return string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal) &&
-                   string.Equals(descriptorX.TagName, descriptorY.TagName, StringComparison.OrdinalIgnoreCase) &&
-                   string.Equals(descriptorX.AssemblyName, descriptorY.AssemblyName, StringComparison.Ordinal) &&
-                   Enumerable.SequenceEqual(
-                       descriptorX.RequiredAttributes.OrderBy(
-                           attribute => attribute,
-                           StringComparer.OrdinalIgnoreCase),
-                       descriptorY.RequiredAttributes.OrderBy(
-                           attribute => attribute,
-                           StringComparer.OrdinalIgnoreCase),
-                       StringComparer.OrdinalIgnoreCase);
+                string.Equals(descriptorX.TagName, descriptorY.TagName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(descriptorX.AssemblyName, descriptorY.AssemblyName, StringComparison.Ordinal) &&
+                Enumerable.SequenceEqual(
+                    descriptorX.RequiredAttributes.OrderBy(attribute => attribute, StringComparer.OrdinalIgnoreCase),
+                    descriptorY.RequiredAttributes.OrderBy(attribute => attribute, StringComparer.OrdinalIgnoreCase),
+                    StringComparer.OrdinalIgnoreCase);
         }
 
-        /// <summary>
-        /// Returns an <see cref="int"/> value that uniquely identifies the given <see cref="TagHelperDescriptor"/>.
-        /// </summary>
-        /// <param name="descriptor">The <see cref="TagHelperDescriptor"/> to create a hash code for.</param>
-        /// <returns>An <see cref="int"/> that uniquely identifies the given <paramref name="descriptor"/>.</returns>
-        public int GetHashCode(TagHelperDescriptor descriptor)
+        /// <inheritdoc />
+        public int GetHashCode([NotNull] TagHelperDescriptor descriptor)
         {
             var hashCodeCombiner = HashCodeCombiner
                 .Start()

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperHelper.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperHelper.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.AspNet.Razor.TagHelpers
+{
+    /// <summary>
+    /// Helper methods related to <see cref="TagHelperDescriptor"/> and related classes.
+    /// </summary>
+    public static class TagHelperHelper
+    {
+        /// <summary>
+        /// Determine the full name of the <see cref="Type"/> of the property corresponding to an attribute named
+        /// <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">Name of the attribute.</param>
+        /// <param name="descriptors">
+        /// Collection of <see cref="TagHelperDescriptor"/>s targeting the containing element in the Razor source.
+        /// </param>
+        /// <returns>
+        /// The full name of the <see cref="Type"/> of property or dictionary value (in the case of a
+        /// <see cref="TagHelperAttributeDescriptor.Prefix"/> match) corresponding to an attribute named
+        /// <paramref name="name"/>. <c>null</c> if the attribute is not bound.
+        /// </returns>
+        /// <remarks>
+        /// This method cannot use Reflection to generally determine the most specific <see cref="Type"/> when
+        /// multiple tag helpers bind the attribute. However when it can determine an attribute is bound to a
+        /// <see cref="string"/> property or dictionary value, it always returns <c>"System.String"</c>. Otherwise it
+        /// returns the full <see cref="Type"/> name for the first binding it finds, if any.
+        /// </remarks>
+        public static string GetPropertyType(
+            [NotNull] string name,
+            [NotNull] IEnumerable<TagHelperDescriptor> descriptors)
+        {
+            // Find first TagHelperAttributeDescriptor matching this name.
+            var firstBoundAttribute = descriptors
+                .SelectMany(descriptor => descriptor.Attributes)
+                .FirstOrDefault(attribute =>
+                    string.Equals(attribute.Name, name, StringComparison.OrdinalIgnoreCase) ||
+                    (attribute.Prefix != null &&
+                     name.StartsWith(attribute.Prefix, StringComparison.OrdinalIgnoreCase)));
+            if (firstBoundAttribute == null)
+            {
+                return null;
+            }
+
+            if (!IsBoundNonStringAttribute(name, descriptors))
+            {
+                // Must have been a string attribute since we know it is bound. Use that type.
+                return typeof(string).FullName;
+            }
+
+            if (string.Equals(firstBoundAttribute.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return firstBoundAttribute.TypeName;
+            }
+
+            // Attribute is bound and doesn't match Name. Must be a Prefix match.
+            return firstBoundAttribute.PrefixedValueTypeName;
+        }
+
+        /// <summary>
+        /// Determines whether an attribute named <paramref name="name"/> is bound exclusively to
+        /// non-<see cref="string"/> tag helper properties.
+        /// </summary>
+        /// <param name="name">Name of the attribute.</param>
+        /// <param name="descriptors">
+        /// Collection of <see cref="TagHelperDescriptor"/>s targeting the containing element in the Razor source.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the attribute named <paramref name="name"/> is bound and no associated property or
+        /// dictionary value (in the case of a <see cref="TagHelperAttributeDescriptor.Prefix"/> match) has
+        /// <see cref="Type"/> <see cref="string"/>. <c>false</c> otherwise e.g. if the property is not bound.
+        /// </returns>
+        public static bool IsBoundNonStringAttribute(
+            [NotNull] string name,
+            [NotNull] IEnumerable<TagHelperDescriptor> descriptors)
+        {
+            // Find all TagHelperAttributeDescriptor's matching this name.
+            var boundAttributes = descriptors
+                .SelectMany(descriptor => descriptor.Attributes)
+                .Where(attribute => string.Equals(attribute.Name, name, StringComparison.OrdinalIgnoreCase) ||
+                    (attribute.Prefix != null &&
+                     name.StartsWith(attribute.Prefix, StringComparison.OrdinalIgnoreCase)));
+
+            // Check if any matching TagHelperAttributeDescriptor requires a string value.
+            var isStringValue = boundAttributes.Any(attribute =>
+            {
+                if (string.Equals(attribute.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return attribute.IsStringProperty;
+                }
+
+                // Attribute is bound and doesn't match Name. Must be a Prefix match.
+                return attribute.AreStringPrefixedValues;
+            });
+
+            return boundAttributes.Any() && !isStringValue;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TypeBasedTagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TypeBasedTagHelperDescriptorComparer.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Framework.Internal;
+using Microsoft.Internal.Web.Utils;
+
+namespace Microsoft.AspNet.Razor.TagHelpers
+{
+    /// <summary>
+    /// An <see cref="IEqualityComparer{TagHelperDescriptor}"/> that checks equality between two
+    /// <see cref="TagHelperDescriptor"/>s using only their <see cref="TagHelperDescriptor.AssemblyName"/>s and
+    /// <see cref="TagHelperDescriptor.TypeName"/>s.
+    /// </summary>
+    /// <remarks>
+    /// This class is intended for scenarios where Reflection-based information is all important i.e.
+    /// <see cref="TagHelperDescriptor.RequiredAttributes"/>, <see cref="TagHelperDescriptor.TagName"/>, and related
+    /// properties are not relevant.
+    /// </remarks>
+    public class TypeBasedTagHelperDescriptorComparer : IEqualityComparer<TagHelperDescriptor>
+    {
+        /// <summary>
+        /// A default instance of the <see cref="TypeBasedTagHelperDescriptorComparer"/>.
+        /// </summary>
+        public static readonly TypeBasedTagHelperDescriptorComparer Default =
+            new TypeBasedTagHelperDescriptorComparer();
+
+        private TypeBasedTagHelperDescriptorComparer()
+        {
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Determines equality based on <see cref="TagHelperDescriptor.AssemblyName"/> and
+        /// <see cref="TagHelperDescriptor.TypeName"/>.
+        /// </remarks>
+        public bool Equals(TagHelperDescriptor descriptorX, TagHelperDescriptor descriptorY)
+        {
+            if (descriptorX == null || descriptorY == null)
+            {
+                return descriptorX == null && descriptorY == null;
+            }
+
+            return string.Equals(descriptorX.AssemblyName, descriptorY.AssemblyName, StringComparison.Ordinal) &&
+                string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal);
+        }
+
+        /// <inheritdoc />
+        public int GetHashCode([NotNull] TagHelperDescriptor descriptor)
+        {
+            return HashCodeCombiner.Start()
+                .Add(descriptor.AssemblyName, StringComparer.Ordinal)
+                .Add(descriptor.TypeName, StringComparer.Ordinal)
+                .CombinedHash;
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperAttributeDescriptorComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperAttributeDescriptorComparer.cs
@@ -20,17 +20,28 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public bool Equals(TagHelperAttributeDescriptor descriptorX, TagHelperAttributeDescriptor descriptorY)
         {
             return
-                // Normal comparer doesn't care about case, in tests we do.
+                // Normal comparer doesn't care about case, in tests we do. Also double-check ObjectCreationExpression
+                // and both bool properties though all are inferred from TypeName.
+                descriptorX.AreStringPrefixedValues == descriptorY.AreStringPrefixedValues &&
+                descriptorX.IsStringProperty == descriptorY.IsStringProperty &&
                 string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal) &&
+                string.Equals(
+                    descriptorX.ObjectCreationExpression,
+                    descriptorY.ObjectCreationExpression,
+                    StringComparison.Ordinal) &&
+                string.Equals(descriptorX.Prefix, descriptorY.Prefix, StringComparison.Ordinal) &&
                 string.Equals(descriptorX.PropertyName, descriptorY.PropertyName, StringComparison.Ordinal) &&
                 string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal);
         }
 
         public int GetHashCode(TagHelperAttributeDescriptor descriptor)
         {
+            // Rarely if ever hash TagHelperAttributeDescriptor. If we do, ignore ObjectCreationExpression and both
+            // bool properties since they should not vary for a given TypeName i.e. will not change the bucket.
             return HashCodeCombiner
                 .Start()
                 .Add(descriptor.Name, StringComparer.Ordinal)
+                .Add(descriptor.Prefix, StringComparer.Ordinal)
                 .Add(descriptor.PropertyName, StringComparer.Ordinal)
                 .Add(descriptor.TypeName, StringComparer.Ordinal)
                 .CombinedHash;

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperDescriptorComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperDescriptorComparer.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             new CaseSensitiveTagHelperDescriptorComparer();
 
         private CaseSensitiveTagHelperDescriptorComparer()
+            : base()
         {
         }
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -911,7 +911,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             get
             {
                 var errorFormat = "Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML " +
-                    "attributes beginning with 'data-'.";
+                    "attributes with name '{2}' because name starts with 'data-'.";
 
                 // type, expectedAttributeDescriptors, expectedErrors
                 return new TheoryData<Type, IEnumerable<TagHelperAttributeDescriptor>, string[]>
@@ -922,8 +922,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         new[] {
                             string.Format(
                                 errorFormat,
+                                typeof(InvalidBoundAttribute).FullName,
                                 nameof(InvalidBoundAttribute.DataSomething),
-                                typeof(InvalidBoundAttribute).FullName)
+                                "data-something")
                         }
                     },
                     {
@@ -937,8 +938,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         new[] {
                             string.Format(
                                 errorFormat,
+                                typeof(InvalidBoundAttributeWithValid).FullName,
                                 nameof(InvalidBoundAttributeWithValid.DataSomething),
-                                typeof(InvalidBoundAttributeWithValid).FullName)
+                                "data-something")
                         }
                     },
                     {
@@ -957,8 +959,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         new[] {
                             string.Format(
                                 errorFormat,
+                                typeof(OverriddenValidBoundAttributeWithInvalid).FullName,
                                 nameof(OverriddenValidBoundAttributeWithInvalid.ValidSomething),
-                                typeof(OverriddenValidBoundAttributeWithInvalid).FullName)
+                                "data-something")
                         }
                     },
                     {
@@ -967,8 +970,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         new[] {
                             string.Format(
                                 errorFormat,
+                                typeof(OverriddenValidBoundAttributeWithInvalidUpperCase).FullName,
                                 nameof(OverriddenValidBoundAttributeWithInvalidUpperCase.ValidSomething),
-                                typeof(OverriddenValidBoundAttributeWithInvalidUpperCase).FullName)
+                                "DATA-SOMETHING")
                         }
                     },
                 };

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -905,7 +905,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 name: "bound",
                                 propertyName: "Bound",
-                                typeName: typeof(bool).FullName),
+                                typeName: typeof(bool).FullName,
+                                isStringProperty: false),
                         },
                         requiredAttributes: Enumerable.Empty<string>())
                 };
@@ -928,7 +929,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 name: "bound",
                                 propertyName: "Bound",
-                                typeName: typeof(bool).FullName),
+                                typeName: typeof(bool).FullName,
+                                isStringProperty: false),
                         },
                         requiredAttributes: Enumerable.Empty<string>())
                 };
@@ -1466,11 +1468,13 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 name: "bound",
                                 propertyName: "Bound",
-                                typeName: typeof(bool).FullName),
+                                typeName: typeof(bool).FullName,
+                                isStringProperty: false),
                             new TagHelperAttributeDescriptor(
                                 name: "name",
                                 propertyName: "Name",
-                                typeName: typeof(string).FullName)
+                                typeName: typeof(string).FullName,
+                                isStringProperty: true)
                         })
                 };
             var descriptorProvider = new TagHelperDescriptorProvider(descriptors);
@@ -3713,9 +3717,17 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                 new TagHelperDescriptor("person", "PersonTagHelper", "personAssembly",
                     attributes: new[]
                     {
-                        new TagHelperAttributeDescriptor("age", "Age", typeof(int).FullName),
-                        new TagHelperAttributeDescriptor("birthday", "BirthDay", typeof(DateTime).FullName),
-                        new TagHelperAttributeDescriptor("name", "Name", typeof(string).FullName),
+                        new TagHelperAttributeDescriptor("age", "Age", typeof(int).FullName, isStringProperty: false),
+                        new TagHelperAttributeDescriptor(
+                            "birthday",
+                            "BirthDay",
+                            typeof(DateTime).FullName,
+                            isStringProperty: false),
+                        new TagHelperAttributeDescriptor(
+                            "name",
+                            "Name",
+                            typeof(string).FullName,
+                            isStringProperty: true),
                     })
             };
             var providerContext = new TagHelperDescriptorProvider(descriptors);


### PR DESCRIPTION
- #89
- support adding attributes (that aren't otherwise bound) to a tag helper dictionary
- add `ObjectCreationExpression`, `Prefix` and more to `TagHelperAttributeDescriptor`
 - determine `string`-ness when creating `TagHelperAttributeDescriptor`s
- handle `Prefix` matches in `TagHelperBlockRewriter`
- refactor `CSharpTagHelperCodeRenderer` to handle new indexer property assignments
 - calculate `string`-ness for a bound attribute using all `TagHelperAttributeDescriptor`s
- extend handling of invalid attribute names to include `[HtmlAttributeName]`

known issue: `ObjectCreationExpression` is a C# expression because otherwise
generation has insufficient information to determine correct constructor.
- no VB or F# (for example) workarounds today

no new tests yet

nits:
- add `TagHelperHelper`
- separate `TagHelperAttributeDescriptorComparer` and `TypeBasedTagHelperDescriptorComparer`
 - encourages reuse and most are already used in multiple classes
- use `<inheritdoc/>` in `TagHelperDescriptorComparer`
 - also give it an explicit constructor