### PR TITLE
Add ability to execute TagHelper child content more than once.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContext.cs
@@ -14,22 +14,22 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     /// </summary>
     public class TagHelperContext
     {
-        private readonly Func<Task<TagHelperContent>> _getChildContentAsync;
+        private readonly Func<bool, Task<TagHelperContent>> _getChildContentAsync;
 
         /// <summary>
         /// Instantiates a new <see cref="TagHelperContext"/>.
         /// </summary>
         /// <param name="allAttributes">Every attribute associated with the current HTML element.</param>
         /// <param name="items">Collection of items used to communicate with other <see cref="ITagHelper"/>s.</param>
-        /// <param name="uniqueId">The unique identifier for the source element this <see cref="TagHelperContext" /> 
+        /// <param name="uniqueId">The unique identifier for the source element this <see cref="TagHelperContext" />
         /// applies to.</param>
-        /// <param name="getChildContentAsync">A delegate used to execute and retrieve the rendered child content 
+        /// <param name="getChildContentAsync">A delegate used to execute and retrieve the rendered child content
         /// asynchronously.</param>
         public TagHelperContext(
             [NotNull] IEnumerable<IReadOnlyTagHelperAttribute> allAttributes,
             [NotNull] IDictionary<object, object> items,
             [NotNull] string uniqueId,
-            [NotNull] Func<Task<TagHelperContent>> getChildContentAsync)
+            [NotNull] Func<bool, Task<TagHelperContent>> getChildContentAsync)
         {
             AllAttributes = new ReadOnlyTagHelperAttributeList<IReadOnlyTagHelperAttribute>(
                 allAttributes.Select(attribute => new TagHelperAttribute(attribute.Name, attribute.Value)));
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// Gets the collection of items used to communicate with other <see cref="ITagHelper"/>s.
         /// </summary>
         /// <remarks>
-        /// This <see cref="IDictionary{object, object}"/> is copy-on-write in order to ensure items added to this 
+        /// This <see cref="IDictionary{object, object}"/> is copy-on-write in order to ensure items added to this
         /// collection are visible only to other <see cref="ITagHelper"/>s targeting child elements.
         /// </remarks>
         public IDictionary<object, object> Items { get; }
@@ -61,9 +61,21 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// A delegate used to execute and retrieve the rendered child content asynchronously.
         /// </summary>
         /// <returns>A <see cref="Task"/> that when executed returns content rendered by children.</returns>
+        /// <remarks>This method is memoized.</remarks>
         public Task<TagHelperContent> GetChildContentAsync()
         {
-            return _getChildContentAsync();
+            return GetChildContentAsync(useCachedResult: true);
+        }
+
+        /// <summary>
+        /// A delegate used to execute and retrieve the rendered child content asynchronously.
+        /// </summary>
+        /// <param name="useCachedResult">If <c>true</c> multiple calls to this method will not cause re-execution
+        /// of child content; cached content will be returned.</param>
+        /// <returns>A <see cref="Task"/> that when executed returns content rendered by children.</returns>
+        public Task<TagHelperContent> GetChildContentAsync(bool useCachedResult)
+        {
+            return _getChildContentAsync(useCachedResult);
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -191,9 +191,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// Child content is only executed once. Successive calls to this method or successive executions of the
         /// returned <see cref="Task{TagHelperContent}"/> return a cached result.
         /// </remarks>
-        public async Task<TagHelperContent> GetChildContentAsync()
+        public async Task<TagHelperContent> GetChildContentAsync(bool useCachedResult)
         {
-            if (_childContent == null)
+            if (!useCachedResult || _childContent == null)
             {
                 _startTagHelperWritingScope();
                 await _executeChildContentAsync();

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperContextTest.cs
@@ -11,6 +11,30 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 {
     public class TagHelperContextTest
     {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GetChildContentAsync_PassesUseCachedResultAsExpected(bool expectedUseCachedResultValue)
+        {
+            // Arrange
+            bool? useCachedResultValue = null;
+            var context = new TagHelperContext(
+                allAttributes: Enumerable.Empty<IReadOnlyTagHelperAttribute>(),
+                items: new Dictionary<object, object>(),
+                uniqueId: string.Empty,
+                getChildContentAsync: useCachedResult =>
+                {
+                    useCachedResultValue = useCachedResult;
+                    return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+                });
+
+            // Act
+            await context.GetChildContentAsync(expectedUseCachedResultValue);
+
+            // Assert
+            Assert.Equal(expectedUseCachedResultValue, useCachedResultValue);
+        }
+
         [Fact]
         public void Constructor_SetsProperties_AsExpected()
         {
@@ -25,7 +49,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 allAttributes: Enumerable.Empty<IReadOnlyTagHelperAttribute>(),
                 items: expectedItems,
                 uniqueId: string.Empty,
-                getChildContentAsync: () => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+                getChildContentAsync: useCachedResult =>
+                    Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
 
             // Assert
             Assert.NotNull(context.Items);


### PR DESCRIPTION
- Added a boolean overload that specifies whether the user wants to retrieve cached content.
- Added tests to validate `TagHelperExecutionContext` `GetChildContentAsync` and that `TagHelperContext` passes the appropriate values through.

#459