### PR TITLE
Add `[HtmlAttributeName(..., DictionaryAttributePrefix="prefix")]` part III

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -187,6 +187,38 @@ namespace Microsoft.AspNet.Razor.Runtime
         }
 
         /// <summary>
+        /// name
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_Name
+        {
+            get { return GetString("TagHelperDescriptorFactory_Name"); }
+        }
+
+        /// <summary>
+        /// name
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_Name()
+        {
+            return GetString("TagHelperDescriptorFactory_Name");
+        }
+
+        /// <summary>
+        /// prefix
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_Prefix
+        {
+            get { return GetString("TagHelperDescriptorFactory_Prefix"); }
+        }
+
+        /// <summary>
+        /// prefix
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_Prefix()
+        {
+            return GetString("TagHelperDescriptorFactory_Prefix");
+        }
+
+        /// <summary>
         /// Tag
         /// </summary>
         internal static string TagHelperDescriptorFactory_Tag
@@ -203,19 +235,67 @@ namespace Microsoft.AspNet.Razor.Runtime
         }
 
         /// <summary>
-        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes beginning with '{2}'.
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} contains a '{4}' character.
         /// </summary>
-        internal static string TagHelperDescriptorFactory_InvalidBoundAttributeName
+        internal static string TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixCharacter
         {
-            get { return GetString("TagHelperDescriptorFactory_InvalidBoundAttributeName"); }
+            get { return GetString("TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixCharacter"); }
         }
 
         /// <summary>
-        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes beginning with '{2}'.
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} contains a '{4}' character.
         /// </summary>
-        internal static string FormatTagHelperDescriptorFactory_InvalidBoundAttributeName(object p0, object p1, object p2)
+        internal static string FormatTagHelperDescriptorFactory_InvalidAttributeNameOrPrefixCharacter(object p0, object p1, object p2, object p3, object p4)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidBoundAttributeName"), p0, p1, p2);
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixCharacter"), p0, p1, p2, p3, p4);
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} starts with '{4}'.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixStart
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixStart"); }
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} starts with '{4}'.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidAttributeNameOrPrefixStart(object p0, object p1, object p2, object p3, object p4)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixStart"), p0, p1, p2, p3, p4);
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with a whitespace {2}.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixWhitespace
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixWhitespace"); }
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with a whitespace {2}.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidAttributeNameOrPrefixWhitespace(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixWhitespace"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. '{2}.{3}' must be null unless property type implements '{4}'.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidAttributePrefix
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidAttributePrefix"); }
+        }
+
+        /// <summary>
+        /// Invalid tag helper bound property '{0}.{1}'. '{2}.{3}' must be null unless property type implements '{4}'.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidAttributePrefix(object p0, object p1, object p2, object p3, object p4)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidAttributePrefix"), p0, p1, p2, p3, p4);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -150,11 +150,26 @@
   <data name="TagHelperDescriptorFactory_Attribute" xml:space="preserve">
     <value>Attribute</value>
   </data>
+  <data name="TagHelperDescriptorFactory_Name" xml:space="preserve">
+    <value>name</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_Prefix" xml:space="preserve">
+    <value>prefix</value>
+  </data>
   <data name="TagHelperDescriptorFactory_Tag" xml:space="preserve">
     <value>Tag</value>
   </data>
-  <data name="TagHelperDescriptorFactory_InvalidBoundAttributeName" xml:space="preserve">
-    <value>Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes beginning with '{2}'.</value>
+  <data name="TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixCharacter" xml:space="preserve">
+    <value>Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} contains a '{4}' character.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixStart" xml:space="preserve">
+    <value>Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with {2} '{3}' because {2} starts with '{4}'.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixWhitespace" xml:space="preserve">
+    <value>Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML attributes with a whitespace {2}.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_InvalidAttributePrefix" xml:space="preserve">
+    <value>Invalid tag helper bound property '{0}.{1}'. '{2}.{3}' must be null unless property type implements '{4}'.</value>
   </data>
   <data name="TagHelperAttributeList_CannotAddWithNullName" xml:space="preserve">
     <value>Cannot add a '{0}' with a null '{1}'.</value>

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlAttributeNameAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlAttributeNameAttribute.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     public sealed class HtmlAttributeNameAttribute : Attribute
     {
+        private string _dictionaryAttributePrefix;
+
         /// <summary>
         /// Instantiates a new instance of the <see cref="HtmlAttributeNameAttribute"/> class.
         /// </summary>
@@ -29,5 +31,39 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// HTML attribute name of the associated property.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Gets or sets the prefix used to match HTML attribute names. Matching attributes are added to the
+        /// associated property (an <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/>).
+        /// </summary>
+        /// <remarks>
+        /// If non-<c>null</c> associated property must be compatible with
+        /// <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> where <c>TKey</c> is
+        /// <see cref="string"/>.
+        /// </remarks>
+        /// <value>
+        /// If associated property is compatible with
+        /// <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/>, default value is <c>Name + "-"</c>.
+        /// Otherwise default value is <c>null</c>.
+        /// </value>
+        public string DictionaryAttributePrefix
+        {
+            get
+            {
+                return _dictionaryAttributePrefix;
+            }
+            set
+            {
+                _dictionaryAttributePrefix = value;
+                DictionaryAttributePrefixSet = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets an indication whether <see cref="DictionaryAttributePrefix"/> has been set. Used to distinguish an
+        /// uninitialized <see cref="DictionaryAttributePrefix"/> value from an explicit <c>null</c> setting.
+        /// </summary>
+        /// <value><c>true</c> if <see cref="DictionaryAttributePrefix"/> was set. <c>false</c> otherwise.</value>
+        public bool DictionaryAttributePrefixSet { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -220,7 +220,6 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 var descriptor = ToAttributeDescriptor(property, attributeNameAttribute);
                 if (ValidateTagHelperAttributeDescriptor(descriptor, type, errorSink))
                 {
-                    // Does this property also support indexer assignments?
                     bool isInvalid;
                     var indexerDescriptor = ToIndexerAttributeDescriptor(
                         property,
@@ -261,11 +260,6 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Type parentType,
             ErrorSink errorSink)
         {
-            if (attributeDescriptor == null)
-            {
-                return false;
-            }
-
             var nameOrPrefix = attributeDescriptor.IsIndexer ?
                 Resources.TagHelperDescriptorFactory_Prefix :
                 Resources.TagHelperDescriptorFactory_Name;

--- a/src/Microsoft.AspNet.Razor.Runtime/project.json
+++ b/src/Microsoft.AspNet.Razor.Runtime/project.json
@@ -6,8 +6,7 @@
         "Microsoft.Framework.BufferEntryCollection.Sources": { "type": "build", "version": "1.0.0-*" },
         "Microsoft.Framework.ClosedGenericMatcher.Sources": { "type": "build", "version": "1.0.0-*" },
         "Microsoft.Framework.CopyOnWriteDictionary.Sources": { "type": "build", "version": "1.0.0-*" },
-        "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
-        "Microsoft.Framework.TypeNameHelper.Sources": { "type": "build", "version": "1.0.0-*" }
+        "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" }
     },
     "frameworks": {
         "net45": { },

--- a/src/Microsoft.AspNet.Razor.Runtime/project.json
+++ b/src/Microsoft.AspNet.Razor.Runtime/project.json
@@ -4,8 +4,10 @@
     "dependencies": {
         "Microsoft.AspNet.Razor": "4.0.0-*",
         "Microsoft.Framework.BufferEntryCollection.Sources": { "type": "build", "version": "1.0.0-*" },
+        "Microsoft.Framework.ClosedGenericMatcher.Sources": { "type": "build", "version": "1.0.0-*" },
         "Microsoft.Framework.CopyOnWriteDictionary.Sources": { "type": "build", "version": "1.0.0-*" },
-        "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" }
+        "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
+        "Microsoft.Framework.TypeNameHelper.Sources": { "type": "build", "version": "1.0.0-*" }
     },
     "frameworks": {
         "net45": { },

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
@@ -245,7 +245,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
                             // of InvalidOperationException type.
                             _writer
                                 .Write("throw ")
-                                .WriteStartNewObject(typeof(InvalidOperationException).Name)
+                                .WriteStartNewObject(nameof(InvalidOperationException))
                                 .WriteStartMethodInvocation(_tagHelperContext.FormatInvalidIndexerAssignmentMethodName)
                                 .WriteStringLiteral(attributeName)
                                 .WriteParameterSeparator()

--- a/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/Compiler/CodeBuilder/CSharp/CSharpTagHelperCodeRenderer.cs
@@ -69,12 +69,9 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
 
             // Determine what attributes exist in the element and divide them up.
             var htmlAttributes = chunk.Attributes;
-            var attributeDescriptors = tagHelperDescriptors.SelectMany(descriptor => descriptor.Attributes);
-            var unboundHtmlAttributes = htmlAttributes.Where(
-                attribute => !attributeDescriptors.Any(
-                    descriptor => string.Equals(attribute.Key, descriptor.Name, StringComparison.OrdinalIgnoreCase) ||
-                        (descriptor.Prefix != null &&
-                         attribute.Key.StartsWith(descriptor.Prefix, StringComparison.OrdinalIgnoreCase))));
+            var attributeDescriptors = tagHelperDescriptors.SelectMany(descriptor => descriptor.Attributes).ToArray();
+            var unboundHtmlAttributes = htmlAttributes.Where(attribute => !attributeDescriptors.Any(
+                attributeDescriptor => attributeDescriptor.IsNameMatch(attribute.Key)));
 
             RenderUnboundHTMLAttributes(unboundHtmlAttributes);
 
@@ -184,6 +181,7 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
                 // Render all of the bound attribute values for the tag helper.
                 RenderBoundHTMLAttributes(
                     chunk.Attributes,
+                    tagHelperDescriptor.TypeName,
                     tagHelperVariableName,
                     tagHelperDescriptor.Attributes,
                     htmlAttributeValues);
@@ -192,192 +190,126 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
 
         private void RenderBoundHTMLAttributes(
             IList<KeyValuePair<string, Chunk>> chunkAttributes,
+            string tagHelperTypeName,
             string tagHelperVariableName,
             IEnumerable<TagHelperAttributeDescriptor> attributeDescriptors,
             Dictionary<string, string> htmlAttributeValues)
         {
-            // Pass 1: Initialize all dictionary-typed properties we can (if they're null at runtime).
-            foreach (var attributeDescriptor in attributeDescriptors)
+            // Track dictionary properties we have confirmed are non-null.
+            var confirmedDictionaries = new HashSet<string>(StringComparer.Ordinal);
+
+            // First attribute wins, even if there are duplicates.
+            var distinctAttributes = chunkAttributes.Distinct(KeyValuePairKeyComparer.Default);
+
+            // Go through the HTML attributes in source order, assigning to properties or indexers as we go.
+            foreach (var attributeKeyValuePair in distinctAttributes)
             {
-                if (!string.IsNullOrEmpty(attributeDescriptor.ObjectCreationExpression))
+                var attributeName = attributeKeyValuePair.Key;
+                var attributeValueChunk = attributeKeyValuePair.Value;
+                if (attributeValueChunk == null)
                 {
-                    var valueAccessor = string.Format(
-                        CultureInfo.InvariantCulture,
-                        "{0}.{1}",
-                        tagHelperVariableName,
-                        attributeDescriptor.PropertyName);
-
-                    _writer
-                        .Write("if (")
-                        .Write(valueAccessor)
-                        .WriteLine(" == null)");
-                    using (_writer.BuildScope())
-                    {
-                        _writer
-                            .WriteStartAssignment(valueAccessor)
-                            .Write(attributeDescriptor.ObjectCreationExpression)
-                            .WriteLine(";");
-                    }
-                }
-            }
-
-            // Pass 2: Set all individually-bound properties.
-            var attributeNames = chunkAttributes.Select(kvp => kvp.Key);
-            var remainingAttributeNames = new HashSet<string>(attributeNames, StringComparer.OrdinalIgnoreCase);
-            foreach (var attributeDescriptor in attributeDescriptors)
-            {
-                var matchingAttributes = chunkAttributes.Where(
-                    kvp => string.Equals(kvp.Key, attributeDescriptor.Name, StringComparison.OrdinalIgnoreCase));
-                if (matchingAttributes.Any())
-                {
-                    remainingAttributeNames.Remove(attributeDescriptor.Name);
-
-                    // First attribute wins, even if there are duplicates.
-                    var firstAttribute = matchingAttributes.First();
-                    var attributeValueChunk = firstAttribute.Value;
-
                     // Minimized attributes are not valid for bound attributes. TagHelperBlockRewriter has already
-                    // logged an error for the bound attribute; so we can skip.
-                    if (attributeValueChunk == null)
-                    {
-                        continue;
-                    }
-
-                    // We capture the tag helpers property value accessor so we can retrieve it later (if we need to).
-                    var valueAccessor = string.Format(
-                        CultureInfo.InvariantCulture,
-                        "{0}.{1}",
-                        tagHelperVariableName,
-                        attributeDescriptor.PropertyName);
-
-                    // If we haven't recorded this attribute value before then we need to record its value.
-                    var attributeValueRecorded = htmlAttributeValues.ContainsKey(attributeDescriptor.Name);
-                    if (!attributeValueRecorded)
-                    {
-                        // We only need to create attribute values once per HTML element (not once per tag helper).
-                        // We're saving the value accessor so we can retrieve it later if there are more tag
-                        // helpers that need the value.
-                        htmlAttributeValues.Add(attributeDescriptor.Name, valueAccessor);
-
-                        // Bufferable attributes are attributes that can have Razor code inside of them. Such
-                        // attributes have string values and may be calculated using a temporary TextWriter or other
-                        // buffer.
-                        var bufferableAttribute = attributeDescriptor.IsStringProperty;
-
-                        RenderNewAttributeValueAssignment(
-                            attributeDescriptor,
-                            bufferableAttribute,
-                            attributeValueChunk,
-                            valueAccessor);
-
-                        // Execution contexts are a runtime feature.
-                        if (_designTimeMode)
-                        {
-                            continue;
-                        }
-
-                        // We need to inform the context of the attribute value.
-                        var attributeName = firstAttribute.Key;
-                        _writer
-                            .WriteStartInstanceMethodInvocation(
-                                ExecutionContextVariableName,
-                                _tagHelperContext.ExecutionContextAddTagHelperAttributeMethodName)
-                            .WriteStringLiteral(attributeName)
-                            .WriteParameterSeparator()
-                            .Write(valueAccessor)
-                            .WriteEndMethodInvocation();
-                    }
-                    else
-                    {
-                        // The attribute value has already been recorded, lets retrieve it from the stored value
-                        // accessors.
-                        _writer
-                            .WriteStartAssignment(valueAccessor)
-                            .Write(htmlAttributeValues[attributeDescriptor.Name])
-                            .WriteLine(";");
-                    }
-                }
-            }
-
-            // Pass 3: Add all remaining attributes that match a prefix to corresponding dictionary. Use same order as
-            // above loops but skip everything already bound to a specific property of this tag helper.
-            foreach (var attributeDescriptor in attributeDescriptors)
-            {
-                if (attributeDescriptor.Prefix == null)
-                {
+                    // logged an error if it was a bound attribute; so we can skip.
                     continue;
                 }
 
-                var matchingNames = remainingAttributeNames
-                    .Where(name => name.StartsWith(attributeDescriptor.Prefix, StringComparison.OrdinalIgnoreCase));
-                foreach (var matchingName in matchingNames)
+                // Find the matching TagHelperAttributeDescriptor.
+                var attributeDescriptor = attributeDescriptors.FirstOrDefault(
+                    descriptor => descriptor.IsNameMatch(attributeName));
+                if (attributeDescriptor == null)
                 {
-                    // First attribute wins, even if there are duplicates.
-                    var attributeValueChunk = chunkAttributes
-                        .First(kvp => string.Equals(kvp.Key, matchingName, StringComparison.OrdinalIgnoreCase))
-                        .Value;
+                    // Attribute is not bound to a property or indexer in this tag helper.
+                    continue;
+                }
 
-                    // Minimized attributes are not valid for bound attributes. TagHelperBlockRewriter has already
-                    // logged an error for the bound attribute; so we can skip.
-                    if (attributeValueChunk == null)
+                // We capture the tag helper's property value accessor so we can retrieve it later (if we need to).
+                var valueAccessor = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}.{1}",
+                    tagHelperVariableName,
+                    attributeDescriptor.PropertyName);
+
+                if (attributeDescriptor.IsIndexer)
+                {
+                    // Need a different valueAccessor in this case. But first need to throw a reasonable Exception at
+                    // runtime if the property is null. The check is not required at design time.
+                    if (!_designTimeMode && confirmedDictionaries.Add(attributeDescriptor.PropertyName))
                     {
-                        continue;
+                        _writer
+                            .Write("if (")
+                            .Write(valueAccessor)
+                            .WriteLine(" == null)");
+                        using (_writer.BuildScope())
+                        {
+                            // System is in Host.NamespaceImports for all MVC scenarios. No need to generate FullName
+                            // of InvalidOperationException type.
+                            _writer
+                                .Write("throw ")
+                                .WriteStartNewObject(typeof(InvalidOperationException).Name)
+                                .WriteStartMethodInvocation(_tagHelperContext.FormatInvalidIndexerAssignmentMethodName)
+                                .WriteStringLiteral(attributeName)
+                                .WriteParameterSeparator()
+                                .WriteStringLiteral(tagHelperTypeName)
+                                .WriteParameterSeparator()
+                                .WriteStringLiteral(attributeDescriptor.PropertyName)
+                                .WriteEndMethodInvocation(endLine: false)   // End of method call
+                                .WriteEndMethodInvocation(endLine: true);   // End of new expression / throw statement
+                        }
                     }
 
-                    // We capture the dictionary lookup so we can retrieve it later (if we need to).
-                    var dictionaryKey = matchingName.Substring(attributeDescriptor.Prefix.Length);
-                    var valueAccessor = string.Format(
+                    var dictionaryKey = attributeName.Substring(attributeDescriptor.Name.Length);
+                    valueAccessor = string.Format(
                         CultureInfo.InvariantCulture,
                         "{0}.{1}[\"{2}\"]",
                         tagHelperVariableName,
                         attributeDescriptor.PropertyName,
                         dictionaryKey);
+                }
 
-                    // If we haven't recorded this attribute value before then we need to record its value.
-                    var attributeValueRecorded = htmlAttributeValues.ContainsKey(matchingName);
-                    if (!attributeValueRecorded)
+                // If we haven't recorded this attribute value before then we need to record its value.
+                var attributeValueRecorded = htmlAttributeValues.ContainsKey(attributeName);
+                if (!attributeValueRecorded)
+                {
+                    // We only need to create attribute values once per HTML element (not once per tag helper).
+                    // We're saving the value accessor so we can retrieve it later if there are more tag
+                    // helpers that need the value.
+                    htmlAttributeValues.Add(attributeName, valueAccessor);
+
+                    // Bufferable attributes are attributes that can have Razor code inside of them. Such
+                    // attributes have string values and may be calculated using a temporary TextWriter or other
+                    // buffer.
+                    var bufferableAttribute = attributeDescriptor.IsStringProperty;
+
+                    RenderNewAttributeValueAssignment(
+                        attributeDescriptor,
+                        bufferableAttribute,
+                        attributeValueChunk,
+                        valueAccessor);
+
+                    // Execution contexts are a runtime feature.
+                    if (_designTimeMode)
                     {
-                        // We only need to create attribute values once per HTML element (not once per tag helper).
-                        // We're saving the value accessor so we can retrieve it later if there are more tag
-                        // helpers that need the value.
-                        htmlAttributeValues.Add(matchingName, valueAccessor);
-
-                        // Bufferable attributes are attributes that can have Razor code inside of them. Such
-                        // attributes have string values and may be calculated using a temporary TextWriter or other
-                        // buffer.
-                        var bufferableAttribute = attributeDescriptor.AreStringPrefixedValues;
-
-                        RenderNewAttributeValueAssignment(
-                            attributeDescriptor,
-                            bufferableAttribute,
-                            attributeValueChunk,
-                            valueAccessor);
-
-                        // Execution contexts are a runtime feature.
-                        if (_designTimeMode)
-                        {
-                            continue;
-                        }
-
-                        // We need to inform the context of the attribute value.
-                        _writer
-                            .WriteStartInstanceMethodInvocation(
-                                ExecutionContextVariableName,
-                                _tagHelperContext.ExecutionContextAddTagHelperAttributeMethodName)
-                            .WriteStringLiteral(matchingName)
-                            .WriteParameterSeparator()
-                            .Write(valueAccessor)
-                            .WriteEndMethodInvocation();
+                        continue;
                     }
-                    else
-                    {
-                        // The attribute value has already been recorded, lets retrieve it from the stored value
-                        // accessors.
-                        _writer
-                            .WriteStartAssignment(valueAccessor)
-                            .Write(htmlAttributeValues[matchingName])
-                            .WriteLine(";");
-                    }
+
+                    // We need to inform the context of the attribute value.
+                    _writer
+                        .WriteStartInstanceMethodInvocation(
+                            ExecutionContextVariableName,
+                            _tagHelperContext.ExecutionContextAddTagHelperAttributeMethodName)
+                        .WriteStringLiteral(attributeName)
+                        .WriteParameterSeparator()
+                        .Write(valueAccessor)
+                        .WriteEndMethodInvocation();
+                }
+                else
+                {
+                    // The attribute value has already been recorded, lets retrieve it from the stored value
+                    // accessors.
+                    _writer
+                        .WriteStartAssignment(valueAccessor)
+                        .Write(htmlAttributeValues[attributeName])
+                        .WriteLine(";");
                 }
             }
         }
@@ -691,6 +623,26 @@ namespace Microsoft.AspNet.Razor.Generator.Compiler.CSharp
             plainText = literalChildChunk.Text;
 
             return true;
+        }
+
+        // An IEqualityComparer for string -> Chunk mappings which compares only the Key.
+        private class KeyValuePairKeyComparer : IEqualityComparer<KeyValuePair<string, Chunk>>
+        {
+            public static KeyValuePairKeyComparer Default = new KeyValuePairKeyComparer();
+
+            private KeyValuePairKeyComparer()
+            {
+            }
+
+            public bool Equals(KeyValuePair<string, Chunk> keyValuePairX, KeyValuePair<string, Chunk> keyValuePairY)
+            {
+                return string.Equals(keyValuePairX.Key, keyValuePairY.Key, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public int GetHashCode(KeyValuePair<string, Chunk> keyValuePair)
+            {
+                return keyValuePair.Key.GetHashCode();
+            }
         }
 
         // A CSharpCodeVisitor which does not HTML encode values. Used when rendering bound string attribute values.

--- a/src/Microsoft.AspNet.Razor/Generator/GeneratedTagHelperContext.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/GeneratedTagHelperContext.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNet.Razor.Generator
             ExecutionContextAddMinimizedHtmlAttributeMethodName = "AddMinimizedHtmlAttribute";
             ExecutionContextAddHtmlAttributeMethodName = "AddHtmlAttribute";
             ExecutionContextOutputPropertyName = "Output";
+            FormatInvalidIndexerAssignmentMethodName = "FormatInvalidIndexerAssignment";
             MarkAsHtmlEncodedMethodName = "Html.Raw";
             StartTagHelperWritingScopeMethodName = "StartTagHelperWritingScope";
             EndTagHelperWritingScopeMethodName = "EndTagHelperWritingScope";
@@ -77,6 +78,21 @@ namespace Microsoft.AspNet.Razor.Generator
         /// The property accessor for the tag helper's output.
         /// </summary>
         public string ExecutionContextOutputPropertyName { get; set; }
+
+        /// <summary>
+        /// The name of the method used to format an error message about using an indexer when the tag helper property
+        /// is <c>null</c>.
+        /// </summary>
+        /// <remarks>
+        /// Method signature should be
+        /// <code>
+        /// public string FormatInvalidIndexerAssignment(
+        ///     string attributeName,       // Name of the HTML attribute associated with the indexer.
+        ///     string tagHelperTypeName,   // Full name of the tag helper type.
+        ///     string propertyName)        // Dictionary property in the tag helper.
+        /// </code>
+        /// </remarks>
+        public string FormatInvalidIndexerAssignmentMethodName { get; set; }
 
         /// <summary>
         /// The name of the method used to wrap a <see cref="string"/> value and mark it as HTML-encoded.

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -65,20 +64,39 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
                 // Only want to track the attribute if we succeeded in parsing its corresponding Block/Span.
                 if (result != null)
                 {
+                    SourceLocation? errorLocation = null;
+
                     // Check if it's a bound attribute that is minimized or if it's a bound non-string attribute that
                     // is null or whitespace.
                     if ((result.IsBoundAttribute && result.AttributeValueNode == null) ||
                         (result.IsBoundNonStringAttribute &&
                          IsNullOrWhitespaceAttributeValue(result.AttributeValueNode)))
                     {
-                        var errorLocation = GetAttributeNameStartLocation(child);
+                        errorLocation = GetAttributeNameStartLocation(child);
 
                         errorSink.OnError(
-                            errorLocation,
+                            errorLocation.Value,
                             RazorResources.FormatRewriterError_EmptyTagHelperBoundAttribute(
                                 result.AttributeName,
                                 tagName,
                                 GetPropertyType(result.AttributeName, descriptors)),
+                            result.AttributeName.Length);
+                    }
+
+                    // Check if the attribute was a prefix match for a tag helper dictionary property but the
+                    // dictionary key would be the empty string.
+                    if (result.IsMissingDictionaryKey)
+                    {
+                        if (!errorLocation.HasValue)
+                        {
+                            errorLocation = GetAttributeNameStartLocation(child);
+                        }
+
+                        errorSink.OnError(
+                            errorLocation.Value,
+                            RazorResources.FormatTagHelperBlockRewriter_IndexerAttributeNameMustIncludeKey(
+                                result.AttributeName,
+                                tagName),
                             result.AttributeName.Length);
                     }
 
@@ -224,24 +242,19 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
                 {
                     errorSink.OnError(
                         span.Start,
-                        RazorResources.TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed,
+                        RazorResources.TagHelperBlockRewriter_TagHelperAttributeListMustBeWellFormed,
                         span.Content.Length);
                 }
 
                 return null;
             }
 
-            bool isBoundNonStringAttribute;
-            var result = new TryParseResult
-            {
-                IsBoundAttribute = IsBoundAttribute(name, descriptors, out isBoundNonStringAttribute),
-                AttributeName = name,
-            };
-            result.IsBoundNonStringAttribute = isBoundNonStringAttribute;
+            var result = CreateTryParseResult(name, descriptors);
 
             // If we're not after an equal then we should treat the value as if it were a minimized attribute.
             var attributeValueBuilder = afterEquals ? builder : null;
-            result.AttributeValueNode = CreateMarkupAttribute(name, attributeValueBuilder, isBoundNonStringAttribute);
+            result.AttributeValueNode =
+                CreateMarkupAttribute(name, attributeValueBuilder, result.IsBoundNonStringAttribute);
 
             return result;
         }
@@ -286,13 +299,7 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             }
 
             // Have a name now. Able to determine correct isBoundNonStringAttribute value.
-            bool isBoundNonStringAttribute;
-            var result = new TryParseResult
-            {
-                IsBoundAttribute = IsBoundAttribute(name, descriptors, out isBoundNonStringAttribute),
-                AttributeName = name,
-            };
-            result.IsBoundNonStringAttribute = isBoundNonStringAttribute;
+            var result = CreateTryParseResult(name, descriptors);
 
             // Remove first child i.e. foo="
             builder.Children.RemoveAt(0);
@@ -324,13 +331,13 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             if (block.Children.Count() == 1)
             {
                 var child = block.Children.First() as Span;
-
                 if (child != null)
                 {
                     // After pulling apart the block we just have a value span.
                     var spanBuilder = new SpanBuilder(child);
 
-                    result.AttributeValueNode = CreateMarkupAttribute(name, spanBuilder, isBoundNonStringAttribute);
+                    result.AttributeValueNode =
+                        CreateMarkupAttribute(name, spanBuilder, result.IsBoundNonStringAttribute);
 
                     return result;
                 }
@@ -480,59 +487,41 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
         // Determines the full name of the Type of the property corresponding to an attribute with the given name.
         private static string GetPropertyType(string name, IEnumerable<TagHelperDescriptor> descriptors)
         {
-            bool isNameMatch;
-            var firstBoundAttribute = FindFirstBoundAttribute(name, descriptors, out isNameMatch);
-            if (isNameMatch)
-            {
-                return firstBoundAttribute.TypeName;
-            }
+            var firstBoundAttribute = FindFirstBoundAttribute(name, descriptors);
 
-            return firstBoundAttribute?.PrefixedValueTypeName;
+            return firstBoundAttribute?.TypeName;
         }
 
-        // Determines whether an attribute with the given name is bound to a non-string tag helper property.
-        private static bool IsBoundAttribute(
-            string name,
-            IEnumerable<TagHelperDescriptor> descriptors,
-            out bool isBoundNonStringAttribute)
+        // Create a TryParseResult for given name, filling in binding details.
+        private static TryParseResult CreateTryParseResult(string name, IEnumerable<TagHelperDescriptor> descriptors)
         {
-            bool isNameMatch;
-            var firstBoundAttribute = FindFirstBoundAttribute(name, descriptors, out isNameMatch);
+            var firstBoundAttribute = FindFirstBoundAttribute(name, descriptors);
             var isBoundAttribute = firstBoundAttribute != null;
-            if (isNameMatch)
-            {
-                isBoundNonStringAttribute = !firstBoundAttribute.IsStringProperty;
-            }
-            else
-            {
-                isBoundNonStringAttribute = isBoundAttribute && !firstBoundAttribute.AreStringPrefixedValues;
-            }
+            var isBoundNonStringAttribute = isBoundAttribute && !firstBoundAttribute.IsStringProperty;
+            var isMissingDictionaryKey = isBoundAttribute &&
+                firstBoundAttribute.IsIndexer &&
+                name.Length == firstBoundAttribute.Name.Length;
 
-            return isBoundAttribute;
+            return new TryParseResult
+            {
+                AttributeName = name,
+                IsBoundAttribute = isBoundAttribute,
+                IsBoundNonStringAttribute = isBoundNonStringAttribute,
+                IsMissingDictionaryKey = isMissingDictionaryKey,
+            };
         }
 
         // Finds first TagHelperAttributeDescriptor matching given name.
         private static TagHelperAttributeDescriptor FindFirstBoundAttribute(
             string name,
-            IEnumerable<TagHelperDescriptor> descriptors,
-            out bool isNameMatch)
+            IEnumerable<TagHelperDescriptor> descriptors)
         {
-            var matchedName = false;
+            // Non-indexers (exact HTML attribute name matches) have higher precedence than indexers (prefix matches).
+            // Attributes already sorted to ensure this precedence.
             var firstBoundAttribute = descriptors
                 .SelectMany(descriptor => descriptor.Attributes)
-                .FirstOrDefault(attribute =>
-                {
-                    if (string.Equals(attribute.Name, name, StringComparison.OrdinalIgnoreCase))
-                    {
-                        matchedName = true;
-                        return true;
-                    }
+                .FirstOrDefault(attributeDescriptor => attributeDescriptor.IsNameMatch(name));
 
-                    return attribute.Prefix != null &&
-                        name.StartsWith(attribute.Prefix, StringComparison.OrdinalIgnoreCase);
-                });
-
-            isNameMatch = matchedName;
             return firstBoundAttribute;
         }
 
@@ -551,6 +540,8 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
             public bool IsBoundAttribute { get; set; }
 
             public bool IsBoundNonStringAttribute { get; set; }
+
+            public bool IsMissingDictionaryKey { get; set; }
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
@@ -1367,19 +1367,35 @@ namespace Microsoft.AspNet.Razor
         }
 
         /// <summary>
-        /// TagHelper attributes must be welformed.
+        /// TagHelper attributes must be well-formed.
         /// </summary>
-        internal static string TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed
+        internal static string TagHelperBlockRewriter_TagHelperAttributeListMustBeWellFormed
         {
-            get { return GetString("TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed"); }
+            get { return GetString("TagHelperBlockRewriter_TagHelperAttributeListMustBeWellFormed"); }
         }
 
         /// <summary>
-        /// TagHelper attributes must be welformed.
+        /// TagHelper attributes must be well-formed.
         /// </summary>
-        internal static string FormatTagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed()
+        internal static string FormatTagHelperBlockRewriter_TagHelperAttributeListMustBeWellFormed()
         {
-            return GetString("TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed");
+            return GetString("TagHelperBlockRewriter_TagHelperAttributeListMustBeWellFormed");
+        }
+
+        /// <summary>
+        /// The tag helper attribute '{0}' in element '{1}' is missing a key. The syntax is '&lt;{1} {0}{{ key }}="value"&gt;'.
+        /// </summary>
+        internal static string TagHelperBlockRewriter_IndexerAttributeNameMustIncludeKey
+        {
+            get { return GetString("TagHelperBlockRewriter_IndexerAttributeNameMustIncludeKey"); }
+        }
+
+        /// <summary>
+        /// The tag helper attribute '{0}' in element '{1}' is missing a key. The syntax is '&lt;{1} {0}{{ key }}="value"&gt;'.
+        /// </summary>
+        internal static string FormatTagHelperBlockRewriter_IndexerAttributeNameMustIncludeKey(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperBlockRewriter_IndexerAttributeNameMustIncludeKey"), p0, p1);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Razor/RazorResources.resx
+++ b/src/Microsoft.AspNet.Razor/RazorResources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -390,8 +390,11 @@ Instead, wrap the contents of the block in "{{}}":
   <data name="TagHelpersParseTreeRewriter_MissingCloseAngle" xml:space="preserve">
     <value>Missing close angle for tag helper '{0}'.</value>
   </data>
-  <data name="TagHelperBlockRewriter_TagHelperAttributeListMustBeWelformed" xml:space="preserve">
-    <value>TagHelper attributes must be welformed.</value>
+  <data name="TagHelperBlockRewriter_TagHelperAttributeListMustBeWellFormed" xml:space="preserve">
+    <value>TagHelper attributes must be well-formed.</value>
+  </data>
+  <data name="TagHelperBlockRewriter_IndexerAttributeNameMustIncludeKey" xml:space="preserve">
+    <value>The tag helper attribute '{0}' in element '{1}' is missing a key. The syntax is '&lt;{1} {0}{{ key }}="value"&gt;'.</value>
   </data>
   <data name="TagHelpers_AttributeExpressionRequired" xml:space="preserve">
     <value>Non-string tag helper attribute values must not be empty. Add an expression to this attribute value.</value>

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptor.cs
@@ -18,7 +18,26 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                   name,
                   propertyInfo.Name,
                   propertyInfo.PropertyType.FullName,
-                  isStringProperty: propertyInfo.PropertyType == typeof(string))
+                  isStringProperty: propertyInfo.PropertyType == typeof(string),
+                  prefix: null,
+                  objectCreationExpression: null,
+                  prefixedValueTypeName: null,
+                  areStringPrefixedValues: false)
+        {
+        }
+
+        // Internal for testing i.e. for easy TagHelperAttributeDescriptor creation without Prefix information.
+        internal TagHelperAttributeDescriptor(
+            [NotNull] string name,
+            [NotNull] string propertyName,
+            [NotNull] string typeName)
+            : this(
+                  name,
+                  propertyName,
+                  typeName,
+                  prefix: null,
+                  objectCreationExpression: null,
+                  prefixedValueTypeName: null)
         {
         }
 
@@ -30,30 +49,85 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <param name="typeName">
         /// The full name of the named (see <paramref name="propertyName"/>) property's <see cref="System.Type"/>.
         /// </param>
+        /// <param name="prefix">
+        /// The prefix used to match HTML attribute names. Matching attributes are added to the associated property
+        /// (an <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/>).
+        /// </param>
+        /// <param name="objectCreationExpression">
+        /// The C# object creation expression (<c>new</c> operator invocation) used to initialize the property.
+        /// </param>
+        /// <param name="prefixedValueTypeName">
+        /// The full name of <c>TValue</c> in the <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/>
+        /// the named (see <paramref name="propertyName"/>) property implements.
+        /// </param>
+        /// <remarks>
+        /// <paramref name="objectCreationExpression"/> and <paramref name="prefixedValueTypeName"/> are
+        /// ignored if <paramref name="prefix"/> is <c>null</c>. In turn <paramref name="prefix"/> is expected to be
+        /// non-<c>null</c> only if <paramref name="typeName"/> implements
+        /// <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> where <c>TKey</c> is
+        /// <see cref="string"/>.
+        /// </remarks>
         public TagHelperAttributeDescriptor(
             [NotNull] string name,
             [NotNull] string propertyName,
-            [NotNull] string typeName)
+            [NotNull] string typeName,
+            string prefix,
+            string objectCreationExpression,
+            string prefixedValueTypeName)
             : this(
                   name,
                   propertyName,
                   typeName,
-                  isStringProperty: string.Equals(typeName, typeof(string).FullName, StringComparison.Ordinal))
+                  isStringProperty: string.Equals(typeName, typeof(string).FullName, StringComparison.Ordinal),
+                  prefix: prefix,
+                  objectCreationExpression: objectCreationExpression,
+                  prefixedValueTypeName: prefixedValueTypeName,
+                  areStringPrefixedValues: string.Equals(
+                      prefixedValueTypeName,
+                      typeof(string).FullName,
+                      StringComparison.Ordinal))
         {
         }
 
