### PR TITLE
Add support for '*' at the end of required attributes.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         // https://github.com/aspnet/Razor/issues/165
 
         public static ICollection<char> InvalidNonWhitespaceNameCharacters { get; } = new HashSet<char>(
-            new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'' });
+            new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*' });
 
         /// <summary>
         /// Creates a <see cref="TagHelperDescriptor"/> from the given <paramref name="type"/>.
@@ -169,6 +169,26 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             bool targetingAttributes,
             ErrorSink errorSink)
         {
+            if (!targetingAttributes &&
+                string.Equals(
+                    name,
+                    TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                // '*' as the entire name is ok if we're not targeting attributes because it's the TargetElement
+                // catch-all case.
+                return true;
+            }
+            else if (targetingAttributes &&
+                name.EndsWith(
+                    TagHelperDescriptorProvider.RequiredAttributeWildcardSuffix,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                // A single '*' at the end of a required attribute is valid; everywhere else is invalid. Strip it from
+                // the end so we can validate the rest of the name.
+                name = name.Substring(0, name.Length - 1);
+            }
+
             var targetName = targetingAttributes ?
                 Resources.TagHelperDescriptorFactory_Attribute :
                 Resources.TagHelperDescriptorFactory_Tag;

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TargetElementAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TargetElementAttribute.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// Instantiates a new instance of the <see cref="TargetElementAttribute"/> class with <see cref="Tag"/>
         /// set to <c>*</c>.
         /// </summary>
-        /// <remarks>A <c>*</c> <see cref="Tag"/> value indicates an <see cref="ITagHelper"/> 
+        /// <remarks>A <c>*</c> <see cref="Tag"/> value indicates an <see cref="ITagHelper"/>
         /// that targets all HTML elements with the required <see cref="Attributes"/>.</remarks>
         public TargetElementAttribute()
             : this(CatchAllDescriptorTarget)
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="tag">
         /// The HTML tag the <see cref="ITagHelper"/> targets.
         /// </param>
-        /// <remarks>A <c>*</c> <paramref name="tag"/> value indicates an <see cref="ITagHelper"/> 
+        /// <remarks>A <c>*</c> <paramref name="tag"/> value indicates an <see cref="ITagHelper"/>
         /// that targets all HTML elements with the required <see cref="Attributes"/>.</remarks>
         public TargetElementAttribute(string tag)
         {
@@ -41,14 +41,17 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// The HTML tag the <see cref="ITagHelper"/> targets.
         /// </summary>
-        /// <remarks>A <c>*</c> <see cref="Tag"/> value indicates an <see cref="ITagHelper"/> 
+        /// <remarks>A <c>*</c> <see cref="Tag"/> value indicates an <see cref="ITagHelper"/>
         /// that targets all HTML elements with the required <see cref="Attributes"/>.</remarks>
         public string Tag { get; }
 
         /// <summary>
-        /// A comma-separated <see cref="string"/> of attributes the HTML element must contain for the 
+        /// A comma-separated <see cref="string"/> of attributes the HTML element must contain for the
         /// <see cref="ITagHelper"/> to run.
         /// </summary>
+        /// <remarks>
+        /// <c>*</c> at the end of an attribute acts as a wild card.
+        /// </remarks>
         public string Attributes { get; set; }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Razor.TagHelpers;
@@ -166,6 +167,30 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 AssemblyName,
                                 attributes,
                                 requiredAttributes: new[] { "class", "style" }),
+                        }
+                    },
+                    {
+                        typeof(AttributeWildcardTargetingTagHelper),
+                        new[]
+                        {
+                            new TagHelperDescriptor(
+                                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                                typeof(AttributeWildcardTargetingTagHelper).FullName,
+                                AssemblyName,
+                                attributes,
+                                requiredAttributes: new[] { "class*" })
+                        }
+                    },
+                    {
+                        typeof(MultiAttributeWildcardTargetingTagHelper),
+                        new[]
+                        {
+                            new TagHelperDescriptor(
+                                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                                typeof(MultiAttributeWildcardTargetingTagHelper).FullName,
+                                AssemblyName,
+                                attributes,
+                                requiredAttributes: new[] { "class*", "style*" })
                         }
                     },
                 };
@@ -1381,51 +1406,65 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         onNameError("'he'lo'", "'"),
                     }
                 },
