### PR TITLE
Add support for '*' at the end of required attributes.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TargetElementAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TargetElementAttribute.cs
@@ -12,16 +12,16 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     public sealed class TargetElementAttribute : Attribute
     {
-        public const string CatchAllDescriptorTarget = TagHelperDescriptorProvider.CatchAllDescriptorTarget;
+        public const string ElementCatchAllTarget = TagHelperDescriptorProvider.ElementCatchAllTarget;
 
         /// <summary>
         /// Instantiates a new instance of the <see cref="TargetElementAttribute"/> class with <see cref="Tag"/>
         /// set to <c>*</c>.
         /// </summary>
-        /// <remarks>A <c>*</c> <see cref="Tag"/> value indicates an <see cref="ITagHelper"/> 
+        /// <remarks>A <c>*</c> <see cref="Tag"/> value indicates an <see cref="ITagHelper"/>
         /// that targets all HTML elements with the required <see cref="Attributes"/>.</remarks>
         public TargetElementAttribute()
-            : this(CatchAllDescriptorTarget)
+            : this(ElementCatchAllTarget)
         {
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="tag">
         /// The HTML tag the <see cref="ITagHelper"/> targets.
         /// </param>
-        /// <remarks>A <c>*</c> <paramref name="tag"/> value indicates an <see cref="ITagHelper"/> 
+        /// <remarks>A <c>*</c> <paramref name="tag"/> value indicates an <see cref="ITagHelper"/>
         /// that targets all HTML elements with the required <see cref="Attributes"/>.</remarks>
         public TargetElementAttribute(string tag)
         {
@@ -41,14 +41,17 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// The HTML tag the <see cref="ITagHelper"/> targets.
         /// </summary>
-        /// <remarks>A <c>*</c> <see cref="Tag"/> value indicates an <see cref="ITagHelper"/> 
+        /// <remarks>A <c>*</c> <see cref="Tag"/> value indicates an <see cref="ITagHelper"/>
         /// that targets all HTML elements with the required <see cref="Attributes"/>.</remarks>
         public string Tag { get; }
 
         /// <summary>
-        /// A comma-separated <see cref="string"/> of attributes the HTML element must contain for the 
+        /// A comma-separated <see cref="string"/> of attribute names the HTML element must contain for the
         /// <see cref="ITagHelper"/> to run.
         /// </summary>
+        /// <remarks>
+        /// <c>*</c> at the end of an attribute name acts as a prefix match.
+        /// </remarks>
         public string Attributes { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
@@ -133,6 +133,9 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <summary>
         /// The list of required attribute names the tag helper expects to target an element.
         /// </summary>
+        /// <remarks>
+        /// <c>*</c> at the end of an attribute name acts as a prefix match.
+        /// </remarks>
         public IReadOnlyList<string> RequiredAttributes { get; private set; }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNet.Razor.TagHelpers;
@@ -29,7 +30,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         new[]
                         {
                             new TagHelperDescriptor(
-                                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                                TagHelperDescriptorProvider.ElementCatchAllTarget,
                                 typeof(AttributeTargetingTagHelper).FullName,
                                 AssemblyName,
                                 attributes,
@@ -41,7 +42,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         new[]
                         {
                             new TagHelperDescriptor(
-                                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                                TagHelperDescriptorProvider.ElementCatchAllTarget,
                                 typeof(MultiAttributeTargetingTagHelper).FullName,
                                 AssemblyName,
                                 attributes,
@@ -53,13 +54,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         new[]
                         {
                             new TagHelperDescriptor(
-                                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                                TagHelperDescriptorProvider.ElementCatchAllTarget,
                                 typeof(MultiAttributeAttributeTargetingTagHelper).FullName,
                                 AssemblyName,
                                 attributes,
                                 requiredAttributes: new[] { "custom" }),
                             new TagHelperDescriptor(
-                                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                                TagHelperDescriptorProvider.ElementCatchAllTarget,
                                 typeof(MultiAttributeAttributeTargetingTagHelper).FullName,
                                 AssemblyName,
                                 attributes,
@@ -71,7 +72,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         new[]
                         {
                             new TagHelperDescriptor(
-                                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                                TagHelperDescriptorProvider.ElementCatchAllTarget,
                                 typeof(InheritedAttributeTargetingTagHelper).FullName,
                                 AssemblyName,
                                 attributes,
@@ -166,6 +167,30 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 AssemblyName,
                                 attributes,
                                 requiredAttributes: new[] { "class", "style" }),
+                        }
+                    },
+                    {
+                        typeof(AttributeWildcardTargetingTagHelper),
+                        new[]
+                        {
+                            new TagHelperDescriptor(
+                                TagHelperDescriptorProvider.ElementCatchAllTarget,
+                                typeof(AttributeWildcardTargetingTagHelper).FullName,
+                                AssemblyName,
+                                attributes,
+                                requiredAttributes: new[] { "class*" })
+                        }
+                    },
+                    {
+                        typeof(MultiAttributeWildcardTargetingTagHelper),
+                        new[]
+                        {
+                            new TagHelperDescriptor(
+                                TagHelperDescriptorProvider.ElementCatchAllTarget,
+                                typeof(MultiAttributeWildcardTargetingTagHelper).FullName,
+                                AssemblyName,
+                                attributes,
+                                requiredAttributes: new[] { "class*", "style*" })
                         }
                     },
                 };
@@ -1381,51 +1406,65 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         onNameError("'he'lo'", "'"),
                     }
                 },
+                { "hello*", new[] { onNameError("hello*", "*") } },
+                { "*hello", new[] { onNameError("*hello", "*") } },
+                { "he*lo", new[] { onNameError("he*lo", "*") } },
+                {
+                    "*he*lo*",
+                    new[]
+                    {
+                        onNameError("*he*lo*", "*"),
+                        onNameError("*he*lo*", "*"),
+                        onNameError("*he*lo*", "*"),
+                    }
+                },
                 { Environment.NewLine, new[] { whitespaceErrorString } },
                 { "\t", new[] { whitespaceErrorString } },
                 { " \t ", new[] { whitespaceErrorString } },
                 { " ", new[] { whitespaceErrorString } },
                 { Environment.NewLine + " ", new[] { whitespaceErrorString } },
                 {
-                    "! \t\r\n@/<>?[]=\"'",
+                    "! \t\r\n@/<>?[]=\"'*",
                     new[]
                     {
-                        onNameError("! \t\r\n@/<>?[]=\"'", "!"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", " "),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "\t"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "\r"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "\n"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "@"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "/"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "<"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", ">"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "?"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "["),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "]"),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "="),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "\""),
-                        onNameError("! \t\r\n@/<>?[]=\"'", "'"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "!"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", " "),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "\t"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "\r"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "\n"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "@"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "/"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "<"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", ">"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "?"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "["),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "]"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "="),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "\""),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "'"),
+                        onNameError("! \t\r\n@/<>?[]=\"'*", "*"),
                     }
                 },
                 {
-                    "! \tv\ra\nl@i/d<>?[]=\"'",
+                    "! \tv\ra\nl@i/d<>?[]=\"'*",
                     new[]
                     {
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "!"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", " "),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\t"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\r"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\n"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "@"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "/"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "<"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", ">"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "?"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "["),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "]"),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "="),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "\""),
-                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'", "'"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "!"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", " "),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "\t"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "\r"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "\n"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "@"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "/"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "<"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", ">"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "?"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "["),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "]"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "="),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "\""),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "'"),
+                        onNameError("! \tv\ra\nl@i/d<>?[]=\"'*", "*"),
                     }
                 },
             };