-        // Internal for testing i.e. for confirming above constructor sets `IsStringProperty` as expected.
+        // Internal for testing i.e. for confirming above constructor sets IsStringProperty and
+        // AreStringPrefixedValues as expected.
         internal TagHelperAttributeDescriptor(
             [NotNull] string name,
             [NotNull] string propertyName,
             [NotNull] string typeName,
-            bool isStringProperty)
+            bool isStringProperty,
+            string prefix,
+            string objectCreationExpression,
+            string prefixedValueTypeName,
+            bool areStringPrefixedValues)
         {
             Name = name;
             PropertyName = propertyName;
             TypeName = typeName;
             IsStringProperty = isStringProperty;
+
+            Prefix = prefix;
+            if (prefix != null)
+            {
+                ObjectCreationExpression = objectCreationExpression;
+                PrefixedValueTypeName = prefixedValueTypeName;
+                AreStringPrefixedValues = areStringPrefixedValues;
+            }
         }
+
+        /// <summary>
+        /// Gets an indication whether this property type implements
+        /// <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> where <c>TValue</c> is
+        /// <see cref="string"/>.
+        /// </summary>
+        /// <value>
+        /// If <c>true</c> the <see cref="TypeName"/> is for an
+        /// <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> where both <c>TKey</c> and
+        /// <c>TValue</c> are <see cref="string"/>. This causes the razor parser to allow empty values for attributes
+        /// that have names starting with <see cref="Prefix"/>. If <c>false</c> empty values for such matching
+        /// attributes lead to errors.
+        /// </value>
+        public bool AreStringPrefixedValues { get; }
 
         /// <summary>
         /// Gets an indication whether this property is of type <see cref="string"/>.
@@ -69,6 +143,25 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// The HTML attribute name.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Gets the C# object creation expression (<c>new</c> operator invocation) used to initialize the property.
+        /// Ignored if <paramref name="prefix"/> is <c>null</c>.
+        /// </summary>
+        public string ObjectCreationExpression { get; }
+
+        /// <summary>
+        /// Gets the prefix used to match HTML attribute names. Matching attributes are added to the associated
+        /// property (an <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/>).
+        /// </summary>
+        public string Prefix { get; }
+
+        /// <summary>
+        /// Gets the full name of <c>TValue</c> in the
+        /// <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> the named (see
+        /// <see cref="PropertyName"/>) property implements.
+        /// </summary>
+        public string PrefixedValueTypeName { get; }
 
         /// <summary>
         /// The name of the CLR property that corresponds to the HTML attribute.

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptorComparer.cs
@@ -29,9 +29,11 @@ namespace Microsoft.AspNet.Razor.TagHelpers
 
         /// <inheritdoc />
         /// <remarks>
-        /// Determines equality based on <see cref="TagHelperAttributeDescriptor.Name"/>,
-        /// <see cref="TagHelperAttributeDescriptor.PropertyName"/>,
-        /// and <see cref="TagHelperAttributeDescriptor.TypeName"/>.
+        /// Determines equality based on <see cref="TagHelperAttributeDescriptor.IsIndexer"/>,
+        /// <see cref="TagHelperAttributeDescriptor.Name"/>, <see cref="TagHelperAttributeDescriptor.PropertyName"/>,
+        /// and <see cref="TagHelperAttributeDescriptor.TypeName"/>. Ignores
+        /// <see cref="TagHelperAttributeDescriptor.IsStringProperty"/> because it can be inferred directly from
+        /// <see cref="TagHelperAttributeDescriptor.TypeName"/>.
         /// </remarks>
         public virtual bool Equals(TagHelperAttributeDescriptor descriptorX, TagHelperAttributeDescriptor descriptorY)
         {
@@ -40,9 +42,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 return true;
             }
 
+            // Check Name and TypeName though each property in a particular tag helper has at most two
+            // TagHelperAttributeDescriptors (one for the indexer and one not). May be comparing attributes between
+            // tag helpers and should be as specific as we can.
             return descriptorX != null &&
+                descriptorX.IsIndexer == descriptorY.IsIndexer &&
                 string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(descriptorX.Prefix, descriptorY.Prefix, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(descriptorX.PropertyName, descriptorY.PropertyName, StringComparison.Ordinal) &&
                 string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal);
         }
@@ -50,9 +55,11 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <inheritdoc />
         public virtual int GetHashCode([NotNull] TagHelperAttributeDescriptor descriptor)
         {
+            // Rarely if ever hash TagHelperAttributeDescriptor. If we do, include the Name and TypeName since context
+            // information is not available in the hash.
             return HashCodeCombiner.Start()
+                .Add(descriptor.IsIndexer)
                 .Add(descriptor.Name, StringComparer.OrdinalIgnoreCase)
-                .Add(descriptor.Prefix, StringComparer.OrdinalIgnoreCase)
                 .Add(descriptor.PropertyName, StringComparer.Ordinal)
                 .Add(descriptor.TypeName, StringComparer.Ordinal)
                 .CombinedHash;

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperAttributeDescriptorComparer.cs
@@ -42,6 +42,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
 
             return descriptorX != null &&
                 string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(descriptorX.Prefix, descriptorY.Prefix, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(descriptorX.PropertyName, descriptorY.PropertyName, StringComparison.Ordinal) &&
                 string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal);
         }
@@ -51,6 +52,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         {
             return HashCodeCombiner.Start()
                 .Add(descriptor.Name, StringComparer.OrdinalIgnoreCase)
+                .Add(descriptor.Prefix, StringComparer.OrdinalIgnoreCase)
                 .Add(descriptor.PropertyName, StringComparer.Ordinal)
                 .Add(descriptor.TypeName, StringComparer.Ordinal)
                 .CombinedHash;

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperAttributeDescriptorComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperAttributeDescriptorComparer.cs
@@ -24,27 +24,20 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 return true;
             }
 
-            // Normal comparer doesn't care about case, in tests we do. Also double-check ObjectCreationExpression
-            // and both bool properties though all are inferred from TypeName.
+            // Base comparer does not care about Name case but in tests we do. Also double-check IsStringProperty
+            // though it is inferred from TypeName.
             return base.Equals(descriptorX, descriptorY) &&
-                descriptorX.AreStringPrefixedValues == descriptorY.AreStringPrefixedValues &&
                 descriptorX.IsStringProperty == descriptorY.IsStringProperty &&
-                string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal) &&
-                string.Equals(
-                    descriptorX.ObjectCreationExpression,
-                    descriptorY.ObjectCreationExpression,
-                    StringComparison.Ordinal) &&
-                string.Equals(descriptorX.Prefix, descriptorY.Prefix, StringComparison.Ordinal);
+                string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal);
         }
 
         public override int GetHashCode(TagHelperAttributeDescriptor descriptor)
         {
-            // Rarely if ever hash TagHelperAttributeDescriptor. If we do, ignore ObjectCreationExpression and both
-            // bool properties since they should not vary for a given TypeName i.e. will not change the bucket.
+            // Ignore IsStringProperty because it is directly inferred from TypeName and thus won't vary the hash
+            // bucket. Base comparer does not care about Name case in its hash code but in tests we do.
             return HashCodeCombiner.Start()
                 .Add(base.GetHashCode(descriptor))
                 .Add(descriptor.Name, StringComparer.Ordinal)
-                .Add(descriptor.Prefix, StringComparer.Ordinal)
                 .CombinedHash;
         }
     }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperAttributeDescriptorComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/CaseSensitiveTagHelperAttributeDescriptorComparer.cs
@@ -24,20 +24,27 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 return true;
             }
 
-            // Normal comparer doesn't care about case, in tests we do. Also double-check IsStringProperty though
-            // it is inferred from TypeName.
+            // Normal comparer doesn't care about case, in tests we do. Also double-check ObjectCreationExpression
+            // and both bool properties though all are inferred from TypeName.
             return base.Equals(descriptorX, descriptorY) &&
+                descriptorX.AreStringPrefixedValues == descriptorY.AreStringPrefixedValues &&
                 descriptorX.IsStringProperty == descriptorY.IsStringProperty &&
-                string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal);
+                string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal) &&
+                string.Equals(
+                    descriptorX.ObjectCreationExpression,
+                    descriptorY.ObjectCreationExpression,
+                    StringComparison.Ordinal) &&
+                string.Equals(descriptorX.Prefix, descriptorY.Prefix, StringComparison.Ordinal);
         }
 
         public override int GetHashCode(TagHelperAttributeDescriptor descriptor)
         {
-            // Rarely if ever hash TagHelperAttributeDescriptor. If we do, ignore IsStringProperty since it should
-            // not vary for a given TypeName i.e. will not change the bucket.
+            // Rarely if ever hash TagHelperAttributeDescriptor. If we do, ignore ObjectCreationExpression and both
+            // bool properties since they should not vary for a given TypeName i.e. will not change the bucket.
             return HashCodeCombiner.Start()
                 .Add(base.GetHashCode(descriptor))
                 .Add(descriptor.Name, StringComparer.Ordinal)
+                .Add(descriptor.Prefix, StringComparer.Ordinal)
                 .CombinedHash;
         }
     }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -221,7 +221,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         [Theory]
         [MemberData(nameof(HtmlCaseData))]
-        public void CreateDescriptor_HtmlCasesTagNameAndAttributeName(
+        public void CreateDescriptors_HtmlCasesTagNameAndAttributeName(
             Type tagHelperType,
             string expectedTagName,
             string expectedAttributeName)
@@ -244,7 +244,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_OverridesAttributeNameFromAttribute()
+        public void CreateDescriptors_OverridesAttributeNameFromAttribute()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -273,11 +273,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.Empty(errorSink.Errors);
-            Assert.Equal(expectedDescriptors, descriptors.ToArray(), CaseSensitiveTagHelperDescriptorComparer.Default);
+            Assert.Equal(expectedDescriptors, descriptors, CaseSensitiveTagHelperDescriptorComparer.Default);
         }
 
         [Fact]
-        public void CreateDescriptor_DoesNotInheritOverridenAttributeName()
+        public void CreateDescriptors_DoesNotInheritOverridenAttributeName()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -306,11 +306,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.Empty(errorSink.Errors);
-            Assert.Equal(expectedDescriptors, descriptors.ToArray(), CaseSensitiveTagHelperDescriptorComparer.Default);
+            Assert.Equal(expectedDescriptors, descriptors, CaseSensitiveTagHelperDescriptorComparer.Default);
         }
 
         [Fact]
-        public void CreateDescriptor_AllowsOverridenAttributeNameOnUnimplementedVirtual()
+        public void CreateDescriptors_AllowsOverridenAttributeNameOnUnimplementedVirtual()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -343,7 +343,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_BuildsDescriptorsFromSimpleTypes()
+        public void CreateDescriptors_BuildsDescriptorsFromSimpleTypes()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -364,7 +364,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_BuildsDescriptorsWithInheritedProperties()
+        public void CreateDescriptors_BuildsDescriptorsWithInheritedProperties()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -380,7 +380,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         "int-attribute",
                         nameof(InheritedSingleAttributeTagHelper.IntAttribute),
                         typeof(int).FullName,
-                        isStringProperty: false)
+                        isStringProperty: false,
+                        prefix: null,
+                        objectCreationExpression: null,
+                        prefixedValueTypeName: null,
+                        areStringPrefixedValues: false)
                 });
 
             // Act
@@ -396,7 +400,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_BuildsDescriptorsWithConventionNames()
+        public void CreateDescriptors_BuildsDescriptorsWithConventionNames()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -423,7 +427,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_OnlyAcceptsPropertiesWithGetAndSet()
+        public void CreateDescriptors_OnlyAcceptsPropertiesWithGetAndSet()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -451,7 +455,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_OnlyAcceptsPropertiesWithPublicGetAndSet()
+        public void CreateDescriptors_OnlyAcceptsPropertiesWithPublicGetAndSet()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -479,7 +483,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_DoesNotIncludePropertiesWithNotBound()
+        public void CreateDescriptors_DoesNotIncludePropertiesWithNotBound()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -495,7 +499,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         "bound-property",
                         nameof(NotBoundAttributeTagHelper.BoundProperty),
                         typeof(object).FullName,
-                        isStringProperty: false)
+                        isStringProperty: false,
+                        prefix: null,
+                        objectCreationExpression: null,
+                        prefixedValueTypeName: null,
+                        areStringPrefixedValues: false)
                 });
 
             // Act
@@ -511,7 +519,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact(Skip = "#364")]
-        public void CreateDescriptor_AddsErrorForTagHelperWithDuplicateAttributeNames()
+        public void CreateDescriptors_AddsErrorForTagHelperWithDuplicateAttributeNames()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -528,7 +536,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_ResolvesMultipleTagHelperDescriptorsFromSingleType()
+        public void CreateDescriptors_ResolvesMultipleTagHelperDescriptorsFromSingleType()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -546,7 +554,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                             "valid-attribute",
                             nameof(MultiTagTagHelper.ValidAttribute),
                             typeof(string).FullName,
