### PR TITLE
Two quick fixes

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -145,7 +145,7 @@
     <value>Invalid tag helper directive '{0}'. Cannot have multiple '{0}' directives on a page.</value>
   </data>
   <data name="TagHelperDescriptorResolver_InvalidTagHelperPrefixValue" xml:space="preserve">
-    <value>Invalid tag helper directive '{0}' value. '{1} is not allowed in prefix '{2}'.</value>
+    <value>Invalid tag helper directive '{0}' value. '{1}' is not allowed in prefix '{2}'.</value>
   </data>
   <data name="TagHelperDescriptorFactory_Attribute" xml:space="preserve">
     <value>Attribute</value>

--- a/src/Microsoft.AspNet.Razor/project.json
+++ b/src/Microsoft.AspNet.Razor/project.json
@@ -20,19 +20,11 @@
     "dnx451": { },
     "dnxcore50": {
       "dependencies": {
-        "System.Collections": "4.0.11-beta-*",
-        "System.Diagnostics.Debug": "4.0.11-beta-*",
         "System.Diagnostics.Tools": "4.0.1-beta-*",
-        "System.IO": "4.0.11-beta-*",
         "System.IO.FileSystem": "4.0.1-beta-*",
         "System.Linq": "4.0.1-beta-*",
-        "System.Reflection": "4.0.11-beta-*",
-        "System.Resources.ResourceManager": "4.0.1-beta-*",
-        "System.Runtime.Extensions": "4.0.11-beta-*",
-        "System.Threading": "4.0.11-beta-*",
-        "System.Threading.Tasks": "4.0.11-beta-*",
-        "System.Threading.Thread": "4.0.0-beta-*",
-        "System.Security.Cryptography.Algorithms": "4.0.0-beta-*"
+        "System.Security.Cryptography.Algorithms": "4.0.0-beta-*",
+        "System.Threading.Thread": "4.0.0-beta-*"
       }
     }
   }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorResolverTest.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 var multipleDirectiveError =
                     "Invalid tag helper directive '{0}'. Cannot have multiple '{0}' directives on a page.";
                 var invalidTagHelperPrefixValueError =
-                    "Invalid tag helper directive '{0}' value. '{1} is not allowed in prefix '{2}'.";
+                    "Invalid tag helper directive '{0}' value. '{1}' is not allowed in prefix '{2}'.";
 
                 return new TheoryData<Dictionary<string, IEnumerable<Type>>, // descriptorAssemblyLookups
                                       IEnumerable<TagHelperDirectiveDescriptor>, // directiveDescriptors


### PR DESCRIPTION
- add missing closing quote in a resource
- cleanup `project.json` files
  - remove some package references that are found transitively