@@ -1439,6 +1478,16 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             }
 
             return data;
+        }
+
+        [TargetElement(Attributes = "class*")]
+        private class AttributeWildcardTargetingTagHelper : TagHelper
+        {
+        }
+
+        [TargetElement(Attributes = "class*,style*")]
+        private class MultiAttributeWildcardTargetingTagHelper : TagHelper
+        {
         }
 
         [TargetElement(Attributes = "class")]

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorProviderTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorProviderTest.cs
@@ -25,20 +25,34 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     assemblyName: "SomeAssembly",
                     attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                     requiredAttributes: new[] { "class", "style" });
+                var inputWildcardPrefixDescriptor = new TagHelperDescriptor(
+                    tagName: "input",
+                    typeName: "InputWildCardAttribute",
+                    assemblyName: "SomeAssembly",
+                    attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
+                    requiredAttributes: new[] { "nodashprefix*" });
                 var catchAllDescriptor = new TagHelperDescriptor(
-                    tagName: TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                    tagName: TagHelperDescriptorProvider.ElementCatchAllTarget,
                     typeName: "CatchAllTagHelper",
                     assemblyName: "SomeAssembly",
                     attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                     requiredAttributes: new[] { "class" });
                 var catchAllDescriptor2 = new TagHelperDescriptor(
-                    tagName: TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                    tagName: TagHelperDescriptorProvider.ElementCatchAllTarget,
                     typeName: "CatchAllTagHelper",
                     assemblyName: "SomeAssembly",
                     attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                     requiredAttributes: new[] { "custom", "class" });
+                var catchAllWildcardPrefixDescriptor = new TagHelperDescriptor(
+                    tagName: TagHelperDescriptorProvider.ElementCatchAllTarget,
+                    typeName: "CatchAllWildCardAttribute",
+                    assemblyName: "SomeAssembly",
+                    attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
+                    requiredAttributes: new[] { "prefix-*" });
                 var defaultAvailableDescriptors =
                     new[] { divDescriptor, inputDescriptor, catchAllDescriptor, catchAllDescriptor2 };
+                var defaultWildcardDescriptors =
+                    new[] { inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor };
 
                 return new TheoryData<
                     string, // tagName
