### PR TITLE
Allow `TagHelper`s inside of text/html typed script tags.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.Block.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.Block.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Chunks.Generators;
+using Microsoft.AspNet.Razor.Editor;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 using Microsoft.AspNet.Razor.Text;
 using Microsoft.AspNet.Razor.Tokenizer.Symbols;
@@ -937,9 +937,17 @@ namespace Microsoft.AspNet.Razor.Parser
                     }
                     else if (string.Equals(tagName, ScriptTagName, StringComparison.OrdinalIgnoreCase))
                     {
-                        CompleteTagBlockWithSpan(tagBlockWrapper, AcceptedCharacters.None, SpanKind.Markup);
+                        if (!CurrentScriptTagExpectsHtml())
+                        {
+                            CompleteTagBlockWithSpan(tagBlockWrapper, AcceptedCharacters.None, SpanKind.Markup);
 
-                        SkipToEndScriptAndParseCode(endTagAcceptedCharacters: AcceptedCharacters.None);
+                            SkipToEndScriptAndParseCode(endTagAcceptedCharacters: AcceptedCharacters.None);
+                        }
+                        else
+                        {
+                            // Push the script tag onto the tag stack, it should be treated like all other HTML tags.
+                            tags.Push(tag);
+                        }
                     }
                     else
                     {

--- a/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
@@ -1459,6 +1459,58 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                 contentLength: 1),
                         }
                     },
+                    {
+                        "NestedScriptTagTagHelpers",
+                        "NestedScriptTagTagHelpers.DesignTime",
+                        DefaultPAndInputTagHelperDescriptors,
+                        new[]
+                        {
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 14,
+                                documentLineIndex: 0,
+                                generatedAbsoluteIndex: 495,
+                                generatedLineIndex: 15,
+                                characterOffsetIndex: 14,
+                                contentLength: 17),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 182,
+                                documentLineIndex: 5,
+                                generatedAbsoluteIndex: 1033,
+                                generatedLineIndex: 35,
+                                characterOffsetIndex: 0,
+                                contentLength: 12),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 195,
+                                documentLineIndex: 5,
+                                documentCharacterOffsetIndex: 13,
+                                generatedAbsoluteIndex: 1136,
+                                generatedLineIndex: 41,
+                                generatedCharacterOffsetIndex: 12,
+                                contentLength: 30),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 339,
+                                documentLineIndex: 7,
+                                documentCharacterOffsetIndex: 50,
+                                generatedAbsoluteIndex: 1385,
+                                generatedLineIndex: 49,
+                                generatedCharacterOffsetIndex: 6,
+                                contentLength: 23),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 389,
+                                documentLineIndex: 7,
+                                generatedAbsoluteIndex: 1692,
+                                generatedLineIndex: 56,
+                                characterOffsetIndex: 100,
+                                contentLength: 4),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 424,
+                                documentLineIndex: 9,
+                                generatedAbsoluteIndex: 1775,
+                                generatedLineIndex: 61,
+                                characterOffsetIndex: 0,
+                                contentLength: 15),
+                        }
+                    },
                 };
             }
         }
@@ -1505,7 +1557,8 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     },
                     { "DuplicateAttributeTagHelpers", null, DefaultPAndInputTagHelperDescriptors },
                     { "DynamicAttributeTagHelpers", null, DynamicAttributeTagHelpers_Descriptors },