-                            isStringProperty: true)
+                            isStringProperty: true,
+                            prefix: null,
+                            objectCreationExpression: null,
+                            prefixedValueTypeName: null,
+                            areStringPrefixedValues: false)
                     }),
                 new TagHelperDescriptor(
                     "p",
@@ -558,7 +570,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                             "valid-attribute",
                             nameof(MultiTagTagHelper.ValidAttribute),
                             typeof(string).FullName,
-                            isStringProperty: true)
+                            isStringProperty: true,
+                            prefix: null,
+                            objectCreationExpression: null,
+                            prefixedValueTypeName: null,
+                            areStringPrefixedValues: false)
                     })
             };
 
@@ -579,7 +595,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_DoesntResolveInheritedTagNames()
+        public void CreateDescriptors_DoesNotResolveInheritedTagNames()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -606,7 +622,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_IgnoresDuplicateTagNamesFromAttribute()
+        public void CreateDescriptors_IgnoresDuplicateTagNamesFromAttribute()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -639,7 +655,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void CreateDescriptor_OverridesTagNameFromAttribute()
+        public void CreateDescriptors_OverridesTagNameFromAttribute()
         {
             // Arrange
             var errorSink = new ErrorSink();
@@ -658,215 +674,23 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.Empty(errorSink.Errors);
-            Assert.Equal(expectedDescriptors, descriptors.ToArray(), CaseSensitiveTagHelperDescriptorComparer.Default);
+            Assert.Equal(expectedDescriptors, descriptors, CaseSensitiveTagHelperDescriptorComparer.Default);
         }
 
-        public static TheoryData InvalidNameData
+        // name, expectedErrorMessages
+        public static TheoryData<string, string[]> InvalidNameData
         {
             get
             {
-                var invalidNameError =
-                    "Tag helpers cannot target {0} name '{1}' because it contains a '{2}' character.";
-                var nullOrWhitespaceNameError =
-                    "{0} name cannot be null or whitespace.";
-                Func<string, string, string> onNameError = (invalidText, invalidCharacter) =>
-                    string.Format(invalidNameError, "tag", invalidText, invalidCharacter);
+                Func<string, string, string> onNameError =
+                    (invalidText, invalidCharacter) => $"Tag helpers cannot target tag name '{ invalidText }' " +
+                        $"because it contains a '{ invalidCharacter }' character.";
+                var whitespaceErrorString = "Tag name cannot be null or whitespace.";
 
-                // name, expectedErrorMessages
-                return new TheoryData<string, string[]>
-                {
-                    { "!", new[] {  onNameError("!", "!") } },
-                    { "hello!", new[] { onNameError("hello!", "!") } },
-                    { "!hello", new[] { onNameError("!hello", "!") } },
-                    { "he!lo", new[] { onNameError("he!lo", "!") } },
-                    {
-                        "!he!lo!",
-                        new[]
-                        {
-                            onNameError("!he!lo!", "!"),
-                            onNameError("!he!lo!", "!"),
-                            onNameError("!he!lo!", "!")
-                        }
-                    },
-                    { "@", new[] { onNameError("@", "@") } },
-                    { "hello@", new[] { onNameError("hello@", "@") } },
-                    { "@hello", new[] { onNameError("@hello", "@") } },
-                    { "he@lo", new[] { onNameError("he@lo", "@") } },
-                    {
-                        "@he@lo@",
-                        new[]
-                        {
-                            onNameError("@he@lo@", "@"),
-                            onNameError("@he@lo@", "@"),
-                            onNameError("@he@lo@", "@")
-                        }
-                    },
-                    { "/", new[] { onNameError("/", "/") } },
-                    { "hello/", new[] { onNameError("hello/", "/") } },
-                    { "/hello", new[] { onNameError("/hello", "/") } },
-                    { "he/lo", new[] { onNameError("he/lo", "/") } },
-                    {
-                        "/he/lo/",
-                        new[]
-                        {
-                            onNameError("/he/lo/", "/"),
-                            onNameError("/he/lo/", "/"),
-                            onNameError("/he/lo/", "/")
-                        }
-                    },
-                    { "<", new[] { onNameError("<", "<") } },
-                    { "hello<", new[] { onNameError("hello<", "<") } },
-                    { "<hello", new[] { onNameError("<hello", "<") } },
-                    { "he<lo", new[] { onNameError("he<lo", "<") } },
-                    {
-                        "<he<lo<",
-                        new[]
-                        {
-                            onNameError("<he<lo<", "<"),
-                            onNameError("<he<lo<", "<"),
-                            onNameError("<he<lo<", "<")
-                        }
-                    },
-                    { "?", new[] { onNameError("?", "?") } },
-                    { "hello?", new[] { onNameError("hello?", "?") } },
-                    { "?hello", new[] { onNameError("?hello", "?") } },
-                    { "he?lo", new[] { onNameError("he?lo", "?") } },
-                    {
-                        "?he?lo?",
-                        new[]
-                        {
-                            onNameError("?he?lo?", "?"),
-                            onNameError("?he?lo?", "?"),
-                            onNameError("?he?lo?", "?")
-                        }
-                    },
-                    { "[", new[] { onNameError("[", "[") } },
-                    { "hello[", new[] { onNameError("hello[", "[") } },
-                    { "[hello", new[] { onNameError("[hello", "[") } },
-                    { "he[lo", new[] { onNameError("he[lo", "[") } },
-                    {
-                        "[he[lo[",
-                        new[]
-                        {
-                            onNameError("[he[lo[", "["),
-                            onNameError("[he[lo[", "["),
-                            onNameError("[he[lo[", "[")
-                        }
-                    },
-                    { ">", new[] { onNameError(">", ">") } },
-                    { "hello>", new[] { onNameError("hello>", ">") } },
-                    { ">hello", new[] { onNameError(">hello", ">") } },
-                    { "he>lo", new[] { onNameError("he>lo", ">") } },
-                    {
-                        ">he>lo>",
-                        new[]
-                        {
-                            onNameError(">he>lo>", ">"),
-                            onNameError(">he>lo>", ">"),
-                            onNameError(">he>lo>", ">")
-                        }
-                    },
-                    { "]", new[] { onNameError("]", "]") } },
-                    { "hello]", new[] { onNameError("hello]", "]") } },
-                    { "]hello", new[] { onNameError("]hello", "]") } },
-                    { "he]lo", new[] { onNameError("he]lo", "]") } },
-                    {
-                        "]he]lo]",
-                        new[]
-                        {
-                            onNameError("]he]lo]", "]"),
-                            onNameError("]he]lo]", "]"),
-                            onNameError("]he]lo]", "]")
-                        }
-                    },
-                    { "=", new[] { onNameError("=", "=") } },
-                    { "hello=", new[] { onNameError("hello=", "=") } },
-                    { "=hello", new[] { onNameError("=hello", "=") } },
-                    { "he=lo", new[] { onNameError("he=lo", "=") } },
-                    {
-                        "=he=lo=",
-                        new[]
-                        {
-                            onNameError("=he=lo=", "="),
-                            onNameError("=he=lo=", "="),
-                            onNameError("=he=lo=", "=")
-                        }
-                    },
-                    { "\"", new[] { onNameError("\"", "\"") } },
-                    { "hello\"", new[] { onNameError("hello\"", "\"") } },
-                    { "\"hello", new[] { onNameError("\"hello", "\"") } },
-                    { "he\"lo", new[] { onNameError("he\"lo", "\"") } },
-                    {
-                        "\"he\"lo\"",
-                        new[]
-                        {
-                            onNameError("\"he\"lo\"", "\""),
-                            onNameError("\"he\"lo\"", "\""),
-                            onNameError("\"he\"lo\"", "\"")
-                        }
-                    },
-                    { "'", new[] { onNameError("'", "'") } },
-                    { "hello'", new[] { onNameError("hello'", "'") } },
-                    { "'hello", new[] { onNameError("'hello", "'") } },
-                    { "he'lo", new[] { onNameError("he'lo", "'") } },
-                    {
-                        "'he'lo'",
-                        new[]
-                        {
-                            onNameError("'he'lo'", "'"),
-                            onNameError("'he'lo'", "'"),
-                            onNameError("'he'lo'", "'")
-                        }
-                    },
-                    { string.Empty, new[] { string.Format(nullOrWhitespaceNameError, "Tag") } },
-                    { Environment.NewLine, new[] { string.Format(nullOrWhitespaceNameError, "Tag") } },
-                    { "\t", new[] { string.Format(nullOrWhitespaceNameError, "Tag") } },
-                    { " \t ", new[] { string.Format(nullOrWhitespaceNameError, "Tag") } },
-                    { " ", new[] { string.Format(nullOrWhitespaceNameError, "Tag") } },
-                    { Environment.NewLine + " ", new[] { string.Format(nullOrWhitespaceNameError, "Tag") } },
-                    {
-                        "! \t\r\n@/<>?[]=\"'",
-                        new[]
-                        {
-                            onNameError("! \t\r\n@/<>?[]=\"'", "!"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", " "),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "\t"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "\r"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "\n"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "@"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "/"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "<"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", ">"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "?"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "["),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "]"),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "="),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "\""),
-                            onNameError("! \t\r\n@/<>?[]=\"'", "'"),
-                        }
-                    },
-                    {
-                        "! \tv\ra\nl@i/d<>?[]=\"'",
-                        new[]
-                        {
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "!"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", " "),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\t"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\r"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\n"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "@"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "/"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "<"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", ">"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "?"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "["),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "]"),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "="),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\""),
-                            onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "'"),
-                        }
-                    },
-                };
+                var data = GetInvalidNameOrPrefixData(onNameError, whitespaceErrorString, onDataError: null);
+                data.Add(string.Empty, new[] { whitespaceErrorString });
+
+                return data;
             }
         }
 
@@ -884,10 +708,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             var errors = errorSink.Errors.ToArray();
-            for (var i = 0; i < errors.Length; i++)
+            Assert.Equal(expectedErrorMessages.Length, errors.Length);
+            for (var i = 0; i < expectedErrorMessages.Length; i++)
             {
-                Assert.Equal(expectedErrorMessages[i], errors[i].Message);
+                Assert.Equal(1, errors[i].Length);
                 Assert.Equal(SourceLocation.Zero, errors[i].Location);
+                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
             }
         }
 
@@ -943,7 +769,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             get
             {
                 var errorFormat = "Invalid tag helper bound property '{0}.{1}'. Tag helpers cannot bind to HTML " +
-                    "attributes beginning with 'data-'.";
+                    "attributes with name '{2}' because name starts with 'data-'.";
 
                 // type, expectedAttributeDescriptors, expectedErrors
                 return new TheoryData<Type, IEnumerable<TagHelperAttributeDescriptor>, string[]>
@@ -955,8 +781,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         {
                             string.Format(
                                 errorFormat,
+                                typeof(InvalidBoundAttribute).FullName,
                                 nameof(InvalidBoundAttribute.DataSomething),
-                                typeof(InvalidBoundAttribute).FullName)
+                                "data-something")
                         }
                     },
                     {
@@ -972,8 +799,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         {
                             string.Format(
                                 errorFormat,
+                                typeof(InvalidBoundAttributeWithValid).FullName,
                                 nameof(InvalidBoundAttributeWithValid.DataSomething),
-                                typeof(InvalidBoundAttributeWithValid).FullName)
+                                "data-something")
                         }
                     },
                     {
@@ -994,8 +822,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         {
                             string.Format(
                                 errorFormat,
+                                typeof(OverriddenValidBoundAttributeWithInvalid).FullName,
                                 nameof(OverriddenValidBoundAttributeWithInvalid.ValidSomething),
-                                typeof(OverriddenValidBoundAttributeWithInvalid).FullName)
+                                "data-something")
                         }
                     },
                     {
@@ -1005,8 +834,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         {
                             string.Format(
                                 errorFormat,
+                                typeof(OverriddenValidBoundAttributeWithInvalidUpperCase).FullName,
                                 nameof(OverriddenValidBoundAttributeWithInvalidUpperCase.ValidSomething),
-                                typeof(OverriddenValidBoundAttributeWithInvalidUpperCase).FullName)
+                                "DATA-SOMETHING")
                         }
                     },
                 };
@@ -1015,7 +845,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         [Theory]
         [MemberData(nameof(InvalidTagHelperAttributeDescriptorData))]
-        public void CreateDescriptor_DoesNotAllowDataDashAttributes(
+        public void CreateDescriptors_DoesNotAllowDataDashAttributes(
             Type type,
             IEnumerable<TagHelperAttributeDescriptor> expectedAttributeDescriptors,
             string[] expectedErrors)
@@ -1035,7 +865,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 var actualError = actualErrors[i];
                 Assert.Equal(1, actualError.Length);
                 Assert.Equal(SourceLocation.Zero, actualError.Location);
-                Assert.Equal(expectedErrors[i], actualError.Message);
+                Assert.Equal(expectedErrors[i], actualError.Message, StringComparer.Ordinal);
             }
 
             var actualDescriptor = Assert.Single(descriptors);
@@ -1043,6 +873,735 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 expectedAttributeDescriptors,
                 actualDescriptor.Attributes,
                 CaseSensitiveTagHelperAttributeDescriptorComparer.Default);
