### PR TITLE
Change logged errors to consistently provide error lengths.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -315,7 +315,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             if (string.IsNullOrWhiteSpace(name))
             {
-                errorSink.OnError(SourceLocation.Zero, whitespaceError);
+                errorSink.OnError(SourceLocation.Zero, whitespaceError, length: 0);
 
                 validName = false;
             }
@@ -327,7 +327,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         InvalidNonWhitespaceNameCharacters.Contains(character))
                     {
                         var error = characterErrorBuilder(character);
-                        errorSink.OnError(SourceLocation.Zero, error);
+                        errorSink.OnError(SourceLocation.Zero, error, length: 0);
 
                         validName = false;
                     }
@@ -379,7 +379,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                             type.FullName,
                             property.Name,
                             typeof(HtmlAttributeNameAttribute).FullName,
-                            nameof(HtmlAttributeNameAttribute.Name)));
+                            nameof(HtmlAttributeNameAttribute.Name)),
+                        length: 0);
                     continue;
                 }
 
@@ -438,7 +439,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     SourceLocation.Zero,
                     Resources.FormatTagHelperDescriptorFactory_InvalidAttributeNameNullOrEmpty(
                         parentType.FullName,
-                        attributeDescriptor.PropertyName));
+                        attributeDescriptor.PropertyName),
+                    length: 0);
 
                 return false;
             }
@@ -492,7 +494,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     Resources.FormatTagHelperDescriptorFactory_InvalidAttributeNameOrPrefixWhitespace(
                         parentType.FullName,
                         propertyName,
-                        nameOrPrefix));
+                        nameOrPrefix),
+                    length: 0);
 
                 return false;
             }
@@ -508,7 +511,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         propertyName,
                         nameOrPrefix,
                         attributeNameOrPrefix,
-                        DataDashPrefix));
+                        DataDashPrefix),
+                    length: 0);
 
                 return false;
             }
@@ -525,7 +529,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                             propertyName,
                             nameOrPrefix,
                             attributeNameOrPrefix,
-                            character));
+                            character),
+                    length: 0);
 
                     isValid = false;
                 }
@@ -576,7 +581,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                             property.Name,
                             nameof(HtmlAttributeNameAttribute),
                             nameof(HtmlAttributeNameAttribute.DictionaryAttributePrefix),
-                            "IDictionary<string, TValue>"));
+                            "IDictionary<string, TValue>"),
+                        length: 0);
                 }
                 else if (attributeNameAttribute != null && !hasPublicSetter)
                 {
@@ -589,7 +595,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                             parentType.FullName,
                             property.Name,
                             nameof(HtmlAttributeNameAttribute),
-                            "IDictionary<string, TValue>"));
+                            "IDictionary<string, TValue>"),
+                        length: 0);
                 }
 
                 return null;
@@ -608,7 +615,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         property.Name,
                         nameof(HtmlAttributeNameAttribute),
                         nameof(HtmlAttributeNameAttribute.DictionaryAttributePrefix),
-                        "IDictionary<string, TValue>"));
+                        "IDictionary<string, TValue>"),
+                    length: 0);
 
                 return null;
             }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     {
                         var descriptors = ResolveDescriptorsInAssembly(
                             lookupInfo.AssemblyName,
-                            directiveDescriptor.Location,
+                            lookupInfo.AssemblyNameLocation,
                             context.ErrorSink);
 
                         // Only use descriptors that match our lookup info
@@ -101,7 +101,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         Resources.FormatTagHelperDescriptorResolver_EncounteredUnexpectedError(
                             "@" + directiveName,
                             directiveDescriptor.DirectiveText,
-                            ex.Message));
+                            ex.Message),
+                        GetErrorLength(directiveDescriptor.DirectiveText));
                 }
             }
 
@@ -183,7 +184,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     context.ErrorSink.OnError(
                         directive.Location,
                         Resources.FormatTagHelperDescriptorResolver_InvalidTagHelperDirective(
-                            SyntaxConstants.CSharp.TagHelperPrefixKeyword));
+                            SyntaxConstants.CSharp.TagHelperPrefixKeyword),
+                        GetErrorLength(directive.DirectiveText));
                 }
             }
 
@@ -213,7 +215,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         Resources.FormatTagHelperDescriptorResolver_InvalidTagHelperPrefixValue(
                             SyntaxConstants.CSharp.TagHelperPrefixKeyword,
                             character,
-                            prefix));
+                            prefix),
+                        prefix.Length);
 
                     return false;
                 }
@@ -241,8 +244,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             return regex.IsMatch(descriptor.TypeName);
         }
 
-        private static LookupInfo GetLookupInfo(TagHelperDirectiveDescriptor directiveDescriptor,
-                                                ErrorSink errorSink)
+        private static LookupInfo GetLookupInfo(
+            TagHelperDirectiveDescriptor directiveDescriptor,
+            ErrorSink errorSink)
         {
             var lookupText = directiveDescriptor.DirectiveText;
             var lookupStrings = lookupText?.Split(new[] { ',' });
@@ -256,16 +260,33 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             {
                 errorSink.OnError(
                     directiveDescriptor.Location,
-                    Resources.FormatTagHelperDescriptorResolver_InvalidTagHelperLookupText(lookupText));
+                    Resources.FormatTagHelperDescriptorResolver_InvalidTagHelperLookupText(lookupText),
+                    GetErrorLength(lookupText));
 
                 return null;
             }
 
+            var trimmedAssemblyName = lookupStrings[1].Trim();
+
+            // + 1 is for the comma separator in the lookup text.
+            var assemblyNameIndex = lookupStrings[0].Length + 1 + lookupStrings[1].IndexOf(trimmedAssemblyName);
+            var assemblyNamePrefix = directiveDescriptor.DirectiveText.Substring(0, assemblyNameIndex);
+            var assemblyNameLocation = SourceLocation.Advance(directiveDescriptor.Location, assemblyNamePrefix);
+
             return new LookupInfo
             {
                 TypePattern = lookupStrings[0].Trim(),
-                AssemblyName = lookupStrings[1].Trim()
+                AssemblyName = trimmedAssemblyName,
+                AssemblyNameLocation = assemblyNameLocation,
             };
+        }
+
+        private static int GetErrorLength(string directiveText)
+        {
+            var nonNullLength = directiveText == null ? 1 : directiveText.Length;
+            var normalizeEmptyStringLength = Math.Max(nonNullLength, 1);
+
+            return normalizeEmptyStringLength;
         }
 
         private class LookupInfo
@@ -273,6 +294,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             public string AssemblyName { get; set; }
 
             public string TypePattern { get; set; }
+
+            public SourceLocation AssemblyNameLocation { get; set; }
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperTypeResolver.cs
@@ -35,14 +35,18 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <see cref="ITagHelper"/> <see cref="Type"/>s.</param>
         /// <returns>An <see cref="IEnumerable{Type}"/> of valid <see cref="ITagHelper"/> <see cref="Type"/>s.
         /// </returns>
-        public IEnumerable<Type> Resolve(string name, 
-                                         SourceLocation documentLocation, 
-                                         [NotNull] ErrorSink errorSink)
+        public IEnumerable<Type> Resolve(
+            string name,
+            SourceLocation documentLocation,
+            [NotNull] ErrorSink errorSink)
         {
             if (string.IsNullOrEmpty(name))
             {
-                errorSink.OnError(documentLocation,
-                                  Resources.TagHelperTypeResolver_TagHelperAssemblyNameCannotBeEmptyOrNull);
+                var errorLength = name == null ? 1 : Math.Max(name.Length, 1);
+                errorSink.OnError(
+                    documentLocation,
+                    Resources.TagHelperTypeResolver_TagHelperAssemblyNameCannotBeEmptyOrNull,
+                    errorLength);
 
                 return Type.EmptyTypes;
             }
@@ -60,7 +64,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     documentLocation,
                     Resources.FormatTagHelperTypeResolver_CannotResolveTagHelperAssembly(
                         assemblyName.Name,
-                        ex.Message));
+                        ex.Message),
+                    name.Length);
 
                 return Type.EmptyTypes;
             }

--- a/src/Microsoft.AspNet.Razor/ErrorSink.cs
+++ b/src/Microsoft.AspNet.Razor/ErrorSink.cs
@@ -45,16 +45,6 @@ namespace Microsoft.AspNet.Razor
         /// </summary>
         /// <param name="location"><see cref="SourceLocation"/> of the error.</param>
         /// <param name="message">A message describing the error.</param>
