### PR TITLE
Ensure `CodeVisitor`s consistenctly find tag helpers

### DIFF
--- a/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpTagHelperRunnerInitializationVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpTagHelperRunnerInitializationVisitor.cs
@@ -26,6 +26,25 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
             _tagHelperContext = Context.Host.GeneratedClassContext.GeneratedTagHelperContext;
         }
 
+        /// <inheritdoc />
+        public override void Accept(Chunk chunk)
+        {
+            // If at any ParentChunk other than a TagHelperChunk, then dive into its Children to search for more
+            // TagHelperChunk nodes. This method avoids overriding each of the ParentChunk-specific Visit() methods to
+            // dive into Children.
+            var parentChunk = chunk as ParentChunk;
+            if (parentChunk != null && !(parentChunk is TagHelperChunk))
+            {
+                Accept(parentChunk.Children);
+            }
+            else
+            {
+                // If at a TagHelperChunk or any non-ParentChunk, "Accept()" it. This ensures the Visit(TagHelperChunk)
+                // method below is called.
+                base.Accept(chunk);
+            }
+        }
+
         /// <summary>
         /// Writes the TagHelperRunner initialization code to the Writer.
         /// </summary>

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpUsingVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpUsingVisitor.cs
@@ -23,6 +23,25 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
 
         public IList<string> ImportedUsings { get; set; }
 
+        /// <inheritdoc />
+        public override void Accept(Chunk chunk)
+        {
+            // If at any ParentChunk other than a TagHelperChunk, then dive into its Children to search for more
+            // TagHelperChunk or UsingChunk nodes. This method avoids overriding each of the ParentChunk-specific
+            // Visit() methods to dive into Children.
+            var parentChunk = chunk as ParentChunk;
+            if (parentChunk != null && !(parentChunk is TagHelperChunk))
+            {
+                Accept(parentChunk.Children);
+            }
+            else
+            {
+                // If at a TagHelperChunk or any non-ParentChunk (e.g. UsingChunk), "Accept()" it. This ensures the
+                // Visit(UsingChunk) and Visit(TagHelperChunk) methods below are called.
+                base.Accept(chunk);
+            }
+        }
+
         protected override void Visit(UsingChunk chunk)
         {
             var documentContent = ((Span)chunk.Association).Content.Trim();

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
@@ -1,6 +1,7 @@
 #pragma checksum "TagHelpersInSection.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "b6492c68360b85d4993de94eeac547b7fb012a26"
 namespace TestOutput
 {
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
     using System;
     using System.Threading.Tasks;
 
@@ -23,6 +24,7 @@ namespace TestOutput
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
+            __tagHelperRunner = __tagHelperRunner ?? new TagHelperRunner();
             Instrumentation.BeginContext(33, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();


### PR DESCRIPTION
- #412
- fix `CSharpTagHelperRunnerInitializationVisitor` and `CSharpUsingVisitor`
- fix existing test of the tag helper in a section scenario