+        }
+
+        // tagTelperType, expectedAttributeDescriptors, expectedErrorMessages
+        public static TheoryData<Type, IEnumerable<TagHelperAttributeDescriptor>, string[]> TagHelperWithPrefixData
+        {
+            get
+            {
+                Func<string, string, string> onError = (typeName, propertyName) =>
+                    $"Invalid tag helper bound property '{ typeName }.{ propertyName }'. " +
+                    $"'{ nameof(HtmlAttributeNameAttribute) }." +
+                    $"{ nameof(HtmlAttributeNameAttribute.DictionaryAttributePrefix) }' must be null unless " +
+                    "property type implements 'IDictionary<string, TValue>'.";
+
+                // tagTelperType, expectedAttributeDescriptors, expectedErrorMessages
+                return new TheoryData<Type, IEnumerable<TagHelperAttributeDescriptor>, string[]>
+                {
+                    {
+                        typeof(DefaultValidHtmlAttributePrefix),
+                        new[]
+                        {
+                            new TagHelperAttributeDescriptor(
+                                name: "dictionary-property",
+                                propertyName: nameof(DefaultValidHtmlAttributePrefix.DictionaryProperty),
+                                typeName: typeof(IDictionary<string, string>).FullName,
+                                isStringProperty: false,
+                                prefix: "dictionary-property-",
+                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, string>()",
+                                prefixedValueTypeName: typeof(string).FullName,
+                                areStringPrefixedValues: true),
+                        },
+                        new string[0]
+                    },
+                    {
+                        typeof(SingleValidHtmlAttributePrefix),
+                        new[]
+                        {
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-name",
+                                propertyName: nameof(SingleValidHtmlAttributePrefix.DictionaryProperty),
+                                typeName: typeof(IDictionary<string, string>).FullName,
+                                isStringProperty: false,
+                                prefix: "valid-prefix",
+                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, string>()",
+                                prefixedValueTypeName: typeof(string).FullName,
+                                areStringPrefixedValues: true),
+                        },
+                        new string[0]
+                    },
+                    {
+                        typeof(MultipleValidHtmlAttributePrefix),
+                        new[]
+                        {
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-name1",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.DictionaryProperty),
+                                typeName: typeof(Dictionary<string, object>).FullName,
+                                isStringProperty: false,
+                                prefix: "valid-prefix1-",
+                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, object>()",
+                                prefixedValueTypeName: typeof(object).FullName,
+                                areStringPrefixedValues: false),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-name2",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.DictionarySubclassProperty),
+                                typeName: typeof(DictionarySubclass).FullName,
+                                isStringProperty: false,
+                                prefix: "valid-prefix2-",
+                                // See minor aspnet/Common#21 bug here. Separator should be a '.'.
+                                objectCreationExpression: $"new { typeof(TagHelperDescriptorFactoryTest).FullName }+" +
+                                    $"{ nameof(DictionarySubclass) }()",
+                                prefixedValueTypeName: typeof(string).FullName,
+                                areStringPrefixedValues: true),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-name3",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.DictionaryWithoutParameterlessConstructorProperty),
+                                typeName: typeof(DictionaryWithoutParameterlessConstructor).FullName,
+                                isStringProperty: false,
+                                prefix: "valid-prefix3-",
+                                objectCreationExpression: null,
+                                prefixedValueTypeName: typeof(string).FullName,
+                                areStringPrefixedValues: true),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-name4",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.GenericDictionarySubclassProperty),
+                                typeName: typeof(GenericDictionarySubclass<object>).FullName,
+                                isStringProperty: false,
+                                prefix: "valid-prefix4-",
+                                // See minor aspnet/Common#21 bug here. Separator should be a '.'.
+                                objectCreationExpression: $"new { typeof(TagHelperDescriptorFactoryTest).FullName }+" +
+                                    $"{ nameof(GenericDictionarySubclass<object>) }<object>()",
+                                prefixedValueTypeName: typeof(object).FullName,
+                                areStringPrefixedValues: false),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-name5",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.SortedDictionaryProperty),
+                                typeName: typeof(SortedDictionary<string, int>).FullName,
+                                isStringProperty: false,
+                                prefix: "valid-prefix5-",
+                                objectCreationExpression: "new System.Collections.Generic.SortedDictionary<string, int>()",
+                                prefixedValueTypeName: typeof(int).FullName,
+                                areStringPrefixedValues: false),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-name6",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.StringProperty),
+                                typeName: typeof(string).FullName,
+                                isStringProperty: true,
+                                prefix: null,
+                                objectCreationExpression: null,
+                                prefixedValueTypeName: null,
+                                areStringPrefixedValues: false),
+                        },
+                        new string[0]
+                    },
+                    {
+                        typeof(SingleInvalidHtmlAttributePrefix),
+                        Enumerable.Empty<TagHelperAttributeDescriptor>(),
+                        new[]
+                        {
+                            onError(
+                                typeof(SingleInvalidHtmlAttributePrefix).FullName,
+                                nameof(SingleInvalidHtmlAttributePrefix.StringProperty)),
+                        }
+                    },
+                    {
+                        typeof(MultipleInvalidHtmlAttributePrefix),
+                        new[]
+                        {
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-name1",
+                                propertyName: nameof(MultipleInvalidHtmlAttributePrefix.LongProperty),
+                                typeName: typeof(long).FullName,
+                                isStringProperty: false,
+                                prefix: null,
+                                objectCreationExpression: null,
+                                prefixedValueTypeName: null,
+                                areStringPrefixedValues: false),
+                        },
+                        new[]
+                        {
+                            onError(
+                                typeof(MultipleInvalidHtmlAttributePrefix).FullName,
+                                nameof(MultipleInvalidHtmlAttributePrefix.DictionaryOfIntProperty)),
+                            onError(
+                                typeof(MultipleInvalidHtmlAttributePrefix).FullName,
+                                nameof(MultipleInvalidHtmlAttributePrefix.ReadOnlyDictionaryProperty)),
+                            onError(
+                                typeof(MultipleInvalidHtmlAttributePrefix).FullName,
+                                nameof(MultipleInvalidHtmlAttributePrefix.IntProperty)),
+                            onError(
+                                typeof(MultipleInvalidHtmlAttributePrefix).FullName,
+                                nameof(MultipleInvalidHtmlAttributePrefix.DictionaryOfIntSubclassProperty)),
+                        }
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TagHelperWithPrefixData))]
+        public void CreateDescriptors_WithPrefixes_ReturnsExpectedAttributeDescriptors(
+            Type tagHelperType,
+            IEnumerable<TagHelperAttributeDescriptor> expectedAttributeDescriptors,
+            string[] expectedErrorMessages)
+        {
+            // Arrange
+            var errorSink = new ErrorSink();
+
+            // Act
+            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(AssemblyName, tagHelperType, errorSink);
+
+            // Assert
+            var errors = errorSink.Errors.ToArray();
+            Assert.Equal(expectedErrorMessages.Length, errors.Length);
+
+            for (var i = 0; i < errors.Length; i++)
+            {
+                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(SourceLocation.Zero, errors[i].Location);
+                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
+            }
+
+            var descriptor = Assert.Single(descriptors);
+            Assert.Equal(
+                expectedAttributeDescriptors,
+                descriptor.Attributes,
+                CaseSensitiveTagHelperAttributeDescriptorComparer.Default);
+        }
+
+        public static TheoryData<string> ValidAttributeNameOrPrefixData
+        {
+            get
+            {
+                return new TheoryData<string>
+                {
+                    null,
+                    string.Empty,
+                    "data",
+                    "dataa-",
+                    "ValidName",
+                    "valid-name",
+                    "--valid--name--",
+                    ",,--__..oddly.valid::;;",
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidAttributeNameOrPrefixData))]
+        public void ValidateTagHelperAttributeDescriptor_WithValidName_ReturnsTrue(string name)
+        {
+            // Arrange
+            var descriptor =
+                new TagHelperAttributeDescriptor(name, propertyName: "ValidProperty", typeName: "PropertyType");
+            var errorSink = new ErrorSink();
+
+            // Act
+            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
+                descriptor,
+                typeof(MultiTagTagHelper),
+                errorSink,
+                isExplicitPrefix: false);
+
+            // Assert
+            Assert.True(result);
+            Assert.Empty(errorSink.Errors);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidAttributeNameOrPrefixData))]
+        public void ValidateTagHelperAttributeDescriptor_WithValidNameAndValidPrefix_ReturnsTrue(string prefix)
+        {
+            // Arrange
+            var descriptor = new TagHelperAttributeDescriptor(
+                name: "ValidName",
+                propertyName: "InvalidProperty",
+                typeName: "PropertyType",
+                prefix: prefix,
+                objectCreationExpression: null,
+                prefixedValueTypeName: "ValuesType");
+            var errorSink = new ErrorSink();
+
+            // Act
+            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
+                descriptor,
+                typeof(MultiTagTagHelper),
+                errorSink,
+                isExplicitPrefix: true);
+
+            // Assert
+            Assert.True(result);
+            Assert.Empty(errorSink.Errors);
+        }
+
+        // name, expectedErrorMessages
+        public static TheoryData<string, string[]> InvalidAttributeNameData
+        {
+            get
+            {
+                Func<string, string, string> onNameError = (invalidText, invalidCharacter) => "Invalid tag helper " +
+                    $"bound property '{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot " +
+                    $"bind to HTML attributes with name '{ invalidText }' because name contains a " +
+                    $"'{ invalidCharacter }' character.";
+                var whitespaceErrorString = "Invalid tag helper bound property " +
+                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
+                    "attributes with a whitespace name.";
+                Func<string, string> onDataError = invalidText => "Invalid tag helper bound property " +
+                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
+                    $"attributes with name '{ invalidText }' because name starts with 'data-'.";
+
+                return GetInvalidNameOrPrefixData(onNameError, whitespaceErrorString, onDataError);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidAttributeNameData))]
+        public void ValidateTagHelperAttributeDescriptor_WithInvalidName_AddsExpectedErrors(
+            string name,
+            string[] expectedErrorMessages)
+        {
+            // Arrange
+            var descriptor =
+                new TagHelperAttributeDescriptor(name, propertyName: "InvalidProperty", typeName: "PropertyType");
+            var errorSink = new ErrorSink();
+
+            // Act
+            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
+                descriptor,
+                typeof(MultiTagTagHelper),
+                errorSink,
+                isExplicitPrefix: false);
+
+            // Assert
+            Assert.False(result);
+
+            var errors = errorSink.Errors.ToArray();
+            Assert.Equal(expectedErrorMessages.Length, errors.Length);
+            for (var i = 0; i < expectedErrorMessages.Length; i++)
+            {
+                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(SourceLocation.Zero, errors[i].Location);
+                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidAttributeNameData))]
+        public void ValidateTagHelperAttributeDescriptor_WithInvalidNameAndValidPrefix_AddsExpectedErrors(
+            string name,
+            string[] expectedErrorMessages)
+        {
+            // Arrange
+            var descriptor = new TagHelperAttributeDescriptor(
+                name,
+                propertyName: "InvalidProperty",
+                typeName: "PropertyType",
+                prefix: "ValidPrefix",
+                objectCreationExpression: null,
+                prefixedValueTypeName: "ValuesType");
+            var errorSink = new ErrorSink();
+
+            // Act
+            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
+                descriptor,
+                typeof(MultiTagTagHelper),
+                errorSink,
+                isExplicitPrefix: true);
+
+            // Assert
+            Assert.False(result);
+
+            var errors = errorSink.Errors.ToArray();
+            Assert.Equal(expectedErrorMessages.Length, errors.Length);
+            for (var i = 0; i < expectedErrorMessages.Length; i++)
+            {
+                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(SourceLocation.Zero, errors[i].Location);
+                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidAttributeNameData))]
+        public void ValidateTagHelperAttributeDescriptor_WithInvalidNameAndDefaultPrefix_AddsExpectedErrors(
+            string name,
+            string[] expectedErrorMessages)
+        {
+            // Arrange
+            var descriptor = new TagHelperAttributeDescriptor(
+                name,
+                propertyName: "InvalidProperty",
+                typeName: "PropertyType",
+                prefix: (name + "-"),
+                objectCreationExpression: null,
+                prefixedValueTypeName: "ValuesType");
+            var errorSink = new ErrorSink();
+
+            // Act
+            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
+                descriptor,
+                typeof(MultiTagTagHelper),
+                errorSink,
+                isExplicitPrefix: false);
+
+            // Assert
+            Assert.False(result);
+
+            // Errors are not duplicated for the invalid prefix.
+            var errors = errorSink.Errors.ToArray();
+            Assert.Equal(expectedErrorMessages.Length, errors.Length);
+            for (var i = 0; i < expectedErrorMessages.Length; i++)
+            {
+                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(SourceLocation.Zero, errors[i].Location);
+                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
+            }
+        }
+
+        // prefix, expectedErrorMessages
+        public static TheoryData<string, string[]> InvalidAttributePrefixData
+        {
+            get
+            {
+                Func<string, string, string> onPrefixError = (invalidText, invalidCharacter) => "Invalid tag helper " +
+                    $"bound property '{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot " +
+                    $"bind to HTML attributes with prefix '{ invalidText }' because prefix contains a " +
+                    $"'{ invalidCharacter }' character.";
+                var whitespaceErrorString = "Invalid tag helper bound property " +
+                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
+                    "attributes with a whitespace prefix.";
+                Func<string, string> onDataError = invalidText => "Invalid tag helper bound property " +
+                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
+                    $"attributes with prefix '{ invalidText }' because prefix starts with 'data-'.";
+
+                return GetInvalidNameOrPrefixData(onPrefixError, whitespaceErrorString, onDataError);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidAttributePrefixData))]
+        public void ValidateTagHelperAttributeDescriptor_WithValidNameAndInvalidPrefix_AddsExpectedErrors(
+            string prefix,
+            string[] expectedErrorMessages)
+        {
+            // Arrange
+            var descriptor = new TagHelperAttributeDescriptor(
+                name: "ValidName",
+                propertyName: "InvalidProperty",
+                typeName: "PropertyType",
+                prefix: prefix,
+                objectCreationExpression: null,
+                prefixedValueTypeName: "ValuesType");
+            var errorSink = new ErrorSink();
+
+            // Act
+            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
+                descriptor,
+                typeof(MultiTagTagHelper),
+                errorSink,
+                isExplicitPrefix: true);
+
+            // Assert
+            Assert.False(result);
+
+            var errors = errorSink.Errors.ToArray();
+            Assert.Equal(expectedErrorMessages.Length, errors.Length);
+            for (var i = 0; i < expectedErrorMessages.Length; i++)
+            {
+                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(SourceLocation.Zero, errors[i].Location);
+                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
+            }
+        }
+
+        // name and prefix, expectedErrorMessages
+        public static TheoryData<string, string[]> InvalidAttributeNameAndPrefixData
+        {
+            get
+            {
+                Func<string, string, string> onNameError = (invalidText, invalidCharacter) => "Invalid tag helper " +
+                    $"bound property '{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot " +
+                    $"bind to HTML attributes with name '{ invalidText }' because name contains a " +
+                    $"'{ invalidCharacter }' character.";
+                var whitespaceNameErrorString = "Invalid tag helper bound property " +
+                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
+                    "attributes with a whitespace name.";
+                Func<string, string> onNameDataError = invalidText => "Invalid tag helper bound property " +
+                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
+                    $"attributes with name '{ invalidText }' because name starts with 'data-'.";
+                Func<string, string, string> onPrefixError = (invalidText, invalidCharacter) => "Invalid tag helper " +
+                    $"bound property '{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot " +
+                    $"bind to HTML attributes with prefix '{ invalidText }' because prefix contains a " +
+                    $"'{ invalidCharacter }' character.";
+                var whitespacePrefixErrorString = "Invalid tag helper bound property " +
+                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
+                    "attributes with a whitespace prefix.";
+                Func<string, string> onPrefixDataError = invalidText => "Invalid tag helper bound property " +
+                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
+                    $"attributes with prefix '{ invalidText }' because prefix starts with 'data-'.";
+
+                var invalidNameData =
+                    GetInvalidNameOrPrefixData(onNameError, whitespaceNameErrorString, onNameDataError);
+                var invalidPrefixData =
+                    GetInvalidNameOrPrefixData(onPrefixError, whitespacePrefixErrorString, onPrefixDataError);
+
+                var combinedData = new TheoryData<string, string[]>();
+                var index = 0;
+                foreach (var invalidName in invalidNameData)
+                {
+                    var invalidNameErrors = (string[])invalidName[1];
+                    var invalidPrefix = invalidPrefixData.ElementAt(index);
+                    var invalidPrefixErrors = (string[])invalidPrefix[1];
+
+                    var errors = new string[invalidNameErrors.Length * 2];
+                    invalidNameErrors.CopyTo(errors, 0);
+                    invalidPrefixErrors.CopyTo(errors, invalidNameErrors.Length);
+
+                    combinedData.Add((string)invalidName[0], errors);
+
+                    index++;
+                }
+
+                return combinedData;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidAttributeNameAndPrefixData))]
+        public void ValidateTagHelperAttributeDescriptor_WithInvalidNameAndInvalidPrefix_AddsExpectedErrors(
+            string nameAndPrefix,
+            string[] expectedErrorMessages)
+        {
+            // Arrange
+            var descriptor = new TagHelperAttributeDescriptor(
+                name: nameAndPrefix,
+                propertyName: "InvalidProperty",
+                typeName: "PropertyType",
+                prefix: nameAndPrefix,
+                objectCreationExpression: null,
+                prefixedValueTypeName: "ValuesType");
+            var errorSink = new ErrorSink();
+
+            // Act
+            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
+                descriptor,
+                typeof(MultiTagTagHelper),
+                errorSink,
+                isExplicitPrefix: true);
+
+            // Assert
+            Assert.False(result);
+
+            var errors = errorSink.Errors.ToArray();
+            Assert.Equal(expectedErrorMessages.Length, errors.Length);
+            for (var i = 0; i < expectedErrorMessages.Length; i++)
+            {
+                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(SourceLocation.Zero, errors[i].Location);
+                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
+            }
+        }
+
+        private static TheoryData<string, string[]> GetInvalidNameOrPrefixData(
+            Func<string, string, string> onNameError,
+            string whitespaceErrorString,
+            Func<string, string> onDataError)
+        {
+            // name, expectedErrorMessages
+            var data = new TheoryData<string, string[]>
+            {
+                { "!", new[] {  onNameError("!", "!") } },
+                { "hello!", new[] { onNameError("hello!", "!") } },
+                { "!hello", new[] { onNameError("!hello", "!") } },
+                { "he!lo", new[] { onNameError("he!lo", "!") } },
+                {
+                    "!he!lo!",
+                    new[]
+                    {
+                        onNameError("!he!lo!", "!"),
+                        onNameError("!he!lo!", "!"),
+                        onNameError("!he!lo!", "!"),
+                    }
+                },
+                { "@", new[] { onNameError("@", "@") } },
+                { "hello@", new[] { onNameError("hello@", "@") } },
+                { "@hello", new[] { onNameError("@hello", "@") } },
+                { "he@lo", new[] { onNameError("he@lo", "@") } },
+                {
+                    "@he@lo@",
+                    new[]
+                    {
+                        onNameError("@he@lo@", "@"),
+                        onNameError("@he@lo@", "@"),
+                        onNameError("@he@lo@", "@"),
+                    }
+                },
+                { "/", new[] { onNameError("/", "/") } },
+                { "hello/", new[] { onNameError("hello/", "/") } },
+                { "/hello", new[] { onNameError("/hello", "/") } },
+                { "he/lo", new[] { onNameError("he/lo", "/") } },
+                {
+                    "/he/lo/",
+                    new[] {
+                        onNameError("/he/lo/", "/"),
+                        onNameError("/he/lo/", "/"),
+                        onNameError("/he/lo/", "/"),
+                    }
+                },
+                { "<", new[] { onNameError("<", "<") } },
+                { "hello<", new[] { onNameError("hello<", "<") } },
+                { "<hello", new[] { onNameError("<hello", "<") } },
+                { "he<lo", new[] { onNameError("he<lo", "<") } },
+                {
+                    "<he<lo<",
+                    new[]
+                    {
+                        onNameError("<he<lo<", "<"),
+                        onNameError("<he<lo<", "<"),
+                        onNameError("<he<lo<", "<"),
+                    }
+                },
+                { "?", new[] { onNameError("?", "?") } },
+                { "hello?", new[] { onNameError("hello?", "?") } },
+                { "?hello", new[] { onNameError("?hello", "?") } },
+                { "he?lo", new[] { onNameError("he?lo", "?") } },
+                {
+                    "?he?lo?",
+                    new[]
+                    {
+                        onNameError("?he?lo?", "?"),
+                        onNameError("?he?lo?", "?"),
+                        onNameError("?he?lo?", "?"),
+                    }
+                },
+                { "[", new[] { onNameError("[", "[") } },
+                { "hello[", new[] { onNameError("hello[", "[") } },
+                { "[hello", new[] { onNameError("[hello", "[") } },
+                { "he[lo", new[] { onNameError("he[lo", "[") } },
+                {
+                    "[he[lo[",
+                    new[]
+                    {
+                        onNameError("[he[lo[", "["),
+                        onNameError("[he[lo[", "["),
+                        onNameError("[he[lo[", "["),
+                    }
+                },
+                { ">", new[] { onNameError(">", ">") } },
+                { "hello>", new[] { onNameError("hello>", ">") } },
+                { ">hello", new[] { onNameError(">hello", ">") } },
+                { "he>lo", new[] { onNameError("he>lo", ">") } },
+                {
+                    ">he>lo>",
+                    new[]
+                    {
+                        onNameError(">he>lo>", ">"),
+                        onNameError(">he>lo>", ">"),
+                        onNameError(">he>lo>", ">"),
+                    }
+                },
+                { "]", new[] { onNameError("]", "]") } },
+                { "hello]", new[] { onNameError("hello]", "]") } },
+                { "]hello", new[] { onNameError("]hello", "]") } },
+                { "he]lo", new[] { onNameError("he]lo", "]") } },
+                {
+                    "]he]lo]",
+                    new[]
+                    {
+                        onNameError("]he]lo]", "]"),
+                        onNameError("]he]lo]", "]"),
+                        onNameError("]he]lo]", "]"),
+                    }
+                },
+                { "=", new[] { onNameError("=", "=") } },
+                { "hello=", new[] { onNameError("hello=", "=") } },
+                { "=hello", new[] { onNameError("=hello", "=") } },
+                { "he=lo", new[] { onNameError("he=lo", "=") } },
+                {
+                    "=he=lo=",
+                    new[]
+                    {
+                        onNameError("=he=lo=", "="),
+                        onNameError("=he=lo=", "="),
+                        onNameError("=he=lo=", "="),
+                    }
+                },
+                { "\"", new[] { onNameError("\"", "\"") } },
+                { "hello\"", new[] { onNameError("hello\"", "\"") } },
+                { "\"hello", new[] { onNameError("\"hello", "\"") } },
+                { "he\"lo", new[] { onNameError("he\"lo", "\"") } },
+                {
+                    "\"he\"lo\"",
+                    new[]
+                    {
+                        onNameError("\"he\"lo\"", "\""),
+                        onNameError("\"he\"lo\"", "\""),
+                        onNameError("\"he\"lo\"", "\""),
+                    }
+                },
+                { "'", new[] { onNameError("'", "'") } },
+                { "hello'", new[] { onNameError("hello'", "'") } },
+                { "'hello", new[] { onNameError("'hello", "'") } },
+                { "he'lo", new[] { onNameError("he'lo", "'") } },
+                {
+                    "'he'lo'",
+                    new[]
+                    {
+                        onNameError("'he'lo'", "'"),
+                        onNameError("'he'lo'", "'"),
+                        onNameError("'he'lo'", "'"),
+                    }
+                },
+                { Environment.NewLine, new[] { whitespaceErrorString } },
+                { "\t", new[] { whitespaceErrorString } },
+                { " \t ", new[] { whitespaceErrorString } },
+                { " ", new[] { whitespaceErrorString } },
+                { Environment.NewLine + " ", new[] { whitespaceErrorString } },
+                {
+                    "! \t\r\n@/<>?[]=\"'",
+                    new[]
+                    {
+                        onNameError("! \t\r\n@/<>?[]=\"'", "!"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", " "),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "\t"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "\r"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "\n"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "@"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "/"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "<"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", ">"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "?"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "["),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "]"),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "="),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "\""),
+                        onNameError("! \t\r\n@/<>?[]=\"'", "'"),
+                    }
+                },
+                {
+                    "! \tv\ra\nl@i/d<>?[]=\"'",
+                    new[]
+                    {
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "!"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", " "),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\t"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\r"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\n"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "@"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "/"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "<"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", ">"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "?"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "["),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "]"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "="),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\""),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "'"),
+                    }
+                },
+            };
+
+            if (onDataError != null)
+            {
+                data.Add("data-", new[] { onDataError("data-") });
+                data.Add("data-something", new[] { onDataError("data-something") });
+                data.Add("Data-Something", new[] { onDataError("Data-Something") });
+                data.Add("DATA-SOMETHING", new[] { onDataError("DATA-SOMETHING") });
+            }
+
+            return data;
         }
 
         [TargetElement(Attributes = "class")]
@@ -1231,6 +1790,82 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             [HtmlAttributeName("DATA-SOMETHING")]
             public string ValidSomething { get; set; }
+        }
+
+        private class DefaultValidHtmlAttributePrefix : TagHelper
+        {
+            public IDictionary<string, string> DictionaryProperty { get; set; }
+        }
+
+        private class SingleValidHtmlAttributePrefix : TagHelper
+        {
+            [HtmlAttributeName("valid-name", DictionaryAttributePrefix = "valid-prefix")]
+            public IDictionary<string, string> DictionaryProperty { get; set; }
+        }
+
+        private class MultipleValidHtmlAttributePrefix : TagHelper
+        {
+            [HtmlAttributeName("valid-name1", DictionaryAttributePrefix = "valid-prefix1-")]
+            public Dictionary<string, object> DictionaryProperty { get; set; }
+
+            [HtmlAttributeName("valid-name2", DictionaryAttributePrefix = "valid-prefix2-")]
+            public DictionarySubclass DictionarySubclassProperty { get; set; }
+
+            [HtmlAttributeName("valid-name3", DictionaryAttributePrefix = "valid-prefix3-")]
+            public DictionaryWithoutParameterlessConstructor DictionaryWithoutParameterlessConstructorProperty { get; set; }
+
+            [HtmlAttributeName("valid-name4", DictionaryAttributePrefix = "valid-prefix4-")]
+            public GenericDictionarySubclass<object> GenericDictionarySubclassProperty { get; set; }
+
+            [HtmlAttributeName("valid-name5", DictionaryAttributePrefix = "valid-prefix5-")]
+            public SortedDictionary<string, int> SortedDictionaryProperty { get; set; }
+
+            [HtmlAttributeName("valid-name6")]
+            public string StringProperty { get; set; }
+        }
+
+        private class SingleInvalidHtmlAttributePrefix : TagHelper
+        {
+            [HtmlAttributeName("valid-name", DictionaryAttributePrefix = "valid-prefix")]
+            public string StringProperty { get; set; }
+        }
+
+        private class MultipleInvalidHtmlAttributePrefix : TagHelper
+        {
+            [HtmlAttributeName("valid-name1")]
+            public long LongProperty { get; set; }
+
+            [HtmlAttributeName("valid-name2", DictionaryAttributePrefix = "valid-prefix2-")]
+            public Dictionary<int, string> DictionaryOfIntProperty { get; set; }
+
+            [HtmlAttributeName("valid-name3", DictionaryAttributePrefix = "valid-prefix3-")]
+            public IReadOnlyDictionary<string, object> ReadOnlyDictionaryProperty { get; set; }
+
+            [HtmlAttributeName("valid-name4", DictionaryAttributePrefix = "valid-prefix4-")]
+            public int IntProperty { get; set; }
+
+            [HtmlAttributeName("valid-name5", DictionaryAttributePrefix = "valid-prefix5-")]
+            public DictionaryOfIntSubclass DictionaryOfIntSubclassProperty { get; set; }
+        }
+
+        private class DictionarySubclass : Dictionary<string, string>
+        {
+        }
+
+        private class DictionaryWithoutParameterlessConstructor : Dictionary<string, string>
+        {
+            public DictionaryWithoutParameterlessConstructor(int count)
+                : base()
+            {
+            }
+        }
+
+        private class DictionaryOfIntSubclass : Dictionary<int, string>
+        {
+        }
+
+        private class GenericDictionarySubclass<TValue> : Dictionary<string, TValue>
+        {
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -380,11 +380,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         "int-attribute",
                         nameof(InheritedSingleAttributeTagHelper.IntAttribute),
                         typeof(int).FullName,
-                        isStringProperty: false,
-                        prefix: null,
-                        objectCreationExpression: null,
-                        prefixedValueTypeName: null,
-                        areStringPrefixedValues: false)
+                        isIndexer: false,
+                        isStringProperty: false)
                 });
 
             // Act
@@ -499,11 +496,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         "bound-property",
                         nameof(NotBoundAttributeTagHelper.BoundProperty),
                         typeof(object).FullName,
-                        isStringProperty: false,
-                        prefix: null,
-                        objectCreationExpression: null,
-                        prefixedValueTypeName: null,
-                        areStringPrefixedValues: false)
+                        isIndexer: false,
+                        isStringProperty: false)
                 });
 
             // Act
@@ -554,11 +548,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                             "valid-attribute",
                             nameof(MultiTagTagHelper.ValidAttribute),
                             typeof(string).FullName,
-                            isStringProperty: true,
-                            prefix: null,
-                            objectCreationExpression: null,
-                            prefixedValueTypeName: null,
-                            areStringPrefixedValues: false)
+                            isIndexer: false,
+                            isStringProperty: true)
                     }),
                 new TagHelperDescriptor(
                     "p",
@@ -570,11 +561,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                             "valid-attribute",
                             nameof(MultiTagTagHelper.ValidAttribute),
                             typeof(string).FullName,
-                            isStringProperty: true,
-                            prefix: null,
-                            objectCreationExpression: null,
-                            prefixedValueTypeName: null,
-                            areStringPrefixedValues: false)
+                            isIndexer: false,
+                            isStringProperty: true)
                     })
             };
 
@@ -897,11 +885,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 name: "dictionary-property",
                                 propertyName: nameof(DefaultValidHtmlAttributePrefix.DictionaryProperty),
                                 typeName: typeof(IDictionary<string, string>).FullName,
-                                isStringProperty: false,
-                                prefix: "dictionary-property-",
-                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, string>()",
-                                prefixedValueTypeName: typeof(string).FullName,
-                                areStringPrefixedValues: true),
+                                isIndexer: false,
+                                isStringProperty: false),
+                            new TagHelperAttributeDescriptor(
+                                name: "dictionary-property-",
+                                propertyName: nameof(DefaultValidHtmlAttributePrefix.DictionaryProperty),
+                                typeName: typeof(string).FullName,
+                                isIndexer: true,
+                                isStringProperty: true),
                         },
                         new string[0]
                     },
@@ -913,11 +904,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 name: "valid-name",
                                 propertyName: nameof(SingleValidHtmlAttributePrefix.DictionaryProperty),
                                 typeName: typeof(IDictionary<string, string>).FullName,
-                                isStringProperty: false,
-                                prefix: "valid-prefix",
-                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, string>()",
-                                prefixedValueTypeName: typeof(string).FullName,
-                                areStringPrefixedValues: true),
+                                isIndexer: false,
+                                isStringProperty: false),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-prefix",
+                                propertyName: nameof(SingleValidHtmlAttributePrefix.DictionaryProperty),
+                                typeName: typeof(string).FullName,
+                                isIndexer: true,
+                                isStringProperty: true),
                         },
                         new string[0]
                     },
@@ -929,60 +923,68 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 name: "valid-name1",
                                 propertyName: nameof(MultipleValidHtmlAttributePrefix.DictionaryProperty),
                                 typeName: typeof(Dictionary<string, object>).FullName,
-                                isStringProperty: false,
-                                prefix: "valid-prefix1-",
-                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, object>()",
-                                prefixedValueTypeName: typeof(object).FullName,
-                                areStringPrefixedValues: false),
+                                isIndexer: false,
+                                isStringProperty: false),
                             new TagHelperAttributeDescriptor(
                                 name: "valid-name2",
                                 propertyName: nameof(MultipleValidHtmlAttributePrefix.DictionarySubclassProperty),
                                 typeName: typeof(DictionarySubclass).FullName,
-                                isStringProperty: false,
-                                prefix: "valid-prefix2-",
-                                // See minor aspnet/Common#21 bug here. Separator should be a '.'.
-                                objectCreationExpression: $"new { typeof(TagHelperDescriptorFactoryTest).FullName }+" +
-                                    $"{ nameof(DictionarySubclass) }()",
-                                prefixedValueTypeName: typeof(string).FullName,
-                                areStringPrefixedValues: true),
+                                isIndexer: false,
+                                isStringProperty: false),
                             new TagHelperAttributeDescriptor(
                                 name: "valid-name3",
                                 propertyName: nameof(MultipleValidHtmlAttributePrefix.DictionaryWithoutParameterlessConstructorProperty),
                                 typeName: typeof(DictionaryWithoutParameterlessConstructor).FullName,
-                                isStringProperty: false,
-                                prefix: "valid-prefix3-",
-                                objectCreationExpression: null,
-                                prefixedValueTypeName: typeof(string).FullName,
-                                areStringPrefixedValues: true),
+                                isIndexer: false,
+                                isStringProperty: false),
                             new TagHelperAttributeDescriptor(
                                 name: "valid-name4",
                                 propertyName: nameof(MultipleValidHtmlAttributePrefix.GenericDictionarySubclassProperty),
                                 typeName: typeof(GenericDictionarySubclass<object>).FullName,
-                                isStringProperty: false,
-                                prefix: "valid-prefix4-",
-                                // See minor aspnet/Common#21 bug here. Separator should be a '.'.
-                                objectCreationExpression: $"new { typeof(TagHelperDescriptorFactoryTest).FullName }+" +
-                                    $"{ nameof(GenericDictionarySubclass<object>) }<object>()",
-                                prefixedValueTypeName: typeof(object).FullName,
-                                areStringPrefixedValues: false),
+                                isIndexer: false,
+                                isStringProperty: false),
                             new TagHelperAttributeDescriptor(
                                 name: "valid-name5",
                                 propertyName: nameof(MultipleValidHtmlAttributePrefix.SortedDictionaryProperty),
                                 typeName: typeof(SortedDictionary<string, int>).FullName,
-                                isStringProperty: false,
-                                prefix: "valid-prefix5-",
-                                objectCreationExpression: "new System.Collections.Generic.SortedDictionary<string, int>()",
-                                prefixedValueTypeName: typeof(int).FullName,
-                                areStringPrefixedValues: false),
+                                isIndexer: false,
+                                isStringProperty: false),
                             new TagHelperAttributeDescriptor(
                                 name: "valid-name6",
                                 propertyName: nameof(MultipleValidHtmlAttributePrefix.StringProperty),
                                 typeName: typeof(string).FullName,
-                                isStringProperty: true,
-                                prefix: null,
-                                objectCreationExpression: null,
-                                prefixedValueTypeName: null,
-                                areStringPrefixedValues: false),
+                                isIndexer: false,
+                                isStringProperty: true),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-prefix1-",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.DictionaryProperty),
+                                typeName: typeof(object).FullName,
+                                isIndexer: true,
+                                isStringProperty: false),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-prefix2-",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.DictionarySubclassProperty),
+                                typeName: typeof(string).FullName,
+                                isIndexer: true,
+                                isStringProperty: true),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-prefix3-",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.DictionaryWithoutParameterlessConstructorProperty),
+                                typeName: typeof(string).FullName,
+                                isIndexer: true,
+                                isStringProperty: true),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-prefix4-",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.GenericDictionarySubclassProperty),
+                                typeName: typeof(object).FullName,
+                                isIndexer: true,
+                                isStringProperty: false),
+                            new TagHelperAttributeDescriptor(
+                                name: "valid-prefix5-",
+                                propertyName: nameof(MultipleValidHtmlAttributePrefix.SortedDictionaryProperty),
+                                typeName: typeof(int).FullName,
+                                isIndexer: true,
+                                isStringProperty: false),
                         },
                         new string[0]
                     },
@@ -1004,11 +1006,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 name: "valid-name1",
                                 propertyName: nameof(MultipleInvalidHtmlAttributePrefix.LongProperty),
                                 typeName: typeof(long).FullName,