-        public void OnError(SourceLocation location, string message)
-        {
-            OnError(location, message, RazorError.DefaultErrorLength);
-        }
-
-        /// <summary>
-        /// Creates and tracks a new <see cref="RazorError"/>.
-        /// </summary>
-        /// <param name="location"><see cref="SourceLocation"/> of the error.</param>
-        /// <param name="message">A message describing the error.</param>
         /// <param name="length">The length of the error.</param>
         public void OnError(SourceLocation location, string message, int length)
         {

--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
@@ -102,7 +102,10 @@ namespace Microsoft.AspNet.Razor.Parser
                 if (!errorReported)
                 {
                     errorReported = true;
-                    Context.OnError(errorLocation, RazorResources.ParseError_MissingOpenBraceAfterSection);
+                    Context.OnError(
+                        errorLocation,
+                        RazorResources.ParseError_MissingOpenBraceAfterSection,
+                        length: 1  /* { */);
                 }
 
                 PutCurrentBack();
@@ -133,9 +136,10 @@ namespace Microsoft.AspNet.Razor.Parser
             if (!Optional(CSharpSymbolType.RightBrace))
             {
                 editHandler.AutoCompleteString = "}";
-                Context.OnError(CurrentLocation,
-                                RazorResources.FormatParseError_Expected_X(
-                                    Language.GetSample(CSharpSymbolType.RightBrace)));
+                Context.OnError(
+                    CurrentLocation,
+                    RazorResources.FormatParseError_Expected_X(Language.GetSample(CSharpSymbolType.RightBrace)),
+                    length: 1 /* } */);
             }
             else
             {
@@ -160,8 +164,10 @@ namespace Microsoft.AspNet.Razor.Parser
 
             if (!At(CSharpSymbolType.LeftBrace))
             {
-                Context.OnError(CurrentLocation,
-                                RazorResources.FormatParseError_Expected_X(Language.GetSample(CSharpSymbolType.LeftBrace)));
+                Context.OnError(
+                    CurrentLocation,
+                    RazorResources.FormatParseError_Expected_X(Language.GetSample(CSharpSymbolType.LeftBrace)),
+                    length: 1 /* { */);
                 CompleteBlock();
                 Output(SpanKind.MetaCode);
                 return;
@@ -186,7 +192,10 @@ namespace Microsoft.AspNet.Razor.Parser
             if (!At(CSharpSymbolType.RightBrace))
             {
                 editHandler.AutoCompleteString = "}";
-                Context.OnError(blockStart, RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(block.Name, "}", "{"));
+                Context.OnError(
+                    blockStart,
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(block.Name, "}", "{"),
+                    length: 1 /* } */);
                 CompleteBlock();
                 Output(SpanKind.Code);
             }

--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Statements.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Statements.cs
@@ -29,7 +29,10 @@ namespace Microsoft.AspNet.Razor.Parser
 
         protected virtual void ReservedDirective(bool topLevel)
         {
-            Context.OnError(CurrentLocation, RazorResources.FormatParseError_ReservedWord(CurrentSymbol.Content));
+            Context.OnError(
+                CurrentLocation,
+                RazorResources.FormatParseError_ReservedWord(CurrentSymbol.Content),
+                CurrentSymbol.Content.Length);
             AcceptAndMoveNext();
             Span.EditHandler.AcceptedCharacters = AcceptedCharacters.None;
             Span.ChunkGenerator = SpanChunkGenerator.Null;
@@ -109,7 +112,10 @@ namespace Microsoft.AspNet.Razor.Parser
                 // using Identifier ==> Using Declaration
                 if (!topLevel)
                 {
-                    Context.OnError(block.Start, RazorResources.ParseError_NamespaceImportAndTypeAlias_Cannot_Exist_Within_CodeBlock);
+                    Context.OnError(
+                        block.Start,
+                        RazorResources.ParseError_NamespaceImportAndTypeAlias_Cannot_Exist_Within_CodeBlock,
+                        block.Name.Length);
                     StandardStatement();
                 }
                 else
@@ -327,10 +333,12 @@ namespace Microsoft.AspNet.Razor.Parser
                 // Check for "{" to make sure we're at a block
                 if (!At(CSharpSymbolType.LeftBrace))
                 {
-                    Context.OnError(CurrentLocation,
-                                    RazorResources.FormatParseError_SingleLine_ControlFlowStatements_Not_Allowed(
-                                        Language.GetSample(CSharpSymbolType.LeftBrace),
-                                        CurrentSymbol.Content));
+                    Context.OnError(
+                        CurrentLocation,
+                        RazorResources.FormatParseError_SingleLine_ControlFlowStatements_Not_Allowed(
+                            Language.GetSample(CSharpSymbolType.LeftBrace),
+                            CurrentSymbol.Content),
+                        CurrentSymbol.Content.Length);
                 }
 
                 // Parse the statement and then we're done
@@ -480,7 +488,10 @@ namespace Microsoft.AspNet.Razor.Parser
             {
                 if (type == CSharpSymbolType.Transition && !isSingleLineMarkup)
                 {
-                    Context.OnError(loc, RazorResources.ParseError_AtInCode_Must_Be_Followed_By_Colon_Paren_Or_Identifier_Start);
+                    Context.OnError(
+                        loc,
+                        RazorResources.ParseError_AtInCode_Must_Be_Followed_By_Colon_Paren_Or_Identifier_Start,
+                        length: 1 /* @ */);
                 }
 
                 // Markup block
@@ -560,7 +571,10 @@ namespace Microsoft.AspNet.Razor.Parser
                 // Throw errors as necessary, but continue parsing
                 if (At(CSharpSymbolType.LeftBrace))
                 {
-                    Context.OnError(CurrentLocation, RazorResources.ParseError_Unexpected_Nested_CodeBlock);
+                    Context.OnError(
+                        CurrentLocation,
+                        RazorResources.ParseError_Unexpected_Nested_CodeBlock,
+                        length: 1  /* { */);
                 }
 
                 // @( or @foo - Nested expression, parse a child block
@@ -649,7 +663,10 @@ namespace Microsoft.AspNet.Razor.Parser
 
             if (EndOfFile)
             {
-                Context.OnError(block.Start, RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(block.Name, '}', '{'));
+                Context.OnError(
+                    block.Start,
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(block.Name, '}', '{'),
+                    length: 1  /* { OR } */);
             }
             else if (acceptTerminatingBrace)
             {

--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.cs
@@ -256,15 +256,25 @@ namespace Microsoft.AspNet.Razor.Parser
                     };
                     if (At(CSharpSymbolType.WhiteSpace) || At(CSharpSymbolType.NewLine))
                     {
-                        Context.OnError(CurrentLocation, RazorResources.ParseError_Unexpected_WhiteSpace_At_Start_Of_CodeBlock_CS);
+                        Context.OnError(
+                            CurrentLocation,
+                            RazorResources.ParseError_Unexpected_WhiteSpace_At_Start_Of_CodeBlock_CS,
+                            CurrentSymbol.Content.Length);
                     }
                     else if (EndOfFile)
                     {
-                        Context.OnError(CurrentLocation, RazorResources.ParseError_Unexpected_EndOfFile_At_Start_Of_CodeBlock);
+                        Context.OnError(
+                            CurrentLocation,
+                            RazorResources.ParseError_Unexpected_EndOfFile_At_Start_Of_CodeBlock,
+                            length: 1 /* end of file */);
                     }
                     else
                     {
-                        Context.OnError(CurrentLocation, RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS(CurrentSymbol.Content));
+                        Context.OnError(
+                            CurrentLocation,
+                            RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS(
+                                CurrentSymbol.Content),
+                            CurrentSymbol.Content.Length);
                     }
                 }
                 finally
@@ -529,7 +539,10 @@ namespace Microsoft.AspNet.Razor.Parser
                 if (!success)
                 {
                     AcceptUntil(CSharpSymbolType.LessThan);
-                    Context.OnError(block.Start, RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(block.Name, ")", "("));
+                    Context.OnError(
+                        block.Start,
+                        RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(block.Name, ")", "("),
+                        length: 1 /* ( */);
                 }
 
                 // If necessary, put an empty-content marker symbol here
@@ -556,7 +569,10 @@ namespace Microsoft.AspNet.Razor.Parser
         {
             if (Context.IsWithin(BlockType.Template))
             {
-                Context.OnError(CurrentLocation, RazorResources.ParseError_InlineMarkup_Blocks_Cannot_Be_Nested);
+                Context.OnError(
+                    CurrentLocation,
+                    RazorResources.ParseError_InlineMarkup_Blocks_Cannot_Be_Nested,
+                    length: 1 /* @ */);
             }
             Output(SpanKind.Code);
             using (Context.StartBlock(BlockType.Template))

--- a/src/Microsoft.AspNet.Razor/Parser/ParserContext.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/ParserContext.cs
@@ -200,14 +200,6 @@ namespace Microsoft.AspNet.Razor.Parser
             _errorSink.OnError(error);
         }
 
-        public void OnError(SourceLocation location, string message)
-        {
-            EnusreNotTerminated();
-            AssertOnOwnerTask();
-
-            _errorSink.OnError(location, message);
-        }
-
         public void OnError(SourceLocation location, string message, int length)
         {
             EnusreNotTerminated();
@@ -216,12 +208,12 @@ namespace Microsoft.AspNet.Razor.Parser
             _errorSink.OnError(location, message, length);
         }
 
-        public void OnError(SourceLocation location, string message, params object[] args)
+        public void OnError(SourceLocation location, string message, int length, params object[] args)
         {
             EnusreNotTerminated();
             AssertOnOwnerTask();
 
-            OnError(location, string.Format(CultureInfo.CurrentCulture, message, args));
+            OnError(location, string.Format(CultureInfo.CurrentCulture, message, args), length);
         }
 
         public ParserResults CompleteParse()

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
@@ -296,8 +296,10 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
 
             if (childSpan == null || childSpan.Kind != SpanKind.Markup)
             {
-                errorSink.OnError(block.Children.First().Start,
-                                  RazorResources.FormatTagHelpers_CannotHaveCSharpInTagDeclaration(tagName));
+                errorSink.OnError(
+                    block.Start,
+                    RazorResources.FormatTagHelpers_CannotHaveCSharpInTagDeclaration(tagName),
+                    block.Length);
 
                 return null;
             }
@@ -316,7 +318,10 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
 
             if (name == null)
             {
-                errorSink.OnError(childSpan.Start, RazorResources.FormatTagHelpers_AttributesMustHaveAName(tagName));
+                errorSink.OnError(
+                    childSpan.Start,
+                    RazorResources.FormatTagHelpers_AttributesMustHaveAName(tagName),
+                    childSpan.Length);
 
                 return null;
             }

--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperDirectiveSpanVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperDirectiveSpanVisitor.cs
@@ -67,11 +67,12 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
                     chunkGenerator.RemoveTagHelperDescriptors ?
                     TagHelperDirectiveType.RemoveTagHelper :
                     TagHelperDirectiveType.AddTagHelper;
+                var textLocation = GetSubTextSourceLocation(span, chunkGenerator.LookupText);
 
                 var directiveDescriptor = new TagHelperDirectiveDescriptor
                 {
                     DirectiveText = chunkGenerator.LookupText,
-                    Location = span.Start,
+                    Location = textLocation,
                     DirectiveType = directive
                 };
 
@@ -80,16 +81,26 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers
             else if (span.ChunkGenerator is TagHelperPrefixDirectiveChunkGenerator)
             {
                 var chunkGenerator = (TagHelperPrefixDirectiveChunkGenerator)span.ChunkGenerator;
+                var textLocation = GetSubTextSourceLocation(span, chunkGenerator.Prefix);
 
                 var directiveDescriptor = new TagHelperDirectiveDescriptor
                 {
                     DirectiveText = chunkGenerator.Prefix,
-                    Location = span.Start,
+                    Location = textLocation,
                     DirectiveType = TagHelperDirectiveType.TagHelperPrefix
                 };
 
                 _directiveDescriptors.Add(directiveDescriptor);
             }
+        }
+
+        private static SourceLocation GetSubTextSourceLocation(Span span, string text)
+        {
+            var startOffset = span.Content.IndexOf(text);
+            var offsetContent = span.Content.Substring(0, startOffset);
+            var offsetTextLocation = SourceLocation.Advance(span.Start, offsetContent);
+
+            return offsetTextLocation;
         }
     }
 }

--- a/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.Helpers.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.Helpers.cs
@@ -71,10 +71,12 @@ namespace Microsoft.AspNet.Razor.Parser
             AcceptAndMoveNext();
             if (EndOfFile && ((mode & BalancingModes.NoErrorOnFailure) != BalancingModes.NoErrorOnFailure))
             {
-                Context.OnError(start,
-                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF(
-                                    Language.GetSample(left),
-                                    Language.GetSample(right)));
+                Context.OnError(
+                    start,
+                    RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF(
+                        Language.GetSample(left),
+                        Language.GetSample(right)),
+                    length: 1 /* { OR } */);
             }
 
             return Balance(mode, left, right, start);
@@ -119,10 +121,12 @@ namespace Microsoft.AspNet.Razor.Parser
                 {
                     if ((mode & BalancingModes.NoErrorOnFailure) != BalancingModes.NoErrorOnFailure)
                     {
-                        Context.OnError(start,
-                                        RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF(
-                                            Language.GetSample(left),
-                                            Language.GetSample(right)));
+                        Context.OnError(
+                            start,
+                            RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF(
+                                Language.GetSample(left),
+                                Language.GetSample(right)),
+                            length: 1 /* { OR } */);
                     }
                     if ((mode & BalancingModes.BacktrackOnFailure) == BalancingModes.BacktrackOnFailure)
                     {
@@ -355,9 +359,17 @@ namespace Microsoft.AspNet.Razor.Parser
                     error = RazorResources.FormatErrorComponent_Character(CurrentSymbol.Content);
                 }
 
-                Context.OnError(
-                    CurrentLocation,
-                    errorBase(error));
+                int errorLength;
+                if (CurrentSymbol == null || CurrentSymbol.Content == null)
+                {
+                    errorLength = 1;
+                }
+                else
+                {
+                    errorLength = Math.Max(CurrentSymbol.Content.Length, 1);
+                }
+
+                Context.OnError(CurrentLocation, errorBase(error), errorLength);
             }
             return found;
         }
@@ -521,7 +533,10 @@ namespace Microsoft.AspNet.Razor.Parser
                     if (!Optional(KnownSymbolType.CommentStar))
                     {
                         errorReported = true;
-                        Context.OnError(start, RazorResources.ParseError_RazorComment_Not_Terminated);
+                        Context.OnError(
+                            start,
+                            RazorResources.ParseError_RazorComment_Not_Terminated,
+                            length: 2 /* @* */);
                     }
                     else
                     {
@@ -533,7 +548,10 @@ namespace Microsoft.AspNet.Razor.Parser
                         if (!errorReported)
                         {
                             errorReported = true;
-                            Context.OnError(start, RazorResources.ParseError_RazorComment_Not_Terminated);
+                            Context.OnError(
+                                start,
+                                RazorResources.ParseError_RazorComment_Not_Terminated,
+                                length: 2 /* @* */);
                         }
                     }
                     else

--- a/src/Microsoft.AspNet.Razor/RazorError.cs
+++ b/src/Microsoft.AspNet.Razor/RazorError.cs
@@ -11,18 +11,16 @@ namespace Microsoft.AspNet.Razor
     {
         internal const int DefaultErrorLength = 1;
 
+        /// <summary>
+        /// Used only for deserialization.
+        /// </summary>
         public RazorError()
-            : this(message: string.Empty, location: SourceLocation.Undefined)
+            : this(message: string.Empty, location: SourceLocation.Undefined, length: -1)
         {
         }
 
-        public RazorError(string message, SourceLocation location)
-            : this(message, location, DefaultErrorLength)
-        {
-        }
-
-        public RazorError(string message, int absoluteIndex, int lineIndex, int columnIndex)
-            : this(message, new SourceLocation(absoluteIndex, lineIndex, columnIndex))
+        public RazorError(string message, int absoluteIndex, int lineIndex, int columnIndex, int length)
+            : this(message, new SourceLocation(absoluteIndex, lineIndex, columnIndex), length)
         {
         }
 
@@ -31,11 +29,6 @@ namespace Microsoft.AspNet.Razor
             Message = message;
             Location = location;
             Length = length;
-        }
-
-        public RazorError(string message, int absoluteIndex, int lineIndex, int columnIndex, int length)
-            : this(message, new SourceLocation(absoluteIndex, lineIndex, columnIndex), length)
-        {
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Razor/Tokenizer/CSharpTokenizer.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/CSharpTokenizer.cs
@@ -264,7 +264,11 @@ namespace Microsoft.AspNet.Razor.Tokenizer
             }
             else if (EndOfFile)
             {
-                CurrentErrors.Add(new RazorError(RazorResources.ParseError_Unterminated_String_Literal, CurrentStart));
+                CurrentErrors.Add(
+                    new RazorError(
+                        RazorResources.ParseError_Unterminated_String_Literal,
+                        CurrentStart,
+                        length: 1 /* end of file */));
             }
             return Transition(EndSymbol(CSharpSymbolType.StringLiteral), Data);
         }
