### PR TITLE
Add ability for `TagHelper`s to specify restricted children.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -394,6 +394,38 @@ namespace Microsoft.AspNet.Razor.Runtime
             return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperAttributeList_CannotAddAttribute"), p0, p1, p2, p3);
         }
 
+        /// <summary>
+        /// Invalid '{0}' tag name '{1}' for tag helper '{2}'. Tag helpers cannot restrict child elements that contain a '{3}' character.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeName
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeName"); }
+        }
+
+        /// <summary>
+        /// Invalid '{0}' tag name '{1}' for tag helper '{2}'. Tag helpers cannot restrict child elements that contain a '{3}' character.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidRestrictChildrenAttributeName(object p0, object p1, object p2, object p3)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeName"), p0, p1, p2, p3);
+        }
+
+        /// <summary>
+        /// Invalid '{0}' tag name for tag helper '{1}'. Name cannot be null or whitespace.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace"); }
+        }
+
+        /// <summary>
+        /// Invalid '{0}' tag name for tag helper '{1}'. Name cannot be null or whitespace.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -189,4 +189,10 @@
   <data name="TagHelperAttributeList_CannotAddAttribute" xml:space="preserve">
     <value>Cannot add a {0} with inconsistent names. The {1} property '{2}' must match the location '{3}'.</value>
   </data>
+  <data name="TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeName" xml:space="preserve">
+    <value>Invalid '{0}' tag name '{1}' for tag helper '{2}'. Tag helpers cannot restrict child elements that contain a '{3}' character.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace" xml:space="preserve">
+    <value>Invalid '{0}' tag name for tag helper '{1}'. Name cannot be null or whitespace.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/RestrictChildrenAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/RestrictChildrenAttribute.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// Restricts children of the <see cref="ITagHelper"/>'s element.
+    /// </summary>
+    /// <remarks>Combining this attribute with a <see cref="TargetElementAttribute"/> that specifies its
+    /// <see cref="TargetElementAttribute.TagStructure"/> as <see cref="TagStructure.WithoutEndTag"/> will result in
+    /// this attribute being ignored.</remarks>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    public class RestrictChildrenAttribute : Attribute
+    {
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="RestrictChildrenAttribute"/> class.
+        /// </summary>
+        /// <param name="tagName">
+        /// The tag name of an element allowed as a child. Tag helpers must target the element.
+        /// </param>
+        /// <param name="tagNames">
+        /// Additional names of elements allowed as children. Tag helpers must target all such elements.
+        /// </param>
+        public RestrictChildrenAttribute(string tagName, params string[] tagNames)
+        {
+            var concatenatedNames = new string[1 + tagNames.Length];
+            concatenatedNames[0] = tagName;
+
+            tagNames.CopyTo(concatenatedNames, 1);
+
+            ChildTagNames = concatenatedNames;
+        }
+
+        /// <summary>
+        /// Get the names of elements allowed as children. Tag helpers must target all such elements.
+        /// </summary>
+        public IEnumerable<string> ChildTagNames { get; }
+    }
+}

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
@@ -154,6 +154,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         descriptor.AssemblyName,
                         descriptor.Attributes,
                         descriptor.RequiredAttributes,
+                        descriptor.AllowedChildren,
                         descriptor.TagStructure,
                         descriptor.DesignTimeDescriptor));
             }

--- a/src/Microsoft.AspNet.Razor.Test.Sources/CaseSensitiveTagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor.Test.Sources/CaseSensitiveTagHelperDescriptorComparer.cs
@@ -26,14 +26,19 @@ namespace Microsoft.AspNet.Razor.Test.Internal
             }
 
             return base.Equals(descriptorX, descriptorY) &&
-                // Normal comparer doesn't care about the case, required attribute order, attributes or prefixes.
-                // In tests we do.
+                // Normal comparer doesn't care about the case, required attribute order, allowed children order,
+                // attributes or prefixes. In tests we do.
                 string.Equals(descriptorX.TagName, descriptorY.TagName, StringComparison.Ordinal) &&
                 string.Equals(descriptorX.Prefix, descriptorY.Prefix, StringComparison.Ordinal) &&
                 Enumerable.SequenceEqual(
                     descriptorX.RequiredAttributes,
                     descriptorY.RequiredAttributes,
                     StringComparer.Ordinal) &&