-                                isStringProperty: false,
-                                prefix: null,
-                                objectCreationExpression: null,
-                                prefixedValueTypeName: null,
-                                areStringPrefixedValues: false),
+                                isIndexer: false,
+                                isStringProperty: false),
                         },
                         new[]
                         {
@@ -1084,16 +1083,18 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public void ValidateTagHelperAttributeDescriptor_WithValidName_ReturnsTrue(string name)
         {
             // Arrange
-            var descriptor =
-                new TagHelperAttributeDescriptor(name, propertyName: "ValidProperty", typeName: "PropertyType");
+            var descriptor = new TagHelperAttributeDescriptor(
+                name,
+                propertyName: "ValidProperty",
+                typeName: "PropertyType",
+                isIndexer: false);
             var errorSink = new ErrorSink();
 
             // Act
             var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
                 descriptor,
                 typeof(MultiTagTagHelper),
-                errorSink,
-                isExplicitPrefix: false);
+                errorSink);
 
             // Assert
             Assert.True(result);
@@ -1102,24 +1103,21 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         [Theory]
         [MemberData(nameof(ValidAttributeNameOrPrefixData))]
-        public void ValidateTagHelperAttributeDescriptor_WithValidNameAndValidPrefix_ReturnsTrue(string prefix)
+        public void ValidateTagHelperAttributeDescriptor_WithValidPrefix_ReturnsTrue(string prefix)
         {
             // Arrange
             var descriptor = new TagHelperAttributeDescriptor(
-                name: "ValidName",
-                propertyName: "InvalidProperty",
+                name: prefix,
+                propertyName: "ValidProperty",
                 typeName: "PropertyType",
-                prefix: prefix,
-                objectCreationExpression: null,
-                prefixedValueTypeName: "ValuesType");
+                isIndexer: true);
             var errorSink = new ErrorSink();
 
             // Act
             var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
                 descriptor,
                 typeof(MultiTagTagHelper),
-                errorSink,
-                isExplicitPrefix: true);
+                errorSink);
 
             // Assert
             Assert.True(result);
@@ -1153,93 +1151,22 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             string[] expectedErrorMessages)
         {
             // Arrange
-            var descriptor =
-                new TagHelperAttributeDescriptor(name, propertyName: "InvalidProperty", typeName: "PropertyType");
-            var errorSink = new ErrorSink();
-
-            // Act
-            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
-                descriptor,
-                typeof(MultiTagTagHelper),
-                errorSink,
-                isExplicitPrefix: false);
-
-            // Assert
-            Assert.False(result);
-
-            var errors = errorSink.Errors.ToArray();
-            Assert.Equal(expectedErrorMessages.Length, errors.Length);
-            for (var i = 0; i < expectedErrorMessages.Length; i++)
-            {
-                Assert.Equal(1, errors[i].Length);
-                Assert.Equal(SourceLocation.Zero, errors[i].Location);
-                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InvalidAttributeNameData))]
-        public void ValidateTagHelperAttributeDescriptor_WithInvalidNameAndValidPrefix_AddsExpectedErrors(
-            string name,
-            string[] expectedErrorMessages)
-        {
-            // Arrange
             var descriptor = new TagHelperAttributeDescriptor(
                 name,
                 propertyName: "InvalidProperty",
                 typeName: "PropertyType",
-                prefix: "ValidPrefix",
-                objectCreationExpression: null,
-                prefixedValueTypeName: "ValuesType");
+                isIndexer: false);
             var errorSink = new ErrorSink();
 
             // Act
             var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
                 descriptor,
                 typeof(MultiTagTagHelper),
-                errorSink,
-                isExplicitPrefix: true);
+                errorSink);
 
             // Assert
             Assert.False(result);
 
-            var errors = errorSink.Errors.ToArray();
-            Assert.Equal(expectedErrorMessages.Length, errors.Length);
-            for (var i = 0; i < expectedErrorMessages.Length; i++)
-            {
-                Assert.Equal(1, errors[i].Length);
-                Assert.Equal(SourceLocation.Zero, errors[i].Location);
-                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InvalidAttributeNameData))]
-        public void ValidateTagHelperAttributeDescriptor_WithInvalidNameAndDefaultPrefix_AddsExpectedErrors(
-            string name,
-            string[] expectedErrorMessages)
-        {
-            // Arrange
-            var descriptor = new TagHelperAttributeDescriptor(
-                name,
-                propertyName: "InvalidProperty",
-                typeName: "PropertyType",
-                prefix: (name + "-"),
-                objectCreationExpression: null,
-                prefixedValueTypeName: "ValuesType");
-            var errorSink = new ErrorSink();
-
-            // Act
-            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
-                descriptor,
-                typeof(MultiTagTagHelper),
-                errorSink,
-                isExplicitPrefix: false);
-
-            // Assert
-            Assert.False(result);
-
-            // Errors are not duplicated for the invalid prefix.
             var errors = errorSink.Errors.ToArray();
             Assert.Equal(expectedErrorMessages.Length, errors.Length);
             for (var i = 0; i < expectedErrorMessages.Length; i++)
@@ -1272,114 +1199,23 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         [Theory]
         [MemberData(nameof(InvalidAttributePrefixData))]
-        public void ValidateTagHelperAttributeDescriptor_WithValidNameAndInvalidPrefix_AddsExpectedErrors(
+        public void ValidateTagHelperAttributeDescriptor_WithInvalidPrefix_AddsExpectedErrors(
             string prefix,
             string[] expectedErrorMessages)
         {
             // Arrange
             var descriptor = new TagHelperAttributeDescriptor(
-                name: "ValidName",
+                name: prefix,
                 propertyName: "InvalidProperty",
-                typeName: "PropertyType",
-                prefix: prefix,
-                objectCreationExpression: null,
-                prefixedValueTypeName: "ValuesType");
+                typeName: "ValuesType",
+                isIndexer: true);
             var errorSink = new ErrorSink();
 
             // Act
             var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
                 descriptor,
                 typeof(MultiTagTagHelper),
-                errorSink,
-                isExplicitPrefix: true);
-
-            // Assert
-            Assert.False(result);
-
-            var errors = errorSink.Errors.ToArray();
-            Assert.Equal(expectedErrorMessages.Length, errors.Length);
-            for (var i = 0; i < expectedErrorMessages.Length; i++)
-            {
-                Assert.Equal(1, errors[i].Length);
-                Assert.Equal(SourceLocation.Zero, errors[i].Location);
-                Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
-            }
-        }
-
-        // name and prefix, expectedErrorMessages
-        public static TheoryData<string, string[]> InvalidAttributeNameAndPrefixData
-        {
-            get
-            {
-                Func<string, string, string> onNameError = (invalidText, invalidCharacter) => "Invalid tag helper " +
-                    $"bound property '{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot " +
-                    $"bind to HTML attributes with name '{ invalidText }' because name contains a " +
-                    $"'{ invalidCharacter }' character.";
-                var whitespaceNameErrorString = "Invalid tag helper bound property " +
-                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
-                    "attributes with a whitespace name.";
-                Func<string, string> onNameDataError = invalidText => "Invalid tag helper bound property " +
-                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
-                    $"attributes with name '{ invalidText }' because name starts with 'data-'.";
-                Func<string, string, string> onPrefixError = (invalidText, invalidCharacter) => "Invalid tag helper " +
-                    $"bound property '{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot " +
-                    $"bind to HTML attributes with prefix '{ invalidText }' because prefix contains a " +
-                    $"'{ invalidCharacter }' character.";
-                var whitespacePrefixErrorString = "Invalid tag helper bound property " +
-                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
-                    "attributes with a whitespace prefix.";
-                Func<string, string> onPrefixDataError = invalidText => "Invalid tag helper bound property " +
-                    $"'{ typeof(MultiTagTagHelper).FullName }.InvalidProperty'. Tag helpers cannot bind to HTML " +
-                    $"attributes with prefix '{ invalidText }' because prefix starts with 'data-'.";
-
-                var invalidNameData =
-                    GetInvalidNameOrPrefixData(onNameError, whitespaceNameErrorString, onNameDataError);
-                var invalidPrefixData =
-                    GetInvalidNameOrPrefixData(onPrefixError, whitespacePrefixErrorString, onPrefixDataError);
-
-                var combinedData = new TheoryData<string, string[]>();
-                var index = 0;
-                foreach (var invalidName in invalidNameData)
-                {
-                    var invalidNameErrors = (string[])invalidName[1];
-                    var invalidPrefix = invalidPrefixData.ElementAt(index);
-                    var invalidPrefixErrors = (string[])invalidPrefix[1];
-
-                    var errors = new string[invalidNameErrors.Length * 2];
-                    invalidNameErrors.CopyTo(errors, 0);
-                    invalidPrefixErrors.CopyTo(errors, invalidNameErrors.Length);
-
-                    combinedData.Add((string)invalidName[0], errors);
-
-                    index++;
-                }
-
-                return combinedData;
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(InvalidAttributeNameAndPrefixData))]
-        public void ValidateTagHelperAttributeDescriptor_WithInvalidNameAndInvalidPrefix_AddsExpectedErrors(
-            string nameAndPrefix,
-            string[] expectedErrorMessages)
-        {
-            // Arrange
-            var descriptor = new TagHelperAttributeDescriptor(
-                name: nameAndPrefix,
-                propertyName: "InvalidProperty",
-                typeName: "PropertyType",
-                prefix: nameAndPrefix,
-                objectCreationExpression: null,
-                prefixedValueTypeName: "ValuesType");
-            var errorSink = new ErrorSink();
-
-            // Act
-            var result = TagHelperDescriptorFactory.ValidateTagHelperAttributeDescriptor(
-                descriptor,
-                typeof(MultiTagTagHelper),
-                errorSink,
-                isExplicitPrefix: true);
+                errorSink);
 
             // Assert
             Assert.False(result);
@@ -1434,7 +1270,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 { "he/lo", new[] { onNameError("he/lo", "/") } },
                 {
                     "/he/lo/",
-                    new[] {
+                    new[]
+                    {
                         onNameError("/he/lo/", "/"),
                         onNameError("/he/lo/", "/"),
                         onNameError("/he/lo/", "/"),

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
@@ -575,6 +575,101 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                              contentLength: 4)
                         }
                     },
+                    {
+                        "PrefixedAttributeTagHelpers",
+                        "PrefixedAttributeTagHelpers.DesignTime",
+                        PrefixedAttributeTagHelperDescriptors,
+                        new List<LineMapping>
+                        {
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 14,
+                                documentLineIndex: 0,
+                                generatedAbsoluteIndex: 499,
+                                generatedLineIndex: 15,
+                                characterOffsetIndex: 14,
+                                contentLength: 17),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 37,
+                                documentLineIndex: 2,
+                                generatedAbsoluteIndex: 996,
+                                generatedLineIndex: 34,
+                                characterOffsetIndex: 2,
+                                contentLength: 242),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 370,
+                                documentLineIndex: 15,
+                                generatedAbsoluteIndex: 1430,
+                                generatedLineIndex: 50,
+                                characterOffsetIndex: 43,
+                                contentLength: 13),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 404,
+                                documentLineIndex: 15,
+                                generatedAbsoluteIndex: 1601,
+                                generatedLineIndex: 55,
+                                characterOffsetIndex: 77,
+                                contentLength: 16),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 468,
+                                documentLineIndex: 16,
+                                generatedAbsoluteIndex: 2077,
+                                generatedLineIndex: 64,
+                                characterOffsetIndex: 43,
+                                contentLength: 13),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 502,
+                                documentLineIndex: 16,
+                                generatedAbsoluteIndex: 2248,
+                                generatedLineIndex: 69,
+                                characterOffsetIndex: 77,
+                                contentLength: 2),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 526,
+                                documentLineIndex: 16,
+                                generatedAbsoluteIndex: 2432,
+                                generatedLineIndex: 74,
+                                characterOffsetIndex: 101,
+                                contentLength: 2),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 590,
+                                documentLineIndex: 18,
+                                documentCharacterOffsetIndex: 31,
+                                generatedAbsoluteIndex: 2994,
+                                generatedLineIndex: 84,
+                                generatedCharacterOffsetIndex: 32,
+                                contentLength: 2),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 611,
+                                documentLineIndex: 18,
+                                generatedAbsoluteIndex: 3129,
+                                generatedLineIndex: 89,
+                                characterOffsetIndex: 52,
+                                contentLength: 2),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 634,
+                                documentLineIndex: 18,
+                                generatedAbsoluteIndex: 3287,
+                                generatedLineIndex: 94,
+                                characterOffsetIndex: 75,
+                                contentLength: 2),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 783,
+                                documentLineIndex: 20,
+                                documentCharacterOffsetIndex: 42,
+                                generatedAbsoluteIndex: 3521,
+                                generatedLineIndex: 101,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 8),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 826,
+                                documentLineIndex: 21,
+                                documentCharacterOffsetIndex: 29,
+                                generatedAbsoluteIndex: 4552,
+                                generatedLineIndex: 115,
+                                generatedCharacterOffsetIndex: 51,
+                                contentLength: 2),
+                        }
+                    },
                 };
             }
         }
@@ -628,13 +723,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
             string baseLineName,
             IEnumerable<TagHelperDescriptor> tagHelperDescriptors)
         {
-            // Arrange
-            if (baseLineName == null)
-            {
-                baseLineName = testName;
-            }
-
-            // Act & Assert
+            // Arrange & Act & Assert
             RunTagHelperTest(testName, baseLineName, tagHelperDescriptors: tagHelperDescriptors);
         }
 

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
@@ -34,7 +34,8 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                             new TagHelperAttributeDescriptor(
                                 "catchall-bound-string",
                                 "BoundRequiredString",
-                                typeof(string).FullName),
+                                typeof(string).FullName,
+                                isIndexer: false),
                         },
                         requiredAttributes: new[] { "catchall-unbound-required" }),
                     new TagHelperDescriptor(
@@ -46,11 +47,13 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                             new TagHelperAttributeDescriptor(
                                 "input-bound-required-string",
                                 "BoundRequiredString",
-                                typeof(string).FullName),
+                                typeof(string).FullName,
+                                isIndexer: false),
                             new TagHelperAttributeDescriptor(
                                 "input-bound-string",
                                 "BoundString",
-                                typeof(string).FullName)
+                                typeof(string).FullName,
+                                isIndexer: false)
                         },
                         requiredAttributes: new[] { "input-bound-required-string", "input-unbound-required" }),
                 };
@@ -167,25 +170,33 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                             new TagHelperAttributeDescriptor(
                                 name: "int-prefix-grabber",
                                 propertyName: "IntProperty",
-                                typeName: typeof(int).FullName),
+                                typeName: typeof(int).FullName,
+                                isIndexer: false),
                             new TagHelperAttributeDescriptor(
                                 name: "int-dictionary",
                                 propertyName: "IntDictionaryProperty",
                                 typeName: typeof(IDictionary<string, int>).FullName,
-                                prefix: "int-prefix-",
-                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, int>()",
-                                prefixedValueTypeName: typeof(int).FullName),
+                                isIndexer: false),
                             new TagHelperAttributeDescriptor(
                                 name: "string-dictionary",
                                 propertyName: "StringDictionaryProperty",
                                 typeName: "Namespace.DictionaryWithoutParameterlessConstructor<string, string>",
-                                prefix: "string-prefix-",
-                                objectCreationExpression: null,
-                                prefixedValueTypeName: typeof(string).FullName),
+                                isIndexer: false),
                             new TagHelperAttributeDescriptor(
                                 name: "string-prefix-grabber",
                                 propertyName: "StringProperty",
-                                typeName: typeof(string).FullName),
+                                typeName: typeof(string).FullName,
+                                isIndexer: false),
+                            new TagHelperAttributeDescriptor(
+                                name: "int-prefix-",
+                                propertyName: "IntDictionaryProperty",
+                                typeName: typeof(int).FullName,
+                                isIndexer: true),
+                            new TagHelperAttributeDescriptor(
+                                name: "string-prefix-",
+                                propertyName: "StringDictionaryProperty",
+                                typeName: typeof(string).FullName,
+                                isIndexer: true),
                         }),
                     new TagHelperDescriptor(
                         tagName: "input",
@@ -197,16 +208,22 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                 name: "int-dictionary",
                                 propertyName: "IntDictionaryProperty",
                                 typeName: typeof(IDictionary<string, int>).FullName,
-                                prefix: "int-prefix-",
-                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, int>()",
-                                prefixedValueTypeName: typeof(int).FullName),
+                                isIndexer: false),
                             new TagHelperAttributeDescriptor(
                                 name: "string-dictionary",
                                 propertyName: "StringDictionaryProperty",
                                 typeName: "Namespace.DictionaryWithoutParameterlessConstructor<string, string>",
-                                prefix: "string-prefix-",
-                                objectCreationExpression: null,
-                                prefixedValueTypeName: typeof(string).FullName),
+                                isIndexer: false),
+                            new TagHelperAttributeDescriptor(
+                                name: "int-prefix-",
+                                propertyName: "IntDictionaryProperty",
+                                typeName: typeof(int).FullName,
+                                isIndexer: true),
+                            new TagHelperAttributeDescriptor(
+                                name: "string-prefix-",
+                                propertyName: "StringDictionaryProperty",
+                                typeName: typeof(string).FullName,
+                                isIndexer: true),
                         }),
                 };
             }

--- a/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/CSharpTagHelperRenderingTest.cs
@@ -152,6 +152,66 @@ namespace Microsoft.AspNet.Razor.Test.Generator
             }
         }
 
+        private static IEnumerable<TagHelperDescriptor> PrefixedAttributeTagHelperDescriptors
+        {
+            get
+            {
+                return new[]
+                {
+                    new TagHelperDescriptor(
+                        tagName: "input",
+                        typeName: "InputTagHelper1",
+                        assemblyName: "SomeAssembly",
+                        attributes: new[]
+                        {
+                            new TagHelperAttributeDescriptor(
+                                name: "int-prefix-grabber",
+                                propertyName: "IntProperty",
+                                typeName: typeof(int).FullName),
+                            new TagHelperAttributeDescriptor(
+                                name: "int-dictionary",
+                                propertyName: "IntDictionaryProperty",
+                                typeName: typeof(IDictionary<string, int>).FullName,
+                                prefix: "int-prefix-",
+                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, int>()",
+                                prefixedValueTypeName: typeof(int).FullName),
+                            new TagHelperAttributeDescriptor(
+                                name: "string-dictionary",
+                                propertyName: "StringDictionaryProperty",
+                                typeName: "Namespace.DictionaryWithoutParameterlessConstructor<string, string>",
+                                prefix: "string-prefix-",
+                                objectCreationExpression: null,
+                                prefixedValueTypeName: typeof(string).FullName),
+                            new TagHelperAttributeDescriptor(
+                                name: "string-prefix-grabber",
+                                propertyName: "StringProperty",
+                                typeName: typeof(string).FullName),
+                        }),
+                    new TagHelperDescriptor(
+                        tagName: "input",
+                        typeName: "InputTagHelper2",
+                        assemblyName: "SomeAssembly",
+                        attributes: new[]
+                        {
+                            new TagHelperAttributeDescriptor(
+                                name: "int-dictionary",
+                                propertyName: "IntDictionaryProperty",
+                                typeName: typeof(IDictionary<string, int>).FullName,
+                                prefix: "int-prefix-",
+                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, int>()",
+                                prefixedValueTypeName: typeof(int).FullName),
+                            new TagHelperAttributeDescriptor(
+                                name: "string-dictionary",
+                                propertyName: "StringDictionaryProperty",
+                                typeName: "Namespace.DictionaryWithoutParameterlessConstructor<string, string>",
+                                prefix: "string-prefix-",
+                                objectCreationExpression: null,
+                                prefixedValueTypeName: typeof(string).FullName),
+                        }),
+                };
+            }
+        }
+
         public static TheoryData TagHelperDescriptorFlowTestData
         {
             get
@@ -523,28 +583,42 @@ namespace Microsoft.AspNet.Razor.Test.Generator
             {
                 // Test resource name, expected TagHelperDescriptors
                 // Note: The baseline resource name is equivalent to the test resource name.
-                return new TheoryData<string, IEnumerable<TagHelperDescriptor>>
+                return new TheoryData<string, string, IEnumerable<TagHelperDescriptor>>
                 {
-                    { "SingleTagHelper", DefaultPAndInputTagHelperDescriptors },
-                    { "BasicTagHelpers", DefaultPAndInputTagHelperDescriptors },
-                    { "BasicTagHelpers.RemoveTagHelper", DefaultPAndInputTagHelperDescriptors },
-                    { "BasicTagHelpers.Prefixed", PrefixedPAndInputTagHelperDescriptors },
-                    { "ComplexTagHelpers", DefaultPAndInputTagHelperDescriptors },
-                    { "DuplicateTargetTagHelper", DuplicateTargetTagHelperDescriptors },
-                    { "EmptyAttributeTagHelpers", DefaultPAndInputTagHelperDescriptors },
-                    { "EscapedTagHelpers", DefaultPAndInputTagHelperDescriptors },
-                    { "AttributeTargetingTagHelpers", AttributeTargetingTagHelperDescriptors },
+                    { "SingleTagHelper", null, DefaultPAndInputTagHelperDescriptors },
+                    { "BasicTagHelpers", null, DefaultPAndInputTagHelperDescriptors },
+                    { "BasicTagHelpers.RemoveTagHelper", null, DefaultPAndInputTagHelperDescriptors },
+                    { "BasicTagHelpers.Prefixed", null, PrefixedPAndInputTagHelperDescriptors },
+                    { "ComplexTagHelpers", null, DefaultPAndInputTagHelperDescriptors },
+                    { "DuplicateTargetTagHelper", null, DuplicateTargetTagHelperDescriptors },
+                    { "EmptyAttributeTagHelpers", null, DefaultPAndInputTagHelperDescriptors },
+                    { "EscapedTagHelpers", null, DefaultPAndInputTagHelperDescriptors },
+                    { "AttributeTargetingTagHelpers", null, AttributeTargetingTagHelperDescriptors },
+                    { "PrefixedAttributeTagHelpers", null, PrefixedAttributeTagHelperDescriptors },
+                    {
+                        "PrefixedAttributeTagHelpers",
+                        "PrefixedAttributeTagHelpers.Reversed",
+                        PrefixedAttributeTagHelperDescriptors.Reverse()
+                    },
                 };
             }
         }
 
         [Theory]
         [MemberData(nameof(RuntimeTimeTagHelperTestData))]
-        public void TagHelpers_GenerateExpectedRuntimeOutput(string testName,
-                                                             IEnumerable<TagHelperDescriptor> tagHelperDescriptors)
+        public void TagHelpers_GenerateExpectedRuntimeOutput(
+            string testName,
+            string baseLineName,
+            IEnumerable<TagHelperDescriptor> tagHelperDescriptors)
         {
+            // Arrange
+            if (baseLineName == null)
+            {
+                baseLineName = testName;
+            }
+
             // Act & Assert
-            RunTagHelperTest(testName, tagHelperDescriptors: tagHelperDescriptors);
+            RunTagHelperTest(testName, baseLineName, tagHelperDescriptors: tagHelperDescriptors);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
@@ -181,6 +181,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 var noErrors = new RazorError[0];
                 var errorFormat = "Attribute '{0}' on tag helper element '{1}' requires a value. Tag helper bound " +
                     "attributes of type '{2}' cannot be empty or contain only whitespace.";
+                var emptyKeyFormat = "The tag helper attribute '{0}' in element '{1}' is missing a key. The " +
+                    "syntax is '<{1} {0}{{ key }}=\"value\">'.";
                 var stringType = typeof(string).FullName;
                 var intType = typeof(int).FullName;
                 var expressionString = "@DateTime.Now + 1";
@@ -327,6 +329,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 lineIndex: 0,
                                 columnIndex: 7,
                                 length: 11),