@@ -285,7 +289,11 @@ namespace Microsoft.AspNet.Razor.Tokenizer
             }
             else if (EndOfFile || ParserHelpers.IsNewLine(CurrentCharacter))
             {
-                CurrentErrors.Add(new RazorError(RazorResources.ParseError_Unterminated_String_Literal, CurrentStart));
+                CurrentErrors.Add(
+                    new RazorError(
+                        RazorResources.ParseError_Unterminated_String_Literal,
+                        CurrentStart,
+                        length: 1 /* " */));
             }
             else
             {
@@ -300,7 +308,11 @@ namespace Microsoft.AspNet.Razor.Tokenizer
             TakeUntil(c => c == '*');
             if (EndOfFile)
             {
-                CurrentErrors.Add(new RazorError(RazorResources.ParseError_BlockComment_Not_Terminated, CurrentStart));
+                CurrentErrors.Add(
+                    new RazorError(
+                        RazorResources.ParseError_BlockComment_Not_Terminated,
+                        CurrentStart,
+                        length: 1 /* end of file */));
                 return Transition(EndSymbol(CSharpSymbolType.Comment), Data);
             }
             if (CurrentCharacter == '*')

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -1221,7 +1221,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Assert.Equal(expectedErrorMessages.Length, errors.Length);
             for (var i = 0; i < expectedErrorMessages.Length; i++)
             {
-                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(0, errors[i].Length);
                 Assert.Equal(SourceLocation.Zero, errors[i].Location);
                 Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
             }
@@ -1377,7 +1377,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             for (var i = 0; i < actualErrors.Length; i++)
             {
                 var actualError = actualErrors[i];
-                Assert.Equal(1, actualError.Length);
+                Assert.Equal(0, actualError.Length);
                 Assert.Equal(SourceLocation.Zero, actualError.Location);
                 Assert.Equal(expectedErrors[i], actualError.Message, StringComparer.Ordinal);
             }
@@ -1607,7 +1607,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             for (var i = 0; i < errors.Length; i++)
             {
-                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(0, errors[i].Length);
                 Assert.Equal(SourceLocation.Zero, errors[i].Location);
                 Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
             }
@@ -1749,7 +1749,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Assert.Equal(expectedErrorMessages.Length, errors.Length);
             for (var i = 0; i < expectedErrorMessages.Length; i++)
             {
-                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(0, errors[i].Length);
                 Assert.Equal(SourceLocation.Zero, errors[i].Location);
                 Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
             }
@@ -1804,7 +1804,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Assert.Equal(expectedErrorMessages.Length, errors.Length);
             for (var i = 0; i < expectedErrorMessages.Length; i++)
             {
-                Assert.Equal(1, errors[i].Length);
+                Assert.Equal(0, errors[i].Length);
                 Assert.Equal(SourceLocation.Zero, errors[i].Location);
                 Assert.Equal(expectedErrorMessages[i], errors[i].Message, StringComparer.Ordinal);
             }
@@ -1837,7 +1837,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
-            var expectedErrors = expectedErrorMessages.Select(message => new RazorError(message, SourceLocation.Zero));
+            var expectedErrors = expectedErrorMessages.Select(
+                message => new RazorError(message, SourceLocation.Zero, 0));
 
             // Act
             TagHelperDescriptorFactory.GetValidAllowedChildren(new[] { name }, "SomeTagHelper", errorSink);

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperTypeResolverTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             var error = Assert.Single(errorSink.Errors);
-            Assert.Equal(1, error.Length);
+            Assert.Equal(4, error.Length);
             Assert.Equal(documentLocation, error.Location);
 
             // The framework throws the underlying Exception. Only confirm Message mentions expected assembly.

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpAutoCompleteTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpAutoCompleteTest.cs
@@ -16,20 +16,23 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
         [Fact]
         public void FunctionsDirectiveAutoCompleteAtEOF()
         {
-            ParseBlockTest("@functions{",
-                           new FunctionsBlock(
-                               Factory.CodeTransition("@")
-                                   .Accepts(AcceptedCharacters.None),
-                               Factory.MetaCode("functions{")
-                                   .Accepts(AcceptedCharacters.None),
-                               Factory.EmptyCSharp()
-                                   .AsFunctionsBody()
-                                   .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString)
-                                   {
-                                       AutoCompleteString = "}"
-                                   })),
-                           new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", "}", "{"),
-                                          10, 0, 10));
+            ParseBlockTest(
+                "@functions{",
+                new FunctionsBlock(
+                    Factory.CodeTransition("@")
+                        .Accepts(AcceptedCharacters.None),
+                    Factory.MetaCode("functions{")
+                        .Accepts(AcceptedCharacters.None),
+                    Factory.EmptyCSharp()
+                        .AsFunctionsBody()
+                        .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString)
+                        {
+                            AutoCompleteString = "}"
+                        })),
+                new RazorError(
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", "}", "{"),
+                    new SourceLocation(10, 0, 10),
+                    length: 1));
         }
 
         [Fact]
@@ -44,7 +47,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     new MarkupBlock()),
                 new RazorError(
                     RazorResources.FormatParseError_Expected_X("}"),
-                    17, 0, 17));
+                    new SourceLocation(17, 0, 17),
+                    length: 1));
         }
 
         [Fact]
@@ -58,8 +62,11 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    .AsStatement()
                                    .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString) { AutoCompleteString = "}" })
                                ),
-                           new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, "}", "{"),
-                                          1, 0, 1));
+                           new RazorError(
+                               RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
+                                   RazorResources.BlockName_Code, "}", "{"),
+                                new SourceLocation(1, 0, 1),
+                                length: 1));
         }
 
         [Fact]
@@ -78,8 +85,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    {
                                        AutoCompleteString = "}"
                                    })),
-                           new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", "}", "{"),
-                                          10, 0, 10));
+                           new RazorError(
+                               RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", "}", "{"),
+                               new SourceLocation(10, 0, 10),
+                               length: 1));
         }
 
         [Fact]
@@ -99,8 +108,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.Markup("Foo"),
                         new MarkupTagBlock(
                             Factory.Markup("</p>")))),
-                new RazorError(RazorResources.FormatParseError_Expected_X("}"),
-                                27 + Environment.NewLine.Length, 1, 10));
+                new RazorError(
+                    RazorResources.FormatParseError_Expected_X("}"),
+                    new SourceLocation(27 + Environment.NewLine.Length, 1, 10),
+                    length: 1));
         }
 
         [Fact]
@@ -122,8 +133,11 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.Span(SpanKind.Code, new CSharpSymbol(Factory.LocationTracker.CurrentLocation, string.Empty, CSharpSymbolType.Unknown))
                                    .With(new StatementChunkGenerator())
                                ),
-                           new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, "}", "{"),
-                                          1, 0, 1));
+                           new RazorError(
+                               RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
+                                   RazorResources.BlockName_Code, "}", "{"),
+                                new SourceLocation(1, 0, 1),
+                                length: 1));
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpBlockTest.cs
@@ -124,11 +124,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
         [Fact]
         public void ParseBlockTerminatesParenBalancingAtEOF()
         {
-            ImplicitExpressionTest("Html.En(code()", "Html.En(code()",
-                                   AcceptedCharacters.Any,
-                                   new RazorError(
-                                       RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                                       new SourceLocation(8, 0, 8)));
+            ImplicitExpressionTest(
+                "Html.En(code()", "Html.En(code()",
+                AcceptedCharacters.Any,
+                new RazorError(
+                    RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
+                    new SourceLocation(8, 0, 8),
+                    length: 1));
         }
 
         [Fact]
@@ -468,7 +470,8 @@ while(true);", BlockType.Statement, SpanKind.Code, acceptedCharacters: AcceptedC
                 SpanKind.Code,
                 new RazorError(
                     RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("foreach", '}', '{'),
-                    SourceLocation.Zero));
+                    SourceLocation.Zero,
+                    length: 1));
         }
 
         [Fact]
@@ -480,18 +483,29 @@ while(true);", BlockType.Statement, SpanKind.Code, acceptedCharacters: AcceptedC
                 document,
                 BlockType.Statement,
                 SpanKind.Code,
-                new RazorError(RazorResources.ParseError_BlockComment_Not_Terminated, 24, 0, 24),
+                new RazorError(
+                    RazorResources.ParseError_BlockComment_Not_Terminated,
+                    new SourceLocation(24, 0, 24),
+                    length: 1),
                 new RazorError(
                     RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("foreach", '}', '{'),
-                    SourceLocation.Zero));
+                    SourceLocation.Zero,
+                    length: 1));
         }
 
         [Fact]
         public void ParseBlockTerminatesSingleSlashAtEndOfFile()
         {
             const string document = "foreach(var f in Foo) { / foo bar baz";
-            SingleSpanBlockTest(document, document, BlockType.Statement, SpanKind.Code,
-                                new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("foreach", '}', '{'), SourceLocation.Zero));
+            SingleSpanBlockTest(
+                document,
+                document,
+                BlockType.Statement,
+                SpanKind.Code,
+                new RazorError(
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("foreach", '}', '{'),
+                    SourceLocation.Zero,
+                    length: 1));
         }
 
         [Fact]
@@ -1102,8 +1116,14 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
                 Factory.EmptyHtml()));
             var expectedErrors = new RazorError[]
             {
-                new RazorError(@"End of file or an unexpected character was reached before the ""span"" tag could be parsed.  Elements inside markup blocks must be complete. They must either be self-closing (""<br />"") or have matching end tags (""<p>Hello</p>"").  If you intended to display a ""<"" character, use the ""&lt;"" HTML entity.", new SourceLocation(1, 0, 1)),
-                new RazorError(@"The code block is missing a closing ""}"" character.  Make sure you have a matching ""}"" character for all the ""{"" characters within this block, and that none of the ""}"" characters are being interpreted as markup.", new SourceLocation(0, 0, 0)),
+                new RazorError(
+                    @"End of file or an unexpected character was reached before the ""span"" tag could be parsed.  Elements inside markup blocks must be complete. They must either be self-closing (""<br />"") or have matching end tags (""<p>Hello</p>"").  If you intended to display a ""<"" character, use the ""&lt;"" HTML entity.",
+                    new SourceLocation(2, 0, 2),
+                    length: 4),
+                new RazorError(
+                    @"The code block is missing a closing ""}"" character.  Make sure you have a matching ""}"" character for all the ""{"" characters within this block, and that none of the ""}"" characters are being interpreted as markup.",
+                    SourceLocation.Zero,
+                    length: 1),
             };
 
             // Act & Assert
@@ -1139,8 +1159,14 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
                 Factory.MetaCode("}").Accepts(AcceptedCharacters.None));
             var expectedErrors = new RazorError[]
             {
-                new RazorError(@"A space or line break was encountered after the ""@"" character.  Only valid identifiers, keywords, comments, ""("" and ""{"" are valid at the start of a code block and they must occur immediately following ""@"" with no space in between.", new SourceLocation(13, 0, 13)),
-                new RazorError(@"""' />}"" is not valid at the start of a code block.  Only identifiers, keywords, comments, ""("" and ""{"" are valid.", new SourceLocation(15, 0, 15)),
+                new RazorError(
+                    @"A space or line break was encountered after the ""@"" character.  Only valid identifiers, keywords, comments, ""("" and ""{"" are valid at the start of a code block and they must occur immediately following ""@"" with no space in between.",
+                    new SourceLocation(13, 0, 13),
+                    length: 1),
+                new RazorError(
+                    @"""' />}"" is not valid at the start of a code block.  Only identifiers, keywords, comments, ""("" and ""{"" are valid.",
+                    new SourceLocation(15, 0, 15),
+                    length: 5),
             };
 
             // Act & Assert
@@ -1187,7 +1213,7 @@ catch(bar) { baz(); }", BlockType.Statement, SpanKind.Code);
             {
                 errors = new RazorError[]
                 {
-                    new RazorError(errorMessage, location.Value)
+                    new RazorError(errorMessage, location.Value, length: 1)
                 };
             }
             ParseBlockTest(content,

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         .AsTagHelperPrefixDirective("Foo")),
                 new RazorError(
                     RazorResources.ParseError_Unterminated_String_Literal,
-                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
                 new RazorError(
                     RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.TagHelperPrefixKeyword),
@@ -89,7 +89,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 20, lineIndex: 0, columnIndex: 20),
+                     absoluteIndex: 20, lineIndex: 0, columnIndex: 20, length: 1),
                  new RazorError(
                      RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.TagHelperPrefixKeyword),
@@ -168,7 +168,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         .AsRemoveTagHelper("Foo")),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
+                     absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
                  new RazorError(
                      RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.RemoveTagHelperKeyword),
@@ -188,7 +188,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 20, lineIndex: 0, columnIndex: 20),
+                     absoluteIndex: 20, lineIndex: 0, columnIndex: 20, length: 1),
                  new RazorError(
                      RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.RemoveTagHelperKeyword),
@@ -264,7 +264,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         .AsAddTagHelper("Foo")),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 14, lineIndex: 0, columnIndex: 14),
+                     absoluteIndex: 14, lineIndex: 0, columnIndex: 14, length: 1),
                  new RazorError(
                      RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.AddTagHelperKeyword),
@@ -284,7 +284,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
+                     absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
                  new RazorError(
                      RazorResources.FormatParseError_DirectiveMustBeSurroundedByQuotes(
                         SyntaxConstants.CSharp.AddTagHelperKeyword),

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpErrorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpErrorTest.cs
@@ -23,7 +23,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS('"'),
-                               1, 0, 1));
+                               new SourceLocation(1, 0, 1),
+                               length: 1));
         }
 
         [Fact]
@@ -48,7 +49,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, "}", "{"),
-                               SourceLocation.Zero));
+                               SourceLocation.Zero,
+                               length: 1));
         }
 
         [Fact]
@@ -73,7 +75,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.EmptyCSharp()
                                    .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                    .Accepts(AcceptedCharacters.NonWhiteSpace)),
-                           new RazorError(RazorResources.ParseError_Unexpected_WhiteSpace_At_Start_Of_CodeBlock_CS, new SourceLocation(1, 0, 1)));
+                           new RazorError(
+                               RazorResources.ParseError_Unexpected_WhiteSpace_At_Start_Of_CodeBlock_CS,
+                               new SourceLocation(1, 0, 1),
+                               Environment.NewLine.Length));
         }
 
         [Fact]