+                (descriptorX.AllowedChildren == descriptorY.AllowedChildren ||
+                Enumerable.SequenceEqual(
+                    descriptorX.AllowedChildren,
+                    descriptorY.AllowedChildren,
+                    StringComparer.Ordinal)) &&
                 descriptorX.Attributes.SequenceEqual(
                     descriptorY.Attributes,
                     TagHelperAttributeDescriptorComparer.Default) &&
@@ -58,6 +63,14 @@ namespace Microsoft.AspNet.Razor.Test.Internal
             foreach (var requiredAttribute in descriptor.RequiredAttributes)
             {
                 hashCodeCombiner.Add(requiredAttribute, StringComparer.Ordinal);
+            }
+
+            if (descriptor.AllowedChildren != null)
+            {
+                foreach (var child in descriptor.AllowedChildren)
+                {
+                    hashCodeCombiner.Add(child, StringComparer.Ordinal);
+                }
             }
 
             foreach (var attribute in descriptor.Attributes)

--- a/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor/Properties/RazorResources.Designer.cs
@@ -1514,6 +1514,38 @@ namespace Microsoft.AspNet.Razor
             return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperParseTreeRewriter_EndTagTagHelperMustNotHaveAnEndTag"), p0, p1, p2);
         }
 
+        /// <summary>
+        /// The parent &amp;lt;{0}&amp;gt; tag helper does not allow non-tag content. Only child tag helper(s) targeting tag name(s) '{1}' are allowed.
+        /// </summary>
+        internal static string TagHelperParseTreeRewriter_CannotHaveNonTagContent
+        {
+            get { return GetString("TagHelperParseTreeRewriter_CannotHaveNonTagContent"); }
+        }
+
+        /// <summary>
+        /// The parent &amp;lt;{0}&amp;gt; tag helper does not allow non-tag content. Only child tag helper(s) targeting tag name(s) '{1}' are allowed.
+        /// </summary>
+        internal static string FormatTagHelperParseTreeRewriter_CannotHaveNonTagContent(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperParseTreeRewriter_CannotHaveNonTagContent"), p0, p1);
+        }
+
+        /// <summary>
+        /// The &amp;lt;{0}&amp;gt; tag is not allowed by parent &amp;lt;{1}&amp;gt; tag helper. Only child tag helper(s) targeting tag name(s) '{2}' are allowed.
+        /// </summary>
+        internal static string TagHelperParseTreeRewriter_InvalidNestedTag
+        {
+            get { return GetString("TagHelperParseTreeRewriter_InvalidNestedTag"); }
+        }
+
+        /// <summary>
+        /// The &amp;lt;{0}&amp;gt; tag is not allowed by parent &amp;lt;{1}&amp;gt; tag helper. Only child tag helper(s) targeting tag name(s) '{2}' are allowed.
+        /// </summary>
+        internal static string FormatTagHelperParseTreeRewriter_InvalidNestedTag(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperParseTreeRewriter_InvalidNestedTag"), p0, p1, p2);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Razor/RazorResources.resx
+++ b/src/Microsoft.AspNet.Razor/RazorResources.resx
@@ -419,4 +419,10 @@ Instead, wrap the contents of the block in "{{}}":
   <data name="TagHelperParseTreeRewriter_EndTagTagHelperMustNotHaveAnEndTag" xml:space="preserve">
     <value>Found an end tag (&amp;lt;/{0}&amp;gt;) for tag helper '{1}' with tag structure that disallows an end tag ('{2}').</value>
   </data>
+  <data name="TagHelperParseTreeRewriter_CannotHaveNonTagContent" xml:space="preserve">
+    <value>The parent &amp;lt;{0}&amp;gt; tag helper does not allow non-tag content. Only child tag helper(s) targeting tag name(s) '{1}' are allowed.</value>
+  </data>
+  <data name="TagHelperParseTreeRewriter_InvalidNestedTag" xml:space="preserve">
+    <value>The &amp;lt;{0}&amp;gt; tag is not allowed by parent &amp;lt;{1}&amp;gt; tag helper. Only child tag helper(s) targeting tag name(s) '{2}' are allowed.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
@@ -61,6 +61,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 assemblyName: assemblyName,
                 attributes: attributes,
                 requiredAttributes: requiredAttributes,
+                allowedChildren: null,
                 tagStructure: TagStructure.Unspecified,
                 designTimeDescriptor: null)
         {
@@ -84,6 +85,10 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <param name="requiredAttributes">
         /// The attribute names required for the tag helper to target the HTML tag.
         /// </param>
+        /// <param name="allowedChildren">
+        /// The names of elements allowed as children. Tag helpers must target all such elements.
+        /// </param>
+        /// <param name="tagStructure">The expected tag structure.</param>
         /// <param name="designTimeDescriptor">The <see cref="TagHelperDesignTimeDescriptor"/> that contains design
         /// time information about the tag helper.</param>
         public TagHelperDescriptor(
@@ -93,6 +98,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             [NotNull] string assemblyName,
             [NotNull] IEnumerable<TagHelperAttributeDescriptor> attributes,
             [NotNull] IEnumerable<string> requiredAttributes,
+            IEnumerable<string> allowedChildren,
             TagStructure tagStructure,
             TagHelperDesignTimeDescriptor designTimeDescriptor)
         {
@@ -105,6 +111,11 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             RequiredAttributes = new List<string>(requiredAttributes);
             TagStructure = tagStructure;
             DesignTimeDescriptor = designTimeDescriptor;
+
+            if (allowedChildren != null)
+            {
+                AllowedChildren = new List<string>(allowedChildren);
+            }
         }
 
         /// <summary>
@@ -146,6 +157,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <c>*</c> at the end of an attribute name acts as a prefix match.
         /// </remarks>
         public IReadOnlyList<string> RequiredAttributes { get; }
+
+        /// <summary>
+        /// Get the names of elements allowed as children. Tag helpers must target all such elements.
+        /// </summary>
+        /// <remarks><c>null</c> indicates all children are allowed.</remarks>
+        public IReadOnlyList<string> AllowedChildren { get; }
 
         /// <summary>
         /// The expected tag structure.

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
@@ -30,7 +30,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <remarks>
         /// Determines equality based on <see cref="TagHelperDescriptor.TypeName"/>,
         /// <see cref="TagHelperDescriptor.AssemblyName"/>, <see cref="TagHelperDescriptor.TagName"/>,
-        /// <see cref="TagHelperDescriptor.RequiredAttributes"/>, and <see cref="TagHelperDescriptor.TagStructure"/>.
+        /// <see cref="TagHelperDescriptor.RequiredAttributes"/>, <see cref="TagHelperDescriptor.AllowedChildren"/>,
+        /// and <see cref="TagHelperDescriptor.TagStructure"/>.
         /// Ignores <see cref="TagHelperDescriptor.DesignTimeDescriptor"/> because it can be inferred directly from
         /// <see cref="TagHelperDescriptor.TypeName"/> and <see cref="TagHelperDescriptor.AssemblyName"/>.
         /// </remarks>
@@ -49,6 +50,13 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     descriptorX.RequiredAttributes.OrderBy(attribute => attribute, StringComparer.OrdinalIgnoreCase),
                     descriptorY.RequiredAttributes.OrderBy(attribute => attribute, StringComparer.OrdinalIgnoreCase),
                     StringComparer.OrdinalIgnoreCase) &&