+                            new RazorError(
+                                string.Format(emptyKeyFormat, "int-prefix-", "input"),
+                                absoluteIndex: 7,
+                                lineIndex: 0,
+                                columnIndex: 7,
+                                length: 11),
                         }
                     },
                     {
@@ -343,6 +351,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormat, "string-prefix-", "input", typeof(string).FullName),
+                                absoluteIndex: 7,
+                                lineIndex: 0,
+                                columnIndex: 7,
+                                length: 14),
+                            new RazorError(
+                                string.Format(emptyKeyFormat, "string-prefix-", "input"),
                                 absoluteIndex: 7,
                                 lineIndex: 0,
                                 columnIndex: 7,
@@ -1056,7 +1070,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 "bound-required-string",
                                 "BoundRequiredString",
-                                typeof(string).FullName)
+                                typeof(string).FullName,
+                                isIndexer: false)
                         },
                         requiredAttributes: new[] { "unbound-required" }),
                     new TagHelperDescriptor(
@@ -1068,7 +1083,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 "bound-required-string",
                                 "BoundRequiredString",
-                                typeof(string).FullName)
+                                typeof(string).FullName,
+                                isIndexer: false)
                         },
                         requiredAttributes: new[] { "bound-required-string" }),
                     new TagHelperDescriptor(
@@ -1080,7 +1096,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 "bound-required-int",
                                 "BoundRequiredInt",
-                                typeof(int).FullName)
+                                typeof(int).FullName,
+                                isIndexer: false)
                         },
                         requiredAttributes: new[] { "bound-required-int" }),
                     new TagHelperDescriptor(
@@ -1093,16 +1110,22 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 "int-dictionary",
                                 "DictionaryOfIntProperty",
                                 typeof(IDictionary<string, int>).FullName,
-                                prefix: "int-prefix-",
-                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, int>()",
-                                prefixedValueTypeName: typeof(int).FullName),
+                                isIndexer: false),
                             new TagHelperAttributeDescriptor(
                                 "string-dictionary",
                                 "DictionaryOfStringProperty",
                                 typeof(IDictionary<string, string>).FullName,
-                                prefix: "string-prefix-",
-                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, string>()",
-                                prefixedValueTypeName: typeof(string).FullName),
+                                isIndexer: false),
+                            new TagHelperAttributeDescriptor(
+                                "int-prefix-",
+                                "DictionaryOfIntProperty",
+                                typeof(int).FullName,
+                                isIndexer: true),
+                            new TagHelperAttributeDescriptor(
+                                "string-prefix-",
+                                "DictionaryOfStringProperty",
+                                typeof(string).FullName,
+                                isIndexer: true),
                         },
                         requiredAttributes: Enumerable.Empty<string>()),
                     new TagHelperDescriptor(
@@ -1114,11 +1137,13 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 "bound-string",
                                 "BoundRequiredString",
-                                typeof(string).FullName),
+                                typeof(string).FullName,
+                                isIndexer: false),
                             new TagHelperAttributeDescriptor(
                                 "bound-int",
                                 "BoundRequiredString",
-                                typeof(int).FullName)
+                                typeof(int).FullName,
+                                isIndexer: false)
                         },
                         requiredAttributes: Enumerable.Empty<string>()),
                 };

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
@@ -270,6 +270,184 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         new[] { new RazorError(string.Format(errorFormat, "bound-int", "p", intType), 3, 0, 3, 9) }
                     },
                     {
+                        "<input int-dictionary/>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("int-dictionary", null),
+                                })),
+                        new[]
+                        {
+                            new RazorError(
+                                string.Format(errorFormat, "int-dictionary", "input", typeof(IDictionary<string, int>).FullName),
+                                absoluteIndex: 7,
+                                lineIndex: 0,
+                                columnIndex: 7,
+                                length: 14),
+                        }
+                    },
+                    {
+                        "<input string-dictionary />",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("string-dictionary", null),
+                                })),
+                        new[]
+                        {
+                            new RazorError(
+                                string.Format(errorFormat, "string-dictionary", "input", typeof(IDictionary<string, string>).FullName),
+                                absoluteIndex: 7,
+                                lineIndex: 0,
+                                columnIndex: 7,
+                                length: 17),
+                        }
+                    },
+                    {
+                        "<input int-prefix- />",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("int-prefix-", null),
+                                })),
+                        new[]
+                        {
+                            new RazorError(
+                                string.Format(errorFormat, "int-prefix-", "input", typeof(int).FullName),
+                                absoluteIndex: 7,
+                                lineIndex: 0,
+                                columnIndex: 7,
+                                length: 11),
+                        }
+                    },
+                    {
+                        "<input string-prefix-/>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("string-prefix-", null),
+                                })),
+                        new[]
+                        {
+                            new RazorError(
+                                string.Format(errorFormat, "string-prefix-", "input", typeof(string).FullName),
+                                absoluteIndex: 7,
+                                lineIndex: 0,
+                                columnIndex: 7,
+                                length: 14),
+                        }
+                    },
+                    {
+                        "<input int-prefix-value/>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("int-prefix-value", null),
+                                })),
+                        new[]
+                        {
+                            new RazorError(
+                                string.Format(errorFormat, "int-prefix-value", "input", typeof(int).FullName),
+                                absoluteIndex: 7,
+                                lineIndex: 0,
+                                columnIndex: 7,
+                                length: 16),
+                        }
+                    },
+                    {
+                        "<input string-prefix-value />",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("string-prefix-value", null),
+                                })),
+                        new[]
+                        {
+                            new RazorError(
+                                string.Format(errorFormat, "string-prefix-value", "input", typeof(string).FullName),
+                                absoluteIndex: 7,
+                                lineIndex: 0,
+                                columnIndex: 7,
+                                length: 19),
+                        }
+                    },
+                    {
+                        "<input int-prefix-value='' />",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("int-prefix-value", new MarkupBlock()),
+                                })),
+                        new[]
+                        {
+                            new RazorError(
+                                string.Format(errorFormat, "int-prefix-value", "input", typeof(int).FullName),
+                                absoluteIndex: 7,
+                                lineIndex: 0,
+                                columnIndex: 7,
+                                length: 16),
+                        }
+                    },
+                    {
+                        "<input string-prefix-value=''/>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("string-prefix-value", new MarkupBlock()),
+                                })),
+                        new RazorError[0]
+                    },
+                    {
+                        "<input int-prefix-value='3'/>",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("int-prefix-value", factory.CodeMarkup("3")),
+                                })),
+                        new RazorError[0]
+                    },
+                    {
+                        "<input string-prefix-value='some string' />",
+                        new MarkupBlock(
+                            new MarkupTagHelperBlock(
+                                "input",
+                                selfClosing: true,
+                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                {
+                                    new KeyValuePair<string, SyntaxTreeNode>("string-prefix-value", new MarkupBlock(
+                                        factory.Markup("some"),
+                                        factory.Markup(" string"))),
+                                })),
+                        new RazorError[0]
+                    },
+                    {
                         "<input unbound-required bound-required-string />",
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
@@ -905,6 +1083,28 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 typeof(int).FullName)
                         },
                         requiredAttributes: new[] { "bound-required-int" }),
+                    new TagHelperDescriptor(
+                        tagName: "input",
+                        typeName: "InputTagHelper3",
+                        assemblyName: "SomeAssembly",
+                        attributes: new[]
+                        {
+                            new TagHelperAttributeDescriptor(
+                                "int-dictionary",
+                                "DictionaryOfIntProperty",
+                                typeof(IDictionary<string, int>).FullName,
+                                prefix: "int-prefix-",
+                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, int>()",
+                                prefixedValueTypeName: typeof(int).FullName),
+                            new TagHelperAttributeDescriptor(
+                                "string-dictionary",
+                                "DictionaryOfStringProperty",
+                                typeof(IDictionary<string, string>).FullName,
+                                prefix: "string-prefix-",
+                                objectCreationExpression: "new System.Collections.Generic.Dictionary<string, string>()",
+                                prefixedValueTypeName: typeof(string).FullName),
+                        },
+                        requiredAttributes: Enumerable.Empty<string>()),
                     new TagHelperDescriptor(
                         tagName: "p",
                         typeName: "PTagHelper",

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
@@ -66,12 +66,81 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperDescriptor.TypeName) }\":\"type name\"," +
                 $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
                 $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[" +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute one\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":null," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":null," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":null," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"property type name\"}}," +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute two\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":null," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":null," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":null," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"}}]," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]}}";
+
+            // Act
+            var serializedDescriptor = JsonConvert.SerializeObject(descriptor);
+
+            // Assert
+            Assert.Equal(expectedSerializedDescriptor, serializedDescriptor, StringComparer.Ordinal);
+        }
+
+        [Fact]
+        public void TagHelperDescriptor_WithAttributesAndPrefixes_CanBeSerialized()
+        {
+            // Arrange
+            var descriptor = new TagHelperDescriptor(
+                prefix: "prefix:",
+                tagName: "tag name",
+                typeName: "type name",
+                assemblyName: "assembly name",
+                attributes: new[]
+                {
+                    new TagHelperAttributeDescriptor(
+                        name: "attribute one",
+                        propertyName: "property name",
+                        typeName: "property type name",
+                        prefix: "prefix one",
+                        objectCreationExpression:
+                            $"new Dictionary<{ typeof(string).FullName }, { typeof(string).FullName }>()",
+                        prefixedValueTypeName: typeof(string).FullName),
+                    new TagHelperAttributeDescriptor(
+                        name: "attribute two",
+                        propertyName: "property name",
+                        typeName: typeof(string).FullName,
+                        prefix: "prefix two",
+                        objectCreationExpression: "new CustomDictionary()",
+                        prefixedValueTypeName: "values type name"),
+                },
+                requiredAttributes: Enumerable.Empty<string>());
+            var expectedSerializedDescriptor =
+                $"{{\"{ nameof(TagHelperDescriptor.Prefix) }\":\"prefix:\"," +
+                $"\"{ nameof(TagHelperDescriptor.TagName) }\":\"tag name\"," +
+                $"\"{ nameof(TagHelperDescriptor.FullTagName) }\":\"prefix:tag name\"," +
+                $"\"{ nameof(TagHelperDescriptor.TypeName) }\":\"type name\"," +
+                $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
+                $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[" +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":true," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute one\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":" +
+                $"\"new Dictionary<{ typeof(string).FullName }, { typeof(string).FullName }>()\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":\"prefix one\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":\"{ typeof(string).FullName }\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"property type name\"}}," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute two\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":\"new CustomDictionary()\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":\"prefix two\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":\"values type name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]}}";
@@ -129,12 +198,20 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperDescriptor.TypeName) }\":\"type name\"," +
                 $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
                 $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[" +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute one\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":null," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":null," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":null," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"property type name\"}}," +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute two\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":null," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":null," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":null," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]}}";
@@ -179,6 +256,129 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 StringComparer.Ordinal);
             Assert.Equal(expectedDescriptor.Attributes[1].IsStringProperty, descriptor.Attributes[1].IsStringProperty);
             Assert.Equal(expectedDescriptor.Attributes[1].Name, descriptor.Attributes[1].Name, StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[1].PropertyName,
+                descriptor.Attributes[1].PropertyName,
+                StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[1].TypeName,
+                descriptor.Attributes[1].TypeName,
+                StringComparer.Ordinal);
+            Assert.Empty(descriptor.RequiredAttributes);
+        }
+
+        [Fact]
+        public void TagHelperDescriptor_WithAttributesAndPrefixes_CanBeDeserialized()
+        {
+            // Arrange
+            var serializedDescriptor =
+                $"{{\"{ nameof(TagHelperDescriptor.Prefix) }\":\"prefix:\"," +
+                $"\"{ nameof(TagHelperDescriptor.TagName) }\":\"tag name\"," +
+                $"\"{ nameof(TagHelperDescriptor.FullTagName) }\":\"prefix:tag name\"," +
+                $"\"{ nameof(TagHelperDescriptor.TypeName) }\":\"type name\"," +
+                $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
+                $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[" +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":true," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute one\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":" +
+                $"\"new Dictionary<{ typeof(string).FullName }, { typeof(string).FullName }>()\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":\"prefix one\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":\"{ typeof(string).FullName }\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"property type name\"}}," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute two\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":\"new CustomDictionary()\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":\"prefix two\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":\"values type name\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"}}]," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]}}";
+            var expectedDescriptor = new TagHelperDescriptor(
+                prefix: "prefix:",
+                tagName: "tag name",
+                typeName: "type name",
+                assemblyName: "assembly name",
+                attributes: new[]
+                {
+                    new TagHelperAttributeDescriptor(
+                        name: "attribute one",
+                        propertyName: "property name",
+                        typeName: "property type name",
+                        prefix: "prefix one",
+                        objectCreationExpression:
+                            $"new Dictionary<{ typeof(string).FullName }, { typeof(string).FullName }>()",
+                        prefixedValueTypeName: typeof(string).FullName),
+                    new TagHelperAttributeDescriptor(
+                        name: "attribute two",
+                        propertyName: "property name",
+                        typeName: typeof(string).FullName,
+                        prefix: "prefix two",
+                        objectCreationExpression: "new CustomDictionary()",
+                        prefixedValueTypeName: "values type name"),
+                },
+                requiredAttributes: Enumerable.Empty<string>());
+
+            // Act
+            var descriptor = JsonConvert.DeserializeObject<TagHelperDescriptor>(serializedDescriptor);
+
+            // Assert
+            Assert.NotNull(descriptor);
+            Assert.Equal(expectedDescriptor.Prefix, descriptor.Prefix, StringComparer.Ordinal);
+            Assert.Equal(expectedDescriptor.TagName, descriptor.TagName, StringComparer.Ordinal);
+            Assert.Equal(expectedDescriptor.FullTagName, descriptor.FullTagName, StringComparer.Ordinal);
+            Assert.Equal(expectedDescriptor.TypeName, descriptor.TypeName, StringComparer.Ordinal);
+            Assert.Equal(expectedDescriptor.AssemblyName, descriptor.AssemblyName, StringComparer.Ordinal);
+
+            Assert.Equal(2, descriptor.Attributes.Count);
+            Assert.Equal(
+                expectedDescriptor.Attributes[0].AreStringPrefixedValues,
+                descriptor.Attributes[0].AreStringPrefixedValues);
+            Assert.Equal(expectedDescriptor.Attributes[0].IsStringProperty, descriptor.Attributes[0].IsStringProperty);
+            Assert.Equal(expectedDescriptor.Attributes[0].Name, descriptor.Attributes[0].Name, StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[0].ObjectCreationExpression,
+                descriptor.Attributes[0].ObjectCreationExpression,
+                StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[0].Prefix,
+                descriptor.Attributes[0].Prefix,
+                StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[0].PrefixedValueTypeName,
+                descriptor.Attributes[0].PrefixedValueTypeName,
+                StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[0].PropertyName,
+                descriptor.Attributes[0].PropertyName,
+                StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[0].TypeName,
+                descriptor.Attributes[0].TypeName,
+                StringComparer.Ordinal);
+
+            Assert.Equal(
+                expectedDescriptor.Attributes[1].AreStringPrefixedValues,
+                descriptor.Attributes[1].AreStringPrefixedValues);
+            Assert.Equal(
+                expectedDescriptor.Attributes[1].AreStringPrefixedValues,
+                descriptor.Attributes[1].AreStringPrefixedValues);
+            Assert.Equal(expectedDescriptor.Attributes[1].IsStringProperty, descriptor.Attributes[1].IsStringProperty);
+            Assert.Equal(expectedDescriptor.Attributes[1].Name, descriptor.Attributes[1].Name, StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[1].ObjectCreationExpression,
+                descriptor.Attributes[1].ObjectCreationExpression,
+                StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[1].Prefix,
+                descriptor.Attributes[1].Prefix,
+                StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[1].PrefixedValueTypeName,
+                descriptor.Attributes[1].PrefixedValueTypeName,
+                StringComparer.Ordinal);
             Assert.Equal(
                 expectedDescriptor.Attributes[1].PropertyName,
                 descriptor.Attributes[1].PropertyName,

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
@@ -52,11 +52,13 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     new TagHelperAttributeDescriptor(
                         name: "attribute one",
                         propertyName: "property name",
-                        typeName: "property type name"),
+                        typeName: "property type name",
+                        isIndexer: false),
                     new TagHelperAttributeDescriptor(
                         name: "attribute two",
                         propertyName: "property name",
-                        typeName: typeof(string).FullName),
+                        typeName: typeof(string).FullName,
+                        isIndexer: false),
                 },
                 requiredAttributes: Enumerable.Empty<string>());
             var expectedSerializedDescriptor =
@@ -66,20 +68,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperDescriptor.TypeName) }\":\"type name\"," +
                 $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
                 $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[" +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsIndexer) }\":false," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute one\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":null," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":null," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":null," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"property type name\"}}," +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsIndexer) }\":false," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute two\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":null," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":null," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":null," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]}}";
@@ -92,7 +88,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         }
 
         [Fact]
-        public void TagHelperDescriptor_WithAttributesAndPrefixes_CanBeSerialized()
+        public void TagHelperDescriptor_WithIndexerAttributes_CanBeSerialized()
         {
             // Arrange
             var descriptor = new TagHelperDescriptor(
@@ -106,17 +102,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         name: "attribute one",
                         propertyName: "property name",
                         typeName: "property type name",
-                        prefix: "prefix one",
-                        objectCreationExpression:
-                            $"new Dictionary<{ typeof(string).FullName }, { typeof(string).FullName }>()",
-                        prefixedValueTypeName: typeof(string).FullName),
+                        isIndexer: true),
                     new TagHelperAttributeDescriptor(
                         name: "attribute two",
                         propertyName: "property name",
                         typeName: typeof(string).FullName,
-                        prefix: "prefix two",
-                        objectCreationExpression: "new CustomDictionary()",
-                        prefixedValueTypeName: "values type name"),
+                        isIndexer: true),
                 },
                 requiredAttributes: Enumerable.Empty<string>());
             var expectedSerializedDescriptor =
@@ -126,21 +117,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperDescriptor.TypeName) }\":\"type name\"," +
                 $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
                 $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[" +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":true," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsIndexer) }\":true," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute one\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":" +
-                $"\"new Dictionary<{ typeof(string).FullName }, { typeof(string).FullName }>()\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":\"prefix one\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":\"{ typeof(string).FullName }\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"property type name\"}}," +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsIndexer) }\":true," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute two\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":\"new CustomDictionary()\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":\"prefix two\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":\"values type name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]}}";
@@ -198,101 +182,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperDescriptor.TypeName) }\":\"type name\"," +
                 $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
                 $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[" +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsIndexer) }\":false," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute one\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":null," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":null," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":null," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"property type name\"}}," +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsIndexer) }\":false," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute two\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":null," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":null," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":null," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"}}]," +
-                $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]}}";
-            var expectedDescriptor = new TagHelperDescriptor(
-                prefix: "prefix:",
-                tagName: "tag name",
-                typeName: "type name",
-                assemblyName: "assembly name",
-                attributes: new[]
-                {
-                    new TagHelperAttributeDescriptor(
-                        name: "attribute one",
-                        propertyName: "property name",
-                        typeName: "property type name"),
-                    new TagHelperAttributeDescriptor(
-                        name: "attribute two",
-                        propertyName: "property name",
-                        typeName: typeof(string).FullName),
-                },
-                requiredAttributes: Enumerable.Empty<string>());
-
-            // Act
-            var descriptor = JsonConvert.DeserializeObject<TagHelperDescriptor>(serializedDescriptor);
-
-            // Assert
-            Assert.NotNull(descriptor);
-            Assert.Equal(expectedDescriptor.Prefix, descriptor.Prefix, StringComparer.Ordinal);
-            Assert.Equal(expectedDescriptor.TagName, descriptor.TagName, StringComparer.Ordinal);
-            Assert.Equal(expectedDescriptor.FullTagName, descriptor.FullTagName, StringComparer.Ordinal);
-            Assert.Equal(expectedDescriptor.TypeName, descriptor.TypeName, StringComparer.Ordinal);
-            Assert.Equal(expectedDescriptor.AssemblyName, descriptor.AssemblyName, StringComparer.Ordinal);
-            Assert.Equal(2, descriptor.Attributes.Count);
-            Assert.Equal(expectedDescriptor.Attributes[0].IsStringProperty, descriptor.Attributes[0].IsStringProperty);
-            Assert.Equal(expectedDescriptor.Attributes[0].Name, descriptor.Attributes[0].Name, StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[0].PropertyName,
-                descriptor.Attributes[0].PropertyName,
-                StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[0].TypeName,
-                descriptor.Attributes[0].TypeName,
-                StringComparer.Ordinal);
-            Assert.Equal(expectedDescriptor.Attributes[1].IsStringProperty, descriptor.Attributes[1].IsStringProperty);
-            Assert.Equal(expectedDescriptor.Attributes[1].Name, descriptor.Attributes[1].Name, StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[1].PropertyName,
-                descriptor.Attributes[1].PropertyName,
-                StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[1].TypeName,
-                descriptor.Attributes[1].TypeName,
-                StringComparer.Ordinal);
-            Assert.Empty(descriptor.RequiredAttributes);
-        }
-
-        [Fact]
-        public void TagHelperDescriptor_WithAttributesAndPrefixes_CanBeDeserialized()
-        {
-            // Arrange
-            var serializedDescriptor =
-                $"{{\"{ nameof(TagHelperDescriptor.Prefix) }\":\"prefix:\"," +
-                $"\"{ nameof(TagHelperDescriptor.TagName) }\":\"tag name\"," +
-                $"\"{ nameof(TagHelperDescriptor.FullTagName) }\":\"prefix:tag name\"," +
-                $"\"{ nameof(TagHelperDescriptor.TypeName) }\":\"type name\"," +
-                $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
-                $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[" +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":true," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute one\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":" +
-                $"\"new Dictionary<{ typeof(string).FullName }, { typeof(string).FullName }>()\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":\"prefix one\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":\"{ typeof(string).FullName }\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"property type name\"}}," +
-                $"{{\"{ nameof(TagHelperAttributeDescriptor.AreStringPrefixedValues) }\":false," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute two\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.ObjectCreationExpression) }\":\"new CustomDictionary()\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.Prefix) }\":\"prefix two\"," +
-                $"\"{ nameof(TagHelperAttributeDescriptor.PrefixedValueTypeName) }\":\"values type name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]}}";
@@ -307,17 +204,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         name: "attribute one",
                         propertyName: "property name",
                         typeName: "property type name",
-                        prefix: "prefix one",
-                        objectCreationExpression:
-                            $"new Dictionary<{ typeof(string).FullName }, { typeof(string).FullName }>()",
-                        prefixedValueTypeName: typeof(string).FullName),
+                        isIndexer: false),
                     new TagHelperAttributeDescriptor(
                         name: "attribute two",
                         propertyName: "property name",
                         typeName: typeof(string).FullName,
-                        prefix: "prefix two",
-                        objectCreationExpression: "new CustomDictionary()",
-                        prefixedValueTypeName: "values type name"),
+                        isIndexer: false),
                 },
                 requiredAttributes: Enumerable.Empty<string>());
 
@@ -333,23 +225,9 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             Assert.Equal(expectedDescriptor.AssemblyName, descriptor.AssemblyName, StringComparer.Ordinal);
 
             Assert.Equal(2, descriptor.Attributes.Count);
-            Assert.Equal(
-                expectedDescriptor.Attributes[0].AreStringPrefixedValues,
-                descriptor.Attributes[0].AreStringPrefixedValues);
+            Assert.Equal(expectedDescriptor.Attributes[0].IsIndexer, descriptor.Attributes[0].IsIndexer);
             Assert.Equal(expectedDescriptor.Attributes[0].IsStringProperty, descriptor.Attributes[0].IsStringProperty);
             Assert.Equal(expectedDescriptor.Attributes[0].Name, descriptor.Attributes[0].Name, StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[0].ObjectCreationExpression,
-                descriptor.Attributes[0].ObjectCreationExpression,
-                StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[0].Prefix,
-                descriptor.Attributes[0].Prefix,
-                StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[0].PrefixedValueTypeName,
-                descriptor.Attributes[0].PrefixedValueTypeName,
-                StringComparer.Ordinal);
             Assert.Equal(
                 expectedDescriptor.Attributes[0].PropertyName,
                 descriptor.Attributes[0].PropertyName,
@@ -359,26 +237,9 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 descriptor.Attributes[0].TypeName,
                 StringComparer.Ordinal);
 
-            Assert.Equal(
-                expectedDescriptor.Attributes[1].AreStringPrefixedValues,
-                descriptor.Attributes[1].AreStringPrefixedValues);
-            Assert.Equal(
-                expectedDescriptor.Attributes[1].AreStringPrefixedValues,
-                descriptor.Attributes[1].AreStringPrefixedValues);
+            Assert.Equal(expectedDescriptor.Attributes[1].IsIndexer, descriptor.Attributes[1].IsIndexer);
             Assert.Equal(expectedDescriptor.Attributes[1].IsStringProperty, descriptor.Attributes[1].IsStringProperty);
             Assert.Equal(expectedDescriptor.Attributes[1].Name, descriptor.Attributes[1].Name, StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[1].ObjectCreationExpression,
-                descriptor.Attributes[1].ObjectCreationExpression,
-                StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[1].Prefix,
-                descriptor.Attributes[1].Prefix,
-                StringComparer.Ordinal);
-            Assert.Equal(
-                expectedDescriptor.Attributes[1].PrefixedValueTypeName,
-                descriptor.Attributes[1].PrefixedValueTypeName,
-                StringComparer.Ordinal);
             Assert.Equal(
                 expectedDescriptor.Attributes[1].PropertyName,
                 descriptor.Attributes[1].PropertyName,
@@ -387,6 +248,88 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 expectedDescriptor.Attributes[1].TypeName,
                 descriptor.Attributes[1].TypeName,
                 StringComparer.Ordinal);