-                    { "TransitionsInTagHelperAttributes", null, DefaultPAndInputTagHelperDescriptors }
+                    { "TransitionsInTagHelperAttributes", null, DefaultPAndInputTagHelperDescriptors },
+                    { "NestedScriptTagTagHelpers", null, DefaultPAndInputTagHelperDescriptors },
                 };
             }
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.DesignTime.cs
@@ -1,0 +1,71 @@
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class NestedScriptTagTagHelpers
+    {
+        private static object @__o;
+        private void @__RazorDesignTimeHelpers__()
+        {
+            #pragma warning disable 219
+            string __tagHelperDirectiveSyntaxHelper = null;
+            __tagHelperDirectiveSyntaxHelper = 
+#line 1 "NestedScriptTagTagHelpers.cshtml"
+              "something, nice"
+
+#line default
+#line hidden
+            ;
+            #pragma warning restore 219
+        }
+        #line hidden
+        private PTagHelper __PTagHelper = null;
+        private InputTagHelper __InputTagHelper = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        #line hidden
+        public NestedScriptTagTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+#line 6 "NestedScriptTagTagHelpers.cshtml"
+            
+
+#line default
+#line hidden
+
+#line 6 "NestedScriptTagTagHelpers.cshtml"
+            for(var i = 0; i < 5; i++) {
+
+#line default
+#line hidden
+
+            __InputTagHelper = CreateTagHelper<InputTagHelper>();
+            __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+#line 8 "NestedScriptTagTagHelpers.cshtml"
+__o = ViewBag.DefaultInterval;
+
+#line default
+#line hidden
+            __InputTagHelper.Type = "text";
+            __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 8 "NestedScriptTagTagHelpers.cshtml"
+                                                                        __InputTagHelper2.Checked = true;
+
+#line default
+#line hidden
+#line 10 "NestedScriptTagTagHelpers.cshtml"
+            }
+
+#line default
+#line hidden
+
+            __PTagHelper = CreateTagHelper<PTagHelper>();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.DesignTime.lineMappings.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.DesignTime.lineMappings.cs
@@ -1,0 +1,49 @@
+// !!! Do not check in. Instead paste content into test method. !!!
+
+            var expectedLineMappings = new[]
+            {
+                BuildLineMapping(
+                    documentAbsoluteIndex: 14,
+                    documentLineIndex: 0,
+                    generatedAbsoluteIndex: 495,
+                    generatedLineIndex: 15,
+                    characterOffsetIndex: 14,
+                    contentLength: 17),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 182,
+                    documentLineIndex: 5,
+                    generatedAbsoluteIndex: 1033,
+                    generatedLineIndex: 35,
+                    characterOffsetIndex: 0,
+                    contentLength: 12),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 195,
+                    documentLineIndex: 5,
+                    documentCharacterOffsetIndex: 13,
+                    generatedAbsoluteIndex: 1136,
+                    generatedLineIndex: 41,
+                    generatedCharacterOffsetIndex: 12,
+                    contentLength: 30),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 339,
+                    documentLineIndex: 7,
+                    documentCharacterOffsetIndex: 50,
+                    generatedAbsoluteIndex: 1385,
+                    generatedLineIndex: 49,
+                    generatedCharacterOffsetIndex: 6,
+                    contentLength: 23),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 389,
+                    documentLineIndex: 7,
+                    generatedAbsoluteIndex: 1692,
+                    generatedLineIndex: 56,
+                    characterOffsetIndex: 100,
+                    contentLength: 4),
+                BuildLineMapping(
+                    documentAbsoluteIndex: 424,
+                    documentLineIndex: 9,
+                    generatedAbsoluteIndex: 1775,
+                    generatedLineIndex: 61,
+                    characterOffsetIndex: 0,
+                    contentLength: 15),
+            };

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
@@ -1,0 +1,114 @@
+#pragma checksum "NestedScriptTagTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "9e6bc8d09df124eda650118b208b7c5e6e058f6b"
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class NestedScriptTagTagHelpers
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private TagHelperContent __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private TagHelperRunner __tagHelperRunner = null;
+        private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private PTagHelper __PTagHelper = null;
+        private InputTagHelper __InputTagHelper = null;
+        private InputTagHelper2 __InputTagHelper2 = null;
+        #line hidden
+        public NestedScriptTagTagHelpers()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __tagHelperRunner = __tagHelperRunner ?? new TagHelperRunner();
+            Instrumentation.BeginContext(33, 106, true);
+            WriteLiteral("\r\n<script type=\"text/html\">\r\n    <div data-animation=\"fade\" class=\"randomNonTagHe" +
+"lperAttribute\">\r\n        ");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(180, 2, true);
+                WriteLiteral("\r\n");
+                Instrumentation.EndContext();
+#line 6 "NestedScriptTagTagHelpers.cshtml"
+            
+
+#line default
+#line hidden
+
+#line 6 "NestedScriptTagTagHelpers.cshtml"
+             for(var i = 0; i < 5; i++) {
+
+#line default
+#line hidden
+
+                Instrumentation.BeginContext(225, 84, true);
+                WriteLiteral("                <script id=\"nestedScriptTag\" type=\"text/html\">\r\n                 " +
+"   ");
+                Instrumentation.EndContext();
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", TagMode.StartTagOnly, "test", async() => {
+                }
+                , StartTagHelperWritingScope, EndTagHelperWritingScope);
+                __InputTagHelper = CreateTagHelper<InputTagHelper>();
+                __tagHelperExecutionContext.Add(__InputTagHelper);
+                __InputTagHelper2 = CreateTagHelper<InputTagHelper2>();
+                __tagHelperExecutionContext.Add(__InputTagHelper2);
+                StartTagHelperWritingScope();
+                WriteLiteral("2000 + ");
+#line 8 "NestedScriptTagTagHelpers.cshtml"
+Write(ViewBag.DefaultInterval);
+
+#line default
+#line hidden
+                WriteLiteral(" + 1");
+                __tagHelperStringValueBuffer = EndTagHelperWritingScope();
+                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer.ToString()));
+                __InputTagHelper.Type = "text";
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __InputTagHelper.Type);
+                __InputTagHelper2.Type = __InputTagHelper.Type;
+#line 8 "NestedScriptTagTagHelpers.cshtml"
+                                                                        __InputTagHelper2.Checked = true;
+
+#line default
+#line hidden
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __InputTagHelper2.Checked);
+                __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+                Instrumentation.BeginContext(309, 86, false);
+                await WriteTagHelperAsync(__tagHelperExecutionContext);
+                Instrumentation.EndContext();
+                __tagHelperExecutionContext = __tagHelperScopeManager.End();
+                Instrumentation.BeginContext(395, 29, true);
+                WriteLiteral("\r\n                </script>\r\n");
+                Instrumentation.EndContext();
+#line 10 "NestedScriptTagTagHelpers.cshtml"
+            }
+
+#line default
+#line hidden
+
+                Instrumentation.BeginContext(439, 129, true);
+                WriteLiteral("            <script type=\"text/javascript\">\r\n                var tag = \'<input ch" +
+"ecked=\"true\">\';\r\n            </script>\r\n        ");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __PTagHelper = CreateTagHelper<PTagHelper>();
+            __tagHelperExecutionContext.Add(__PTagHelper);
+            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
+            __tagHelperExecutionContext.AddHtmlAttribute("data-delay", Html.Raw("1000"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(139, 433, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(572, 23, true);
+            WriteLiteral("\r\n    </div>\r\n</script>");
+            Instrumentation.EndContext();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Source/NestedScriptTagTagHelpers.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Source/NestedScriptTagTagHelpers.cshtml
@@ -1,0 +1,16 @@
+﻿@addTagHelper "something, nice"
+
+<script type="text/html">
+    <div data-animation="fade" class="randomNonTagHelperAttribute">
+        <p class="Hello World" data-delay="1000">
+            @for(var i = 0; i < 5; i++) {
+                <script id="nestedScriptTag" type="text/html">
+                    <input data-interval="2000 + @ViewBag.DefaultInterval + 1" type="text" checked="true">
+                </script>
+            }
+            <script type="text/javascript">
+                var tag = '<input checked="true">';
+            </script>
+        </p>
+    </div>
+</script>


### PR DESCRIPTION
- To limit the impact of the change ensured that we only do extra work in the case that we detect a script tag with a `type` attribute.
- The parsing changes include normal HTML parsing behaviors when we detect that a script tag has a `type` attribute with value `text/html`.
- Added unit and code generation tests to validate `text/html` script tag behavior.

#502