### PR TITLE
Add support for C# 6 exception filters.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Tokenizer/CSharpKeywordDetector.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/CSharpKeywordDetector.cs
@@ -88,7 +88,8 @@ namespace Microsoft.AspNet.Razor.Tokenizer
             { "interface", CSharpKeyword.Interface },
             { "break", CSharpKeyword.Break },
             { "checked", CSharpKeyword.Checked },
-            { "namespace", CSharpKeyword.Namespace }
+            { "namespace", CSharpKeyword.Namespace },
+            { "when", CSharpKeyword.When }
         };
 
         public static CSharpKeyword? SymbolTypeForIdentifier(string id)

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/CSharpKeyword.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Symbols/CSharpKeyword.cs
@@ -82,6 +82,7 @@ namespace Microsoft.AspNet.Razor.Tokenizer.Symbols
         Interface,
         Break,
         Checked,
-        Namespace
+        Namespace,
+        When
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Tokenizer/CSharpTokenizerIdentifierTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Tokenizer/CSharpTokenizerIdentifierTest.cs
@@ -160,6 +160,7 @@ namespace Microsoft.AspNet.Razor.Test.Tokenizer
             TestKeyword("break", CSharpKeyword.Break);
             TestKeyword("checked", CSharpKeyword.Checked);
             TestKeyword("namespace", CSharpKeyword.Namespace);
+            TestKeyword("when", CSharpKeyword.When);
         }
 
         private void TestKeyword(string keyword, CSharpKeyword keywordType)


### PR DESCRIPTION
- Added new handling of the C# try catch statement to allow exception filters after catch statements.
- Added tests to validate valid and invalid scenarios.

#402