@@ -73,28 +87,82 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         new[] { inputDescriptor, catchAllDescriptor }
                     },
                     {
-                        TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                        TagHelperDescriptorProvider.ElementCatchAllTarget,
                         new[] { "custom" },
                         defaultAvailableDescriptors,
                         Enumerable.Empty<TagHelperDescriptor>()
                     },
                     {
-                        TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                        TagHelperDescriptorProvider.ElementCatchAllTarget,
                         new[] { "class" },
                         defaultAvailableDescriptors,
                         new[] { catchAllDescriptor }
                     },
                     {
-                        TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                        TagHelperDescriptorProvider.ElementCatchAllTarget,
                         new[] { "class", "style" },
                         defaultAvailableDescriptors,
                         new[] { catchAllDescriptor }
                     },
                     {
-                        TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                        TagHelperDescriptorProvider.ElementCatchAllTarget,
                         new[] { "class", "custom" },
                         defaultAvailableDescriptors,
                         new[] { catchAllDescriptor, catchAllDescriptor2 }
+                    },
+                    {
+                        "input",
+                        new[] { "nodashprefixA" },
+                        defaultWildcardDescriptors,
+                        new[] { inputWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "nodashprefix-ABC-DEF", "random" },
+                        defaultWildcardDescriptors,
+                        new[] { inputWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "prefixABCnodashprefix" },
+                        defaultWildcardDescriptors,
+                        Enumerable.Empty<TagHelperDescriptor>()
+                    },
+                    {
+                        "input",
+                        new[] { "prefix-" },
+                        defaultWildcardDescriptors,
+                        Enumerable.Empty<TagHelperDescriptor>()
+                    },
+                    {
+                        "input",
+                        new[] { "nodashprefix" },
+                        defaultWildcardDescriptors,
+                        Enumerable.Empty<TagHelperDescriptor>()
+                    },
+                    {
+                        "input",
+                        new[] { "prefix-A" },
+                        defaultWildcardDescriptors,
+                        new[] { catchAllWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "prefix-ABC-DEF", "random" },
+                        defaultWildcardDescriptors,
+                        new[] { catchAllWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "prefix-abc", "nodashprefix-def" },
+                        defaultWildcardDescriptors,
+                        new[] { inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor }
+                    },
+                    {
+                        "input",
+                        new[] { "class", "prefix-abc", "onclick", "nodashprefix-def", "style" },
+                        defaultWildcardDescriptors,
+                        new[] { inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor }
                     },
                 };
             }
@@ -124,7 +192,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             // Arrange
             var catchAllDescriptor = CreatePrefixedDescriptor(
                 "th",
-                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                TagHelperDescriptorProvider.ElementCatchAllTarget,
                 "foo1");
             var descriptors = new[] { catchAllDescriptor };
             var provider = new TagHelperDescriptorProvider(descriptors);
@@ -159,7 +227,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         public void GetDescriptors_ReturnsCatchAllDescriptorsForPrefixedTags()
         {
             // Arrange
-            var catchAllDescriptor = CreatePrefixedDescriptor("th:", TagHelperDescriptorProvider.CatchAllDescriptorTarget, "foo1");
+            var catchAllDescriptor = CreatePrefixedDescriptor("th:", TagHelperDescriptorProvider.ElementCatchAllTarget, "foo1");
             var descriptors = new[] { catchAllDescriptor };
             var provider = new TagHelperDescriptorProvider(descriptors);
 
@@ -230,14 +298,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             var divDescriptor = new TagHelperDescriptor("div", "foo1", "SomeAssembly");
             var spanDescriptor = new TagHelperDescriptor("span", "foo2", "SomeAssembly");
             var catchAllDescriptor = new TagHelperDescriptor(
-                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                TagHelperDescriptorProvider.ElementCatchAllTarget,
                 "foo3",
                 "SomeAssembly");
             var descriptors = new TagHelperDescriptor[] { divDescriptor, spanDescriptor, catchAllDescriptor };
             var provider = new TagHelperDescriptorProvider(descriptors);
 
             // Act
-            var retrievedDescriptors = provider.GetDescriptors(TagHelperDescriptorProvider.CatchAllDescriptorTarget, attributeNames: Enumerable.Empty<string>());
+            var retrievedDescriptors = provider.GetDescriptors(TagHelperDescriptorProvider.ElementCatchAllTarget, attributeNames: Enumerable.Empty<string>());
 
             // Assert
             var descriptor = Assert.Single(retrievedDescriptors);
@@ -251,7 +319,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             var divDescriptor = new TagHelperDescriptor("div", "foo1", "SomeAssembly");
             var spanDescriptor = new TagHelperDescriptor("span", "foo2", "SomeAssembly");
             var catchAllDescriptor = new TagHelperDescriptor(
-                TagHelperDescriptorProvider.CatchAllDescriptorTarget,
+                TagHelperDescriptorProvider.ElementCatchAllTarget,
                 "foo3",
                 "SomeAssembly");
             var descriptors = new TagHelperDescriptor[] { divDescriptor, spanDescriptor, catchAllDescriptor };


### PR DESCRIPTION
- `[TargetElement(Attributes ="prefix-*")]` is now supported.
- Added '*' to the list of invalid non whitespace characters in `TagHelperDescriptorFactory`.
- Modified `TagHelperDescriptorProvider` to respect suffixed wildcards in `TagHelperAttributeDescriptor.Attributes`.
- Added tests to validate wildcard required attributes

#361