### PR TITLE
React to BufferedHtmlContent changes

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
@@ -125,6 +125,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             return this;
         }
 
+        public override TagHelperContent AppendEncoded(string value)
+        {
+            Buffer.AppendEncoded(value);
+            return this;
+        }
+
         /// <inheritdoc />
         public override TagHelperContent AppendFormat([NotNull] string format, object arg0)
         {

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContent.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContent.cs
@@ -60,6 +60,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public abstract TagHelperContent Append(string value);
 
         /// <summary>
+        /// Appends <paramref name="value"/> to the existing content. <paramref name="value"/> is assumed
+        /// to be an HTML encoded <see cref="string"/> and no further encoding will be performed.
+        /// </summary>
+        /// <param name="value">The <see cref="string"/> to be appended.</param>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        public abstract TagHelperContent AppendEncoded(string value);
+
+        /// <summary>
         /// Appends the specified <paramref name="format"/> to the existing content after
         /// replacing the format item with the <see cref="string"/> representation of the
         /// <paramref name="arg0"/>.

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
@@ -615,5 +615,37 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             // Assert
             Assert.Equal("HtmlEncode[[Hello ]]HtmlEncode[[World]]", writer.ToString());
         }
+
+        [Fact]
+        public void Append_WrittenAsEncoded()
+        {
+            // Arrange
+            var tagHelperContent = new DefaultTagHelperContent();
+            tagHelperContent.Append("Hi");
+
+            var writer = new StringWriter();
+
+            // Act
+            tagHelperContent.WriteTo(writer, new CommonTestEncoder());
+
+            // Assert
+            Assert.Equal("HtmlEncode[[Hi]]", writer.ToString());
+        }
+
+        [Fact]
+        public void AppendEncoded_DoesNotGetEncoded()
+        {
+            // Arrange
+            var tagHelperContent = new DefaultTagHelperContent();
+            tagHelperContent.AppendEncoded("Hi");
+
+            var writer = new StringWriter();
+
+            // Act
+            tagHelperContent.WriteTo(writer, new CommonTestEncoder());
+
+            // Assert
+            Assert.Equal("Hi", writer.ToString());
+        }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
@@ -613,7 +613,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             tagHelperContent.WriteTo(writer, new CommonTestEncoder());
 
             // Assert
-            Assert.Equal("Hello World", writer.ToString());
+            Assert.Equal("HtmlEncode[[Hello ]]HtmlEncode[[World]]", writer.ToString());
         }
     }
 }


### PR DESCRIPTION
This changes all TagHelperContent methods to assume that input has NOT
YET been encoded.