+
+            Assert.Empty(descriptor.RequiredAttributes);
+        }
+
+        [Fact]
+        public void TagHelperDescriptor_WithIndexerAttributes_CanBeDeserialized()
+        {
+            // Arrange
+            var serializedDescriptor =
+                $"{{\"{ nameof(TagHelperDescriptor.Prefix) }\":\"prefix:\"," +
+                $"\"{ nameof(TagHelperDescriptor.TagName) }\":\"tag name\"," +
+                $"\"{ nameof(TagHelperDescriptor.FullTagName) }\":\"prefix:tag name\"," +
+                $"\"{ nameof(TagHelperDescriptor.TypeName) }\":\"type name\"," +
+                $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
+                $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[" +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsIndexer) }\":true," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":false," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute one\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"property type name\"}}," +
+                $"{{\"{ nameof(TagHelperAttributeDescriptor.IsIndexer) }\":true," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.IsStringProperty) }\":true," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.Name) }\":\"attribute two\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.PropertyName) }\":\"property name\"," +
+                $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"}}]," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]}}";
+            var expectedDescriptor = new TagHelperDescriptor(
+                prefix: "prefix:",
+                tagName: "tag name",
+                typeName: "type name",
+                assemblyName: "assembly name",
+                attributes: new[]
+                {
+                    new TagHelperAttributeDescriptor(
+                        name: "attribute one",
+                        propertyName: "property name",
+                        typeName: "property type name",
+                        isIndexer: true),
+                    new TagHelperAttributeDescriptor(
+                        name: "attribute two",
+                        propertyName: "property name",
+                        typeName: typeof(string).FullName,
+                        isIndexer: true),
+                },
+                requiredAttributes: Enumerable.Empty<string>());
+
+            // Act
+            var descriptor = JsonConvert.DeserializeObject<TagHelperDescriptor>(serializedDescriptor);
+
+            // Assert
+            Assert.NotNull(descriptor);
+            Assert.Equal(expectedDescriptor.Prefix, descriptor.Prefix, StringComparer.Ordinal);
+            Assert.Equal(expectedDescriptor.TagName, descriptor.TagName, StringComparer.Ordinal);
+            Assert.Equal(expectedDescriptor.FullTagName, descriptor.FullTagName, StringComparer.Ordinal);
+            Assert.Equal(expectedDescriptor.TypeName, descriptor.TypeName, StringComparer.Ordinal);
+            Assert.Equal(expectedDescriptor.AssemblyName, descriptor.AssemblyName, StringComparer.Ordinal);
+
+            Assert.Equal(2, descriptor.Attributes.Count);
+            Assert.Equal(expectedDescriptor.Attributes[0].IsIndexer, descriptor.Attributes[0].IsIndexer);
+            Assert.Equal(expectedDescriptor.Attributes[0].IsStringProperty, descriptor.Attributes[0].IsStringProperty);
+            Assert.Equal(expectedDescriptor.Attributes[0].Name, descriptor.Attributes[0].Name, StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[0].PropertyName,
+                descriptor.Attributes[0].PropertyName,
+                StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[0].TypeName,
+                descriptor.Attributes[0].TypeName,
+                StringComparer.Ordinal);
+
+            Assert.Equal(expectedDescriptor.Attributes[1].IsIndexer, descriptor.Attributes[1].IsIndexer);
+            Assert.Equal(expectedDescriptor.Attributes[1].IsStringProperty, descriptor.Attributes[1].IsStringProperty);
+            Assert.Equal(expectedDescriptor.Attributes[1].Name, descriptor.Attributes[1].Name, StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[1].PropertyName,
+                descriptor.Attributes[1].PropertyName,
+                StringComparer.Ordinal);
+            Assert.Equal(
+                expectedDescriptor.Attributes[1].TypeName,
+                descriptor.Attributes[1].TypeName,
+                StringComparer.Ordinal);
+
             Assert.Empty(descriptor.RequiredAttributes);
         }
     }

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -921,7 +921,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 name: "bound",
                                 propertyName: "Bound",
-                                typeName: typeof(bool).FullName),
+                                typeName: typeof(bool).FullName,
+                                isIndexer: false),
                         },
                         requiredAttributes: Enumerable.Empty<string>())
                 };
@@ -944,7 +945,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 name: "bound",
                                 propertyName: "Bound",
-                                typeName: typeof(bool).FullName),
+                                typeName: typeof(bool).FullName,
+                                isIndexer: false),
                         },
                         requiredAttributes: Enumerable.Empty<string>())
                 };
@@ -1508,11 +1510,13 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new TagHelperAttributeDescriptor(
                                 name: "bound",
                                 propertyName: "Bound",
-                                typeName: typeof(bool).FullName),
+                                typeName: typeof(bool).FullName,
+                                isIndexer: false),
                             new TagHelperAttributeDescriptor(
                                 name: "name",
                                 propertyName: "Name",
-                                typeName: typeof(string).FullName)
+                                typeName: typeof(string).FullName,
+                                isIndexer: false)
                         })
                 };
             var descriptorProvider = new TagHelperDescriptorProvider(descriptors);
@@ -3396,7 +3400,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
                                 SourceLocation.Zero),
                             new RazorError(
-                                "TagHelper attributes must be welformed.",
+                                "TagHelper attributes must be well-formed.",
                                 absoluteIndex: 12,
                                 lineIndex: 0,
                                 columnIndex: 12)
@@ -3962,9 +3966,13 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                 new TagHelperDescriptor("person", "PersonTagHelper", "personAssembly",
                     attributes: new[]
                     {
-                        new TagHelperAttributeDescriptor("age", "Age", typeof(int).FullName),
-                        new TagHelperAttributeDescriptor("birthday", "BirthDay", typeof(DateTime).FullName),
-                        new TagHelperAttributeDescriptor("name", "Name", typeof(string).FullName),
+                        new TagHelperAttributeDescriptor("age", "Age", typeof(int).FullName, isIndexer: false),
+                        new TagHelperAttributeDescriptor(
+                            "birthday",
+                            "BirthDay",
+                            typeof(DateTime).FullName,
+                            isIndexer: false),
+                        new TagHelperAttributeDescriptor("name", "Name", typeof(string).FullName, isIndexer: false),
                     })
             };
             var providerContext = new TagHelperDescriptorProvider(descriptors);

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.DesignTime.cs
@@ -1,0 +1,127 @@
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class PrefixedAttributeTagHelpers
+    {
+        private static object @__o;
+        private void @__RazorDesignTimeHelpers__()
+        {
+            #pragma warning disable 219
+            string __tagHelperDirectiveSyntaxHelper = null;
+            __tagHelperDirectiveSyntaxHelper = 
+#line 1 "PrefixedAttributeTagHelpers.cshtml"
+              "something, nice"
+
+#line default
+#line hidden
+            ;
+            #pragma warning restore 219
+        }
+        #line hidden
+        private InputTagHelper1 __InputTagHelper1 = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        #line hidden
+        public PrefixedAttributeTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+#line 3 "PrefixedAttributeTagHelpers.cshtml"
+  
+    var literate = "or illiterate";
+    var intDictionary = new Dictionary<string, int>
+    {
+        { "three", 3 },
+    };
+    var stringDictionary = new SortedDictionary<string, string>
+    {
+        { "name", "value" },
+    };
+
+#line default
+#line hidden
+
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
+ __InputTagHelper1.IntDictionaryProperty = intDictionary;
+
+#line default
+#line hidden
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
+                                __InputTagHelper1.StringDictionaryProperty = stringDictionary;
+
+#line default
+#line hidden
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __InputTagHelper2.IntDictionaryProperty = __InputTagHelper1.IntDictionaryProperty;
+            __InputTagHelper2.StringDictionaryProperty = __InputTagHelper1.StringDictionaryProperty;
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+#line 17 "PrefixedAttributeTagHelpers.cshtml"
+ __InputTagHelper1.IntDictionaryProperty = intDictionary;
+
+#line default
+#line hidden
+#line 17 "PrefixedAttributeTagHelpers.cshtml"
+                         __InputTagHelper1.IntDictionaryProperty["garlic"] = 37;
+
+#line default
+#line hidden
+#line 17 "PrefixedAttributeTagHelpers.cshtml"
+                                                                     __InputTagHelper1.IntProperty = 42;
+
+#line default
+#line hidden
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __InputTagHelper2.IntDictionaryProperty = __InputTagHelper1.IntDictionaryProperty;
+            __InputTagHelper2.IntDictionaryProperty["garlic"] = __InputTagHelper1.IntDictionaryProperty["garlic"];
+            __InputTagHelper2.IntDictionaryProperty["grabber"] = __InputTagHelper1.IntProperty;
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+#line 19 "PrefixedAttributeTagHelpers.cshtml"
+__InputTagHelper1.IntProperty = 42;
+
+#line default
+#line hidden
+#line 19 "PrefixedAttributeTagHelpers.cshtml"
+  __InputTagHelper1.IntDictionaryProperty["salt"] = 37;
+
+#line default
+#line hidden
+#line 19 "PrefixedAttributeTagHelpers.cshtml"
+                       __InputTagHelper1.IntDictionaryProperty["pepper"] = 98;
+
+#line default
+#line hidden
+            __InputTagHelper1.StringProperty = "string";
+            __InputTagHelper1.StringDictionaryProperty["paprika"] = "another string";
+#line 21 "PrefixedAttributeTagHelpers.cshtml"
+__o = literate;
+
+#line default
+#line hidden
+            __InputTagHelper1.StringDictionaryProperty["cumin"] = string.Empty;
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __InputTagHelper2.IntDictionaryProperty["grabber"] = __InputTagHelper1.IntProperty;
+            __InputTagHelper2.IntDictionaryProperty["salt"] = __InputTagHelper1.IntDictionaryProperty["salt"];
+            __InputTagHelper2.IntDictionaryProperty["pepper"] = __InputTagHelper1.IntDictionaryProperty["pepper"];
+            __InputTagHelper2.StringDictionaryProperty["grabber"] = __InputTagHelper1.StringProperty;
+            __InputTagHelper2.StringDictionaryProperty["paprika"] = __InputTagHelper1.StringDictionaryProperty["paprika"];
+            __InputTagHelper2.StringDictionaryProperty["cumin"] = __InputTagHelper1.StringDictionaryProperty["cumin"];
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+#line 22 "PrefixedAttributeTagHelpers.cshtml"
+__InputTagHelper1.IntDictionaryProperty["value"] = 37;
+
+#line default
+#line hidden
+            __InputTagHelper1.StringDictionaryProperty["thyme"] = "string";
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __InputTagHelper2.IntDictionaryProperty["value"] = __InputTagHelper1.IntDictionaryProperty["value"];
+            __InputTagHelper2.StringDictionaryProperty["thyme"] = __InputTagHelper1.StringDictionaryProperty["thyme"];
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.Reversed.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.Reversed.cs
@@ -1,4 +1,4 @@
-#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "ad6b545da741ad711339a34893d12d2da6f945c6"
+#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "f60f9d6a7ca3b1b2b1b337737ef23552228df78c"
 namespace TestOutput
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -50,10 +50,6 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
             __tagHelperExecutionContext.Add(__InputTagHelper2);
-            if (__InputTagHelper2.IntDictionaryProperty == null)
-            {
-                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
-            }
 #line 15 "PrefixedAttributeTagHelpers.cshtml"
  __InputTagHelper2.IntDictionaryProperty = intDictionary;
 
@@ -68,10 +64,6 @@ namespace TestOutput
             __tagHelperExecutionContext.AddTagHelperAttribute("string-dictionary", __InputTagHelper2.StringDictionaryProperty);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
-            if (__InputTagHelper1.IntDictionaryProperty == null)
-            {
-                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
-            }
             __InputTagHelper1.IntDictionaryProperty = __InputTagHelper2.IntDictionaryProperty;
             __InputTagHelper1.StringDictionaryProperty = __InputTagHelper2.StringDictionaryProperty;
             __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("checkbox"));
@@ -86,42 +78,42 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
             __tagHelperExecutionContext.Add(__InputTagHelper2);
-            if (__InputTagHelper2.IntDictionaryProperty == null)
-            {
-                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
-            }
 #line 16 "PrefixedAttributeTagHelpers.cshtml"
  __InputTagHelper2.IntDictionaryProperty = intDictionary;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __InputTagHelper2.IntDictionaryProperty);
+            if (__InputTagHelper2.IntDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-garlic", "InputTagHelper2", "IntDictionaryProperty"));
+            }
 #line 16 "PrefixedAttributeTagHelpers.cshtml"
-                         __InputTagHelper2.IntDictionaryProperty[""] = 37;
+                         __InputTagHelper2.IntDictionaryProperty["garlic"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-", __InputTagHelper2.IntDictionaryProperty[""]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-garlic", __InputTagHelper2.IntDictionaryProperty["garlic"]);
 #line 16 "PrefixedAttributeTagHelpers.cshtml"
-                                          __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
+                                                __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper2.IntDictionaryProperty["grabber"]);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
+            __InputTagHelper1.IntDictionaryProperty = __InputTagHelper2.IntDictionaryProperty;
             if (__InputTagHelper1.IntDictionaryProperty == null)
             {
-                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-garlic", "InputTagHelper1", "IntDictionaryProperty"));
             }
+            __InputTagHelper1.IntDictionaryProperty["garlic"] = __InputTagHelper2.IntDictionaryProperty["garlic"];
             __InputTagHelper1.IntProperty = __InputTagHelper2.IntDictionaryProperty["grabber"];
-            __InputTagHelper1.IntDictionaryProperty = __InputTagHelper2.IntDictionaryProperty;
-            __InputTagHelper1.IntDictionaryProperty[""] = __InputTagHelper2.IntDictionaryProperty[""];
             __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("password"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(490, 6, true);
+            Instrumentation.BeginContext(496, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -131,7 +123,7 @@ namespace TestOutput
             __tagHelperExecutionContext.Add(__InputTagHelper2);
             if (__InputTagHelper2.IntDictionaryProperty == null)
             {
-                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-grabber", "InputTagHelper2", "IntDictionaryProperty"));
             }
 #line 18 "PrefixedAttributeTagHelpers.cshtml"
 __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
@@ -140,30 +132,45 @@ __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper2.IntDictionaryProperty["grabber"]);
 #line 18 "PrefixedAttributeTagHelpers.cshtml"
-  __InputTagHelper2.IntDictionaryProperty[""] = 37;
+  __InputTagHelper2.IntDictionaryProperty["salt"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-", __InputTagHelper2.IntDictionaryProperty[""]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-salt", __InputTagHelper2.IntDictionaryProperty["salt"]);
+#line 18 "PrefixedAttributeTagHelpers.cshtml"
+                       __InputTagHelper2.IntDictionaryProperty["pepper"] = 98;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-pepper", __InputTagHelper2.IntDictionaryProperty["pepper"]);
+            if (__InputTagHelper2.StringDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-grabber", "InputTagHelper2", "StringDictionaryProperty"));
+            }
             __InputTagHelper2.StringDictionaryProperty["grabber"] = "string";
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __InputTagHelper2.StringDictionaryProperty["grabber"]);
-            __InputTagHelper2.StringDictionaryProperty["value"] = "another string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-value", __InputTagHelper2.StringDictionaryProperty["value"]);
+            __InputTagHelper2.StringDictionaryProperty["paprika"] = "another string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __InputTagHelper2.StringDictionaryProperty["paprika"]);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
+            __InputTagHelper1.IntProperty = __InputTagHelper2.IntDictionaryProperty["grabber"];
             if (__InputTagHelper1.IntDictionaryProperty == null)
             {
-                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-salt", "InputTagHelper1", "IntDictionaryProperty"));
             }
-            __InputTagHelper1.IntProperty = __InputTagHelper2.IntDictionaryProperty["grabber"];
+            __InputTagHelper1.IntDictionaryProperty["salt"] = __InputTagHelper2.IntDictionaryProperty["salt"];
+            __InputTagHelper1.IntDictionaryProperty["pepper"] = __InputTagHelper2.IntDictionaryProperty["pepper"];
             __InputTagHelper1.StringProperty = __InputTagHelper2.StringDictionaryProperty["grabber"];
-            __InputTagHelper1.IntDictionaryProperty[""] = __InputTagHelper2.IntDictionaryProperty[""];
-            __InputTagHelper1.StringDictionaryProperty["value"] = __InputTagHelper2.StringDictionaryProperty["value"];
+            if (__InputTagHelper1.StringDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-paprika", "InputTagHelper1", "StringDictionaryProperty"));
+            }
+            __InputTagHelper1.StringDictionaryProperty["paprika"] = __InputTagHelper2.StringDictionaryProperty["paprika"];
             __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("radio"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(650, 6, true);
+            Instrumentation.BeginContext(705, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -173,7 +180,7 @@ __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
             __tagHelperExecutionContext.Add(__InputTagHelper2);
             if (__InputTagHelper2.IntDictionaryProperty == null)
             {
-                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-value", "InputTagHelper2", "IntDictionaryProperty"));
             }
 #line 20 "PrefixedAttributeTagHelpers.cshtml"
 __InputTagHelper2.IntDictionaryProperty["value"] = 37;
@@ -181,20 +188,28 @@ __InputTagHelper2.IntDictionaryProperty["value"] = 37;
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-value", __InputTagHelper2.IntDictionaryProperty["value"]);
-            __InputTagHelper2.StringDictionaryProperty["value"] = "string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-value", __InputTagHelper2.StringDictionaryProperty["value"]);
+            if (__InputTagHelper2.StringDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-thyme", "InputTagHelper2", "StringDictionaryProperty"));
+            }
+            __InputTagHelper2.StringDictionaryProperty["thyme"] = "string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-thyme", __InputTagHelper2.StringDictionaryProperty["thyme"]);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
             if (__InputTagHelper1.IntDictionaryProperty == null)
             {
-                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-value", "InputTagHelper1", "IntDictionaryProperty"));
             }
             __InputTagHelper1.IntDictionaryProperty["value"] = __InputTagHelper2.IntDictionaryProperty["value"];
-            __InputTagHelper1.StringDictionaryProperty["value"] = __InputTagHelper2.StringDictionaryProperty["value"];
+            if (__InputTagHelper1.StringDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-thyme", "InputTagHelper1", "StringDictionaryProperty"));
+            }
+            __InputTagHelper1.StringDictionaryProperty["thyme"] = __InputTagHelper2.StringDictionaryProperty["thyme"];
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(716, 8, true);
+            Instrumentation.BeginContext(771, 8, true);
             WriteLiteral("\r\n</div>");
             Instrumentation.EndContext();
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.Reversed.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.Reversed.cs
@@ -1,4 +1,4 @@
-#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "f60f9d6a7ca3b1b2b1b337737ef23552228df78c"
+#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "4e7fe9697b745af1a07d41f6a8532fdc288fa046"
 namespace TestOutput
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -29,7 +29,8 @@ namespace TestOutput
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
 #line 3 "PrefixedAttributeTagHelpers.cshtml"
-   
+  
+    var literate = "or illiterate";
     var intDictionary = new Dictionary<string, int>
     {
         { "three", 3 },
@@ -42,7 +43,7 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(244, 51, true);
+            Instrumentation.BeginContext(280, 51, true);
             WriteLiteral("\r\n\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -50,13 +51,13 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
             __tagHelperExecutionContext.Add(__InputTagHelper2);
-#line 15 "PrefixedAttributeTagHelpers.cshtml"
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
  __InputTagHelper2.IntDictionaryProperty = intDictionary;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __InputTagHelper2.IntDictionaryProperty);
-#line 15 "PrefixedAttributeTagHelpers.cshtml"
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
                                 __InputTagHelper2.StringDictionaryProperty = stringDictionary;
 
 #line default
@@ -70,7 +71,7 @@ namespace TestOutput
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(387, 6, true);
+            Instrumentation.BeginContext(423, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -78,7 +79,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
             __tagHelperExecutionContext.Add(__InputTagHelper2);
-#line 16 "PrefixedAttributeTagHelpers.cshtml"
+#line 17 "PrefixedAttributeTagHelpers.cshtml"
  __InputTagHelper2.IntDictionaryProperty = intDictionary;
 
 #line default
@@ -88,13 +89,13 @@ namespace TestOutput
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-garlic", "InputTagHelper2", "IntDictionaryProperty"));
             }
-#line 16 "PrefixedAttributeTagHelpers.cshtml"
+#line 17 "PrefixedAttributeTagHelpers.cshtml"
                          __InputTagHelper2.IntDictionaryProperty["garlic"] = 37;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-garlic", __InputTagHelper2.IntDictionaryProperty["garlic"]);
-#line 16 "PrefixedAttributeTagHelpers.cshtml"
+#line 17 "PrefixedAttributeTagHelpers.cshtml"
                                                 __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
 
 #line default
@@ -113,7 +114,7 @@ namespace TestOutput
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(496, 6, true);
+            Instrumentation.BeginContext(532, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -125,19 +126,19 @@ namespace TestOutput
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-grabber", "InputTagHelper2", "IntDictionaryProperty"));
             }
-#line 18 "PrefixedAttributeTagHelpers.cshtml"
+#line 19 "PrefixedAttributeTagHelpers.cshtml"
 __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper2.IntDictionaryProperty["grabber"]);
-#line 18 "PrefixedAttributeTagHelpers.cshtml"
+#line 19 "PrefixedAttributeTagHelpers.cshtml"
   __InputTagHelper2.IntDictionaryProperty["salt"] = 37;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-salt", __InputTagHelper2.IntDictionaryProperty["salt"]);
-#line 18 "PrefixedAttributeTagHelpers.cshtml"
+#line 19 "PrefixedAttributeTagHelpers.cshtml"
                        __InputTagHelper2.IntDictionaryProperty["pepper"] = 98;
 
 #line default
@@ -151,6 +152,17 @@ __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __InputTagHelper2.StringDictionaryProperty["grabber"]);
             __InputTagHelper2.StringDictionaryProperty["paprika"] = "another string";
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __InputTagHelper2.StringDictionaryProperty["paprika"]);
+            StartTagHelperWritingScope();
+            WriteLiteral("literate ");
+#line 21 "PrefixedAttributeTagHelpers.cshtml"
+WriteLiteral(literate);
+
+#line default
+#line hidden
+            WriteLiteral("?");
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            __InputTagHelper2.StringDictionaryProperty["cumin"] = __tagHelperStringValueBuffer.ToString();
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-cumin", __InputTagHelper2.StringDictionaryProperty["cumin"]);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
             __InputTagHelper1.IntProperty = __InputTagHelper2.IntDictionaryProperty["grabber"];
@@ -166,11 +178,12 @@ __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-paprika", "InputTagHelper1", "StringDictionaryProperty"));
             }
             __InputTagHelper1.StringDictionaryProperty["paprika"] = __InputTagHelper2.StringDictionaryProperty["paprika"];
