### PR TITLE
[Design] Add ability for unbound complex `TagHelper` attributes to flow through MVC attribute resolution system.

### DIFF
--- a/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpCodeWriter.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpCodeWriter.cs
@@ -63,6 +63,11 @@ namespace Microsoft.AspNet.Razor.CodeGenerators
             return (CSharpCodeWriter)base.WriteLine();
         }
 
+        public CSharpCodeWriter WriteEndLine()
+        {
+            return WriteLine(";");
+        }
+
         public CSharpCodeWriter WriteVariableDeclaration(string type, string name, string value)
         {
             Write(type).Write(" ").Write(name);

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/GeneratedTagHelperContext.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/GeneratedTagHelperContext.cs
@@ -13,6 +13,12 @@ namespace Microsoft.AspNet.Razor.CodeGenerators
         /// </summary>
         public GeneratedTagHelperContext()
         {
+            OutputTextWriterPropertyName = "Output";
+            ShouldRenderAttributeValueMethodName = "ShouldRenderAttributeValue";
+            GetStringAttributeValueMethodName = "GetStringAttributeValue";
+            WriteUnprefixedAttributeValueToMethodName = "WriteUnprefixedAttributeValueTo";
+            UnchangedTagHelperAttributeValueBufferTypeName = "StringCollectionTextWriter";
+            AddHtmlAttributeOnlyMethodName = "HtmlAttributes.Add";
             CreateTagHelperMethodName = "CreateTagHelper";
             RunnerRunAsyncMethodName = "RunAsync";
             ScopeManagerBeginMethodName = "Begin";
@@ -33,6 +39,36 @@ namespace Microsoft.AspNet.Razor.CodeGenerators
             WriteTagHelperAsyncMethodName = "WriteTagHelperAsync";
             WriteTagHelperToAsyncMethodName = "WriteTagHelperToAsync";
         }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public string OutputTextWriterPropertyName { get; set; }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public string ShouldRenderAttributeValueMethodName { get; set; }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public string GetStringAttributeValueMethodName { get; set; }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public string WriteUnprefixedAttributeValueToMethodName { get; set; }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public string UnchangedTagHelperAttributeValueBufferTypeName { get; set; }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public string AddHtmlAttributeOnlyMethodName { get; set; }
 
         /// <summary>
         /// The name of the method used to create a tag helper.

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
@@ -50,9 +50,9 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
                     Writer
                         .Write("private ")
                         .WriteVariableDeclaration(
-                        _tagHelperContext.RunnerTypeName,
-                        CSharpTagHelperCodeRenderer.RunnerVariableName,
-                        value: null);
+                            _tagHelperContext.RunnerTypeName,
+                            CSharpTagHelperCodeRenderer.RunnerVariableName,
+                            value: null);
 
                     Writer.Write("private ")
                           .Write(_tagHelperContext.ScopeManagerTypeName)
@@ -60,6 +60,28 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
                           .WriteStartAssignment(CSharpTagHelperCodeRenderer.ScopeManagerVariableName)
                           .WriteStartNewObject(_tagHelperContext.ScopeManagerTypeName)
                           .WriteEndMethodInvocation();
+
+                    Writer
+                        .Write("private ")
+                        .WriteVariableDeclaration(
+                            _tagHelperContext.UnchangedTagHelperAttributeValueBufferTypeName,
+                            CSharpTagHelperCodeRenderer.OriginalTagHelperAttributeValueVariableName,
+                            value: null);
+
+                    Writer
+                        .Write("private ")
+                        .WriteVariableDeclaration(
+                            "object",
+                            CSharpTagHelperCodeRenderer.RawAttributeValueVariableName,
+                            value: null);
+
+                    Writer
+                        .Write("private ")
+                        .WriteVariableDeclaration(
+                            "bool",
+                            CSharpTagHelperCodeRenderer.ShouldRenderTagHelperAttributeVariableName,
+                            value: "false");
+
                 }
             }
 

--- a/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
@@ -63,6 +63,29 @@ namespace Microsoft.AspNet.Razor.Test.Generator
             }
         }
 
