### PR TITLE
Rename `TargetElementAttribute` => `HtmlTargetElementAttribute`.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -77,17 +77,17 @@ namespace Microsoft.AspNet.Razor.Runtime
         /// <summary>
         /// {0} name cannot be null or whitespace.
         /// </summary>
-        internal static string TargetElementAttribute_NameCannotBeNullOrWhitespace
+        internal static string HtmlTargetElementAttribute_NameCannotBeNullOrWhitespace
         {
-            get { return GetString("TargetElementAttribute_NameCannotBeNullOrWhitespace"); }
+            get { return GetString("HtmlTargetElementAttribute_NameCannotBeNullOrWhitespace"); }
         }
 
         /// <summary>
         /// {0} name cannot be null or whitespace.
         /// </summary>
-        internal static string FormatTargetElementAttribute_NameCannotBeNullOrWhitespace(object p0)
+        internal static string FormatHtmlTargetElementAttribute_NameCannotBeNullOrWhitespace(object p0)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("TargetElementAttribute_NameCannotBeNullOrWhitespace"), p0);
+            return string.Format(CultureInfo.CurrentCulture, GetString("HtmlTargetElementAttribute_NameCannotBeNullOrWhitespace"), p0);
         }
 
         /// <summary>
@@ -125,17 +125,17 @@ namespace Microsoft.AspNet.Razor.Runtime
         /// <summary>
         /// Tag helpers cannot target {0} name '{1}' because it contains a '{2}' character.
         /// </summary>
-        internal static string TargetElementAttribute_InvalidName
+        internal static string HtmlTargetElementAttribute_InvalidName
         {
-            get { return GetString("TargetElementAttribute_InvalidName"); }
+            get { return GetString("HtmlTargetElementAttribute_InvalidName"); }
         }
 
         /// <summary>
         /// Tag helpers cannot target {0} name '{1}' because it contains a '{2}' character.
         /// </summary>
-        internal static string FormatTargetElementAttribute_InvalidName(object p0, object p1, object p2)
+        internal static string FormatHtmlTargetElementAttribute_InvalidName(object p0, object p1, object p2)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("TargetElementAttribute_InvalidName"), p0, p1, p2);
+            return string.Format(CultureInfo.CurrentCulture, GetString("HtmlTargetElementAttribute_InvalidName"), p0, p1, p2);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -129,7 +129,7 @@
   <data name="ScopeManager_EndCannotBeCalledWithoutACallToBegin" xml:space="preserve">
     <value>Must call '{2}.{1}' before calling '{2}.{0}'.</value>
   </data>
-  <data name="TargetElementAttribute_NameCannotBeNullOrWhitespace" xml:space="preserve">
+  <data name="HtmlTargetElementAttribute_NameCannotBeNullOrWhitespace" xml:space="preserve">
     <value>{0} name cannot be null or whitespace.</value>
   </data>
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
@@ -138,7 +138,7 @@
   <data name="TagHelperDescriptorResolver_EncounteredUnexpectedError" xml:space="preserve">
     <value>Encountered an unexpected error when attempting to resolve tag helper directive '{0}' with value '{1}'. Error: {2}</value>
   </data>
