### PR TITLE
Quick fix: Add `System.Runtime.Serialization.Primitives` dependency

### DIFF
--- a/test/Microsoft.AspNet.Razor.Test/project.json
+++ b/test/Microsoft.AspNet.Razor.Test/project.json
@@ -15,7 +15,8 @@
         "dnxcore50": {
             "dependencies": {
                 "System.Diagnostics.TraceSource": "4.0.0-beta-*",
-                "System.Reflection.TypeExtensions": "4.0.0-beta-*"
+                "System.Reflection.TypeExtensions": "4.0.0-beta-*",
+                "System.Runtime.Serialization.Primitives": "4.0.10-beta-*"
             }
         }
     },


### PR DESCRIPTION
- tests failing
- root cause is likely similar to reason MVC Core has same dependency
 - something must have changed in the framework packages without manifest fixes