+                (descriptorX.AllowedChildren == descriptorY.AllowedChildren ||
+                (descriptorX.AllowedChildren != null &&
+                descriptorY.AllowedChildren != null &&
+                Enumerable.SequenceEqual(
+                    descriptorX.AllowedChildren.OrderBy(child => child, StringComparer.OrdinalIgnoreCase),
+                    descriptorY.AllowedChildren.OrderBy(child => child, StringComparer.OrdinalIgnoreCase),
+                    StringComparer.OrdinalIgnoreCase))) &&
                 descriptorX.TagStructure == descriptorY.TagStructure;
         }
 
@@ -67,6 +75,15 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             foreach (var attribute in attributes)
             {
                 hashCodeCombiner.Add(attribute, StringComparer.OrdinalIgnoreCase);
+            }
+
+            if (descriptor.AllowedChildren != null)
+            {
+                var allowedChildren = descriptor.AllowedChildren.OrderBy(child => child, StringComparer.OrdinalIgnoreCase);
+                foreach (var child in allowedChildren)
+                {
+                    hashCodeCombiner.Add(child, StringComparer.OrdinalIgnoreCase);
+                }
             }
 
             return hashCodeCombiner.CombinedHash;

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 assemblyName: AssemblyName,
                                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                                 requiredAttributes: Enumerable.Empty<string>(),