@@ -95,7 +100,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.Code("   {}" + Environment.NewLine).AsStatement(),
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                ),
-                           new RazorError(RazorResources.ParseError_Unexpected_WhiteSpace_At_Start_Of_CodeBlock_CS, 6 + Environment.NewLine.Length, 1, 5));
+                           new RazorError(
+                               RazorResources.ParseError_Unexpected_WhiteSpace_At_Start_Of_CodeBlock_CS,
+                               new SourceLocation(6 + Environment.NewLine.Length, 1, 5),
+                               length: 3));
         }
 
         [Fact]
@@ -116,10 +124,12 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.EmptyCSharp().AsStatement()
                                ),
                            new RazorError(
-                               RazorResources.ParseError_Unexpected_EndOfFile_At_Start_Of_CodeBlock, 6 + Environment.NewLine.Length, 1, 5),
+                               RazorResources.ParseError_Unexpected_EndOfFile_At_Start_Of_CodeBlock,
+                               6 + Environment.NewLine.Length, 1, 5, length: 1),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, "}", "{"),
-                               SourceLocation.Zero));
+                               SourceLocation.Zero,
+                               length: 1));
         }
 
         [Fact]
@@ -133,7 +143,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    .Accepts(AcceptedCharacters.NonWhiteSpace)),
                            new RazorError(
                                RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS("!"),
-                               1, 0, 1));
+                               new SourceLocation(1, 0, 1),
+                               length: 1));
         }
 
         [Fact]
@@ -147,7 +158,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_ExplicitExpression, ')', '('),
-                               new SourceLocation(0, 0, 0)));
+                               SourceLocation.Zero,
+                               length: 1));
         }
 
         [Fact]
@@ -163,7 +175,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_ExplicitExpression, ')', '('),
-                               new SourceLocation(0, 0, 0)));
+                               SourceLocation.Zero,
+                               length: 1));
         }
 
         [Fact]
@@ -177,7 +190,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                               new SourceLocation(4, 0, 4)));
+                               new SourceLocation(4, 0, 4),
+                               length: 1));
         }
 
         [Fact]
@@ -185,14 +199,16 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
         public void ParseBlockShouldReportErrorAndTerminateAtEOFIfParenInImplicitExpressionUnclosed()
         {
             ParseBlockTest("Foo(Bar(Baz)" + Environment.NewLine
-                         + "Biz" + Environment.NewLine
-                         + "Boz",
-                           new ExpressionBlock(
-                               Factory.Code($"Foo(Bar(Baz){Environment.NewLine}Biz{Environment.NewLine}Boz")
-                                   .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                               ),
-                           new RazorError(RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                                          new SourceLocation(3, 0, 3)));
+                            + "Biz" + Environment.NewLine
+                            + "Boz",
+                            new ExpressionBlock(
+                                Factory.Code($"Foo(Bar(Baz){Environment.NewLine}Biz{Environment.NewLine}Boz")
+                                    .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                ),
+                            new RazorError(
+                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
+                                new SourceLocation(3, 0, 3),
+                                length: 1));
         }
 
         [Fact]
@@ -200,16 +216,18 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
         public void ParseBlockShouldReportErrorAndTerminateAtMarkupIfParenInImplicitExpressionUnclosed()
         {
             ParseBlockTest("Foo(Bar(Baz)" + Environment.NewLine
-                         + "Biz" + Environment.NewLine
-                         + "<html>" + Environment.NewLine
-                         + "Boz" + Environment.NewLine
-                         + "</html>",
-                           new ExpressionBlock(
-                               Factory.Code($"Foo(Bar(Baz){Environment.NewLine}Biz{Environment.NewLine}")
-                                   .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                               ),
-                           new RazorError(RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                                          new SourceLocation(3, 0, 3)));
+                            + "Biz" + Environment.NewLine
+                            + "<html>" + Environment.NewLine
+                            + "Boz" + Environment.NewLine
+                            + "</html>",
+                            new ExpressionBlock(
+                                Factory.Code($"Foo(Bar(Baz){Environment.NewLine}Biz{Environment.NewLine}")
+                                    .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                ),
+                            new RazorError(
+                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
+                                new SourceLocation(3, 0, 3),
+                               length: 1));
         }
 
         [Fact]
@@ -225,7 +243,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("[", "]"),
-                               new SourceLocation(3, 0, 3)));
+                               new SourceLocation(3, 0, 3),
+                               length: 1));
         }
 
         [Fact]
@@ -243,7 +262,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("[", "]"),
-                               new SourceLocation(3, 0, 3)));
+                               new SourceLocation(3, 0, 3),
+                               length: 1));
         }
 
         // Simple EOF handling errors:
@@ -257,8 +277,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    .AsStatement()
                                    .AutoCompleteWith("}")),
                            new RazorError(
-                               RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, '}', '{'),
-                               SourceLocation.Zero));
+                               RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
+                                   RazorResources.BlockName_Code, '}', '{'),
+                               SourceLocation.Zero,
+                               length: 1));
         }
 
         [Fact]
@@ -272,7 +294,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    .AutoCompleteWith("}")),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", '}', '{'),
-                               new SourceLocation(10, 0, 10)));
+                               new SourceLocation(10, 0, 10),
+                               length: 1));
         }
 
         [Fact]
@@ -290,7 +313,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("else", '}', '{'),
-                               new SourceLocation(19, 0, 19)));
+                               new SourceLocation(19, 0, 19),
+                               length: 1));
         }
 
         [Fact]
@@ -302,7 +326,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("else if", '}', '{'),
-                               new SourceLocation(19, 0, 19)));
+                               new SourceLocation(19, 0, 19),
+                               length: 1));
         }
 
         [Fact]
@@ -314,7 +339,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("do", '}', '{'),
-                               SourceLocation.Zero));
+                               SourceLocation.Zero,
+                               length: 1));
         }
 
         [Fact]
@@ -326,7 +352,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("try", '}', '{'),
-                               SourceLocation.Zero));
+                               SourceLocation.Zero,
+                               length: 1));
         }
 
         [Fact]
@@ -338,7 +365,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("catch", '}', '{'),
-                               new SourceLocation(15, 0, 15)));
+                               new SourceLocation(15, 0, 15),
+                               length: 1));
         }
 
         [Fact]
@@ -350,7 +378,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("finally", '}', '{'),
-                               new SourceLocation(15, 0, 15)));
+                               new SourceLocation(15, 0, 15),
+                               length: 1));
         }
 
         [Fact]
@@ -414,9 +443,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                     BlockFactory.MarkupTagBlock("</p>", AcceptedCharacters.None)),
                                Factory.EmptyCSharp().AsStatement()
                                ),
-                           new RazorError(expectedMessage, 8, 0, 8),
-                           new RazorError(expectedMessage, 32, 0, 32),
-                           new RazorError(expectedMessage, 48, 0, 48));
+                           new RazorError(expectedMessage, 8, 0, 8, 1),
+                           new RazorError(expectedMessage, 32, 0, 32, 1),
+                           new RazorError(expectedMessage, 48, 0, 48, 1));
         }
 
         [Fact]
@@ -428,7 +457,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_SingleLine_ControlFlowStatements_Not_Allowed("{", ")"),
-                               new SourceLocation(7, 0, 7)));
+                               new SourceLocation(7, 0, 7),
+                               length: 1));
         }
 
         [Fact]
@@ -448,7 +478,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.ParseError_AtInCode_Must_Be_Followed_By_Colon_Paren_Or_Identifier_Start,
-                               10, 0, 10));
+                               new SourceLocation(10, 0, 10),
+                               length: 1));
         }
 
         [Fact]
@@ -461,7 +492,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                               new SourceLocation(2, 0, 2)));
+                               new SourceLocation(2, 0, 2),
+                               length: 1));
         }
 
         [Fact]
@@ -474,7 +506,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                               new SourceLocation(7, 0, 7)));
+                               new SourceLocation(7, 0, 7),
+                               length: 1));
         }
 
         [Fact]
@@ -487,7 +520,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                               new SourceLocation(12, 0, 12)));
+                               new SourceLocation(12, 0, 12),
+                               length: 1));
         }
 
         [Fact]
@@ -500,7 +534,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                               new SourceLocation(5, 0, 5)));
+                               new SourceLocation(5, 0, 5),
+                               length: 1));
         }
 
         [Fact]
@@ -520,7 +555,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                               new SourceLocation(2, 0, 2)));
+                               new SourceLocation(2, 0, 2),
+                               length: 1));
         }
 
         [Fact]
@@ -532,15 +568,23 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                               + "}",
                                 BlockType.Statement, SpanKind.Code,
                                 new RazorError(
-                                    RazorResources.ParseError_Unterminated_String_Literal, 21 + Environment.NewLine.Length, 1, 12));
+                                    RazorResources.ParseError_Unterminated_String_Literal,
+                                    new SourceLocation(21 + Environment.NewLine.Length, 1, 12),
+                                    length: 1));
         }
 
         [Fact]
         public void ParseBlockTerminatesNormalStringAtEndOfFile()
         {
             SingleSpanBlockTest("if(foo) { var foo = \"blah blah blah blah blah", BlockType.Statement, SpanKind.Code,
-                                new RazorError(RazorResources.ParseError_Unterminated_String_Literal, 20, 0, 20),
-                                new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("if", '}', '{'), SourceLocation.Zero));
+                                new RazorError(
+                                    RazorResources.ParseError_Unterminated_String_Literal,
+                                    new SourceLocation(20, 0, 20),
+                                    length: 1),
+                                new RazorError(
+                                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("if", '}', '{'),
+                                    SourceLocation.Zero,
+                                    length: 1));
         }
 
         [Fact]
@@ -552,8 +596,14 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                               + "blah " + Environment.NewLine
                               + "blah",
                                 BlockType.Statement, SpanKind.Code,
-                                new RazorError(RazorResources.ParseError_Unterminated_String_Literal, 20, 0, 20),
-                                new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("if", '}', '{'), SourceLocation.Zero));
+                                new RazorError(
+                                    RazorResources.ParseError_Unterminated_String_Literal,
+                                    new SourceLocation(20, 0, 20),
+                                    length: 1),
+                                new RazorError(
+                                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("if", '}', '{'),
+                                    SourceLocation.Zero,
+                                    length: 1));
         }
 
         [Fact]
@@ -579,7 +629,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.ParseError_Unterminated_String_Literal,
-                               23 + Environment.NewLine.Length, 1, 14));
+                               new SourceLocation(23 + Environment.NewLine.Length, 1, 14),
+                               length: 1));
         }
 
         [Fact]
@@ -611,15 +662,22 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                 {
                     new RazorError(
                         RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                        14, 0, 14)
+                        new SourceLocation(14, 0, 14),
+                        length: 1)
                 });
 
         }
 
         private void RunUnterminatedSimpleKeywordBlock(string keyword)
         {
-            SingleSpanBlockTest(keyword + " (foo) { var foo = bar; if(foo != null) { bar(); } ", BlockType.Statement, SpanKind.Code,
-                                new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(keyword, '}', '{'), SourceLocation.Zero));
+            SingleSpanBlockTest(
+                keyword + " (foo) { var foo = bar; if(foo != null) { bar(); } ",
+                BlockType.Statement,
+                SpanKind.Code,
+                new RazorError(
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(keyword, '}', '{'),
+                    SourceLocation.Zero,
+                    length: 1));
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpExplicitExpressionTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpExplicitExpressionTest.cs
@@ -32,8 +32,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.EmptyCSharp().AsExpression()
                                ),
                            new RazorError(
-                                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_ExplicitExpression, ")", "("),
-                               new SourceLocation(1, 0, 1)));
+                                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
+                                        RazorResources.BlockName_ExplicitExpression, ")", "("),
+                                    new SourceLocation(1, 0, 1),
+                                    length: 1));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpImplicitExpressionTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpImplicitExpressionTest.cs
@@ -26,12 +26,18 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                 Func<int, RazorError[]> missingEndParenError = (index) =>
                     new RazorError[1]
                     {
-                        new RazorError("An opening \"(\" is missing the corresponding closing \")\".", index, 0, index)
+                        new RazorError(
+                            "An opening \"(\" is missing the corresponding closing \")\".",
+                            new SourceLocation(index, 0, index),
+                            length: 1)
                     };
                 Func<int, RazorError[]> missingEndBracketError = (index) =>
                     new RazorError[1]
                     {
-                        new RazorError("An opening \"[\" is missing the corresponding closing \"]\".", index, 0, index)
+                        new RazorError(
+                            "An opening \"[\" is missing the corresponding closing \"]\".",
+                            new SourceLocation(index, 0, index),
+                            length: 1)
                     };
 
                 // implicitExpression, expectedImplicitExpression, acceptedCharacters, expectedErrors
@@ -139,7 +145,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    .Accepts(AcceptedCharacters.NonWhiteSpace)),
                            new RazorError(
                                RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS("/"),
-                               new SourceLocation(1, 0, 1)));
+                               new SourceLocation(1, 0, 1),
+                               length: 1));
         }
 
         [Fact]
@@ -153,7 +160,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    .Accepts(AcceptedCharacters.NonWhiteSpace)),
                            new RazorError(
                                RazorResources.ParseError_Unexpected_EndOfFile_At_Start_Of_CodeBlock,
-                               new SourceLocation(1, 0, 1)));
+                               new SourceLocation(1, 0, 1),
+                               length: 1));
         }
 
         [Fact]
