### PR TITLE
Remove special casing of '*' in TagHelperDescriptorProvider.

### DIFF
--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorProvider.cs
@@ -66,17 +66,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 descriptors = catchAllDescriptors;
             }
 
-            // If the requested tag name is the catch-all target, we shouldn't do the work of concatenating extra
-            // descriptors.
-            if (!tagName.Equals(ElementCatchAllTarget, StringComparison.OrdinalIgnoreCase))
+            // If we have a tag name associated with the requested name, we need to combine matchingDescriptors
+            // with all the catch-all descriptors.
+            HashSet<TagHelperDescriptor> matchingDescriptors;
+            if (_registrations.TryGetValue(tagName, out matchingDescriptors))
             {
-                // If we have a tag name associated with the requested name, we need to combine matchingDescriptors
-                // with all the catch-all descriptors.
-                HashSet<TagHelperDescriptor> matchingDescriptors;
-                if (_registrations.TryGetValue(tagName, out matchingDescriptors))
-                {
-                    descriptors = matchingDescriptors.Concat(descriptors);
-                }
+                descriptors = matchingDescriptors.Concat(descriptors);
             }
 
             var applicableDescriptors = ApplyRequiredAttributes(descriptors, attributeNames);

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorProviderTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorProviderTest.cs
@@ -87,30 +87,6 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         new[] { inputDescriptor, catchAllDescriptor }
                     },
                     {
-                        TagHelperDescriptorProvider.ElementCatchAllTarget,
-                        new[] { "custom" },
-                        defaultAvailableDescriptors,
-                        Enumerable.Empty<TagHelperDescriptor>()
-                    },
-                    {
-                        TagHelperDescriptorProvider.ElementCatchAllTarget,
-                        new[] { "class" },
-                        defaultAvailableDescriptors,
-                        new[] { catchAllDescriptor }
-                    },
-                    {
-                        TagHelperDescriptorProvider.ElementCatchAllTarget,
-                        new[] { "class", "style" },
-                        defaultAvailableDescriptors,
-                        new[] { catchAllDescriptor }
-                    },
-                    {
-                        TagHelperDescriptorProvider.ElementCatchAllTarget,
-                        new[] { "class", "custom" },
-                        defaultAvailableDescriptors,
-                        new[] { catchAllDescriptor, catchAllDescriptor2 }
-                    },
-                    {
                         "input",
                         new[] { "nodashprefixA" },
                         defaultWildcardDescriptors,
@@ -289,27 +265,6 @@ namespace Microsoft.AspNet.Razor.TagHelpers
 
             // Assert
             Assert.Empty(retrievedDescriptors);
-        }
-
-        [Fact]
-        public void GetDescriptors_DoesNotReturnNonCatchAllTagsForCatchAll()
-        {
-            // Arrange
-            var divDescriptor = new TagHelperDescriptor("div", "foo1", "SomeAssembly");
-            var spanDescriptor = new TagHelperDescriptor("span", "foo2", "SomeAssembly");
-            var catchAllDescriptor = new TagHelperDescriptor(
-                TagHelperDescriptorProvider.ElementCatchAllTarget,
-                "foo3",
-                "SomeAssembly");
-            var descriptors = new TagHelperDescriptor[] { divDescriptor, spanDescriptor, catchAllDescriptor };
-            var provider = new TagHelperDescriptorProvider(descriptors);
-
-            // Act
-            var retrievedDescriptors = provider.GetDescriptors(TagHelperDescriptorProvider.ElementCatchAllTarget, attributeNames: Enumerable.Empty<string>());
-
-            // Assert
-            var descriptor = Assert.Single(retrievedDescriptors);
-            Assert.Same(catchAllDescriptor, descriptor);
         }
 
         [Fact]


### PR DESCRIPTION
- Requesting a '*' tagName from the TagHelperDescriptorProvider could only happen if a user was directly calling into it (extremely unlikely). Therefore I've removed the special casing to make the logic more simple.
- Removed tests that expected this behavior.

#324