+                                allowedChildren: null,
                                 tagStructure: TagStructure.WithoutEndTag,
                                 designTimeDescriptor: null)
                         }
@@ -50,6 +51,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 assemblyName: AssemblyName,
                                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                                 requiredAttributes: Enumerable.Empty<string>(),
+                                allowedChildren: null,
                                 tagStructure: TagStructure.WithoutEndTag,
                                 designTimeDescriptor: null),
                             new TagHelperDescriptor(
@@ -59,6 +61,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 assemblyName: AssemblyName,
                                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                                 requiredAttributes: Enumerable.Empty<string>(),
+                                allowedChildren: null,
                                 tagStructure: TagStructure.NormalOrSelfClosing,
                                 designTimeDescriptor: null),
                         }
@@ -74,6 +77,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 assemblyName: AssemblyName,
                                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                                 requiredAttributes: Enumerable.Empty<string>(),
+                                allowedChildren: null,
                                 tagStructure: TagStructure.WithoutEndTag,
                                 designTimeDescriptor: null),
                             new TagHelperDescriptor(
@@ -83,6 +87,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 assemblyName: AssemblyName,
                                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                                 requiredAttributes: Enumerable.Empty<string>(),
+                                allowedChildren: null,
                                 tagStructure: TagStructure.Unspecified,
                                 designTimeDescriptor: null),
                         }
@@ -137,6 +142,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 assemblyName: AssemblyName,
                                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                                 requiredAttributes: Enumerable.Empty<string>(),
+                                allowedChildren: null,
                                 tagStructure: default(TagStructure),
                                 designTimeDescriptor: new TagHelperDesignTimeDescriptor
                                 {
@@ -155,6 +161,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 assemblyName: AssemblyName,
                                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                                 requiredAttributes: Enumerable.Empty<string>(),
+                                allowedChildren: null,
                                 tagStructure: default(TagStructure),
                                 designTimeDescriptor: new TagHelperDesignTimeDescriptor
                                 {
@@ -167,6 +174,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                                 assemblyName: AssemblyName,
                                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                                 requiredAttributes: Enumerable.Empty<string>(),
+                                allowedChildren: null,
                                 tagStructure: default(TagStructure),
                                 designTimeDescriptor: new TagHelperDesignTimeDescriptor
                                 {
@@ -1734,6 +1742,42 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             }
         }
 
+        public static TheoryData<string, string[]> InvalidRestrictChildrenNameData
+        {
+            get
+            {
+                var nullOrWhiteSpaceError =
+                    Resources.FormatTagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace(
+                        nameof(RestrictChildrenAttribute),
+                        "SomeTagHelper");
+
+                return GetInvalidNameOrPrefixData(
+                    onNameError: (invalidInput, invalidCharacter) =>
+                        Resources.FormatTagHelperDescriptorFactory_InvalidRestrictChildrenAttributeName(
+                            nameof(RestrictChildrenAttribute),
+                            invalidInput,
+                            "SomeTagHelper",
+                            invalidCharacter),
+                    whitespaceErrorString: nullOrWhiteSpaceError,
+                    onDataError: null);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidRestrictChildrenNameData))]
+        public void GetValidAllowedChildren_AddsExpectedErrors(string name, string[] expectedErrorMessages)
+        {
+            // Arrange
+            var errorSink = new ErrorSink();
+            var expectedErrors = expectedErrorMessages.Select(message => new RazorError(message, SourceLocation.Zero));
+
+            // Act
+            TagHelperDescriptorFactory.GetValidAllowedChildren(new[] { name }, "SomeTagHelper", errorSink);
+
+            // Assert
+            Assert.Equal(expectedErrors, errorSink.Errors);
+        }
+
         private static TheoryData<string, string[]> GetInvalidNameOrPrefixData(
             Func<string, string, string> onNameError,
             string whitespaceErrorString,
@@ -1973,6 +2017,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 assemblyName: assemblyName,
                 attributes: attributes ?? Enumerable.Empty<TagHelperAttributeDescriptor>(),
                 requiredAttributes: requiredAttributes ?? Enumerable.Empty<string>(),
+                allowedChildren: null,
                 tagStructure: default(TagStructure),
                 designTimeDescriptor: null);
         }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