@@ -250,9 +258,13 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
         [Fact]
         public void ParseBlockStopsBalancingParenthesesAtEOF()
         {
-            ImplicitExpressionTest("foo(()", "foo(()",
-                                   acceptedCharacters: AcceptedCharacters.Any,
-                                   errors: new RazorError(RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"), new SourceLocation(4, 0, 4)));
+            ImplicitExpressionTest(
+                "foo(()", "foo(()",
+                acceptedCharacters: AcceptedCharacters.Any,
+                errors: new RazorError(
+                    RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
+                    new SourceLocation(4, 0, 4),
+                    length: 1));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpRazorCommentsTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpRazorCommentsTest.cs
@@ -29,7 +29,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                             string.Empty,
                             HtmlSymbolType.Unknown))
                                .Accepts(AcceptedCharacters.Any))),
-                new RazorError(RazorResources.ParseError_RazorComment_Not_Terminated, 0, 0, 0));
+                new RazorError(
+                    RazorResources.ParseError_RazorComment_Not_Terminated,
+                    SourceLocation.Zero,
+                    length: 2));
         }
 
         [Fact]
@@ -84,7 +87,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                .AsImplicitExpression(CSharpCodeParser.DefaultKeywords))),
                 new RazorError(
                     RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
-                    4, 0, 4));
+                    new SourceLocation(4, 0, 4),
+                    length: 1));
         }
 
         [Fact]
@@ -107,8 +111,14 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                 string.Empty,
                                 CSharpSymbolType.Unknown))
                                     .Accepts(AcceptedCharacters.Any)))),
-                new RazorError(RazorResources.ParseError_RazorComment_Not_Terminated, 5, 0, 5),
-                new RazorError(RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"), 4, 0, 4));
+                new RazorError(
+                    RazorResources.ParseError_RazorComment_Not_Terminated,
+                    new SourceLocation(5, 0, 5),
+                    length: 2),
+                new RazorError(
+                    RazorResources.FormatParseError_Expected_CloseBracket_Before_EOF("(", ")"),
+                    new SourceLocation(4, 0, 4),
+                    length: 1));
         }
 
         [Fact]
@@ -147,9 +157,18 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                        .Accepts(AcceptedCharacters.None)),
                             Factory.Markup(Environment.NewLine).With(SpanChunkGenerator.Null),
                             Factory.Markup("}")))),
-                new RazorError(RazorResources.ParseError_TextTagCannotContainAttributes, 6 + Environment.NewLine.Length, 1, 4),
-                new RazorError(RazorResources.FormatParseError_MissingEndTag("text"), 6 + Environment.NewLine.Length, 1, 4),
-                new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, "}", "{"), 1, 0, 1));
+                new RazorError(
+                    RazorResources.ParseError_TextTagCannotContainAttributes,
+                    new SourceLocation(7 + Environment.NewLine.Length, 1, 5),
+                    length: 4),
+                new RazorError(
+                    RazorResources.FormatParseError_MissingEndTag("text"),
+                    new SourceLocation(7 + Environment.NewLine.Length, 1, 5),
+                    length: 4),
+                new RazorError(
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, "}", "{"),
+                    new SourceLocation(1, 0, 1),
+                    length: 1));
         }
 
         [Fact]
@@ -173,8 +192,15 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                                                         string.Empty,
                                                                         CSharpSymbolType.Unknown))
                                    .Accepts(AcceptedCharacters.Any)))),
-                new RazorError(RazorResources.ParseError_RazorComment_Not_Terminated, 2, 0, 2),
-                new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, "}", "{"), 1, 0, 1));
+                new RazorError(
+                    RazorResources.ParseError_RazorComment_Not_Terminated,
+                    new SourceLocation(2, 0, 2),
+                    length: 2),
+                new RazorError(
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
+                        RazorResources.BlockName_Code, "}", "{"),
+                    new SourceLocation(1, 0, 1),
+                    length: 1));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpReservedWordsTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpReservedWordsTest.cs
@@ -19,7 +19,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            new DirectiveBlock(
                                Factory.MetaCode(word).Accepts(AcceptedCharacters.None)
                                ),
-                           new RazorError(RazorResources.FormatParseError_ReservedWord(word), SourceLocation.Zero));
+                           new RazorError(
+                               RazorResources.FormatParseError_ReservedWord(word),
+                               SourceLocation.Zero,
+                               word.Length));
         }
 
         [Theory]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSectionTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSectionTest.cs
@@ -24,8 +24,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.CodeTransition(),
                         Factory.MetaCode("section" + Environment.NewLine))),
                 new RazorError(
-                        RazorResources.FormatParseError_Unexpected_Character_At_Section_Name_Start(RazorResources.ErrorComponent_EndOfFile),
-                    8 + Environment.NewLine.Length, 1, 0));
+                    RazorResources.FormatParseError_Unexpected_Character_At_Section_Name_Start(
+                        RazorResources.ErrorComponent_EndOfFile),
+                    new SourceLocation(8 + Environment.NewLine.Length, 1, 0),
+                    length: 1));
         }
 
         [Fact]
@@ -39,7 +41,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.CodeTransition(),
                         Factory.MetaCode("section Foo         " + Environment.NewLine)),
                     Factory.Markup("    ")),
-                new RazorError(RazorResources.ParseError_MissingOpenBraceAfterSection, 12, 0, 12));
+                new RazorError(
+                    RazorResources.ParseError_MissingOpenBraceAfterSection,
+                    new SourceLocation(12, 0, 12),
+                    length: 1));
         }
 
         [Fact]
@@ -54,8 +59,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.MetaCode("section         " + Environment.NewLine)),
                     Factory.Markup("    ")),
                 new RazorError(
-                        RazorResources.FormatParseError_Unexpected_Character_At_Section_Name_Start(RazorResources.ErrorComponent_EndOfFile),
-                    21 + Environment.NewLine.Length, 1, 4));
+                    RazorResources.FormatParseError_Unexpected_Character_At_Section_Name_Start(
+                        RazorResources.ErrorComponent_EndOfFile),
+                    new SourceLocation(21 + Environment.NewLine.Length, 1, 4),
+                    length: 1));
         }
 
         [Fact]
@@ -89,8 +96,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         Factory.Markup("</p>")),
                      Factory.Markup(" }")),
                 new RazorError(
-                        RazorResources.FormatParseError_Unexpected_Character_At_Section_Name_Start(RazorResources.FormatErrorComponent_Character("9")),
-                    9, 0, 9));
+                    RazorResources.FormatParseError_Unexpected_Character_At_Section_Name_Start(
+                        RazorResources.FormatErrorComponent_Character("9")),
+                    new SourceLocation(9, 0, 9),
+                    length: 1));
         }
 
         [Fact]
@@ -109,7 +118,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     new MarkupTagBlock(
                         Factory.Markup("</p>")),
                     Factory.Markup(" }")),
-                new RazorError(RazorResources.ParseError_MissingOpenBraceAfterSection, 12, 0, 12));
+                new RazorError(
+                    RazorResources.ParseError_MissingOpenBraceAfterSection,
+                    new SourceLocation(12, 0, 12),
+                    length: 1));
         }
 
         [Fact]
@@ -159,7 +171,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         new MarkupBlock())),
                 new RazorError(
                     RazorResources.FormatParseError_Expected_X("}"),
-                    14, 0, 14));
+                    new SourceLocation(14, 0, 14),
+                    length: 1));
         }
 
         [Fact]
@@ -182,7 +195,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                 Factory.Markup("</p>"))))),
                 new RazorError(
                     RazorResources.FormatParseError_Expected_X("}"),
-                    27, 0, 27));
+                    new SourceLocation(27, 0, 27),
+                    length: 1));
         }
 
         [Fact]
@@ -194,7 +208,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                     new SectionBlock(new SectionChunkGenerator("foo"),
                         Factory.CodeTransition(),
                         Factory.MetaCode("section foo      " + Environment.NewLine))),
-                new RazorError(RazorResources.ParseError_MissingOpenBraceAfterSection, 12, 0, 12));
+                new RazorError(
+                    RazorResources.ParseError_MissingOpenBraceAfterSection,
+                    new SourceLocation(12, 0, 12),
+                    length: 1));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSpecialBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpSpecialBlockTest.cs
@@ -60,7 +60,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.ParseError_NamespaceImportAndTypeAlias_Cannot_Exist_Within_CodeBlock,
-                               new SourceLocation(2, 0, 2)));
+                               new SourceLocation(2, 0, 2),
+                               length: 5));
         }
 
         [Fact]
@@ -76,7 +77,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.ParseError_NamespaceImportAndTypeAlias_Cannot_Exist_Within_CodeBlock,
-                               new SourceLocation(2, 0, 2)));
+                               new SourceLocation(2, 0, 2),
+                               length: 5));
         }
 
         [Fact]
@@ -165,7 +167,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                ),
                            new RazorError(
                                RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", "}", "{"),
-                               new SourceLocation(10, 0, 10)));
+                               new SourceLocation(10, 0, 10),
+                               length: 1));
         }
 
         [Fact]
@@ -189,7 +192,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                    .Accepts(AcceptedCharacters.NonWhiteSpace)),
                            new RazorError(
                                RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS("/"),
-                               1, 0, 1));
+                               new SourceLocation(1, 0, 1),
+                               length: 1));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpStatementTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpStatementTest.cs
@@ -265,7 +265,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                             factory
                                 .Code("try { someMethod(); } catch(Exception) when (")
                                 .AsStatement()),
-                        new[] { new RazorError(unbalancedParenErrorString, 45, 0, 45) }
+                        new[] { new RazorError(unbalancedParenErrorString, 45, 0, 45, 1) }
                     },
                     {
                         "@try { someMethod(); } catch(Exception) when (someMethod(",
@@ -274,7 +274,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                             factory
                                 .Code("try { someMethod(); } catch(Exception) when (someMethod(")
                                 .AsStatement()),
-                        new[] { new RazorError(unbalancedParenErrorString, 45, 0, 45) }
+                        new[] { new RazorError(unbalancedParenErrorString, 45, 0, 45, 1) }
                     },
                     {
                         "@try { someMethod(); } catch(Exception) when (true) {",
@@ -283,7 +283,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                             factory
                                 .Code("try { someMethod(); } catch(Exception) when (true) {")
                                 .AsStatement()),
-                        new[] { new RazorError(unbalancedBracketCatchErrorString, 23, 0, 23) }
+                        new[] { new RazorError(unbalancedBracketCatchErrorString, 23, 0, 23, 1) }
                     },
                 };
             }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpTemplateTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpTemplateTest.cs
@@ -319,7 +319,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
 
         private static RazorError GetNestedTemplateError(int characterIndex)
         {
-            return new RazorError(RazorResources.ParseError_InlineMarkup_Blocks_Cannot_Be_Nested, new SourceLocation(characterIndex, 0, characterIndex));
+            return new RazorError(
+                RazorResources.ParseError_InlineMarkup_Blocks_Cannot_Be_Nested,
+                new SourceLocation(characterIndex, 0, characterIndex),
+                length: 1);
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpToMarkupSwitchTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpToMarkupSwitchTest.cs
@@ -118,7 +118,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)
                                ), true,
                            new RazorError(
-                               RazorResources.ParseError_AtInCode_Must_Be_Followed_By_Colon_Paren_Or_Identifier_Start, 5 + Environment.NewLine.Length, 1, 4));
+                               RazorResources.ParseError_AtInCode_Must_Be_Followed_By_Colon_Paren_Or_Identifier_Start,
+                               new SourceLocation(5 + Environment.NewLine.Length, 1, 4),
+                               length: 1));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpVerbatimBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpVerbatimBlockTest.cs
@@ -46,7 +46,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            designTimeParser: true,
                            expectedErrors: new[]
                            {
-                               new RazorError(RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS("}"), new SourceLocation(2, 0, 2))
+                               new RazorError(
+                                   RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS("}"),
+                                   new SourceLocation(2, 0, 2),
+                                   length: 1)
                            });
         }
 
@@ -68,7 +71,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            designTimeParser: true,
                            expectedErrors: new[]
                            {
-                               new RazorError(RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS("."), new SourceLocation(2, 0, 2))
+                               new RazorError(
+                                   RazorResources.FormatParseError_Unexpected_Character_At_Start_Of_CodeBlock_CS("."),
+                                   new SourceLocation(2, 0, 2),
+                                   length: 1)
                            });
         }
 
@@ -91,7 +97,9 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                                Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
                 /* designTimeParser */ true,
                            new RazorError(
-                               RazorResources.ParseError_Unexpected_WhiteSpace_At_Start_Of_CodeBlock_CS, 6 + Environment.NewLine.Length, 1, 5));
+                               RazorResources.ParseError_Unexpected_WhiteSpace_At_Start_Of_CodeBlock_CS,
+                               new SourceLocation(6 + Environment.NewLine.Length, 1, 5),
+                               Environment.NewLine.Length));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CallbackParserListenerTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CallbackParserListenerTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.Razor.Test.Parser
 
             // Act/Assert
             listener.VisitStartBlock(new FunctionsBlock());
-            listener.VisitError(new RazorError("Error", SourceLocation.Zero));
+            listener.VisitError(new RazorError("Error", SourceLocation.Zero, length: 1));
             listener.VisitEndBlock(new FunctionsBlock());
         }
 