+            __InputTagHelper1.StringDictionaryProperty["cumin"] = __InputTagHelper2.StringDictionaryProperty["cumin"];
             __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("radio"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(705, 6, true);
+            Instrumentation.BeginContext(795, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -182,7 +195,7 @@ __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-value", "InputTagHelper2", "IntDictionaryProperty"));
             }
-#line 20 "PrefixedAttributeTagHelpers.cshtml"
+#line 22 "PrefixedAttributeTagHelpers.cshtml"
 __InputTagHelper2.IntDictionaryProperty["value"] = 37;
 
 #line default
@@ -209,7 +222,7 @@ __InputTagHelper2.IntDictionaryProperty["value"] = 37;
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(771, 8, true);
+            Instrumentation.BeginContext(861, 8, true);
             WriteLiteral("\r\n</div>");
             Instrumentation.EndContext();
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.Reversed.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.Reversed.cs
@@ -1,0 +1,203 @@
+#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "ad6b545da741ad711339a34893d12d2da6f945c6"
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class PrefixedAttributeTagHelpers
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private TagHelperContent __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private TagHelperRunner __tagHelperRunner = null;
+        private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private InputTagHelper2 __InputTagHelper2 = null;
+        private InputTagHelper1 __InputTagHelper1 = null;
+        #line hidden
+        public PrefixedAttributeTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __tagHelperRunner = __tagHelperRunner ?? new TagHelperRunner();
+            Instrumentation.BeginContext(33, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+#line 3 "PrefixedAttributeTagHelpers.cshtml"
+   
+    var intDictionary = new Dictionary<string, int>
+    {
+        { "three", 3 },
+    };
+    var stringDictionary = new SortedDictionary<string, string>
+    {
+        { "name", "value" },
+    };
+
+#line default
+#line hidden
+
+            Instrumentation.BeginContext(244, 51, true);
+            WriteLiteral("\r\n\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            if (__InputTagHelper2.IntDictionaryProperty == null)
+            {
+                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+#line 15 "PrefixedAttributeTagHelpers.cshtml"
+ __InputTagHelper2.IntDictionaryProperty = intDictionary;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __InputTagHelper2.IntDictionaryProperty);
+#line 15 "PrefixedAttributeTagHelpers.cshtml"
+                                __InputTagHelper2.StringDictionaryProperty = stringDictionary;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-dictionary", __InputTagHelper2.StringDictionaryProperty);
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+            __tagHelperExecutionContext.Add(__InputTagHelper1);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+            __InputTagHelper1.IntDictionaryProperty = __InputTagHelper2.IntDictionaryProperty;
+            __InputTagHelper1.StringDictionaryProperty = __InputTagHelper2.StringDictionaryProperty;
+            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("checkbox"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(387, 6, true);
+            WriteLiteral("\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            if (__InputTagHelper2.IntDictionaryProperty == null)
+            {
+                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
+ __InputTagHelper2.IntDictionaryProperty = intDictionary;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __InputTagHelper2.IntDictionaryProperty);
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
+                         __InputTagHelper2.IntDictionaryProperty[""] = 37;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-", __InputTagHelper2.IntDictionaryProperty[""]);
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
+                                          __InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper2.IntDictionaryProperty["grabber"]);
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+            __tagHelperExecutionContext.Add(__InputTagHelper1);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+            __InputTagHelper1.IntProperty = __InputTagHelper2.IntDictionaryProperty["grabber"];
+            __InputTagHelper1.IntDictionaryProperty = __InputTagHelper2.IntDictionaryProperty;
+            __InputTagHelper1.IntDictionaryProperty[""] = __InputTagHelper2.IntDictionaryProperty[""];
+            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("password"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(490, 6, true);
+            WriteLiteral("\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            if (__InputTagHelper2.IntDictionaryProperty == null)
+            {
+                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+#line 18 "PrefixedAttributeTagHelpers.cshtml"
+__InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper2.IntDictionaryProperty["grabber"]);
+#line 18 "PrefixedAttributeTagHelpers.cshtml"
+  __InputTagHelper2.IntDictionaryProperty[""] = 37;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-", __InputTagHelper2.IntDictionaryProperty[""]);
+            __InputTagHelper2.StringDictionaryProperty["grabber"] = "string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __InputTagHelper2.StringDictionaryProperty["grabber"]);
+            __InputTagHelper2.StringDictionaryProperty["value"] = "another string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-value", __InputTagHelper2.StringDictionaryProperty["value"]);
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+            __tagHelperExecutionContext.Add(__InputTagHelper1);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+            __InputTagHelper1.IntProperty = __InputTagHelper2.IntDictionaryProperty["grabber"];
+            __InputTagHelper1.StringProperty = __InputTagHelper2.StringDictionaryProperty["grabber"];
+            __InputTagHelper1.IntDictionaryProperty[""] = __InputTagHelper2.IntDictionaryProperty[""];
+            __InputTagHelper1.StringDictionaryProperty["value"] = __InputTagHelper2.StringDictionaryProperty["value"];
+            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("radio"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(650, 6, true);
+            WriteLiteral("\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            if (__InputTagHelper2.IntDictionaryProperty == null)
+            {
+                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+#line 20 "PrefixedAttributeTagHelpers.cshtml"
+__InputTagHelper2.IntDictionaryProperty["value"] = 37;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-value", __InputTagHelper2.IntDictionaryProperty["value"]);
+            __InputTagHelper2.StringDictionaryProperty["value"] = "string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-value", __InputTagHelper2.StringDictionaryProperty["value"]);
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+            __tagHelperExecutionContext.Add(__InputTagHelper1);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+            __InputTagHelper1.IntDictionaryProperty["value"] = __InputTagHelper2.IntDictionaryProperty["value"];
+            __InputTagHelper1.StringDictionaryProperty["value"] = __InputTagHelper2.StringDictionaryProperty["value"];
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(716, 8, true);
+            WriteLiteral("\r\n</div>");
+            Instrumentation.EndContext();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.cs
@@ -1,0 +1,203 @@
+#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "ad6b545da741ad711339a34893d12d2da6f945c6"
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class PrefixedAttributeTagHelpers
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private TagHelperContent __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private TagHelperRunner __tagHelperRunner = null;
+        private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private InputTagHelper1 __InputTagHelper1 = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        #line hidden
+        public PrefixedAttributeTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __tagHelperRunner = __tagHelperRunner ?? new TagHelperRunner();
+            Instrumentation.BeginContext(33, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+#line 3 "PrefixedAttributeTagHelpers.cshtml"
+   
+    var intDictionary = new Dictionary<string, int>
+    {
+        { "three", 3 },
+    };
+    var stringDictionary = new SortedDictionary<string, string>
+    {
+        { "name", "value" },
+    };
+
+#line default
+#line hidden
+
+            Instrumentation.BeginContext(244, 51, true);
+            WriteLiteral("\r\n\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+            __tagHelperExecutionContext.Add(__InputTagHelper1);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+#line 15 "PrefixedAttributeTagHelpers.cshtml"
+ __InputTagHelper1.IntDictionaryProperty = intDictionary;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __InputTagHelper1.IntDictionaryProperty);
+#line 15 "PrefixedAttributeTagHelpers.cshtml"
+                                __InputTagHelper1.StringDictionaryProperty = stringDictionary;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-dictionary", __InputTagHelper1.StringDictionaryProperty);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            if (__InputTagHelper2.IntDictionaryProperty == null)
+            {
+                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+            __InputTagHelper2.IntDictionaryProperty = __InputTagHelper1.IntDictionaryProperty;
+            __InputTagHelper2.StringDictionaryProperty = __InputTagHelper1.StringDictionaryProperty;
+            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("checkbox"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(387, 6, true);
+            WriteLiteral("\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+            __tagHelperExecutionContext.Add(__InputTagHelper1);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
+                                                               __InputTagHelper1.IntProperty = 42;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper1.IntProperty);
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
+ __InputTagHelper1.IntDictionaryProperty = intDictionary;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __InputTagHelper1.IntDictionaryProperty);
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
+                         __InputTagHelper1.IntDictionaryProperty[""] = 37;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-", __InputTagHelper1.IntDictionaryProperty[""]);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            if (__InputTagHelper2.IntDictionaryProperty == null)
+            {
+                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+            __InputTagHelper2.IntDictionaryProperty = __InputTagHelper1.IntDictionaryProperty;
+            __InputTagHelper2.IntDictionaryProperty[""] = __InputTagHelper1.IntDictionaryProperty[""];
+            __InputTagHelper2.IntDictionaryProperty["grabber"] = __InputTagHelper1.IntProperty;
+            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("password"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(490, 6, true);
+            WriteLiteral("\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+            __tagHelperExecutionContext.Add(__InputTagHelper1);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+#line 18 "PrefixedAttributeTagHelpers.cshtml"
+__InputTagHelper1.IntProperty = 42;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper1.IntProperty);
+            __InputTagHelper1.StringProperty = "string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __InputTagHelper1.StringProperty);
+#line 18 "PrefixedAttributeTagHelpers.cshtml"
+  __InputTagHelper1.IntDictionaryProperty[""] = 37;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-", __InputTagHelper1.IntDictionaryProperty[""]);
+            __InputTagHelper1.StringDictionaryProperty["value"] = "another string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-value", __InputTagHelper1.StringDictionaryProperty["value"]);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            if (__InputTagHelper2.IntDictionaryProperty == null)
+            {
+                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+            __InputTagHelper2.IntDictionaryProperty["grabber"] = __InputTagHelper1.IntProperty;
+            __InputTagHelper2.IntDictionaryProperty[""] = __InputTagHelper1.IntDictionaryProperty[""];
+            __InputTagHelper2.StringDictionaryProperty["grabber"] = __InputTagHelper1.StringProperty;
+            __InputTagHelper2.StringDictionaryProperty["value"] = __InputTagHelper1.StringDictionaryProperty["value"];
+            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("radio"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(650, 6, true);
+            WriteLiteral("\r\n    ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
+            __tagHelperExecutionContext.Add(__InputTagHelper1);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+#line 20 "PrefixedAttributeTagHelpers.cshtml"
+__InputTagHelper1.IntDictionaryProperty["value"] = 37;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-value", __InputTagHelper1.IntDictionaryProperty["value"]);
+            __InputTagHelper1.StringDictionaryProperty["value"] = "string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-value", __InputTagHelper1.StringDictionaryProperty["value"]);
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__InputTagHelper2);
+            if (__InputTagHelper2.IntDictionaryProperty == null)
+            {
+                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+            }
+            __InputTagHelper2.IntDictionaryProperty["value"] = __InputTagHelper1.IntDictionaryProperty["value"];
+            __InputTagHelper2.StringDictionaryProperty["value"] = __InputTagHelper1.StringDictionaryProperty["value"];
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(716, 8, true);
+            WriteLiteral("\r\n</div>");
+            Instrumentation.EndContext();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.cs
@@ -1,4 +1,4 @@
-#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "ad6b545da741ad711339a34893d12d2da6f945c6"
+#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "f60f9d6a7ca3b1b2b1b337737ef23552228df78c"
 namespace TestOutput
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -50,10 +50,6 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
-            if (__InputTagHelper1.IntDictionaryProperty == null)
-            {
-                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
-            }
 #line 15 "PrefixedAttributeTagHelpers.cshtml"
  __InputTagHelper1.IntDictionaryProperty = intDictionary;
 
@@ -68,10 +64,6 @@ namespace TestOutput
             __tagHelperExecutionContext.AddTagHelperAttribute("string-dictionary", __InputTagHelper1.StringDictionaryProperty);
             __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
             __tagHelperExecutionContext.Add(__InputTagHelper2);
-            if (__InputTagHelper2.IntDictionaryProperty == null)
-            {
-                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
-            }
             __InputTagHelper2.IntDictionaryProperty = __InputTagHelper1.IntDictionaryProperty;
             __InputTagHelper2.StringDictionaryProperty = __InputTagHelper1.StringDictionaryProperty;
             __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("checkbox"));
@@ -86,42 +78,42 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
-            if (__InputTagHelper1.IntDictionaryProperty == null)
-            {
-                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
-            }
-#line 16 "PrefixedAttributeTagHelpers.cshtml"
-                                                               __InputTagHelper1.IntProperty = 42;
-
-#line default
-#line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper1.IntProperty);
 #line 16 "PrefixedAttributeTagHelpers.cshtml"
  __InputTagHelper1.IntDictionaryProperty = intDictionary;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __InputTagHelper1.IntDictionaryProperty);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-garlic", "InputTagHelper1", "IntDictionaryProperty"));
+            }
 #line 16 "PrefixedAttributeTagHelpers.cshtml"
-                         __InputTagHelper1.IntDictionaryProperty[""] = 37;
+                         __InputTagHelper1.IntDictionaryProperty["garlic"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-", __InputTagHelper1.IntDictionaryProperty[""]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-garlic", __InputTagHelper1.IntDictionaryProperty["garlic"]);
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
+                                                                     __InputTagHelper1.IntProperty = 42;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper1.IntProperty);
             __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
             __tagHelperExecutionContext.Add(__InputTagHelper2);
+            __InputTagHelper2.IntDictionaryProperty = __InputTagHelper1.IntDictionaryProperty;
             if (__InputTagHelper2.IntDictionaryProperty == null)
             {
-                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-garlic", "InputTagHelper2", "IntDictionaryProperty"));
             }
-            __InputTagHelper2.IntDictionaryProperty = __InputTagHelper1.IntDictionaryProperty;
-            __InputTagHelper2.IntDictionaryProperty[""] = __InputTagHelper1.IntDictionaryProperty[""];
+            __InputTagHelper2.IntDictionaryProperty["garlic"] = __InputTagHelper1.IntDictionaryProperty["garlic"];
             __InputTagHelper2.IntDictionaryProperty["grabber"] = __InputTagHelper1.IntProperty;
             __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("password"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(490, 6, true);
+            Instrumentation.BeginContext(496, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -129,41 +121,56 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
-            if (__InputTagHelper1.IntDictionaryProperty == null)
-            {
-                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
-            }
 #line 18 "PrefixedAttributeTagHelpers.cshtml"
 __InputTagHelper1.IntProperty = 42;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __InputTagHelper1.IntProperty);
-            __InputTagHelper1.StringProperty = "string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __InputTagHelper1.StringProperty);
+            if (__InputTagHelper1.IntDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-salt", "InputTagHelper1", "IntDictionaryProperty"));
+            }
 #line 18 "PrefixedAttributeTagHelpers.cshtml"
-  __InputTagHelper1.IntDictionaryProperty[""] = 37;
+  __InputTagHelper1.IntDictionaryProperty["salt"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-", __InputTagHelper1.IntDictionaryProperty[""]);
-            __InputTagHelper1.StringDictionaryProperty["value"] = "another string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-value", __InputTagHelper1.StringDictionaryProperty["value"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-salt", __InputTagHelper1.IntDictionaryProperty["salt"]);
+#line 18 "PrefixedAttributeTagHelpers.cshtml"
+                       __InputTagHelper1.IntDictionaryProperty["pepper"] = 98;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-pepper", __InputTagHelper1.IntDictionaryProperty["pepper"]);
+            __InputTagHelper1.StringProperty = "string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __InputTagHelper1.StringProperty);
+            if (__InputTagHelper1.StringDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-paprika", "InputTagHelper1", "StringDictionaryProperty"));
+            }
+            __InputTagHelper1.StringDictionaryProperty["paprika"] = "another string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __InputTagHelper1.StringDictionaryProperty["paprika"]);
             __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
             __tagHelperExecutionContext.Add(__InputTagHelper2);
             if (__InputTagHelper2.IntDictionaryProperty == null)
             {
-                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-grabber", "InputTagHelper2", "IntDictionaryProperty"));
             }
             __InputTagHelper2.IntDictionaryProperty["grabber"] = __InputTagHelper1.IntProperty;
-            __InputTagHelper2.IntDictionaryProperty[""] = __InputTagHelper1.IntDictionaryProperty[""];
+            __InputTagHelper2.IntDictionaryProperty["salt"] = __InputTagHelper1.IntDictionaryProperty["salt"];
+            __InputTagHelper2.IntDictionaryProperty["pepper"] = __InputTagHelper1.IntDictionaryProperty["pepper"];
+            if (__InputTagHelper2.StringDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-grabber", "InputTagHelper2", "StringDictionaryProperty"));
+            }
             __InputTagHelper2.StringDictionaryProperty["grabber"] = __InputTagHelper1.StringProperty;
-            __InputTagHelper2.StringDictionaryProperty["value"] = __InputTagHelper1.StringDictionaryProperty["value"];
+            __InputTagHelper2.StringDictionaryProperty["paprika"] = __InputTagHelper1.StringDictionaryProperty["paprika"];
             __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("radio"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(650, 6, true);
+            Instrumentation.BeginContext(705, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -173,7 +180,7 @@ __InputTagHelper1.IntProperty = 42;
             __tagHelperExecutionContext.Add(__InputTagHelper1);
             if (__InputTagHelper1.IntDictionaryProperty == null)
             {
-                __InputTagHelper1.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-value", "InputTagHelper1", "IntDictionaryProperty"));
             }
 #line 20 "PrefixedAttributeTagHelpers.cshtml"
 __InputTagHelper1.IntDictionaryProperty["value"] = 37;
@@ -181,20 +188,28 @@ __InputTagHelper1.IntDictionaryProperty["value"] = 37;
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-value", __InputTagHelper1.IntDictionaryProperty["value"]);
-            __InputTagHelper1.StringDictionaryProperty["value"] = "string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-value", __InputTagHelper1.StringDictionaryProperty["value"]);
+            if (__InputTagHelper1.StringDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-thyme", "InputTagHelper1", "StringDictionaryProperty"));
+            }
+            __InputTagHelper1.StringDictionaryProperty["thyme"] = "string";
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-thyme", __InputTagHelper1.StringDictionaryProperty["thyme"]);
             __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
             __tagHelperExecutionContext.Add(__InputTagHelper2);
             if (__InputTagHelper2.IntDictionaryProperty == null)
             {
-                __InputTagHelper2.IntDictionaryProperty = new System.Collections.Generic.Dictionary<string, int>();
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-value", "InputTagHelper2", "IntDictionaryProperty"));
             }
             __InputTagHelper2.IntDictionaryProperty["value"] = __InputTagHelper1.IntDictionaryProperty["value"];
-            __InputTagHelper2.StringDictionaryProperty["value"] = __InputTagHelper1.StringDictionaryProperty["value"];
+            if (__InputTagHelper2.StringDictionaryProperty == null)
+            {
+                throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-thyme", "InputTagHelper2", "StringDictionaryProperty"));
+            }
+            __InputTagHelper2.StringDictionaryProperty["thyme"] = __InputTagHelper1.StringDictionaryProperty["thyme"];
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(716, 8, true);
+            Instrumentation.BeginContext(771, 8, true);
             WriteLiteral("\r\n</div>");
             Instrumentation.EndContext();
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Output/PrefixedAttributeTagHelpers.cs
@@ -1,4 +1,4 @@
-#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "f60f9d6a7ca3b1b2b1b337737ef23552228df78c"
+#pragma checksum "PrefixedAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "4e7fe9697b745af1a07d41f6a8532fdc288fa046"
 namespace TestOutput
 {
     using Microsoft.AspNet.Razor.Runtime.TagHelpers;
@@ -29,7 +29,8 @@ namespace TestOutput
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
 #line 3 "PrefixedAttributeTagHelpers.cshtml"
-   
+  
+    var literate = "or illiterate";
     var intDictionary = new Dictionary<string, int>
     {
         { "three", 3 },
@@ -42,7 +43,7 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(244, 51, true);
+            Instrumentation.BeginContext(280, 51, true);
             WriteLiteral("\r\n\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -50,13 +51,13 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
-#line 15 "PrefixedAttributeTagHelpers.cshtml"
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
  __InputTagHelper1.IntDictionaryProperty = intDictionary;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __InputTagHelper1.IntDictionaryProperty);
-#line 15 "PrefixedAttributeTagHelpers.cshtml"
+#line 16 "PrefixedAttributeTagHelpers.cshtml"
                                 __InputTagHelper1.StringDictionaryProperty = stringDictionary;
 
 #line default
@@ -70,7 +71,7 @@ namespace TestOutput
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(387, 6, true);
+            Instrumentation.BeginContext(423, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -78,7 +79,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
-#line 16 "PrefixedAttributeTagHelpers.cshtml"
+#line 17 "PrefixedAttributeTagHelpers.cshtml"
  __InputTagHelper1.IntDictionaryProperty = intDictionary;
 
 #line default
@@ -88,13 +89,13 @@ namespace TestOutput
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-garlic", "InputTagHelper1", "IntDictionaryProperty"));
             }
-#line 16 "PrefixedAttributeTagHelpers.cshtml"
+#line 17 "PrefixedAttributeTagHelpers.cshtml"
                          __InputTagHelper1.IntDictionaryProperty["garlic"] = 37;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-garlic", __InputTagHelper1.IntDictionaryProperty["garlic"]);
-#line 16 "PrefixedAttributeTagHelpers.cshtml"
+#line 17 "PrefixedAttributeTagHelpers.cshtml"
                                                                      __InputTagHelper1.IntProperty = 42;
 
 #line default
@@ -113,7 +114,7 @@ namespace TestOutput
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(496, 6, true);
+            Instrumentation.BeginContext(532, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -121,7 +122,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __InputTagHelper1 = CreateTagHelper<InputTagHelper1>();
             __tagHelperExecutionContext.Add(__InputTagHelper1);
-#line 18 "PrefixedAttributeTagHelpers.cshtml"
+#line 19 "PrefixedAttributeTagHelpers.cshtml"
 __InputTagHelper1.IntProperty = 42;
 
 #line default
@@ -131,13 +132,13 @@ __InputTagHelper1.IntProperty = 42;
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-salt", "InputTagHelper1", "IntDictionaryProperty"));
             }
-#line 18 "PrefixedAttributeTagHelpers.cshtml"
+#line 19 "PrefixedAttributeTagHelpers.cshtml"
   __InputTagHelper1.IntDictionaryProperty["salt"] = 37;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-salt", __InputTagHelper1.IntDictionaryProperty["salt"]);
-#line 18 "PrefixedAttributeTagHelpers.cshtml"
+#line 19 "PrefixedAttributeTagHelpers.cshtml"
                        __InputTagHelper1.IntDictionaryProperty["pepper"] = 98;
 
 #line default
@@ -151,6 +152,17 @@ __InputTagHelper1.IntProperty = 42;
             }
             __InputTagHelper1.StringDictionaryProperty["paprika"] = "another string";
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __InputTagHelper1.StringDictionaryProperty["paprika"]);
+            StartTagHelperWritingScope();
+            WriteLiteral("literate ");
+#line 21 "PrefixedAttributeTagHelpers.cshtml"
+WriteLiteral(literate);
+
+#line default
+#line hidden
+            WriteLiteral("?");
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            __InputTagHelper1.StringDictionaryProperty["cumin"] = __tagHelperStringValueBuffer.ToString();
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-cumin", __InputTagHelper1.StringDictionaryProperty["cumin"]);
             __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
             __tagHelperExecutionContext.Add(__InputTagHelper2);
             if (__InputTagHelper2.IntDictionaryProperty == null)
@@ -166,11 +178,12 @@ __InputTagHelper1.IntProperty = 42;
             }
             __InputTagHelper2.StringDictionaryProperty["grabber"] = __InputTagHelper1.StringProperty;
             __InputTagHelper2.StringDictionaryProperty["paprika"] = __InputTagHelper1.StringDictionaryProperty["paprika"];
+            __InputTagHelper2.StringDictionaryProperty["cumin"] = __InputTagHelper1.StringDictionaryProperty["cumin"];
             __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("radio"));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(705, 6, true);
+            Instrumentation.BeginContext(795, 6, true);
             WriteLiteral("\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
@@ -182,7 +195,7 @@ __InputTagHelper1.IntProperty = 42;
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-value", "InputTagHelper1", "IntDictionaryProperty"));
             }
-#line 20 "PrefixedAttributeTagHelpers.cshtml"
+#line 22 "PrefixedAttributeTagHelpers.cshtml"
 __InputTagHelper1.IntDictionaryProperty["value"] = 37;
 
 #line default
@@ -209,7 +222,7 @@ __InputTagHelper1.IntDictionaryProperty["value"] = 37;
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             await WriteTagHelperAsync(__tagHelperExecutionContext);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(771, 8, true);
+            Instrumentation.BeginContext(861, 8, true);
             WriteLiteral("\r\n</div>");
             Instrumentation.EndContext();
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/PrefixedAttributeTagHelpers.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/PrefixedAttributeTagHelpers.cshtml
@@ -1,0 +1,21 @@
+﻿@addTagHelper "something, nice"
+
+@{ 
+    var intDictionary = new Dictionary<string, int>
+    {
+        { "three", 3 },
+    };
+    var stringDictionary = new SortedDictionary<string, string>
+    {
+        { "name", "value" },
+    };
+}
+
+<div class="randomNonTagHelperAttribute">
+    <input type="checkbox" int-dictionary="intDictionary" string-dictionary="stringDictionary"/>
+    <input type="password" int-dictionary="intDictionary" int-prefix-="37" int-prefix-grabber="42" />
+    <input type="radio"
+           int-prefix-grabber="42" int-prefix-="37"
+           string-prefix-grabber="string" string-prefix-value="another string"/>
+    <input int-prefix-value="37" string-prefix-value="string" />
+</div>

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/PrefixedAttributeTagHelpers.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/PrefixedAttributeTagHelpers.cshtml
@@ -13,9 +13,9 @@
 
 <div class="randomNonTagHelperAttribute">
     <input type="checkbox" int-dictionary="intDictionary" string-dictionary="stringDictionary"/>
-    <input type="password" int-dictionary="intDictionary" int-prefix-="37" int-prefix-grabber="42" />
+    <input type="password" int-dictionary="intDictionary" int-prefix-garlic="37" int-prefix-grabber="42" />
     <input type="radio"
-           int-prefix-grabber="42" int-prefix-="37"
-           string-prefix-grabber="string" string-prefix-value="another string"/>
-    <input int-prefix-value="37" string-prefix-value="string" />
+           int-prefix-grabber="42" int-prefix-salt="37" int-prefix-pepper="98" int-prefix-salt="8"
+           string-prefix-grabber="string" string-prefix-paprika="another string"/>
+    <input int-prefix-value="37" string-prefix-thyme="string" />
 </div>

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/PrefixedAttributeTagHelpers.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/CS/Source/PrefixedAttributeTagHelpers.cshtml
@@ -1,6 +1,7 @@
 ﻿@addTagHelper "something, nice"
 
-@{ 
+@{
+    var literate = "or illiterate";
     var intDictionary = new Dictionary<string, int>
     {
         { "three", 3 },
@@ -16,6 +17,7 @@
     <input type="password" int-dictionary="intDictionary" int-prefix-garlic="37" int-prefix-grabber="42" />
     <input type="radio"
            int-prefix-grabber="42" int-prefix-salt="37" int-prefix-pepper="98" int-prefix-salt="8"
-           string-prefix-grabber="string" string-prefix-paprika="another string"/>
+           string-prefix-grabber="string" string-prefix-paprika="another string"
+           string-prefix-cumin="literate @literate?"/>
     <input int-prefix-value="37" string-prefix-thyme="string" />
 </div>


### PR DESCRIPTION
- #89 remainder
- support adding attributes (that aren't otherwise bound) to a tag helper dictionary
 - add `ObjectCreationExpression`, `Prefix` and more to `TagHelperAttributeDescriptor`
 - handle `Prefix` matches in `TagHelperBlockRewriter`
 - generate code for dictionary property initialization and indexer property assignments
- extend handling of invalid attribute names to include `[HtmlAttributeName]`

known issue:
- `ObjectCreationExpression` is a C# expression because otherwise generation has
  insufficient information to determine correct constructor.
- no VB or F# (for example) workarounds today

nits:
- improve `TagHelperDescriptorFactory_InvalidBoundAttributeName` wording
 - rename resource to `TagHelperDescriptorFactory_InvalidAttributeNameOrPrefixStart`
- correct order of arguments to `FormatTagHelperDescriptorFactory_InvalidBoundAttributeName`
- correct `TagHelperDescriptorFactoryTest` test names
 - remove a few unnecessary `ToArray()` calls