@@ -32,6 +32,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     assemblyName: AssemblyName,
                     attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                     requiredAttributes: Enumerable.Empty<string>(),
+                    allowedChildren: null,
                     tagStructure: default(TagStructure),
                     designTimeDescriptor: null);
             }
@@ -48,6 +49,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     assemblyName: AssemblyName,
                     attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                     requiredAttributes: Enumerable.Empty<string>(),
+                    allowedChildren: null,
                     tagStructure: default(TagStructure),
                     designTimeDescriptor: null);
             }
@@ -609,6 +611,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         assemblyName: assemblyB,
                         attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                         requiredAttributes: Enumerable.Empty<string>(),
+                        allowedChildren: null,
                         tagStructure: default(TagStructure),
                         designTimeDescriptor: null);
 
@@ -1045,6 +1048,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         assemblyName: assemblyB,
                         attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                         requiredAttributes: Enumerable.Empty<string>(),
+                        allowedChildren: null,
                         tagStructure: default(TagStructure),
                         designTimeDescriptor: null);
 
@@ -1444,6 +1448,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 assemblyName,
                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                 requiredAttributes: Enumerable.Empty<string>(),
+                allowedChildren: null,
                 tagStructure: default(TagStructure),
                 designTimeDescriptor: null);
         }

--- a/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
@@ -1550,6 +1550,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                         new TagHelperAttributeDescriptor("age", pAgePropertyInfo)
                     },
                     requiredAttributes: Enumerable.Empty<string>(),
+                    allowedChildren: null,
                     tagStructure: TagStructure.NormalOrSelfClosing,
                     designTimeDescriptor: null),
                 new TagHelperDescriptor(
@@ -1562,6 +1563,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                         new TagHelperAttributeDescriptor("type", inputTypePropertyInfo)
                     },
                     requiredAttributes: Enumerable.Empty<string>(),
+                    allowedChildren: null,
                     tagStructure: TagStructure.WithoutEndTag,
                     designTimeDescriptor: null),
                 new TagHelperDescriptor(
@@ -1575,6 +1577,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                         new TagHelperAttributeDescriptor("checked", checkedPropertyInfo)
                     },
                     requiredAttributes: Enumerable.Empty<string>(),
+                    allowedChildren: null,
                     tagStructure: TagStructure.Unspecified,
                     designTimeDescriptor: null)
             };

--- a/test/Microsoft.AspNet.Razor.Test/CodeGenerators/TagHelperAttributeValueCodeRendererTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/CodeGenerators/TagHelperAttributeValueCodeRendererTest.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                         new TagHelperAttributeDescriptor("type", inputTypePropertyInfo)
                     },
                     requiredAttributes: new string[0],
+                    allowedChildren: null,
                     tagStructure: TagStructure.WithoutEndTag,
                     designTimeDescriptor: null),
                 new TagHelperDescriptor(

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
@@ -87,6 +87,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         assemblyName: "SomeAssembly",
                         attributes: new TagHelperAttributeDescriptor[0],
                         requiredAttributes: Enumerable.Empty<string>(),
+                        allowedChildren: null,
                         tagStructure: TagStructure.WithoutEndTag,
                         designTimeDescriptor: null)
                 };
@@ -189,6 +190,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         assemblyName: "SomeAssembly",
                         attributes: new TagHelperAttributeDescriptor[0],
                         requiredAttributes: Enumerable.Empty<string>(),
+                        allowedChildren: null,
                         tagStructure: structure1,
                         designTimeDescriptor: null),
                     new TagHelperDescriptor(
@@ -198,6 +200,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         assemblyName: "SomeAssembly",
                         attributes: new TagHelperAttributeDescriptor[0],
                         requiredAttributes: Enumerable.Empty<string>(),
+                        allowedChildren: null,
                         tagStructure: structure2,
                         designTimeDescriptor: null)
                 };

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorProviderTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorProviderTest.cs
@@ -322,6 +322,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 assemblyName: "SomeAssembly",
                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                 requiredAttributes: Enumerable.Empty<string>(),
+                allowedChildren: null,
                 tagStructure: default(TagStructure),
                 designTimeDescriptor: null);
         }

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 assemblyName: "assembly name",
                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                 requiredAttributes: new[] { "required attribute one", "required attribute two" },