+        private static IEnumerable<TagHelperDescriptor> DynamicAttributeTagHelpers_Descriptors
+        {
+            get
+            {
+                return new[]
+                {
+                    new TagHelperDescriptor(
+                        tagName: "input",
+                        typeName: "InputTagHelper",
+                        assemblyName: "SomeAssembly",
+                        attributes: new[]
+                        {
+                            new TagHelperAttributeDescriptor(
+                                "bound",
+                                "Bound",
+                                typeof(string).FullName,
+                                isIndexer: false,
+                                designTimeDescriptor: null)
+                        }),
+                };
+            }
+        }
+
         private static IEnumerable<TagHelperDescriptor> DuplicateTargetTagHelperDescriptors
         {
             get
@@ -922,6 +945,261 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                 contentLength: 1),
                         }
                     },
+                    {
+                        "DynamicAttributeTagHelpers",
+                        "DynamicAttributeTagHelpers.DesignTime",
+                        DefaultPAndInputTagHelperDescriptors,
+                        new List<LineMapping>
+                        {
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 14,
+                                documentLineIndex: 0,
+                                generatedAbsoluteIndex: 497,
+                                generatedLineIndex: 15,
+                                characterOffsetIndex: 14,
+                                contentLength: 17),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 61,
+                                documentLineIndex: 3,
+                                documentCharacterOffsetIndex: 24,
+                                generatedAbsoluteIndex: 1130,
+                                generatedLineIndex: 36,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 98,
+                                documentLineIndex: 5,
+                                documentCharacterOffsetIndex: 17,
+                                generatedAbsoluteIndex: 1357,
+                                generatedLineIndex: 43,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 111,
+                                documentLineIndex: 5,
+                                documentCharacterOffsetIndex: 30,
+                                generatedAbsoluteIndex: 1455,
+                                generatedLineIndex: 49,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 123,
+                                documentLineIndex: 5,
+                                documentCharacterOffsetIndex: 42,
+                                generatedAbsoluteIndex: 1546,
+                                generatedLineIndex: 54,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 10),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 134,
+                                documentLineIndex: 5,
+                                documentCharacterOffsetIndex: 53,
+                                generatedAbsoluteIndex: 1642,
+                                generatedLineIndex: 60,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 5),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 139,
+                                documentLineIndex: 5,
+                                documentCharacterOffsetIndex: 58,
+                                generatedAbsoluteIndex: 1726,
+                                generatedLineIndex: 65,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 2),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 178,
+                                documentLineIndex: 7,
+                                documentCharacterOffsetIndex: 22,
+                                generatedAbsoluteIndex: 1950,
+                                generatedLineIndex: 73,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 216,
+                                documentLineIndex: 7,
+                                documentCharacterOffsetIndex: 60,
+                                generatedAbsoluteIndex: 2047,
+                                generatedLineIndex: 78,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 258,
+                                documentLineIndex: 9,
+                                documentCharacterOffsetIndex: 15,
+                                generatedAbsoluteIndex: 2281,
+                                generatedLineIndex: 85,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 13),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 273,
+                                documentLineIndex: 9,
+                                documentCharacterOffsetIndex: 30,
+                                generatedAbsoluteIndex: 2374,
+                                generatedLineIndex: 90,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 286,
+                                documentLineIndex: 9,
+                                documentCharacterOffsetIndex: 43,
+                                generatedAbsoluteIndex: 2473,
+                                generatedLineIndex: 96,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 298,
+                                documentLineIndex: 9,
+                                documentCharacterOffsetIndex: 55,
+                                generatedAbsoluteIndex: 2565,
+                                generatedLineIndex: 101,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 10),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 309,
+                                documentLineIndex: 9,
+                                documentCharacterOffsetIndex: 66,
+                                generatedAbsoluteIndex: 2662,
+                                generatedLineIndex: 107,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 5),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 314,
+                                documentLineIndex: 9,
+                                documentCharacterOffsetIndex: 71,
+                                generatedAbsoluteIndex: 2747,
+                                generatedLineIndex: 112,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 2),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 318,
+                                documentLineIndex: 9,
+                                documentCharacterOffsetIndex: 75,
+                                generatedAbsoluteIndex: 2836,
+                                generatedLineIndex: 118,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 350,
+                                documentLineIndex: 10,
+                                documentCharacterOffsetIndex: 17,
+                                generatedAbsoluteIndex: 2934,
+                                generatedLineIndex: 123,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 13),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 365,
+                                documentLineIndex: 10,
+                                documentCharacterOffsetIndex: 32,
+                                generatedAbsoluteIndex: 3027,
+                                generatedLineIndex: 128,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 378,
+                                documentLineIndex: 10,
+                                documentCharacterOffsetIndex: 45,
+                                generatedAbsoluteIndex: 3126,
+                                generatedLineIndex: 134,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 390,
+                                documentLineIndex: 10,
+                                documentCharacterOffsetIndex: 57,
+                                generatedAbsoluteIndex: 3218,
+                                generatedLineIndex: 139,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 10),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 401,
+                                documentLineIndex: 10,
+                                documentCharacterOffsetIndex: 68,
+                                generatedAbsoluteIndex: 3315,
+                                generatedLineIndex: 145,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 5),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 406,
+                                documentLineIndex: 10,
+                                documentCharacterOffsetIndex: 73,
+                                generatedAbsoluteIndex: 3400,
+                                generatedLineIndex: 150,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 2),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 410,
+                                documentLineIndex: 10,
+                                documentCharacterOffsetIndex: 77,
+                                generatedAbsoluteIndex: 3489,
+                                generatedLineIndex: 156,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 447,
+                                documentLineIndex: 12,
+                                documentCharacterOffsetIndex: 17,
+                                generatedAbsoluteIndex: 3723,
+                                generatedLineIndex: 163,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 13),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 462,
+                                documentLineIndex: 12,
+                                documentCharacterOffsetIndex: 32,
+                                generatedAbsoluteIndex: 3822,
+                                generatedLineIndex: 168,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 494,
+                                documentLineIndex: 12,
+                                documentCharacterOffsetIndex: 64,
+                                generatedAbsoluteIndex: 3920,
+                                generatedLineIndex: 173,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 531,
+                                documentLineIndex: 14,
+                                documentCharacterOffsetIndex: 17,
+                                generatedAbsoluteIndex: 4148,
+                                generatedLineIndex: 180,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 544,
+                                documentLineIndex: 14,
+                                documentCharacterOffsetIndex: 30,
+                                generatedAbsoluteIndex: 4247,
+                                generatedLineIndex: 186,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 556,
+                                documentLineIndex: 14,
+                                documentCharacterOffsetIndex: 42,
+                                generatedAbsoluteIndex: 4339,
+                                generatedLineIndex: 191,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 10),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 567,
+                                documentLineIndex: 14,
+                                documentCharacterOffsetIndex: 53,
+                                generatedAbsoluteIndex: 4436,
+                                generatedLineIndex: 197,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 5),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 572,
+                                documentLineIndex: 14,
+                                documentCharacterOffsetIndex: 58,
+                                generatedAbsoluteIndex: 4521,
+                                generatedLineIndex: 202,
+                                generatedCharacterOffsetIndex: 0,
+                                contentLength: 2),
+                        }
+                    },
                 };
             }
         }