@@ -98,9 +98,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser
         [Fact]
         public void ListenerCallsOnErrorCallbackUsingSynchronizationContextIfSpecified()
         {
-            RunSyncContextTest(new RazorError("Bar", 42, 42, 42),
-                               errorCallback => new CallbackVisitor(_ => { }, errorCallback, _ => { }, _ => { }),
-                               (listener, expected) => listener.VisitError(expected));
+            RunSyncContextTest(
+                new RazorError("Bar", new SourceLocation(42, 42, 42), length: 3),
+                errorCallback => new CallbackVisitor(_ => { }, errorCallback, _ => { }, _ => { }),
+                (listener, expected) => listener.VisitError(expected));
         }
 
         private static void RunSyncContextTest<T>(T expected, Func<Action<T>, CallbackVisitor> ctor, Action<CallbackVisitor, T> call)
@@ -136,7 +137,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser
 
         private static void RunOnErrorTest(Func<Action<RazorError>, CallbackVisitor> ctor, Action<RazorError, RazorError> verifyResults = null)
         {
-            RunCallbackTest(new RazorError("Foo", SourceLocation.Zero), ctor, (listener, expected) => listener.VisitError(expected), verifyResults);
+            RunCallbackTest(
+                new RazorError("Foo", SourceLocation.Zero, length: 3),
+                ctor,
+                (listener, expected) => listener.VisitError(expected), verifyResults);
         }
 
         private static void RunOnEndSpanTest(Func<Action<Span>, CallbackVisitor> ctor, Action<Span, Span> verifyResults = null)

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlBlockTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlBlockTest.cs
@@ -43,8 +43,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                             new MarkupTagBlock(
                                 Factory.Markup("<"))))),
                 new RazorError(
-                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(RazorResources.BlockName_Code, "}", "{"),
-                    1, 0, 1));
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
+                        RazorResources.BlockName_Code, "}", "{"),
+                    new SourceLocation(1, 0, 1),
+                    length: 1));
         }
 
         [Fact]
@@ -75,8 +77,14 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                 designTimeParser: true,
                 expectedErrors: new[]
                 {
-                    new RazorError(RazorResources.FormatParseError_UnexpectedEndTag("html"), 3 + Environment.NewLine.Length * 2, 2, 0),
-                    new RazorError(RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("code", "}", "{"), 1, 0, 1)
+                    new RazorError(
+                        RazorResources.FormatParseError_UnexpectedEndTag("html"),
+                        new SourceLocation(5 + Environment.NewLine.Length * 2, 2, 2),
+                        length: 4),
+                    new RazorError(
+                        RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("code", "}", "{"),
+                        new SourceLocation(1, 0, 1),
+                        length: 1)
                 });
         }
 
@@ -89,7 +97,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                     new MarkupTagBlock(
                         Factory.Markup($"<                      {Environment.NewLine}   "))),
                 designTimeParser: true,
-                expectedErrors: new RazorError(RazorResources.FormatParseError_UnfinishedTag(string.Empty), 0, 0, 0));
+                expectedErrors: new RazorError(
+                    RazorResources.FormatParseError_UnfinishedTag(string.Empty),
+                    new SourceLocation(1, 0, 1),
+                    length: 1));
         }
 
         [Fact]
@@ -319,7 +330,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                 new MarkupBlock(
                     new MarkupTagBlock(
                         Factory.Markup("<foo>").Accepts(AcceptedCharacters.None))),
-                new RazorError(RazorResources.FormatParseError_MissingEndTag("foo"), new SourceLocation(0, 0, 0)));
+                new RazorError(
+                    RazorResources.FormatParseError_MissingEndTag("foo"),
+                    new SourceLocation(1, 0, 1),
+                    length: 3));
         }
 
         [Fact]
@@ -382,7 +396,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                         Factory.Markup("<foo>").Accepts(AcceptedCharacters.None)),
                     new MarkupTagBlock(
                         Factory.Markup("</!-- bar -->").Accepts(AcceptedCharacters.None))),
-                new RazorError(RazorResources.FormatParseError_MissingEndTag("foo"), 0, 0, 0));
+                new RazorError(
+                    RazorResources.FormatParseError_MissingEndTag("foo"),
+                    new SourceLocation(1, 0, 1),
+                    length: 3));
         }
 
 
@@ -545,7 +562,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                 new MarkupBlock(
                     new MarkupTagBlock(
                         Factory.Markup("<br/"))),
-                new RazorError(RazorResources.FormatParseError_UnfinishedTag("br"), SourceLocation.Zero));
+                new RazorError(
+                    RazorResources.FormatParseError_UnfinishedTag("br"),
+                    new SourceLocation(1, 0, 1),
+                    length: 2));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlDocumentTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlDocumentTest.cs
@@ -62,7 +62,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                                .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                .Accepts(AcceptedCharacters.NonWhiteSpace)),
                     Factory.EmptyHtml()),
-                new RazorError(RazorResources.ParseError_Unexpected_EndOfFile_At_Start_Of_CodeBlock, 1, 0, 1));
+                new RazorError(
+                    RazorResources.ParseError_Unexpected_EndOfFile_At_Start_Of_CodeBlock,
+                    new SourceLocation(1, 0, 1),
+                    length: 1));
         }
 
         [Fact]
@@ -148,7 +151,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                                .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                .Accepts(AcceptedCharacters.NonWhiteSpace)),
                     Factory.EmptyHtml()),
-                new RazorError(RazorResources.ParseError_Unexpected_EndOfFile_At_Start_Of_CodeBlock, 5, 0, 5));
+                new RazorError(
+                    RazorResources.ParseError_Unexpected_EndOfFile_At_Start_Of_CodeBlock,
+                    new SourceLocation(5, 0, 5),
+                    length: 1));
         }
 
         [Fact]
@@ -567,8 +573,14 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                     Factory.Markup(" />")));
             var expectedErrors = new RazorError[]
             {
-                new RazorError(@"A space or line break was encountered after the ""@"" character.  Only valid identifiers, keywords, comments, ""("" and ""{"" are valid at the start of a code block and they must occur immediately following ""@"" with no space in between.", new SourceLocation(12, 0, 12)),
-                new RazorError(@"""' />"" is not valid at the start of a code block.  Only identifiers, keywords, comments, ""("" and ""{"" are valid.", new SourceLocation(14, 0, 14)),
+                new RazorError(
+                    @"A space or line break was encountered after the ""@"" character.  Only valid identifiers, keywords, comments, ""("" and ""{"" are valid at the start of a code block and they must occur immediately following ""@"" with no space in between.",
+                    new SourceLocation(12, 0, 12),
+                    length: 1),
+                new RazorError(
+                    @"""' />"" is not valid at the start of a code block.  Only identifiers, keywords, comments, ""("" and ""{"" are valid.",
+                    new SourceLocation(14, 0, 14),
+                    length: 4),
             };
 
             // Act & Assert

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlErrorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlErrorTest.cs
@@ -32,7 +32,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                         Factory.MarkupTransition("<text foo bar>").Accepts(AcceptedCharacters.Any)),
                     new MarkupTagBlock(
                         Factory.MarkupTransition("</text>"))),
-                new RazorError(RazorResources.ParseError_TextTagCannotContainAttributes, SourceLocation.Zero));
+                new RazorError(
+                    RazorResources.ParseError_TextTagCannotContainAttributes,
+                    new SourceLocation(1, 0, 1),
+                    length: 4));
         }
 
         [Fact]
@@ -44,7 +47,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                         Factory.MarkupTransition("<text>")),
                     new MarkupTagBlock(
                         Factory.MarkupTransition("</text foo bar>").Accepts(AcceptedCharacters.Any))),
-                new RazorError(RazorResources.ParseError_TextTagCannotContainAttributes, 6, 0, 6));
+                new RazorError(
+                    RazorResources.ParseError_TextTagCannotContainAttributes,
+                    new SourceLocation(8, 0, 8),
+                    length: 4));
         }
 
         [Fact]
@@ -52,7 +58,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
         {
             ParseBlockTest("foo bar <baz>",
                 new MarkupBlock(),
-                new RazorError(RazorResources.ParseError_MarkupBlock_Must_Start_With_Tag, SourceLocation.Zero));
+                new RazorError(
+                    RazorResources.ParseError_MarkupBlock_Must_Start_With_Tag,
+                    SourceLocation.Zero,
+                    length: 3));
         }
 
         [Fact]
@@ -63,7 +72,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                     new MarkupTagBlock(
                         Factory.Markup("</foo>").Accepts(AcceptedCharacters.None)),
                     Factory.Markup(" ").Accepts(AcceptedCharacters.None)),
-                new RazorError(RazorResources.FormatParseError_UnexpectedEndTag("foo"), SourceLocation.Zero));
+                new RazorError(
+                    RazorResources.FormatParseError_UnexpectedEndTag("foo"),
+                    new SourceLocation(2, 0, 2),
+                    length: 3));
         }
 
         [Fact]
@@ -77,7 +89,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                         Factory.Markup("<foo>").Accepts(AcceptedCharacters.None)),
                     new MarkupTagBlock(
                         Factory.Markup("</bar>").Accepts(AcceptedCharacters.None))),
-                new RazorError(RazorResources.FormatParseError_MissingEndTag("p"), new SourceLocation(0, 0, 0)));
+                new RazorError(
+                    RazorResources.FormatParseError_MissingEndTag("p"),
+                    new SourceLocation(1, 0, 1),
+                    length: 1));
         }
 
         [Fact]
@@ -88,7 +103,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                     new MarkupTagBlock(
                         Factory.Markup("<foo>").Accepts(AcceptedCharacters.None)),
                     Factory.Markup("blah blah blah blah blah")),
-                new RazorError(RazorResources.FormatParseError_MissingEndTag("foo"), new SourceLocation(0, 0, 0)));
+                new RazorError(
+                    RazorResources.FormatParseError_MissingEndTag("foo"),
+                    new SourceLocation(1, 0, 1),
+                    length: 3));
         }
 
         [Fact]
@@ -101,7 +119,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                         new MarkupBlock(new AttributeBlockChunkGenerator("bar", new LocationTagged<string>(" bar=", 4, 0, 4), new LocationTagged<string>(string.Empty, 12, 0, 12)),
                             Factory.Markup(" bar=").With(SpanChunkGenerator.Null),
                             Factory.Markup("baz").With(new LiteralAttributeChunkGenerator(new LocationTagged<string>(string.Empty, 9, 0, 9), new LocationTagged<string>("baz", 9, 0, 9)))))),
-                new RazorError(RazorResources.FormatParseError_UnfinishedTag("foo"), new SourceLocation(0, 0, 0)));
+                new RazorError(
+                    RazorResources.FormatParseError_UnfinishedTag("foo"),
+                    new SourceLocation(1, 0, 1),
+                    length: 3));
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlTagsTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/Html/HtmlTagsTest.cs
@@ -41,7 +41,10 @@ namespace Microsoft.AspNet.Razor.Test.Parser.Html
                     BlockFactory.MarkupTagBlock("<p>", AcceptedCharacters.None),
                     BlockFactory.MarkupTagBlock("</>", AcceptedCharacters.None),
                     Factory.Markup(" ").Accepts(AcceptedCharacters.None)),