-  <data name="TargetElementAttribute_InvalidName" xml:space="preserve">
+  <data name="HtmlTargetElementAttribute_InvalidName" xml:space="preserve">
     <value>Tag helpers cannot target {0} name '{1}' because it contains a '{2}' character.</value>
   </data>
   <data name="TagHelperDescriptorResolver_InvalidTagHelperDirective" xml:space="preserve">

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlTargetElementAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlTargetElementAttribute.cs
@@ -10,30 +10,30 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     /// Provides an <see cref="ITagHelper"/>'s target.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-    public sealed class TargetElementAttribute : Attribute
+    public sealed class HtmlTargetElementAttribute : Attribute
     {
         public const string ElementCatchAllTarget = TagHelperDescriptorProvider.ElementCatchAllTarget;
 
         /// <summary>
-        /// Instantiates a new instance of the <see cref="TargetElementAttribute"/> class with <see cref="Tag"/>
+        /// Instantiates a new instance of the <see cref="HtmlTargetElementAttribute"/> class with <see cref="Tag"/>
         /// set to <c>*</c>.
         /// </summary>
         /// <remarks>A <c>*</c> <see cref="Tag"/> value indicates an <see cref="ITagHelper"/>
         /// that targets all HTML elements with the required <see cref="Attributes"/>.</remarks>
-        public TargetElementAttribute()
+        public HtmlTargetElementAttribute()
             : this(ElementCatchAllTarget)
         {
         }
 
         /// <summary>
-        /// Instantiates a new instance of the <see cref="TargetElementAttribute"/> class.
+        /// Instantiates a new instance of the <see cref="HtmlTargetElementAttribute"/> class.
         /// </summary>
         /// <param name="tag">
         /// The HTML tag the <see cref="ITagHelper"/> targets.
         /// </param>
         /// <remarks>A <c>*</c> <paramref name="tag"/> value indicates an <see cref="ITagHelper"/>
         /// that targets all HTML elements with the required <see cref="Attributes"/>.</remarks>
-        public TargetElementAttribute(string tag)
+        public HtmlTargetElementAttribute(string tag)
         {
             Tag = tag;
         }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/RestrictChildrenAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/RestrictChildrenAttribute.cs
@@ -9,9 +9,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     /// <summary>
     /// Restricts children of the <see cref="ITagHelper"/>'s element.
     /// </summary>
-    /// <remarks>Combining this attribute with a <see cref="TargetElementAttribute"/> that specifies its
-    /// <see cref="TargetElementAttribute.TagStructure"/> as <see cref="TagStructure.WithoutEndTag"/> will result in
-    /// this attribute being ignored.</remarks>
+    /// <remarks>Combining this attribute with a <see cref="HtmlTargetElementAttribute"/> that specifies its
+    /// <see cref="HtmlTargetElementAttribute.TagStructure"/> as <see cref="TagStructure.WithoutEndTag"/> will result
+    /// in this attribute being ignored.</remarks>
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
     public class RestrictChildrenAttribute : Attribute
     {

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             }
 
             var attributeDescriptors = GetAttributeDescriptors(typeInfo, designTime, errorSink);
-            var targetElementAttributes = GetValidTargetElementAttributes(typeInfo, errorSink);
+            var targetElementAttributes = GetValidHtmlTargetElementAttributes(typeInfo, errorSink);
             var allowedChildren = GetAllowedChildren(typeInfo, errorSink);
 
             var tagHelperDescriptors =
@@ -79,20 +79,21 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             return tagHelperDescriptors.Distinct(TagHelperDescriptorComparer.Default);
         }
 