@@ -965,6 +1243,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                         PrefixedAttributeTagHelperDescriptors.Reverse()
                     },
                     { "DuplicateAttributeTagHelpers", null, DefaultPAndInputTagHelperDescriptors },
+                    { "DynamicAttributeTagHelpers", null, DynamicAttributeTagHelpers_Descriptors },
                 };
             }
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/AttributeTargetingTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/AttributeTargetingTagHelpers.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private PTagHelper __PTagHelper = null;
         private CatchAllTagHelper __CatchAllTagHelper = null;
         private InputTagHelper __InputTagHelper = null;

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
@@ -13,6 +13,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private PTagHelper __PTagHelper = null;
         private InputTagHelper __InputTagHelper = null;
         private InputTagHelper2 __InputTagHelper2 = null;
@@ -61,7 +64,7 @@ Write(ViewBag.DefaultInterval);
 #line hidden
                 WriteLiteral(" + 1");
                 __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer.ToString()));
+                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer));
                 __InputTagHelper.Type = **From custom attribute code renderer**: "text";
                 __tagHelperExecutionContext.AddTagHelperAttribute("type", __InputTagHelper.Type);
                 __InputTagHelper2.Type = __InputTagHelper.Type;

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.Prefixed.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.Prefixed.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private PTagHelper __PTagHelper = null;
         private InputTagHelper __InputTagHelper = null;
         private InputTagHelper2 __InputTagHelper2 = null;

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private PTagHelper __PTagHelper = null;
         private InputTagHelper __InputTagHelper = null;
         private InputTagHelper2 __InputTagHelper2 = null;
