### PR TITLE
Avoid errors when generating baselines

### DIFF
--- a/test/Microsoft.AspNet.Razor.Test/CodeGenerators/RazorChunkGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/CodeGenerators/RazorChunkGeneratorTest.cs
@@ -195,15 +195,15 @@ namespace Microsoft.AspNet.Razor.Test.Generator
 
             var textOutput = results.GeneratedCode;
 #if GENERATE_BASELINES
+            var outputFile = string.Format(
+                @"test\Microsoft.AspNet.Razor.Test\TestFiles\CodeGenerator\Output\{0}.{1}",
+                baselineName,
+                BaselineExtension);
+
             // Update baseline files if files do not already match.
             if (!string.Equals(expectedOutput, textOutput, StringComparison.Ordinal))
             {
-            BaselineWriter.WriteBaseline(
-                    string.Format(
-                        @"test\Microsoft.AspNet.Razor.Test\TestFiles\ChunkGenerator\Output\{0}.{1}",
-                        baselineName,
-                        BaselineExtension),
-                    textOutput);
+                BaselineWriter.WriteBaseline(outputFile, textOutput);
             }
 #else
             if (onResults != null)
@@ -232,15 +232,68 @@ namespace Microsoft.AspNet.Razor.Test.Generator
 
                 if (expectedDesignTimePragmas != null)
                 {
-                    Assert.True(results.DesignTimeLineMappings != null); // Guard
+                    Assert.NotNull(results.DesignTimeLineMappings); // Guard
+#if GENERATE_BASELINES
+                    if (expectedDesignTimePragmas == null ||
+                        !Enumerable.SequenceEqual(expectedDesignTimePragmas, results.DesignTimeLineMappings))
+                    {
+                        var lineMappingFile = Path.ChangeExtension(outputFile, "lineMappings.cs");
+                        var lineMappingCode = GetDesignTimeLineMappingsCode(results.DesignTimeLineMappings);
+                        BaselineWriter.WriteBaseline(lineMappingFile, lineMappingCode);
+                    }
+#else
                     for (var i = 0; i < expectedDesignTimePragmas.Count && i < results.DesignTimeLineMappings.Count; i++)
                     {
                         Assert.Equal(expectedDesignTimePragmas[i], results.DesignTimeLineMappings[i]);
                     }
 
                     Assert.Equal(expectedDesignTimePragmas.Count, results.DesignTimeLineMappings.Count);
+#endif
                 }
             }
+        }
+
+        private static string GetDesignTimeLineMappingsCode(IList<LineMapping> designTimeLineMappings)
+        {
+            var lineMappings = new StringBuilder();
+            lineMappings.AppendLine($"// !!! Do not check in. Instead paste content into test method. !!!");
+            lineMappings.AppendLine();
+
+            var indent = "            ";
+            lineMappings.AppendLine($"{ indent }var expectedLineMappings = new[]");
+            lineMappings.AppendLine($"{ indent }{{");
+            foreach (var lineMapping in designTimeLineMappings)
+            {
+                var innerIndent = indent + "    ";
+                var documentLocation = lineMapping.DocumentLocation;
+                var generatedLocation = lineMapping.GeneratedLocation;
+                lineMappings.AppendLine($"{ innerIndent }BuildLineMapping(");
+
+                innerIndent += "    ";
+                lineMappings.AppendLine($"{ innerIndent }documentAbsoluteIndex: { documentLocation.AbsoluteIndex },");
+                lineMappings.AppendLine($"{ innerIndent }documentLineIndex: { documentLocation.LineIndex },");
+                if (documentLocation.CharacterIndex != generatedLocation.CharacterIndex)
+                {
+                    lineMappings.AppendLine($"{ innerIndent }documentCharacterOffsetIndex: { documentLocation.CharacterIndex },");
+                }
+
+                lineMappings.AppendLine($"{ innerIndent }generatedAbsoluteIndex: { generatedLocation.AbsoluteIndex },");
+                lineMappings.AppendLine($"{ innerIndent }generatedLineIndex: { generatedLocation.LineIndex },");
+                if (documentLocation.CharacterIndex != generatedLocation.CharacterIndex)
+                {
+                    lineMappings.AppendLine($"{ innerIndent }generatedCharacterOffsetIndex: { generatedLocation.CharacterIndex },");
+                }
+                else
+                {
+                    lineMappings.AppendLine($"{ innerIndent }characterOffsetIndex: { generatedLocation.CharacterIndex },");
+                }
+
+                lineMappings.AppendLine($"{ innerIndent }contentLength: { generatedLocation.ContentLength }),");
+            }
+
+            lineMappings.AppendLine($"{ indent }}};");
+
+            return lineMappings.ToString();
         }
 
         private void VerifyNoBrokenEndOfLines(string text)

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/CodeBlockWithTextElement.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/CodeBlockWithTextElement.cs
@@ -1,4 +1,4 @@
-﻿#pragma checksum "CodeBlockWithTextElement.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "13e48ff59aab8106ceb68dd4a10b0bdf10c322fc"
+#pragma checksum "CodeBlockWithTextElement.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "13e48ff59aab8106ceb68dd4a10b0bdf10c322fc"
 namespace TestOutput
 {
     using System;


### PR DESCRIPTION
- ignore missing expected output resources in this mode
- update `BaselineWriter` to avoid `IOException`s (file access issues)
 - serialize file operations
 - one file handle per file
- repeatedly `rm TestFiles/CodeGenerator/Output/*; `dnx . test`; no errors

also
- update files only if they have changed
 - new `TestFiles.Exists()` method to support this check
- do not check results in `CSharpCodeBuilderTests` if `GENERATE_BASELINES` set

nits:
- update BOM in CodeBlockWithTextElement.cs to avoid future `git diff`s
- use more `var` and improve variable names in `TestFile`
- wrap long lines