-                new RazorError(RazorResources.FormatParseError_MissingEndTag("p"), 0, 0, 0));
+                new RazorError(
+                    RazorResources.FormatParseError_MissingEndTag("p"),
+                    new SourceLocation(1, 0, 1),
+                    length: 1));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Test/Parser/ParserVisitorExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/ParserVisitorExtensionsTest.cs
@@ -41,8 +41,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser
             var errorSink = new ErrorSink();
             List<RazorError> errors = new List<RazorError>
             {
-                new RazorError("Foo", 1, 0, 1),
-                new RazorError("Bar", 2, 0, 2),
+                new RazorError("Foo", new SourceLocation(1, 0, 1), length: 3),
+                new RazorError("Bar", new SourceLocation(2, 0, 2), length: 3),
             };
             foreach (var error in errors)
             {
@@ -65,8 +65,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser
             Mock<ParserVisitor> targetMock = new Mock<ParserVisitor>();
             var root = new BlockBuilder() { Type = BlockType.Comment }.Build();
             var errorSink = new ErrorSink();
-            errorSink.OnError(new RazorError("Foo", 1, 0, 1));
-            errorSink.OnError(new RazorError("Bar", 2, 0, 2));
+            errorSink.OnError(new RazorError("Foo", new SourceLocation(1, 0, 1), length: 3));
+            errorSink.OnError(new RazorError("Bar", new SourceLocation(2, 0, 2), length: 3));
             var results = new ParserResults(root, Enumerable.Empty<TagHelperDescriptor>(), errorSink);
 
             // Act

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
@@ -237,7 +237,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -252,7 +253,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -269,10 +271,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -291,10 +295,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -311,15 +317,16 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 "TagHelper attributes must be well-formed.",
-                                absoluteIndex: 12,
-                                lineIndex: 0,
-                                columnIndex: 12)
+                                new SourceLocation(12, 0, 12),
+                                length: 1)
                         }
                     },
                     {
@@ -336,10 +343,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -358,10 +367,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -378,13 +389,16 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                absoluteIndex: 10, lineIndex: 0, columnIndex: 10)
+                                new SourceLocation(11, 0, 11),
+                                length: 6)
                         }
                     },
                     {
@@ -399,7 +413,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -414,7 +429,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -433,13 +449,16 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                absoluteIndex: 23, lineIndex: 0, columnIndex: 23)
+                                new SourceLocation(24, 0, 24),
+                                length: 6)
                         }
                     },
                     {
@@ -463,7 +482,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCSharp, "p"),
-                                absoluteIndex: 3, lineIndex: 0 , columnIndex: 3)
+                                absoluteIndex: 3, lineIndex: 0 , columnIndex: 3, length: 13)
                         }
                     },
                     {
@@ -474,7 +493,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCSharp, "p"),
-                                absoluteIndex: 3, lineIndex: 0 , columnIndex: 3)
+                                absoluteIndex: 3, lineIndex: 0 , columnIndex: 3, length: 13)
                         }
                     },
                     {
@@ -502,7 +521,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -519,13 +539,15 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("do", "}", "{"),
-                                absoluteIndex: 11, lineIndex: 0, columnIndex: 11)
+                                absoluteIndex: 11, lineIndex: 0, columnIndex: 11, length: 1)
                         }
                     },
                     {
@@ -540,16 +562,18 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("do", "}", "{"),
-                                absoluteIndex: 11, lineIndex: 0, columnIndex: 11),
+                                absoluteIndex: 11, lineIndex: 0, columnIndex: 11, length: 1),
                             new RazorError(
                                 RazorResources.ParseError_Unterminated_String_Literal,
-                                absoluteIndex: 15, lineIndex: 0, columnIndex: 15)
+                                absoluteIndex: 15, lineIndex: 0, columnIndex: 15, length: 1)
                         }
                     },
                     {
@@ -560,19 +584,21 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCSharp, "p"),
-                                absoluteIndex: 3, lineIndex: 0 , columnIndex: 3),
+                                absoluteIndex: 3, lineIndex: 0 , columnIndex: 3, length: 30),
                             new RazorError(
                                 RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("do", "}", "{"),
-                                absoluteIndex: 4, lineIndex: 0, columnIndex: 4),
+                                absoluteIndex: 4, lineIndex: 0, columnIndex: 4, length: 1),
                             new RazorError(
                                 RazorResources.FormatParseError_UnexpectedEndTag("p"),
-                                absoluteIndex: 29, lineIndex: 0, columnIndex: 29)
+                                absoluteIndex: 31, lineIndex: 0, columnIndex: 31, length: 1)
                         }
                     }
                 };
@@ -609,10 +635,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -623,7 +651,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3)
+                                absoluteIndex: 5, lineIndex: 0, columnIndex: 5, length: 1)
                         }
                     },
                     {
@@ -635,13 +663,16 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "strong"),
-                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3),
+                                new SourceLocation(4, 0, 4),
+                                length: 6),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3)
+                                new SourceLocation(4, 0, 4),
+                                length: 6)
                         }
                     },
                     {
@@ -653,13 +684,16 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "strong"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 6),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 6),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                absoluteIndex: 8, lineIndex: 0, columnIndex: 8)
+                                new SourceLocation(9, 0, 9),
+                                length: 1)
                         }
                     },
                     {
@@ -670,10 +704,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "strong"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 6),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "strong"),
-                                absoluteIndex: 8, lineIndex: 0, columnIndex: 8)
+                                new SourceLocation(10, 0, 10),
+                                length: 6)
                         }
                     },
                     {
@@ -689,10 +725,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                new SourceLocation(4, 0, 4),
+                                length: 6),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                absoluteIndex: 13, lineIndex: 0, columnIndex: 13)
+                                new SourceLocation(14, 0, 14),
+                                length: 1)
                         }
                     },
                     {
@@ -709,7 +747,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                new SourceLocation(3, 0, 3),
+                                length: 6)
                         }
                     },
                     {
@@ -722,7 +761,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                absoluteIndex: 12, lineIndex: 0, columnIndex: 12)
+                                new SourceLocation(14, 0, 14),
+                                length: 1)
                         }
                     }
                 };
@@ -1091,10 +1131,10 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     {
                         new RazorError(
                             string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "strong"),
-                            absoluteIndex: 52, lineIndex: 0, columnIndex: 52),
+                            absoluteIndex: 53, lineIndex: 0, columnIndex: 53, length: 6),
                         new RazorError(
                             string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "strong"),
-                            absoluteIndex: 64, lineIndex: 0, columnIndex: 64)
+                            absoluteIndex: 66, lineIndex: 0, columnIndex: 66, length: 6)
                     }
                 };
                 yield return new object[]
@@ -1111,7 +1151,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     {
                         new RazorError(
                             string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "p"),
-                            absoluteIndex: 5, lineIndex: 0, columnIndex: 5)
+                            absoluteIndex: 6, lineIndex: 0, columnIndex: 6, length: 1)
                     }
                 };
                 yield return new object[]
@@ -1128,10 +1168,10 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     {
                         new RazorError(
                             string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "p"),
-                            absoluteIndex: 5, lineIndex: 0, columnIndex: 5),
+                            absoluteIndex: 6, lineIndex: 0, columnIndex: 6, length: 1),
                         new RazorError(
                             string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "strong"),
-                            absoluteIndex: 14, lineIndex: 0, columnIndex: 14)
+                            absoluteIndex: 15, lineIndex: 0, columnIndex: 15, length: 6)
                     }
                 };
                 yield return new object[]
@@ -1154,7 +1194,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                     {
                         new RazorError(
                             string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "p"),
-                            SourceLocation.Zero)
+                            new SourceLocation(1, 0, 1),
+                            length: 1)
                     }
                 };
             }
@@ -3463,8 +3504,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 })),
                         new[]
                         {
-                            new RazorError(string.Format(errorFormatNoCloseAngle, "input"), SourceLocation.Zero),
-                            new RazorError(string.Format(errorFormatUnclosed, "input"), SourceLocation.Zero),
+                            new RazorError(
+                                string.Format(errorFormatNoCloseAngle, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
                         }
                     },
                     {
@@ -3479,8 +3526,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 })),
                         new[]
                         {
-                            new RazorError(string.Format(errorFormatNoCloseAngle, "input"), SourceLocation.Zero),
-                            new RazorError(string.Format(errorFormatUnclosed, "input"), SourceLocation.Zero),
+                            new RazorError(
+                                string.Format(errorFormatNoCloseAngle, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
                             new RazorError(
                                 string.Format(errorFormatNoValue, "bound-required-string", "input", stringType),
                                 absoluteIndex: 7,
@@ -3501,8 +3554,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 })),
                         new[]
                         {
-                            new RazorError(string.Format(errorFormatNoCloseAngle, "input"), SourceLocation.Zero),
-                            new RazorError(string.Format(errorFormatUnclosed, "input"), SourceLocation.Zero),
+                            new RazorError(
+                                string.Format(errorFormatNoCloseAngle, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
                             new RazorError(
                                 string.Format(errorFormatNoValue, "bound-required-int", "input", intType),
                                 absoluteIndex: 7,
@@ -3525,8 +3584,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 })),
                         new[]
                         {
-                            new RazorError(string.Format(errorFormatNoCloseAngle, "input"), SourceLocation.Zero),
-                            new RazorError(string.Format(errorFormatUnclosed, "input"), SourceLocation.Zero),
+                            new RazorError(
+                                string.Format(errorFormatNoCloseAngle, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
                             new RazorError(
                                 string.Format(errorFormatNoValue, "bound-required-int", "input", intType),
                                 absoluteIndex: 7,
@@ -3553,8 +3618,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 })),
                         new[]
                         {
-                            new RazorError(string.Format(errorFormatNoCloseAngle, "p"), SourceLocation.Zero),
-                            new RazorError(string.Format(errorFormatUnclosed, "p"), SourceLocation.Zero),
+                            new RazorError(
+                                string.Format(errorFormatNoCloseAngle, "p"),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "p"),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(errorFormatNoValue, "bound-string", "p", stringType), 3, 0, 3, 12),
                         }
@@ -3571,8 +3642,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 })),
                         new[]
                         {
-                            new RazorError(string.Format(errorFormatNoCloseAngle, "p"), SourceLocation.Zero),
-                            new RazorError(string.Format(errorFormatUnclosed, "p"), SourceLocation.Zero),
+                            new RazorError(
+                                string.Format(errorFormatNoCloseAngle, "p"),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "p"),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(string.Format(errorFormatNoValue, "bound-int", "p", intType), 3, 0, 3, 9),
                         }
                     },
@@ -3589,8 +3666,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 })),
                         new[]
                         {
-                            new RazorError(string.Format(errorFormatNoCloseAngle, "p"), SourceLocation.Zero),
-                            new RazorError(string.Format(errorFormatUnclosed, "p"), SourceLocation.Zero),
+                            new RazorError(
+                                string.Format(errorFormatNoCloseAngle, "p"),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "p"),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(string.Format(errorFormatNoValue, "bound-int", "p", intType), 3, 0, 3, 9),
                             new RazorError(
                                 string.Format(errorFormatNoValue, "bound-string", "p", stringType), 13, 0, 13, 12),
@@ -3618,8 +3701,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                     }))),
                         new[]
                         {
-                            new RazorError(string.Format(errorFormatNoCloseAngle, "input"), SourceLocation.Zero),
-                            new RazorError(string.Format(errorFormatUnclosed, "input"), SourceLocation.Zero),
+                            new RazorError(
+                                string.Format(errorFormatNoCloseAngle, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "input"),
+                                new SourceLocation(1, 0, 1),
+                                length: 5),
                             new RazorError(
                                 string.Format(errorFormatNoValue, "bound-required-int", "input", intType), 7, 0, 7, 18),
                             new RazorError(
@@ -3628,8 +3717,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                                 lineIndex: 0,
                                 columnIndex: 43,
                                 length: 21),
-                            new RazorError(string.Format(errorFormatNoCloseAngle, "p"), 64, 0, 64),
-                            new RazorError(string.Format(errorFormatUnclosed, "p"), 64, 0, 64),
+                            new RazorError(
+                                string.Format(errorFormatNoCloseAngle, "p"),
+                                new SourceLocation(65, 0, 65),
+                                length: 1),
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "p"),
+                                new SourceLocation(65, 0, 65),
+                                length: 1),
                             new RazorError(string.Format(errorFormatNoValue, "bound-int", "p", intType), 67, 0, 67, 9),
                             new RazorError(
                                 string.Format(errorFormatNoValue, "bound-string", "p", stringType),

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -30,22 +30,22 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
             var expectedErrors = new[] {
                 new RazorError(
                     RazorResources.FormatTagHelperParseTreeRewriter_InvalidNestedTag("strong", "p", "br"),
-                    absoluteIndex: 7 + newLineLength,
+                    absoluteIndex: 8 + newLineLength,
                     lineIndex: 1,
-                    columnIndex: 9 + newLineLength,
-                    length: 8),
+                    columnIndex: 5,
+                    length: 6),
                 new RazorError(
                     RazorResources.FormatTagHelperParseTreeRewriter_CannotHaveNonTagContent("p", "br"),
                     absoluteIndex: 23 + newLineLength * 2,
                     lineIndex: 2,
-                    columnIndex: 23 + newLineLength * 2,
+                    columnIndex: 8,
                     length: 5),
                 new RazorError(
                     RazorResources.FormatTagHelperParseTreeRewriter_InvalidNestedTag("strong", "p", "br"),
-                    absoluteIndex: 32 + newLineLength * 3,
+                    absoluteIndex: 34 + newLineLength * 3,
                     lineIndex: 3,
-                    columnIndex: 32 + newLineLength * 3,
-                    length: 9),
+                    columnIndex: 5,
+                    length: 6),
             };
             var expectedOutput = new MarkupBlock(
                 new MarkupTagHelperBlock("p",
@@ -81,16 +81,16 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
             var expectedErrors = new[] {
                 new RazorError(
                     RazorResources.FormatTagHelperParseTreeRewriter_InvalidNestedTag("strong", "strong", "br"),
-                    absoluteIndex: 17,
+                    absoluteIndex: 18,
                     lineIndex: 0,
-                    columnIndex: 17,
-                    length: 8),
+                    columnIndex: 18,
+                    length: 6),
                 new RazorError(
                     RazorResources.FormatTagHelperParseTreeRewriter_InvalidNestedTag("strong", "strong", "br"),
-                    absoluteIndex: 25,
+                    absoluteIndex: 27,
                     lineIndex: 0,
-                    columnIndex: 25,
-                    length: 9),
+                    columnIndex: 27,
+                    length: 6),
             };
             var expectedOutput = new MarkupBlock(
                 new MarkupTagHelperBlock("strong",
@@ -260,7 +260,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
                                 new MarkupTagHelperBlock("br", TagMode.StartTagOnly))),
-                        new[] { nestedTagError("br", "p", "strong", 3, 4) }
+                        new[] { nestedTagError("br", "p", "strong", 4, 2) }
                     },
                     {
                         "<p>Hello</p>",
@@ -272,7 +272,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         "<p><hr /></p>",
                         new[] { "br", "strong" },
                         new MarkupBlock(new MarkupTagHelperBlock("p", blockFactory.MarkupTagBlock("<hr />"))),
-                        new[] { nestedTagError("hr", "p", "br, strong", 3, 6) }
+                        new[] { nestedTagError("hr", "p", "br, strong", 4, 2) }
                     },
                     {
                         "<p><br>Hello</p>",
@@ -281,7 +281,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock("p",
                                 new MarkupTagHelperBlock("br", TagMode.StartTagOnly),
                                 factory.Markup("Hello"))),
