### PR TITLE
Quick Fix: Remove unneeded NamespaceKeywordLength from AddImportCodeGenerator.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Generator/AddImportCodeGenerator.cs
+++ b/src/Microsoft.AspNet.Razor/Generator/AddImportCodeGenerator.cs
@@ -8,21 +8,18 @@ namespace Microsoft.AspNet.Razor.Generator
 {
     public class AddImportCodeGenerator : SpanCodeGenerator
     {
-        public AddImportCodeGenerator(string ns, int namespaceKeywordLength)
+        public AddImportCodeGenerator(string ns)
         {
             Namespace = ns;
-            NamespaceKeywordLength = namespaceKeywordLength;
         }
 
         public string Namespace { get; }
-
-        public int NamespaceKeywordLength { get; set; }
 
         public override void GenerateCode(Span target, CodeGeneratorContext context)
         {
             var ns = Namespace;
 
-            if (!string.IsNullOrEmpty(ns) && Char.IsWhiteSpace(ns[0]))
+            if (!string.IsNullOrEmpty(ns) && char.IsWhiteSpace(ns[0]))
             {
                 ns = ns.Substring(1);
             }
@@ -32,15 +29,14 @@ namespace Microsoft.AspNet.Razor.Generator
 
         public override string ToString()
         {
-            return "Import:" + Namespace + ";KwdLen:" + NamespaceKeywordLength;
+            return "Import:" + Namespace + ";";
         }
 
         public override bool Equals(object obj)
         {
             var other = obj as AddImportCodeGenerator;
             return other != null &&
-                string.Equals(Namespace, other.Namespace, StringComparison.Ordinal) &&
-                NamespaceKeywordLength == other.NamespaceKeywordLength;
+                string.Equals(Namespace, other.Namespace, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Statements.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Statements.cs
@@ -150,8 +150,7 @@ namespace Microsoft.AspNet.Razor.Parser
 
             Span.EditHandler.AcceptedCharacters = AcceptedCharacters.AnyExceptNewline;
             Span.CodeGenerator = new AddImportCodeGenerator(
-                Span.GetContent(syms => syms.Skip(1)), // Skip "using"
-                SyntaxConstants.CSharp.UsingKeywordLength);
+                Span.GetContent(syms => syms.Skip(1)));
 
             // Optional ";"
             if (EnsureCurrent())

--- a/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Framework/TestSpanBuilder.cs
@@ -298,9 +298,9 @@ namespace Microsoft.AspNet.Razor.Test.Framework
             return _self.With(new TypeMemberCodeGenerator());
         }
 
-        public SpanConstructor AsNamespaceImport(string ns, int namespaceKeywordLength)
+        public SpanConstructor AsNamespaceImport(string ns)
         {
-            return _self.With(new AddImportCodeGenerator(ns, namespaceKeywordLength));
+            return _self.With(new AddImportCodeGenerator(ns));
         }
 
         public SpanConstructor Hidden()

--- a/test/Microsoft.AspNet.Razor.Test/Generator/AddImportCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/AddImportCodeGeneratorTest.cs
@@ -14,12 +14,12 @@ namespace Microsoft.AspNet.Razor.Generator
                 return new TheoryData<AddImportCodeGenerator, AddImportCodeGenerator>
                 {
                     {
-                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 3),
-                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 3)
+                        new AddImportCodeGenerator(ns: null),
+                        new AddImportCodeGenerator(ns: null)
                     },
                     {
-                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
-                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23)
+                        new AddImportCodeGenerator(ns: "Fred"),
+                        new AddImportCodeGenerator(ns: "Fred")
                     },
                 };
             }
