### PR TITLE
Fix `DesignTimeDescriptorFactory.CreateDescriptor` call to properly retrieve type from `TypeInfo`.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 #if !DNXCORE50
             if (designTime)
             {
-                typeDesignTimeDescriptor = TagHelperDesignTimeDescriptorFactory.CreateDescriptor(typeInfo.GetType());
+                typeDesignTimeDescriptor = TagHelperDesignTimeDescriptorFactory.CreateDescriptor(typeInfo.AsType());
             }
 #endif
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDesignTimeDescriptorComparer.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDesignTimeDescriptorComparer.cs
@@ -27,7 +27,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             return descriptorX != null &&
                 descriptorY != null &&
                 string.Equals(descriptorX.Summary, descriptorY.Summary, StringComparison.Ordinal) &&
-                string.Equals(descriptorX.Remarks, descriptorY.Remarks, StringComparison.Ordinal);
+                string.Equals(descriptorX.Remarks, descriptorY.Remarks, StringComparison.Ordinal) &&
+                string.Equals(descriptorX.OutputElementHint, descriptorY.OutputElementHint, StringComparison.Ordinal);
         }
 
         public int GetHashCode(TagHelperDesignTimeDescriptor descriptor)
@@ -36,6 +37,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 .Start()
                 .Add(descriptor.Summary, StringComparer.Ordinal)
                 .Add(descriptor.Remarks, StringComparer.Ordinal)
+                .Add(descriptor.OutputElementHint, StringComparer.Ordinal)
                 .CombinedHash;
         }
     }


### PR DESCRIPTION
- Added `TagHelperDescriptorFactory` level tests to validate correct information is being pased to the `TagHelperDesignTimeDescriptorFactory`.

#457