-        private static IEnumerable<TargetElementAttribute> GetValidTargetElementAttributes(
+        private static IEnumerable<HtmlTargetElementAttribute> GetValidHtmlTargetElementAttributes(
             ITypeInfo typeInfo,
             ErrorSink errorSink)
         {
-            var targetElementAttributes = typeInfo.GetCustomAttributes<TargetElementAttribute>();
+            var targetElementAttributes = typeInfo.GetCustomAttributes<HtmlTargetElementAttribute>();
 
-            return targetElementAttributes.Where(attribute => ValidTargetElementAttributeNames(attribute, errorSink));
+            return targetElementAttributes.Where(
+                attribute => ValidHtmlTargetElementAttributeNames(attribute, errorSink));
         }
 
         private static IEnumerable<TagHelperDescriptor> BuildTagHelperDescriptors(
             ITypeInfo typeInfo,
             string assemblyName,
             IEnumerable<TagHelperAttributeDescriptor> attributeDescriptors,
-            IEnumerable<TargetElementAttribute> targetElementAttributes,
+            IEnumerable<HtmlTargetElementAttribute> targetElementAttributes,
             IEnumerable<string> allowedChildren,
             bool designTime)
         {
@@ -183,9 +184,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             {
                 var valid = TryValidateName(
                     name,
-                    whitespaceError: Resources.FormatTagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace(
-                        nameof(RestrictChildrenAttribute),
-                        tagHelperName),
+                    whitespaceError:
+                        Resources.FormatTagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace(
+                            nameof(RestrictChildrenAttribute),
+                            tagHelperName),
                     characterErrorBuilder: (invalidCharacter) =>
                         Resources.FormatTagHelperDescriptorFactory_InvalidRestrictChildrenAttributeName(
                             nameof(RestrictChildrenAttribute),
@@ -207,7 +209,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             string typeName,
             string assemblyName,
             IEnumerable<TagHelperAttributeDescriptor> attributeDescriptors,
-            TargetElementAttribute targetElementAttribute,
+            HtmlTargetElementAttribute targetElementAttribute,
             IEnumerable<string> allowedChildren,
             TagHelperDesignTimeDescriptor designTimeDescriptor)
         {
@@ -259,8 +261,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// Internal for testing.
         /// </summary>
-        internal static bool ValidTargetElementAttributeNames(
-            TargetElementAttribute attribute,
+        internal static bool ValidHtmlTargetElementAttributeNames(
+            HtmlTargetElementAttribute attribute,
             ErrorSink errorSink)
         {
             var validTagName = ValidateName(attribute.Tag, targetingAttributes: false, errorSink: errorSink);
@@ -289,7 +291,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     TagHelperDescriptorProvider.ElementCatchAllTarget,
                     StringComparison.OrdinalIgnoreCase))
             {
-                // '*' as the entire name is OK in the TargetElement catch-all case.
+                // '*' as the entire name is OK in the HtmlTargetElement catch-all case.
                 return true;
             }
             else if (targetingAttributes &&
@@ -308,9 +310,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             var validName = TryValidateName(
                 name,
-                whitespaceError: Resources.FormatTargetElementAttribute_NameCannotBeNullOrWhitespace(targetName),
+                whitespaceError: Resources.FormatHtmlTargetElementAttribute_NameCannotBeNullOrWhitespace(targetName),
                 characterErrorBuilder: (invalidCharacter) =>
-                    Resources.FormatTargetElementAttribute_InvalidName(targetName.ToLower(), name, invalidCharacter),
+                    Resources.FormatHtmlTargetElementAttribute_InvalidName(
+                        targetName.ToLower(),
+                        name,
+                        invalidCharacter),
                 errorSink: errorSink);
 
             return validName;

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpTagHelperCodeRenderer.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpTagHelperCodeRenderer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.Razor.CodeGenerators
         public void RenderTagHelper(TagHelperChunk chunk)
         {
             // Remove any duplicate TagHelperDescriptors that reference the same type name. Duplicates can occur when
-            // multiple TargetElement attributes are on a TagHelper type and matches overlap for an HTML element.
+            // multiple HtmlTargetElement attributes are on a TagHelper type and matches overlap for an HTML element.
             // Having more than one descriptor with the same TagHelper type results in generated code that runs
             // the same TagHelper X many times (instead of once) over a single HTML element.
             var tagHelperDescriptors = chunk.Descriptors.Distinct(TypeBasedTagHelperDescriptorComparer.Default);

--- a/test/Microsoft.AspNet.Razor.Runtime.Precompilation.Files/TypeWithAttributes.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Precompilation.Files/TypeWithAttributes.cs
@@ -10,8 +10,8 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 
 namespace Microsoft.AspNet.Razor.Runtime.Precompilation
 {
-    [TargetElement("img", Attributes = AppendVersionAttributeName + "," + SrcAttributeName)]
-    [TargetElement("image", Attributes = SrcAttributeName)]
+    [HtmlTargetElement("img", Attributes = AppendVersionAttributeName + "," + SrcAttributeName)]
+    [HtmlTargetElement("image", Attributes = SrcAttributeName)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [EnumProperty(DayOfWeek = DayOfWeek.Friday)]
     [CustomValidation(typeof(Validator), "ValidationMethod", ErrorMessageResourceType = typeof(ResourceManager))]

--- a/test/Microsoft.AspNet.Razor.Runtime.Precompilation.Test/BadFiles/TypeWithMalformedAttribute.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Precompilation.Test/BadFiles/TypeWithMalformedAttribute.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNet.Mvc.Razor.Precompilation
 {
     [RestrictChildren(Never)]
     [CustomValidation(typeof(TypeDoesNotExist)]
-    [TargetElement("img"
+    [HtmlTargetElement("img"
     public class TypeWithMalformedAttribute
     {
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Precompilation.Test/PrecompilationTagHelperTypeResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Precompilation.Test/PrecompilationTagHelperTypeResolverTest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.AspNet.Razor.Runtime.Precompilation
             var actual = Assert.Single(exportedTypes);
             AssertEqual(expected.AsType(), actual);
 
-            AssertAttributes<TargetElementAttribute>(
+            AssertAttributes<HtmlTargetElementAttribute>(
                 expected,
                 actual,
                 (expectedAttribute, actualAttribute) =>
@@ -406,7 +406,7 @@ namespace Microsoft.AspNet.Razor.Runtime.Precompilation
 
             // Assert
             var actual = Assert.Single(exportedTypes);
-            var targetElementAttribute = Assert.Single(actual.GetCustomAttributes<TargetElementAttribute>());
+            var targetElementAttribute = Assert.Single(actual.GetCustomAttributes<HtmlTargetElementAttribute>());
             Assert.Equal("img", targetElementAttribute.Tag);
             Assert.Null(targetElementAttribute.Attributes);
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/RuntimeTypeInfoTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/RuntimeTypeInfoTest.cs
@@ -112,10 +112,10 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             // Arrange
             var typeInfo = typeof(TypeWithAttributes).GetTypeInfo();
             var runtimeTypeInfo = new RuntimeTypeInfo(typeInfo);
-            var expected = typeInfo.GetCustomAttributes<TargetElementAttribute>();
+            var expected = typeInfo.GetCustomAttributes<HtmlTargetElementAttribute>();
 
             // Act
-            var actual = runtimeTypeInfo.GetCustomAttributes<TargetElementAttribute>();
+            var actual = runtimeTypeInfo.GetCustomAttributes<HtmlTargetElementAttribute>();
 
             // Assert
             Assert.Equal(expected, actual);
@@ -380,8 +380,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             private int Property4 { get; set; }
         }
 
-        [TargetElement("test1")]
-        [TargetElement("test2")]
+        [HtmlTargetElement("test1")]
+        [HtmlTargetElement("test2")]
         private class TypeWithAttributes
         {
         }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -1104,15 +1104,15 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
         [Theory]
         [MemberData(nameof(InvalidNameData))]
-        public void ValidTargetElementAttributeNames_CreatesErrorOnInvalidNames(
+        public void ValidHtmlTargetElementAttributeNames_CreatesErrorOnInvalidNames(
             string name, string[] expectedErrorMessages)
         {
             // Arrange
             var errorSink = new ErrorSink();
-            var attribute = new TargetElementAttribute(name);
+            var attribute = new HtmlTargetElementAttribute(name);
 
             // Act
-            TagHelperDescriptorFactory.ValidTargetElementAttributeNames(attribute, errorSink);
+            TagHelperDescriptorFactory.ValidHtmlTargetElementAttributeNames(attribute, errorSink);
 
             // Assert
             var errors = errorSink.Errors.ToArray();

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TestTagHelpers/TagHelperDescriptorFactoryTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TestTagHelpers/TagHelperDescriptorFactoryTagHelpers.cs
@@ -20,26 +20,26 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     {
     }
 
-    [TargetElement("p")]
-    [TargetElement("div")]
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("div")]
     [RestrictChildren("p", "strong")]
     public class MultiTargetRestrictChildrenTagHelper
     {
     }
 
-    [TargetElement("input", TagStructure = TagStructure.WithoutEndTag)]
+    [HtmlTargetElement("input", TagStructure = TagStructure.WithoutEndTag)]
     public class TagStructureTagHelper : TagHelper
     {
     }
 
-    [TargetElement("p", TagStructure = TagStructure.NormalOrSelfClosing)]
-    [TargetElement("input", TagStructure = TagStructure.WithoutEndTag)]
+    [HtmlTargetElement("p", TagStructure = TagStructure.NormalOrSelfClosing)]
+    [HtmlTargetElement("input", TagStructure = TagStructure.WithoutEndTag)]
     public class MultiSpecifiedTagStructureTagHelper : TagHelper
     {
     }
 
-    [TargetElement("p")]
-    [TargetElement("input", TagStructure = TagStructure.WithoutEndTag)]
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("input", TagStructure = TagStructure.WithoutEndTag)]
     public class MultiWithUnspecifiedTagStructureTagHelper : TagHelper
     {
     }
@@ -90,84 +90,84 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         public override int Property { get; set; }
     }
 
-    [TargetElement("p")]
-    [TargetElement("div")]
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("div")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class MultiEditorBrowsableTagHelper : TagHelper
     {
     }
 
-    [TargetElement(Attributes = "class*")]
+    [HtmlTargetElement(Attributes = "class*")]
     public class AttributeWildcardTargetingTagHelper : TagHelper
     {
     }
 
-    [TargetElement(Attributes = "class*,style*")]
+    [HtmlTargetElement(Attributes = "class*,style*")]
     public class MultiAttributeWildcardTargetingTagHelper : TagHelper
     {
     }
 
-    [TargetElement(Attributes = "class")]
+    [HtmlTargetElement(Attributes = "class")]
     public class AttributeTargetingTagHelper : TagHelper
     {
     }
 
-    [TargetElement(Attributes = "class,style")]
+    [HtmlTargetElement(Attributes = "class,style")]
     public class MultiAttributeTargetingTagHelper : TagHelper
     {
     }
 
-    [TargetElement(Attributes = "custom")]
-    [TargetElement(Attributes = "class,style")]
+    [HtmlTargetElement(Attributes = "custom")]
+    [HtmlTargetElement(Attributes = "class,style")]
     public class MultiAttributeAttributeTargetingTagHelper : TagHelper
     {
     }
 
-    [TargetElement(Attributes = "style")]
+    [HtmlTargetElement(Attributes = "style")]
     public class InheritedAttributeTargetingTagHelper : AttributeTargetingTagHelper
     {
     }
 
-    [TargetElement("input", Attributes = "class")]
+    [HtmlTargetElement("input", Attributes = "class")]
     public class RequiredAttributeTagHelper : TagHelper
     {
     }
 
-    [TargetElement("div", Attributes = "class")]
+    [HtmlTargetElement("div", Attributes = "class")]
     public class InheritedRequiredAttributeTagHelper : RequiredAttributeTagHelper
     {
     }
 
-    [TargetElement("div", Attributes = "class")]
-    [TargetElement("input", Attributes = "class")]
+    [HtmlTargetElement("div", Attributes = "class")]
+    [HtmlTargetElement("input", Attributes = "class")]
     public class MultiAttributeRequiredAttributeTagHelper : TagHelper
     {
     }
 
-    [TargetElement("input", Attributes = "style")]
-    [TargetElement("input", Attributes = "class")]
+    [HtmlTargetElement("input", Attributes = "style")]
+    [HtmlTargetElement("input", Attributes = "class")]
     public class MultiAttributeSameTagRequiredAttributeTagHelper : TagHelper
     {
     }
 
-    [TargetElement("input", Attributes = "class,style")]
+    [HtmlTargetElement("input", Attributes = "class,style")]
     public class MultiRequiredAttributeTagHelper : TagHelper
     {
     }
 
-    [TargetElement("div", Attributes = "style")]
+    [HtmlTargetElement("div", Attributes = "style")]
     public class InheritedMultiRequiredAttributeTagHelper : MultiRequiredAttributeTagHelper
     {
     }
 
-    [TargetElement("div", Attributes = "class,style")]
-    [TargetElement("input", Attributes = "class,style")]
+    [HtmlTargetElement("div", Attributes = "class,style")]
+    [HtmlTargetElement("input", Attributes = "class,style")]
     public class MultiTagMultiRequiredAttributeTagHelper : TagHelper
     {
     }
 
-    [TargetElement("p")]
-    [TargetElement("div")]
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("div")]
     public class MultiTagTagHelper
     {
         public string ValidAttribute { get; set; }
@@ -177,15 +177,15 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     {
     }
 
-    [TargetElement("p")]
-    [TargetElement("p")]
-    [TargetElement("div")]
-    [TargetElement("div")]
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("div")]
+    [HtmlTargetElement("div")]
     public class DuplicateTagNameTagHelper
     {
     }
 
-    [TargetElement("data-condition")]
+    [HtmlTargetElement("data-condition")]
     public class OverrideNameTagHelper
     {
     }
@@ -387,8 +387,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     {
     }
 
-    [TargetElement("a")]
-    [TargetElement("p")]
+    [HtmlTargetElement("a")]
+    [HtmlTargetElement("p")]
     [OutputElementHint("div")]
     public class MulitpleDescriptorTagHelperWithOutputElementHint : TagHelper
     {


### PR DESCRIPTION
- Nearly every other `TagHelper` related element targeting attribute has `Html` a part of its name. With this rename, the attribute will be consistent.

#516