+                { "hello*", new[] { onNameError("hello*", "*") } },
+                { "*hello", new[] { onNameError("*hello", "*") } },
+                { "he*lo", new[] { onNameError("he*lo", "*") } },
+                {
+                    "*he*lo*",
+                    new[]
+                    {
+                        onNameError("*he*lo*", "*"),
+                        onNameError("*he*lo*", "*"),
+                        onNameError("*he*lo*", "*"),
+                    }
+                },
                 { Environment.NewLine, new[] { whitespaceErrorString } },
                 { "\t", new[] { whitespaceErrorString } },
                 { " \t ", new[] { whitespaceErrorString } },
                 { " ", new[] { whitespaceErrorString } },
                 { Environment.NewLine + " ", new[] { whitespaceErrorString } },
                 {
-                    "! \t\r\n@/<>?[]=\"'",
+                    "! \t\r\n@/<>?[]=\"'*",
                     new[]
                     {
-                        onNameError("! \t\r\n@/<>?[]=\"'", "!"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", " "),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "\t"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "\r"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "\n"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "@"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "/"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "<"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", ">"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "?"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "["),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "]"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "="),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "\""),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "'"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "!"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", " "),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "\t"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "\r"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "\n"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "@"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "/"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "<"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", ">"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "?"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "["),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "]"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "="),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "\""),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "'"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "*"),
                     }
                 },
                 {
-                    "! \tv\ra\nl@i/d<>?[]=\"'",
+                    "! \tv\ra\nl@i/d<>?[]=\"'*",
                     new[]
                     {
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "!"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", " "),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\t"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\r"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\n"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "@"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "/"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "<"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", ">"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "?"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "["),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "]"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "="),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\""),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "'"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "!"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", " "),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "\t"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "\r"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "\n"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "@"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "/"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "<"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", ">"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "?"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "["),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "]"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "="),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "\""),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "'"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "*"),
                     }
                 },
             };
@@ -1439,6 +1478,16 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             }
 
             return data;
+        }
+
+        [TargetElement(Attributes = "class*")]
+        private class AttributeWildcardTargetingTagHelper : TagHelper
+        {
+        }
+
+        [TargetElement(Attributes = "class*,style*")]
+        private class MultiAttributeWildcardTargetingTagHelper : TagHelper
+        {
         }
 
         [TargetElement(Attributes = "class")]

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorProviderTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorProviderTest.cs
@@ -25,6 +25,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     assemblyName: "SomeAssembly",
                     attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                     requiredAttributes: new[] { "class", "style" });
+                var inputWildcardPrefixDescriptor = new TagHelperDescriptor(
+                    tagName: "input",
+                    typeName: "InputWildCardAttribute",
+                    assemblyName: "SomeAssembly",
+                    attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
+                    requiredAttributes: new[] { "nodashprefix*" });
                 var catchAllDescriptor = new TagHelperDescriptor(
                     tagName: TagHelperDescriptorProvider.CatchAllDescriptorTarget,
                     typeName: "CatchAllTagHelper",
@@ -37,8 +43,16 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     assemblyName: "SomeAssembly",
                     attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                     requiredAttributes: new[] { "custom", "class" });
+                var catchAllWildcardPrefixDescriptor = new TagHelperDescriptor(
+                    tagName: TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                    typeName: "CatchAllWildCardAttribute",
+                    assemblyName: "SomeAssembly",
+                    attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
+                    requiredAttributes: new[] { "prefix-*" });
                 var defaultAvailableDescriptors =
                     new[] { divDescriptor, inputDescriptor, catchAllDescriptor, catchAllDescriptor2 };
+                var defaultWildcardDescriptors =
+                    new[] { inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor };
 
                 return new TheoryData<
                     string, // tagName
@@ -95,6 +109,48 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         new[] { "class", "custom" },
                         defaultAvailableDescriptors,
                         new[] { catchAllDescriptor, catchAllDescriptor2 }
+                    },
+                    {
+                        "input",
+                        new[] { "nodashprefixA" },
+                        defaultWildcardDescriptors,
+                        new[] { inputWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "nodashprefix-ABC-DEF", "random" },
+                        defaultWildcardDescriptors,
+                        new[] { inputWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "prefixABCnodashprefix" },
+                        defaultWildcardDescriptors,
+                        Enumerable.Empty<TagHelperDescriptor>()
+                    },
+                    {
+                        "input",
+                        new[] { "prefix-A" },
+                        defaultWildcardDescriptors,
+                        new[] { catchAllWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "prefix-ABC-DEF", "random" },
+                        defaultWildcardDescriptors,
+                        new[] { catchAllWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "prefix-abc", "nodashprefix-def" },
+                        defaultWildcardDescriptors,
+                        new[] { inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "class", "prefix-abc", "onclick", "nodashprefix-def", "style" },
+                        defaultWildcardDescriptors,
+                        new[] { inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor }
                     },
                 };
             }


### PR DESCRIPTION
- `[TargetElement(Attributes ="prefix-*")]` is now supported.
- Added '*' to the list of invalid non whitespace characters in `TagHelperDescriptorFactory`.
- Modified `TagHelperDescriptorProvider` to respect suffixed wildcards in `TagHelperAttributeDescriptor.Attributes`.
- Added tests to validate wildcard required attributes

#361