@@ -32,40 +32,35 @@ namespace Microsoft.AspNet.Razor.Generator
                 return new TheoryData<AddImportCodeGenerator, object>
                 {
                     {
-                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 0),
+                        new AddImportCodeGenerator(ns: null),
                         null
                     },
                     {
-                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
+                        new AddImportCodeGenerator(ns: "Fred"),
                         null
                     },
                     {
-                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
+                        new AddImportCodeGenerator(ns: "Fred"),
                         new object()
                     },
                     {
-                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
+                        new AddImportCodeGenerator(ns: "Fred"),
                         SpanCodeGenerator.Null
                     },
                     {
-                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 23),
+                        new AddImportCodeGenerator(ns: "Fred"),
                         new StatementCodeGenerator()
                     },
                     {
                         // Different Namespace.
-                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 3),
-                        new AddImportCodeGenerator(ns: "Ginger", namespaceKeywordLength: 3)
+                        new AddImportCodeGenerator(ns: "Fred"),
+                        new AddImportCodeGenerator(ns: "Ginger")
                     },
                     {
                         // Different Namespace (case sensitive).
-                        new AddImportCodeGenerator(ns: "fred", namespaceKeywordLength: 9),
-                        new AddImportCodeGenerator(ns: "FRED", namespaceKeywordLength: 9)
-                    },
-                    {
-                        // Different NamespaceKeywordLength.
-                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 0),
-                        new AddImportCodeGenerator(ns: null, namespaceKeywordLength: 23)
-                    },
+                        new AddImportCodeGenerator(ns: "fred"),
+                        new AddImportCodeGenerator(ns: "FRED")
+                    }
                 };
             }
         }

--- a/test/Microsoft.AspNet.Razor.Test/Generator/RazorCommentCodeGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Generator/RazorCommentCodeGeneratorTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Razor.Generator
                     { new RazorCommentCodeGenerator(), new TemplateBlockCodeGenerator() },
                     {
                         new RazorCommentCodeGenerator(),
-                        new AddImportCodeGenerator(ns: "Fred", namespaceKeywordLength: 0)
+                        new AddImportCodeGenerator(ns: "Fred")
                     },
                 };
             }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpBlockTest.cs
@@ -370,7 +370,7 @@ while(true);", BlockType.Statement, SpanKind.Code, acceptedCharacters: AcceptedC
             ParseBlockTest("using Foo   ",
                            new DirectiveBlock(
                                Factory.Code("using Foo")
-                                   .AsNamespaceImport(" Foo", CSharpCodeParser.UsingKeywordLength)
+                                   .AsNamespaceImport(" Foo")
                                    .Accepts(AcceptedCharacters.NonWhiteSpace | AcceptedCharacters.WhiteSpace)));
         }
 
@@ -1099,7 +1099,7 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
             ParseBlockTest(content,
                            new DirectiveBlock(
                                Factory.Code(content)
-                                   .AsNamespaceImport(expectedNS, CSharpCodeParser.UsingKeywordLength)
+                                   .AsNamespaceImport(expectedNS)
                                    .Accepts(acceptedCharacters)),
                            errors);
         }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpStatementTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpStatementTest.cs
@@ -167,7 +167,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new DirectiveBlock(
                                Factory.CodeTransition(),
                                Factory.Code("using StringDictionary = System.Collections.Generic.Dictionary<string, string>")
-                                   .AsNamespaceImport(" StringDictionary = System.Collections.Generic.Dictionary<string, string>", 5)
+                                   .AsNamespaceImport(" StringDictionary = System.Collections.Generic.Dictionary<string, string>")
                                    .Accepts(AcceptedCharacters.AnyExceptNewline)
                                ));
         }
@@ -179,7 +179,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new DirectiveBlock(
                                Factory.CodeTransition(),
                                Factory.Code("using System.Text.Encoding.ASCIIEncoding")
-                                   .AsNamespaceImport(" System.Text.Encoding.ASCIIEncoding", 5)
+                                   .AsNamespaceImport(" System.Text.Encoding.ASCIIEncoding")
                                    .Accepts(AcceptedCharacters.AnyExceptNewline)
                                ));
         }


### PR DESCRIPTION
- This was completely unused outside of the AddImportCodeGenerator.