### PR TITLE
Extra newline no longer rendered at the end of a code block

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.cs
@@ -316,12 +316,16 @@ namespace Microsoft.AspNet.Razor.Parser
                 Span.ChunkGenerator = SpanChunkGenerator.Null;
             }
 
-            if (!At(CSharpSymbolType.WhiteSpace) && !At(CSharpSymbolType.NewLine))
+            if (!IsNested)
             {
-                PutCurrentBack();
+                EnsureCurrent();
+                if (At(CSharpSymbolType.NewLine) ||
+                    (At(CSharpSymbolType.WhiteSpace) && NextIs(CSharpSymbolType.NewLine)))
+                {
+                    Context.NullGenerateWhitespaceAndNewLine = true;
+                }
             }
 
-            CompleteBlock(insertMarkerIfNecessary: false);
             Output(SpanKind.MetaCode);
         }
 

--- a/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.cs
@@ -71,7 +71,19 @@ namespace Microsoft.AspNet.Razor.Parser
             var startOfLine = false;
             while (!EndOfFile && !condition(CurrentSymbol))
             {
-                if (At(HtmlSymbolType.NewLine))
+                if (Context.NullGenerateWhitespaceAndNewLine)
+                {
+                    Context.NullGenerateWhitespaceAndNewLine = false;
+                    Span.ChunkGenerator = SpanChunkGenerator.Null;
+                    AcceptWhile(symbol => symbol.Type == HtmlSymbolType.WhiteSpace);
+                    if (At(HtmlSymbolType.NewLine))
+                    {
+                        AcceptAndMoveNext();
+                    }
+
+                    Output(SpanKind.Markup);
+                }
+                else if (At(HtmlSymbolType.NewLine))
                 {
                     if (last != null)
                     {

--- a/src/Microsoft.AspNet.Razor/Parser/ParserContext.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/ParserContext.cs
@@ -67,6 +67,8 @@ namespace Microsoft.AspNet.Razor.Parser
         public Span LastSpan { get; private set; }
         public bool WhiteSpaceIsSignificantToAncestorBlock { get; set; }
 
+        public bool NullGenerateWhitespaceAndNewLine { get; set; }
+
         public AcceptedCharacters LastAcceptedCharacters
         {
             get

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Blocks.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Blocks.cs
@@ -21,8 +21,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(21, 4, true);
-            WriteLiteral("\r\n\r\n");
+            Instrumentation.BeginContext(23, 2, true);
+            WriteLiteral("\r\n");
             Instrumentation.EndContext();
 #line 5 "Blocks.cshtml"
  while(i <= 10) {

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/CodeBlockWithTextElement.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/CodeBlockWithTextElement.cs
@@ -57,9 +57,6 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(83, 2, true);
-            WriteLiteral("\r\n");
-            Instrumentation.EndContext();
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
@@ -265,8 +265,8 @@ if(true) {
 #line default
 #line hidden
 
-                Instrumentation.BeginContext(805, 14, true);
-                WriteLiteral("\r\n            ");
+                Instrumentation.BeginContext(807, 12, true);
+                WriteLiteral("            ");
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", TagMode.StartTagOnly, "test", async() => {
                 }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ExpressionsInCode.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ExpressionsInCode.cs
@@ -22,8 +22,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(54, 4, true);
-            WriteLiteral("\r\n\r\n");
+            Instrumentation.BeginContext(56, 2, true);
+            WriteLiteral("\r\n");
             Instrumentation.EndContext();
 #line 6 "ExpressionsInCode.cshtml"
  if(foo != null) {

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Instrumented.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Instrumented.cs
@@ -42,8 +42,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(94, 4, true);
-            WriteLiteral("\r\n\r\n");
+            Instrumentation.BeginContext(96, 2, true);
+            WriteLiteral("\r\n");
             Instrumentation.EndContext();
 #line 8 "Instrumented.cshtml"
  while(i <= 10) {

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/MarkupInCodeBlock.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/MarkupInCodeBlock.cs
@@ -40,9 +40,6 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(96, 2, true);
-            WriteLiteral("\r\n");
-            Instrumentation.EndContext();
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NoLinePragmas.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NoLinePragmas.cs
@@ -21,8 +21,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(21, 4, true);
-            WriteLiteral("\r\n\r\n");
+            Instrumentation.BeginContext(23, 2, true);
+            WriteLiteral("\r\n");
             Instrumentation.EndContext();
 #line 5 ""
  while(i <= 10) {

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NullConditionalExpressions.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NullConditionalExpressions.cs
@@ -76,8 +76,8 @@ Write(ViewBag?.Method(Value?[23]?.More)?["key"]);
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(135, 4, true);
-            WriteLiteral("\r\n\r\n");
+            Instrumentation.BeginContext(137, 2, true);
+            WriteLiteral("\r\n");
             Instrumentation.EndContext();
             Instrumentation.BeginContext(140, 13, false);
 #line 8 "NullConditionalExpressions.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
@@ -43,8 +43,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(280, 51, true);
-            WriteLiteral("\r\n\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
+            Instrumentation.BeginContext(282, 49, true);
+            WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", TagMode.SelfClosing, "test", async() => {
             }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
@@ -43,8 +43,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(280, 51, true);
-            WriteLiteral("\r\n\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
+            Instrumentation.BeginContext(282, 49, true);
+            WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", TagMode.SelfClosing, "test", async() => {
             }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/RazorComments.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/RazorComments.cs
@@ -40,8 +40,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(232, 4, true);
-            WriteLiteral("\r\n\r\n");
+            Instrumentation.BeginContext(234, 2, true);
+            WriteLiteral("\r\n");
             Instrumentation.EndContext();
 #line 12 "RazorComments.cshtml"
    var bar = "@* bar *@"; 
@@ -49,8 +49,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(263, 46, true);
-            WriteLiteral("\r\n<p>But this should show the comment syntax: ");
+            Instrumentation.BeginContext(265, 44, true);
+            WriteLiteral("<p>But this should show the comment syntax: ");
             Instrumentation.EndContext();
             Instrumentation.BeginContext(310, 3, false);
 #line 13 "RazorComments.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Sections.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Sections.cs
@@ -21,8 +21,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(47, 33, true);
-            WriteLiteral("\r\n\r\n<div>This is in the Body>\r\n\r\n");
+            Instrumentation.BeginContext(49, 31, true);
+            WriteLiteral("\r\n<div>This is in the Body>\r\n\r\n");
             Instrumentation.EndContext();
             DefineSection("Section2", async(__razor_template_writer) => {
                 Instrumentation.BeginContext(99, 39, true);

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
@@ -35,8 +35,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(69, 4, true);
-            WriteLiteral("\r\n\r\n");
+            Instrumentation.BeginContext(71, 2, true);
+            WriteLiteral("\r\n");
             Instrumentation.EndContext();
             DefineSection("MySection", async(__razor_template_writer) => {
                 Instrumentation.BeginContext(93, 21, true);

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Templates.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Templates.cs
@@ -72,8 +72,8 @@ Write(foo(""));
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(367, 10, true);
-            WriteLiteral("\r\n\r\n<ul>\r\n");
+            Instrumentation.BeginContext(369, 8, true);
+            WriteLiteral("\r\n<ul>\r\n");
             Instrumentation.EndContext();
             Instrumentation.BeginContext(379, 11, false);
 #line 17 "Templates.cshtml"
@@ -156,8 +156,8 @@ WriteTo(__razor_template_writer, item);
 #line default
 #line hidden
 
-    Instrumentation.BeginContext(574, 79, true);
-    WriteLiteralTo(__razor_template_writer, "\r\n        <ul>\r\n            <li>Child Items... ?</li>\r\n        </ul>\r\n    </li>");
+    Instrumentation.BeginContext(576, 77, true);
+    WriteLiteralTo(__razor_template_writer, "        <ul>\r\n            <li>Child Items... ?</li>\r\n        </ul>\r\n    </li>");
     Instrumentation.EndContext();
 }
 )

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
@@ -32,8 +32,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-            Instrumentation.BeginContext(95, 4, true);
-            WriteLiteral("\r\n\r\n");
+            Instrumentation.BeginContext(97, 2, true);
+            WriteLiteral("\r\n");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", TagMode.StartTagAndEndTag, "test", async() => {
                 Instrumentation.BeginContext(128, 11, true);


### PR DESCRIPTION
Issue - #485 

This fixes the issue with the first example in https://github.com/aspnet/Razor/issues/485#issue-100841789.
The second example no longer seems to be an issue. 
I'm trying various scenarios to see if that issue exists and also to see if this change broke something else. (All tests passing other than the ones updated here)

@NTaylorMullen @dougbu 