@@ -62,7 +65,7 @@ Write(ViewBag.DefaultInterval);
 #line hidden
                 WriteLiteral(" + 1");
                 __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer.ToString()));
+                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer));
                 __InputTagHelper.Type = "text";
                 __tagHelperExecutionContext.AddTagHelperAttribute("type", __InputTagHelper.Type);
                 __InputTagHelper2.Type = __InputTagHelper.Type;

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private PTagHelper __PTagHelper = null;
         private InputTagHelper __InputTagHelper = null;
         private InputTagHelper2 __InputTagHelper2 = null;
@@ -240,14 +243,20 @@ if(true) {
             __PTagHelper = CreateTagHelper<PTagHelper>();
             __tagHelperExecutionContext.Add(__PTagHelper);
             StartTagHelperWritingScope();
-            WriteLiteral("Current Time: ");
-#line 8 "ComplexTagHelpers.cshtml"
-Write(DateTime.Now);
-
-#line default
-#line hidden
+            __originalTagHelperAttributeValue = new StringCollectionTextWriter(Output.Encoding);
+            WriteLiteral("Current Time:");
+            WriteLiteralTo(__originalTagHelperAttributeValue, "Current Time:");
+            __rawTagHelperAttributeValue = DateTime.Now;
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteLiteral(" ");
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("time", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+            }
+            WriteLiteralTo(__originalTagHelperAttributeValue, " ");
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
             __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-            __tagHelperExecutionContext.AddHtmlAttribute("time", Html.Raw(__tagHelperStringValueBuffer.ToString()));
+            __tagHelperExecutionContext.HtmlAttributes.Add("time", Html.Raw(__tagHelperStringValueBuffer));
+            __tagHelperExecutionContext.AddTagHelperAttribute("time", Html.Raw(__originalTagHelperAttributeValue));
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(139, 531, false);
             await WriteTagHelperAsync(__tagHelperExecutionContext);

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private PTagHelper __PTagHelper = null;
         private InputTagHelper __InputTagHelper = null;
         private InputTagHelper2 __InputTagHelper2 = null;

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateTargetTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateTargetTagHelper.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private InputTagHelper __InputTagHelper = null;
         private CatchAllTagHelper __CatchAllTagHelper = null;
         #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.DesignTime.cs
@@ -1,0 +1,211 @@
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class DynamicAttributeTagHelpers
+    {
+        private static object @__o;
+        private void @__RazorDesignTimeHelpers__()
+        {
+            #pragma warning disable 219
+            string __tagHelperDirectiveSyntaxHelper = null;
+            __tagHelperDirectiveSyntaxHelper = 
+#line 1 "DynamicAttributeTagHelpers.cshtml"
+              "something, nice"
+
+#line default
+#line hidden
+            ;
+            #pragma warning restore 219
+        }
+        #line hidden
+        private InputTagHelper __InputTagHelper = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        #line hidden
+        public DynamicAttributeTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+#line 4 "DynamicAttributeTagHelpers.cshtml"
+__o = DateTime.Now;
+
+#line default
+#line hidden
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+if (true) { 
+
+#line default
+#line hidden
+
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+__o = string.Empty;
+
+#line default
+#line hidden
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+ } else { 
+
+#line default
+#line hidden
+
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+__o = false;
+
+#line default
+#line hidden
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+ }
+
+#line default
+#line hidden
+
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+#line 8 "DynamicAttributeTagHelpers.cshtml"
+__o = DateTime.Now;
+
+#line default
+#line hidden
+#line 8 "DynamicAttributeTagHelpers.cshtml"
+__o = DateTime.Now;
+
+#line default
+#line hidden
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+__o = long.MinValue;
+
+#line default
+#line hidden
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+if (true) { 
+
+#line default
+#line hidden
+
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+__o = string.Empty;
+
+#line default
+#line hidden
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+ } else { 
+
+#line default
+#line hidden
+
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+__o = false;
+
+#line default
+#line hidden
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+ }
+
+#line default
+#line hidden
+
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+__o = int.MaxValue;
+
+#line default
+#line hidden
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+__o = long.MinValue;
+
+#line default
+#line hidden
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+if (true) { 
+
+#line default
+#line hidden
+
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+__o = string.Empty;
+
+#line default
+#line hidden
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+ } else { 
+
+#line default
+#line hidden
+
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+__o = false;
+
+#line default
+#line hidden
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+ }
+
+#line default
+#line hidden
+
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+__o = int.MaxValue;
+
+#line default
+#line hidden
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+#line 13 "DynamicAttributeTagHelpers.cshtml"
+__o = long.MinValue;
+
+#line default
+#line hidden
+#line 13 "DynamicAttributeTagHelpers.cshtml"
+__o = DateTime.Now;
+
+#line default
+#line hidden
+#line 13 "DynamicAttributeTagHelpers.cshtml"
+__o = int.MaxValue;
+
+#line default
+#line hidden
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+if (true) { 
+
+#line default
+#line hidden
+
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+__o = string.Empty;
+
+#line default
+#line hidden
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+ } else { 
+
+#line default
+#line hidden
+
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+__o = false;
+
+#line default
+#line hidden
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+ }
+
+#line default
+#line hidden
+
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.cs
@@ -1,0 +1,380 @@
+#pragma checksum "DynamicAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "40990f364c71b55cb3888667144e8558c1645fa4"
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class DynamicAttributeTagHelpers
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private TagHelperContent __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private TagHelperRunner __tagHelperRunner = null;
+        private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
+        private InputTagHelper __InputTagHelper = null;
+        #line hidden
+        public DynamicAttributeTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __tagHelperRunner = __tagHelperRunner ?? new TagHelperRunner();
+            Instrumentation.BeginContext(33, 4, true);
+            WriteLiteral("\r\n\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            StartTagHelperWritingScope();
+            __originalTagHelperAttributeValue = new StringCollectionTextWriter(Output.Encoding);
+            WriteLiteral("prefix");
+            WriteLiteralTo(__originalTagHelperAttributeValue, "prefix");
+            __rawTagHelperAttributeValue = DateTime.Now;
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteLiteral(" ");
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+            }
+            WriteLiteralTo(__originalTagHelperAttributeValue, " ");
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            __tagHelperExecutionContext.HtmlAttributes.Add("unbound", Html.Raw(__tagHelperStringValueBuffer));
+            __tagHelperExecutionContext.AddTagHelperAttribute("unbound", Html.Raw(__originalTagHelperAttributeValue));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(37, 40, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(77, 4, true);
+            WriteLiteral("\r\n\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            StartTagHelperWritingScope();
+            __originalTagHelperAttributeValue = new StringCollectionTextWriter(Output.Encoding);
+            __rawTagHelperAttributeValue = new Template((__razor_attribute_value_writer) => {
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+if (true) { 
+
+#line default
+#line hidden
+
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+WriteTo(__razor_attribute_value_writer, string.Empty);
+
+#line default
+#line hidden
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+ } else { 
+
+#line default
+#line hidden
+
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+WriteTo(__razor_attribute_value_writer, false);
+
+#line default
+#line hidden
+#line 6 "DynamicAttributeTagHelpers.cshtml"
+ }
+
+#line default
+#line hidden
+
+            }
+            );
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+            }
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            WriteLiteral(" suffix");
+            WriteLiteralTo(__originalTagHelperAttributeValue, " suffix");
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            __tagHelperExecutionContext.HtmlAttributes.Add("unbound", Html.Raw(__tagHelperStringValueBuffer));
+            __tagHelperExecutionContext.AddTagHelperAttribute("unbound", Html.Raw(__originalTagHelperAttributeValue));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(81, 71, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(152, 4, true);
+            WriteLiteral("\r\n\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            StartTagHelperWritingScope();
+            WriteLiteral("prefix ");
+#line 8 "DynamicAttributeTagHelpers.cshtml"
+WriteLiteral(DateTime.Now);
+
+#line default
+#line hidden
+            WriteLiteral(" suffix");
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            __InputTagHelper.Bound = __tagHelperStringValueBuffer.ToString();
+            __tagHelperExecutionContext.AddTagHelperAttribute("bound", __InputTagHelper.Bound);
+            StartTagHelperWritingScope();
+            __originalTagHelperAttributeValue = new StringCollectionTextWriter(Output.Encoding);
+            WriteLiteral("prefix");
+            WriteLiteralTo(__originalTagHelperAttributeValue, "prefix");
+            __rawTagHelperAttributeValue = DateTime.Now;
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteLiteral(" ");
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+            }
+            WriteLiteralTo(__originalTagHelperAttributeValue, " ");
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            WriteLiteral(" suffix");
+            WriteLiteralTo(__originalTagHelperAttributeValue, " suffix");
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            __tagHelperExecutionContext.HtmlAttributes.Add("unbound", Html.Raw(__tagHelperStringValueBuffer));
+            __tagHelperExecutionContext.AddTagHelperAttribute("unbound", Html.Raw(__originalTagHelperAttributeValue));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(156, 83, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(239, 4, true);
+            WriteLiteral("\r\n\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            StartTagHelperWritingScope();
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+WriteLiteral(long.MinValue);
+
+#line default
+#line hidden
+            WriteLiteral(" ");
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+if (true) { 
+
+#line default
+#line hidden
+
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+WriteLiteral(string.Empty);
+
+#line default
+#line hidden
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+ } else { 
+
+#line default
+#line hidden
+
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+WriteLiteral(false);
+
+#line default
+#line hidden
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+ }
+
+#line default
+#line hidden
+
+            WriteLiteral(" ");
+#line 10 "DynamicAttributeTagHelpers.cshtml"
+WriteLiteral(int.MaxValue);
+
+#line default
+#line hidden
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            __InputTagHelper.Bound = __tagHelperStringValueBuffer.ToString();
+            __tagHelperExecutionContext.AddTagHelperAttribute("bound", __InputTagHelper.Bound);
+            StartTagHelperWritingScope();
+            __shouldRenderTagHelperAttribute = false;
+            __originalTagHelperAttributeValue = new StringCollectionTextWriter(Output.Encoding);
+            __rawTagHelperAttributeValue = long.MinValue;
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+                __shouldRenderTagHelperAttribute = true;
+            }
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            __rawTagHelperAttributeValue = new Template((__razor_attribute_value_writer) => {
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+if (true) { 
+
+#line default
+#line hidden
+
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+WriteTo(__razor_attribute_value_writer, string.Empty);
+
+#line default
+#line hidden
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+ } else { 
+
+#line default
+#line hidden
+
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+WriteTo(__razor_attribute_value_writer, false);
+
+#line default
+#line hidden
+#line 11 "DynamicAttributeTagHelpers.cshtml"
+ }
+
+#line default
+#line hidden
+
+            }
+            );
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteLiteral(" ");
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+                __shouldRenderTagHelperAttribute = true;
+            }
+            WriteLiteralTo(__originalTagHelperAttributeValue, " ");
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            __rawTagHelperAttributeValue = int.MaxValue;
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteLiteral(" ");
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+                __shouldRenderTagHelperAttribute = true;
+            }
+            WriteLiteralTo(__originalTagHelperAttributeValue, " ");
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            if (__shouldRenderTagHelperAttribute)
+            {
+                __tagHelperExecutionContext.HtmlAttributes.Add("unbound", Html.Raw(__tagHelperStringValueBuffer));
+            }
+            __tagHelperExecutionContext.AddTagHelperAttribute("unbound", Html.Raw(__originalTagHelperAttributeValue));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(243, 183, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(426, 4, true);
+            WriteLiteral("\r\n\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            StartTagHelperWritingScope();
+            __originalTagHelperAttributeValue = new StringCollectionTextWriter(Output.Encoding);
+            __rawTagHelperAttributeValue = long.MinValue;
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+            }
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            __rawTagHelperAttributeValue = DateTime.Now;
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteLiteral(" ");
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+            }
+            WriteLiteralTo(__originalTagHelperAttributeValue, " ");
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            WriteLiteral(" static    content");
+            WriteLiteralTo(__originalTagHelperAttributeValue, " static    content");
+            __rawTagHelperAttributeValue = int.MaxValue;
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteLiteral(" ");
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+            }
+            WriteLiteralTo(__originalTagHelperAttributeValue, " ");
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            __tagHelperExecutionContext.HtmlAttributes.Add("unbound", Html.Raw(__tagHelperStringValueBuffer));
+            __tagHelperExecutionContext.AddTagHelperAttribute("unbound", Html.Raw(__originalTagHelperAttributeValue));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(430, 80, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(510, 4, true);
+            WriteLiteral("\r\n\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", true, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            StartTagHelperWritingScope();
+            __shouldRenderTagHelperAttribute = false;
+            __originalTagHelperAttributeValue = new StringCollectionTextWriter(Output.Encoding);
+            __rawTagHelperAttributeValue = new Template((__razor_attribute_value_writer) => {
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+if (true) { 
+
+#line default
+#line hidden
+
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+WriteTo(__razor_attribute_value_writer, string.Empty);
+
+#line default
+#line hidden
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+ } else { 
+
+#line default
+#line hidden
+
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+WriteTo(__razor_attribute_value_writer, false);
+
+#line default
+#line hidden
+#line 15 "DynamicAttributeTagHelpers.cshtml"
+ }
+
+#line default
+#line hidden
+
+            }
+            );
+            if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+            {
+                WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unbound", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+                __shouldRenderTagHelperAttribute = true;
+            }
+            WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
+            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+            if (__shouldRenderTagHelperAttribute)
+            {
+                __tagHelperExecutionContext.HtmlAttributes.Add("unbound", Html.Raw(__tagHelperStringValueBuffer));
+            }
+            __tagHelperExecutionContext.AddTagHelperAttribute("unbound", Html.Raw(__originalTagHelperAttributeValue));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(514, 64, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/EmptyAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/EmptyAttributeTagHelpers.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private InputTagHelper __InputTagHelper = null;
         private InputTagHelper2 __InputTagHelper2 = null;
         private PTagHelper __PTagHelper = null;

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/EscapedTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/EscapedTagHelpers.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private InputTagHelper __InputTagHelper = null;
         private InputTagHelper2 __InputTagHelper2 = null;
         #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/MinimizedTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/MinimizedTagHelpers.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private CatchAllTagHelper __CatchAllTagHelper = null;
         private InputTagHelper __InputTagHelper = null;
         #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private InputTagHelper2 __InputTagHelper2 = null;
         private InputTagHelper1 __InputTagHelper1 = null;
         #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private InputTagHelper1 __InputTagHelper1 = null;
         private InputTagHelper2 __InputTagHelper2 = null;
         #line hidden

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelper.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private PTagHelper __PTagHelper = null;
         #line hidden
         public SingleTagHelper()

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
@@ -14,6 +14,9 @@ namespace TestOutput
         private TagHelperExecutionContext __tagHelperExecutionContext = null;
         private TagHelperRunner __tagHelperRunner = null;
         private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private StringCollectionTextWriter __originalTagHelperAttributeValue = null;
+        private object __rawTagHelperAttributeValue = null;
+        private bool __shouldRenderTagHelperAttribute = false;
         private MyTagHelper __MyTagHelper = null;
         private NestedTagHelper __NestedTagHelper = null;
         #line hidden
@@ -84,14 +87,20 @@ WriteLiteral(DateTime.Now);
                 __MyTagHelper.BoundProperty = __tagHelperStringValueBuffer.ToString();
                 __tagHelperExecutionContext.AddTagHelperAttribute("boundproperty", __MyTagHelper.BoundProperty);
                 StartTagHelperWritingScope();
-                WriteLiteral("Current Time: ");
-#line 9 "TagHelpersInSection.cshtml"
-Write(DateTime.Now);
-
-#line default
-#line hidden
+                __originalTagHelperAttributeValue = new StringCollectionTextWriter(Output.Encoding);
+                WriteLiteral("Current Time:");
+                WriteLiteralTo(__originalTagHelperAttributeValue, "Current Time:");
+                __rawTagHelperAttributeValue = DateTime.Now;
+                if (ShouldRenderAttributeValue(__rawTagHelperAttributeValue))
+                {
+                    WriteLiteral(" ");
+                    WriteUnprefixedAttributeValueTo(Output, GetStringAttributeValue("unboundproperty", __rawTagHelperAttributeValue), __rawTagHelperAttributeValue, false);
+                }
+                WriteLiteralTo(__originalTagHelperAttributeValue, " ");
+                WriteTo(__originalTagHelperAttributeValue, __rawTagHelperAttributeValue);
                 __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __tagHelperExecutionContext.AddHtmlAttribute("unboundproperty", Html.Raw(__tagHelperStringValueBuffer.ToString()));
+                __tagHelperExecutionContext.HtmlAttributes.Add("unboundproperty", Html.Raw(__tagHelperStringValueBuffer));
+                __tagHelperExecutionContext.AddTagHelperAttribute("unboundproperty", Html.Raw(__originalTagHelperAttributeValue));
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(114, 245, false);
                 await WriteTagHelperToAsync(__razor_template_writer, __tagHelperExecutionContext);

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Source/DynamicAttributeTagHelpers.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Source/DynamicAttributeTagHelpers.cshtml
@@ -1,0 +1,15 @@
+﻿@addTagHelper "something, nice"
+
+
+<input unbound="prefix @DateTime.Now" />
+
+<input unbound="@if (true) { @string.Empty } else { @false } suffix" />
+
+<input bound="prefix @DateTime.Now suffix" unbound="prefix @DateTime.Now suffix" />
+
+<input bound="@long.MinValue @if (true) { @string.Empty } else { @false } @int.MaxValue"
+       unbound="@long.MinValue @if (true) { @string.Empty } else { @false } @int.MaxValue" />
+
+<input unbound="@long.MinValue @DateTime.Now static    content @int.MaxValue" />
+
+<input unbound="@if (true) { @string.Empty } else { @false }" />


### PR DESCRIPTION
- Updated `CSharpCodeVisitor` and `CSharpTagHelperCodeRenderer` to re-use more code.
- Added custom attribute visitor for complex unbound `TagHelper` attributes.
- Added an additional three variables used for `TagHelper` codegen.
- Expanded `GeneratedTagHelperContext` to contain more information about the final `TagHelper` code gen output for complex attributes.
- Updated existing test files.
- Added a new code gen test case to showcase the various use-cases of unbound dynamic `TagHelper` attributes.

**Expected Behavior:**
`TagHelper` attributes that are unbound behave identically to non-`TagHelper` attributes. This means that `checked="@false"` results in the attribute not being rendered. `checked="@true"` results in `checked="checked"` and `checked="hello @null world"` results in `checked="hello world"`.

When an attribute value is modified due to these rules a `TagHelper` author can see the unchanged value via `TagHelperContext.AllAttributes` and the changed value will show up in `TagHelperOutput.Attributes`. Therefore `checked="@true"` results in `checked="checked"` in `TagHelperContext.AllAttributes` and `checked="True"` in `TagHelperOutput.Attributes`. In the case that the attribute is entirely removed, it will only exist in `TagHelperContext.AllAttributes`.

#247