### PR TITLE
Cleanup `project.json` files

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/project.json
+++ b/src/Microsoft.AspNet.Razor.Runtime/project.json
@@ -40,8 +40,8 @@
     },
     "dnxcore50": {
       "dependencies": {
-        "System.Reflection.Extensions": "4.0.0-beta-*",
-        "System.Text.RegularExpressions": "4.0.10-beta-*"
+        "System.Reflection.Extensions": "4.0.0-*",
+        "System.Text.RegularExpressions": "4.0.10-*"
       }
     }
   }

--- a/src/Microsoft.AspNet.Razor/project.json
+++ b/src/Microsoft.AspNet.Razor/project.json
@@ -20,19 +20,11 @@
     "dnx451": { },
     "dnxcore50": {
       "dependencies": {
-        "System.Collections": "4.0.10-beta-*",
-        "System.Diagnostics.Debug": "4.0.10-beta-*",
-        "System.Diagnostics.Tools": "4.0.0-beta-*",
-        "System.IO": "4.0.10-beta-*",
-        "System.IO.FileSystem": "4.0.0-beta-*",
-        "System.Linq": "4.0.0-beta-*",
-        "System.Reflection": "4.0.10-beta-*",
-        "System.Resources.ResourceManager": "4.0.0-beta-*",
-        "System.Runtime.Extensions": "4.0.10-beta-*",
-        "System.Threading": "4.0.10-beta-*",
-        "System.Threading.Tasks": "4.0.10-beta-*",
-        "System.Threading.Thread": "4.0.0-beta-*",
-        "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-*"
+        "System.Diagnostics.Tools": "4.0.0-*",
+        "System.IO.FileSystem": "4.0.0-*",
+        "System.Linq": "4.0.0-*",
+        "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-*",
+        "System.Threading.Thread": "4.0.0-*"
       }
     }
   }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/project.json
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/project.json
@@ -25,8 +25,8 @@
     },
     "dnxcore50": {
       "dependencies": {
-        "System.Reflection.TypeExtensions": "4.0.0-beta-*",
-        "System.Runtime.Extensions": "4.0.10-beta-*"
+        "System.Reflection.TypeExtensions": "4.0.0-*",
+        "System.Runtime.Extensions": "4.0.10-*"
       }
     }
   }

--- a/test/Microsoft.AspNet.Razor.Test/project.json
+++ b/test/Microsoft.AspNet.Razor.Test/project.json
@@ -21,9 +21,9 @@
     },
     "dnxcore50": {
       "dependencies": {
-        "System.Diagnostics.TraceSource": "4.0.0-beta-*",
-        "System.Reflection.TypeExtensions": "4.0.0-beta-*",
-        "System.Runtime.Serialization.Primitives": "4.0.10-beta-*"
+        "System.Diagnostics.TraceSource": "4.0.0-*",
+        "System.Reflection.TypeExtensions": "4.0.0-*",
+        "System.Runtime.Serialization.Primitives": "4.0.10-*"
       }
     }
   },


### PR DESCRIPTION
- react to updated Core package versions
 - remove `-beta`
 - led to warnings but only in VS builds
- remove some package references that are found transitively