-                        new[] { nestedTagError("br", "p", "strong", 3, 4), nestedContentError("p", "strong", 7, 5) }
+                        new[] { nestedTagError("br", "p", "strong", 4, 2), nestedContentError("p", "strong", 7, 5) }
                     },
                     {
                         "<p><strong>Title:</strong><br />Something</p>",
@@ -294,7 +294,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new[]
                         {
                             nestedContentError("strong", "strong", 11, 6),
-                            nestedTagError("br", "p", "strong", 26, 6),
+                            nestedTagError("br", "p", "strong", 27, 2),
                             nestedContentError("p", "strong", 32, 9),
                         }
                     },
@@ -344,11 +344,11 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         new[]
                         {
                             nestedContentError("strong", "strong", 11, 6),
-                            nestedTagError("br", "strong", "strong", 17, 4),
-                            nestedTagError("em", "strong", "strong", 21, 4),
+                            nestedTagError("br", "strong", "strong", 18, 2),
+                            nestedTagError("em", "strong", "strong", 22, 2),
                             nestedContentError("strong", "strong", 25, 11),
-                            nestedTagError("em", "strong", "strong", 36, 5),
-                            nestedTagError("br", "p", "strong", 50, 6),
+                            nestedTagError("em", "strong", "strong", 38, 2),
+                            nestedTagError("br", "p", "strong", 51, 2),
                             nestedContentError("p", "strong", 56, 9)
                         }
                     },
@@ -368,14 +368,14 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 factory.Markup("Something"))),
                         new[]
                         {
-                            nestedTagError("custom", "p", "custom", 3, 8),
+                            nestedTagError("custom", "p", "custom", 4, 6),
                             nestedContentError("p", "custom", 11, 6),
-                            nestedTagError("br", "p", "custom", 17, 4),
-                            nestedTagError("em", "p", "custom", 21, 4),
+                            nestedTagError("br", "p", "custom", 18, 2),
+                            nestedTagError("em", "p", "custom", 22, 2),
                             nestedContentError("p", "custom", 25, 11),
-                            nestedTagError("em", "p", "custom", 36, 5),
-                            nestedTagError("custom", "p", "custom", 41, 9),
-                            nestedTagError("br", "p", "custom", 50, 6),
+                            nestedTagError("em", "p", "custom", 38, 2),
+                            nestedTagError("custom", "p", "custom", 43, 6),
+                            nestedTagError("br", "p", "custom", 51, 2),
                             nestedContentError("p", "custom", 56, 9)
                         }
                     }
@@ -455,10 +455,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                     "input",
                     "InputTagHelper",
                     TagStructure.WithoutEndTag),
-                absoluteIndex: 0,
+                absoluteIndex: 2,
                 lineIndex: 0,
-                columnIndex: 0,
-                length: 8);
+                columnIndex: 2,
+                length: 5);
             var documentContent = "</input>";
             var expectedOutput = new MarkupBlock(blockFactory.MarkupTagBlock("</input>"));
             var descriptors = new TagHelperDescriptor[]
@@ -1237,10 +1237,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -1257,10 +1259,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero)
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -1283,7 +1287,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                absoluteIndex: 15, lineIndex: 0, columnIndex: 15)
+                                new SourceLocation(17, 0, 17),
+                                length: 1)
                         }
                     },
                     {
@@ -1300,7 +1305,8 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                absoluteIndex: 32, lineIndex: 0, columnIndex: 32)
+                                new SourceLocation(34, 0, 34),
+                                length: 1)
                         }
                     },
                     {
@@ -1316,10 +1322,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                         }
                     },
                     {
@@ -1336,10 +1344,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                         }
                     },
                     {
@@ -1355,10 +1365,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                absoluteIndex: 15, lineIndex: 0, columnIndex: 15)
+                                new SourceLocation(17, 0, 17),
+                                length: 1)
                         }
                     },
                     {
@@ -1375,10 +1387,12 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                SourceLocation.Zero),
+                                new SourceLocation(1, 0, 1),
+                                length: 1),
                             new RazorError(
                                 string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                absoluteIndex: 32, lineIndex: 0, columnIndex: 32)
+                                new SourceLocation(34, 0, 34),
+                                length: 1)
                         }
                     },
                 };
@@ -1794,10 +1808,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "!text"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 5)
                         }
                     },
                     {
@@ -1974,10 +1988,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "!text", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 5),
                         }
                     },
                     {
@@ -1989,7 +2003,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalNotStarted, "!text", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 4, lineIndex: 0, columnIndex: 4, length: 5),
                         }
                     },
                     {
@@ -2019,10 +2033,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "!text", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 5),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "text", CultureInfo.InvariantCulture),
-                                absoluteIndex: 9, lineIndex: 0, columnIndex: 9)
+                                absoluteIndex: 11, lineIndex: 0, columnIndex: 11, length: 4)
                         }
                     },
                     {
@@ -2038,7 +2052,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "text", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 4)
                         }
                     },
                     {
@@ -2069,10 +2083,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "text", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 4)
                         }
                     },
                     {
@@ -2094,10 +2108,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalNotStarted, "text", CultureInfo.InvariantCulture),
-                                absoluteIndex: 17, lineIndex: 0, columnIndex: 17),
+                                absoluteIndex: 19, lineIndex: 0, columnIndex: 19, length: 4),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "text", CultureInfo.InvariantCulture),
-                                absoluteIndex: 17, lineIndex: 0, columnIndex: 17)
+                                absoluteIndex: 19, lineIndex: 0, columnIndex: 19, length: 4)
                         }
                     },
                 };
@@ -2152,10 +2166,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorEOFMatchingBrace, "!text}"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 6)
                         }
                     },
                     {
@@ -2170,10 +2184,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorEOFMatchingBrace, "!text"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 5)
                         }
                     },
                     {
@@ -2198,10 +2212,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorEOFMatchingBrace, "!text"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 5)
                         }
                     },
                     {
@@ -2226,10 +2240,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             {
                                 new RazorError(
                                     errorMatchingBrace,
-                                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                                 new RazorError(
                                     string.Format(errorEOFMatchingBrace, "!text"),
-                                    absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                    absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 5)
                             }
                     },
                     {
@@ -2257,10 +2271,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 {
                                     new RazorError(
                                         errorMatchingBrace,
-                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                                     new RazorError(
                                         string.Format(errorEOFMatchingBrace, "!text"),
-                                        absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                        absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 5)
                                 }
                     },
                     {
@@ -2289,10 +2303,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 {
                                     new RazorError(
                                         errorMatchingBrace,
-                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                                     new RazorError(
                                         string.Format(errorEOFMatchingBrace, "!text"),
-                                        absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                        absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 5)
                                 }
                     }
                 };
@@ -2346,10 +2360,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorEOFMatchingBrace, "!}"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2)
                         }
                     },
                     {
@@ -2360,10 +2374,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorEOFMatchingBrace, "!p}"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 3)
                         }
                     },
                     {
@@ -2375,10 +2389,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorEOFMatchingBrace, "!p"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2)
                         }
                     },
                     {
@@ -2403,10 +2417,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorEOFMatchingBrace, "!p"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2)
                         }
                     },
                     {
@@ -2431,10 +2445,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             {
                                 new RazorError(
                                     errorMatchingBrace,
-                                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                                 new RazorError(
                                     string.Format(errorEOFMatchingBrace, "!p"),
-                                    absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                    absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2)
                             }
                     },
                     {
@@ -2466,10 +2480,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             {
                                 new RazorError(
                                     errorMatchingBrace,
-                                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                                 new RazorError(
                                     string.Format(errorEOFMatchingBrace, "!p"),
-                                    absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                    absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2)
                             }
                     },
                     {
@@ -2497,10 +2511,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 {
                                     new RazorError(
                                         errorMatchingBrace,
-                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                                     new RazorError(
                                         string.Format(errorEOFMatchingBrace, "!p"),
-                                        absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                        absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2)
                                 }
                     },
                     {
@@ -2530,10 +2544,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 {
                                     new RazorError(
                                         errorMatchingBrace,
-                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                        absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                                     new RazorError(
                                         string.Format(errorEOFMatchingBrace, "!p"),
-                                        absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                        absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2)
                                 }
                     }
                 };
@@ -2707,10 +2721,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "!p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2),
                         }
                     },
                     {
@@ -2722,7 +2736,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalNotStarted, "!p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 4, lineIndex: 0, columnIndex: 4, length: 2),
                         }
                     },
                     {
@@ -2752,10 +2766,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "!p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 6, lineIndex: 0, columnIndex: 6)
+                                absoluteIndex: 8, lineIndex: 0, columnIndex: 8, length: 1)
                         }
                     },
                     {
@@ -2768,10 +2782,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 1),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 1)
                         }
                     },
                     {
@@ -2799,13 +2813,13 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 1),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 1)
                         }
                     },
                     {
@@ -2827,10 +2841,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalNotStarted, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 11, lineIndex: 0, columnIndex: 11),
+                                absoluteIndex: 13, lineIndex: 0, columnIndex: 13, length: 1),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 11, lineIndex: 0, columnIndex: 11)
+                                absoluteIndex: 13, lineIndex: 0, columnIndex: 13, length: 1)
                         }
                     },
                     {
@@ -2852,16 +2866,16 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "strong", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 6),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "strong", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 6),
                             new RazorError(
                                 string.Format(errorFormatNormalNotStarted, "strong", CultureInfo.InvariantCulture),
-                                absoluteIndex: 15, lineIndex: 0, columnIndex: 15),
+                                absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 6),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "strong", CultureInfo.InvariantCulture),
-                                absoluteIndex: 15, lineIndex: 0, columnIndex: 15)
+                                absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 6)
                         }
                     },
                     {
@@ -2904,22 +2918,22 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 1),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2),
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 1),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "strong", CultureInfo.InvariantCulture),
-                                absoluteIndex: 5, lineIndex: 0, columnIndex: 5),
+                                absoluteIndex: 6, lineIndex: 0, columnIndex: 6, length: 6),
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "!p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 23, lineIndex: 0, columnIndex: 23),
+                                absoluteIndex: 24, lineIndex: 0, columnIndex: 24, length: 2),
                             new RazorError(
                                 string.Format(errorFormatMalformed, "strong", CultureInfo.InvariantCulture),
-                                absoluteIndex: 27, lineIndex: 0, columnIndex: 27),
+                                absoluteIndex: 29, lineIndex: 0, columnIndex: 29, length: 6),
                             new RazorError(
                                 string.Format(errorFormatNormalNotStarted, "!p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 36, lineIndex: 0, columnIndex: 36),
+                                absoluteIndex: 38, lineIndex: 0, columnIndex: 38, length: 2),
                         }
                     },
                 };
@@ -2985,10 +2999,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 errorMatchingBrace,
-                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1),
+                                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 1),
                             new RazorError(
                                 string.Format(errorFormatNormalUnclosed, "!p"),
-                                absoluteIndex: 2, lineIndex: 0, columnIndex: 2)
+                                absoluteIndex: 3, lineIndex: 0, columnIndex: 3, length: 2)
                         }
                     },
                     {
@@ -3174,7 +3188,7 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                         {
                             new RazorError(
                                 string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
-                                absoluteIndex: 4, lineIndex: 0, columnIndex: 4)
+                                absoluteIndex: 6, lineIndex: 0, columnIndex: 6, length: 1)
                         }
                     },
                     {
@@ -3183,8 +3197,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock("p", blockFactory.EscapedMarkupTagBlock("</", "p>"))),
                         new []
                         {
-                            new RazorError(string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
-                            SourceLocation.Zero)
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -3203,8 +3219,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 blockFactory.EscapedMarkupTagBlock("</", "p>"))),
                         new []
                         {
-                            new RazorError(string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
-                            SourceLocation.Zero)
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                     {
@@ -3215,8 +3233,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                             blockFactory.MarkupTagBlock("</p>")),
                         new []
                         {
-                            new RazorError(string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
-                            absoluteIndex: 9, lineIndex: 0, columnIndex: 9)
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
+                                new SourceLocation(11, 0, 11),
+                                length: 1)
                         }
                     },
                     {
@@ -3244,8 +3264,10 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
                                 blockFactory.EscapedMarkupTagBlock("</", "p>"))),
                         new []
                         {
-                            new RazorError(string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
-                            SourceLocation.Zero)
+                            new RazorError(
+                                string.Format(errorFormatUnclosed, "p", CultureInfo.InvariantCulture),
+                                new SourceLocation(1, 0, 1),
+                                length: 1)
                         }
                     },
                 };


### PR DESCRIPTION
- Updated `TagHelper` errors to no longer highlight the entire tag as an error, instead just the tag name is marked as an error. This is now consistent with nested tags in `@{ ... }` errors.
- Updated `RazorError` and corresponding error logging constructs to disallow creation without providing lengths.
- Updated `TagHelperDescriptorResolver` and related classes to properly determine assembly locations within directives. This allows for exact error locations in the `@addTagHelper` directive.
- Update tests to reflect new length provided `RazorError`s.
- Added new tests to validate `TagHelperDescriptorResolver` properly calculates assembly location.

#386