+                allowedChildren: new[] { "allowed child one" },
                 tagStructure: TagStructure.Unspecified,
                 designTimeDescriptor: new TagHelperDesignTimeDescriptor
                 {
@@ -40,6 +41,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":" +
                 "[\"required attribute one\",\"required attribute two\"]," +
+                $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":[\"allowed child one\"]," +
                 $"\"{ nameof(TagHelperDescriptor.TagStructure) }\":0," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":{{"+
                 $"\"{ nameof(TagHelperDesignTimeDescriptor.Summary) }\":\"usage summary\"," +
@@ -78,6 +80,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         designTimeDescriptor: null),
                 },
                 requiredAttributes: Enumerable.Empty<string>(),
+                allowedChildren: null,
                 tagStructure: TagStructure.NormalOrSelfClosing,
                 designTimeDescriptor: null);
             var expectedSerializedDescriptor =
@@ -100,6 +103,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.DesignTimeDescriptor) }\":null}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]," +
+                $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":null," +
                 $"\"{ nameof(TagHelperDescriptor.TagStructure) }\":1," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":null}}";
 
@@ -135,6 +139,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         designTimeDescriptor: null),
                 },
                 requiredAttributes: Enumerable.Empty<string>(),
+                allowedChildren: new[] { "allowed child one", "allowed child two" },
                 tagStructure: default(TagStructure),
                 designTimeDescriptor: null);
             var expectedSerializedDescriptor =
@@ -157,6 +162,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.DesignTimeDescriptor) }\":null}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]," +
+                $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":[\"allowed child one\",\"allowed child two\"]," +
                 $"\"{ nameof(TagHelperDescriptor.TagStructure) }\":0," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":null}}";
 
@@ -180,6 +186,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{nameof(TagHelperDescriptor.Attributes)}\":[]," +
                 $"\"{nameof(TagHelperDescriptor.RequiredAttributes)}\":" +
                 "[\"required attribute one\",\"required attribute two\"]," +
+                $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":[\"allowed child one\",\"allowed child two\"]," +
                 $"\"{nameof(TagHelperDescriptor.TagStructure)}\":2," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":{{" +
                 $"\"{ nameof(TagHelperDesignTimeDescriptor.Summary) }\":\"usage summary\"," +
@@ -192,6 +199,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 assemblyName: "assembly name",
                 attributes: Enumerable.Empty<TagHelperAttributeDescriptor>(),
                 requiredAttributes: new[] { "required attribute one", "required attribute two" },
+                allowedChildren: new[] { "allowed child one", "allowed child two" },
                 tagStructure: TagStructure.WithoutEndTag,
                 designTimeDescriptor: new TagHelperDesignTimeDescriptor
                 {
@@ -242,6 +250,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.DesignTimeDescriptor) }\":null}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]," +
+                $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":null," +
                 $"\"{nameof(TagHelperDescriptor.TagStructure)}\":0," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":null}}";
             var expectedDescriptor = new TagHelperDescriptor(
@@ -265,6 +274,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         designTimeDescriptor: null),
                 },
                 requiredAttributes: Enumerable.Empty<string>(),
+                allowedChildren: null,
                 tagStructure: TagStructure.Unspecified,
                 designTimeDescriptor: null);
 
@@ -331,6 +341,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperAttributeDescriptor.TypeName) }\":\"{ typeof(string).FullName }\"," +
                 $"\"{ nameof(TagHelperAttributeDescriptor.DesignTimeDescriptor) }\":null}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]," +
+                $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":null," +
                 $"\"{nameof(TagHelperDescriptor.TagStructure)}\":1," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":null}}";
             var expectedDescriptor = new TagHelperDescriptor(
@@ -354,6 +365,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         designTimeDescriptor: null),
                 },
                 requiredAttributes: Enumerable.Empty<string>(),
+                allowedChildren: null,
                 tagStructure: TagStructure.NormalOrSelfClosing,
                 designTimeDescriptor: null);
 


### PR DESCRIPTION
- Specifying the `RestrictChildrenAttribute` enables `TagHelper`s to only allow other `TagHelper`s targeting specified names to be in the children.
- Used the `null` value to indicate that `AllowedChildren` was not specified and therefore everything is allowed. This is the default.
- Added name verification to name values to ensure that no bad values pass through the system.
- Added parsing tests to validate a mixture of content generates errors when expected.

#255