### PR TITLE
Add support for data bound symbols as attribute names.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.Block.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.Block.cs
@@ -464,7 +464,7 @@ namespace Microsoft.AspNet.Razor.Parser
             // Read the 'name' (i.e. read until the '=' or whitespace/newline)
             var name = Enumerable.Empty<HtmlSymbol>();
             var whitespaceAfterAttributeName = Enumerable.Empty<HtmlSymbol>();
-            if (At(HtmlSymbolType.Text))
+            if (IsValidAttributeNameSymbol(CurrentSymbol))
             {
                 name = ReadWhile(sym =>
                                  sym.Type != HtmlSymbolType.WhiteSpace &&
@@ -1135,6 +1135,29 @@ namespace Microsoft.AspNet.Razor.Parser
                 AddMarkerSymbolIfNecessary();
             }
             Output(SpanKind.Markup);
+        }
+
+        internal static bool IsValidAttributeNameSymbol(HtmlSymbol symbol)
+        {
+            if (symbol == null)
+            {
+                return false;
+            }
+
+            // These restrictions cover most of the spec defined: http://www.w3.org/TR/html5/syntax.html#attributes-0
+            // However, it's not all of it. For instance we don't special case control characters or allow OpenAngle.
+            // It also doesn't try to exclude Razor specific features such as the @ transition. This is based on the
+            // expectation that the parser handles such scenarios prior to falling through to name resolution.
+            var symbolType = symbol.Type;
+            return symbolType != HtmlSymbolType.WhiteSpace &&
+                symbolType != HtmlSymbolType.NewLine &&
+                symbolType != HtmlSymbolType.CloseAngle &&
+                symbolType != HtmlSymbolType.OpenAngle &&
+                symbolType != HtmlSymbolType.ForwardSlash &&
+                symbolType != HtmlSymbolType.DoubleQuote &&
+                symbolType != HtmlSymbolType.SingleQuote &&
+                symbolType != HtmlSymbolType.Equals &&
+                symbolType != HtmlSymbolType.Unknown;
         }
     }
 }

--- a/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 #if DNXCORE50
@@ -19,6 +20,62 @@ namespace Microsoft.AspNet.Razor.Test.Generator
             = BuildPAndInputTagHelperDescriptors(prefix: string.Empty);
         private static IEnumerable<TagHelperDescriptor> PrefixedPAndInputTagHelperDescriptors { get; }
             = BuildPAndInputTagHelperDescriptors(prefix: "THS");
+
+        private static IEnumerable<TagHelperDescriptor> SymbolBoundTagHelperDescriptors
+        {
+            get
+            {
+                return new[]
+                {
+                    new TagHelperDescriptor
+                    {
+                        TagName = "*",
+                        TypeName = "CatchAllTagHelper",
+                        AssemblyName = "SomeAssembly",
+                        Attributes = new[]
+                        {
+                            new TagHelperAttributeDescriptor
+                            {
+                                Name = "[item]",
+                                PropertyName = "ListItems",
+                                TypeName = typeof(List<string>).FullName
+                            },
+                            new TagHelperAttributeDescriptor
+                            {
+                                Name = "[(item)]",
+                                PropertyName = "ArrayItems",
+                                TypeName = typeof(string[]).FullName
+                            },
+                            new TagHelperAttributeDescriptor
+                            {
+                                Name = "(click)",
+                                PropertyName = "Event1",
+                                TypeName = typeof(Action).FullName
+                            },
+                            new TagHelperAttributeDescriptor
+                            {
+                                Name = "(^click)",
+                                PropertyName = "Event2",
+                                TypeName = typeof(Action).FullName
+                            },
+                            new TagHelperAttributeDescriptor
+                            {
+                                Name = "*something",
+                                PropertyName = "StringProperty1",
+                                TypeName = typeof(string).FullName
+                            },
+                            new TagHelperAttributeDescriptor
+                            {
+                                Name = "#local",
+                                PropertyName = "StringProperty2",
+                                TypeName = typeof(string).FullName
+                            },
+                        },
+                        RequiredAttributes = new[] { "bound" },
+                    },
+                };
+            }
+        }
 
         private static IEnumerable<TagHelperDescriptor> MinimizedTagHelpers_Descriptors
         {
@@ -1518,6 +1575,53 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                                 contentLength: 15),
                         }
                     },
+                    {
+                        "SymbolBoundAttributes",
+                        "SymbolBoundAttributes.DesignTime",
+                        SymbolBoundTagHelperDescriptors,
+                        new[]
+                        {
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 14,
+                                documentLineIndex: 0,
+                                generatedAbsoluteIndex: 487,
+                                generatedLineIndex: 15,
+                                characterOffsetIndex: 14,
+                                contentLength: 9),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 296,
+                                documentLineIndex: 11,
+                                documentCharacterOffsetIndex: 18,
+                                generatedAbsoluteIndex: 1013,
+                                generatedLineIndex: 34,
+                                generatedCharacterOffsetIndex: 32,
+                                contentLength: 5),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 345,
+                                documentLineIndex: 12,
+                                documentCharacterOffsetIndex: 20,
+                                generatedAbsoluteIndex: 1199,
+                                generatedLineIndex: 40,
+                                generatedCharacterOffsetIndex: 33,
+                                contentLength: 5),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 399,
+                                documentLineIndex: 13,
+                                documentCharacterOffsetIndex: 23,
+                                generatedAbsoluteIndex: 1381,
+                                generatedLineIndex: 46,
+                                generatedCharacterOffsetIndex: 29,
+                                contentLength: 13),
+                            BuildLineMapping(
+                                documentAbsoluteIndex: 481,
+                                documentLineIndex: 14,
+                                documentCharacterOffsetIndex: 24,
+                                generatedAbsoluteIndex: 1571,
+                                generatedLineIndex: 52,
+                                generatedCharacterOffsetIndex: 29,
+                                contentLength: 13),
+                        }
+                    }
                 };
             }
         }
@@ -1567,6 +1671,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
                     { "DynamicAttributeTagHelpers", null, DynamicAttributeTagHelpers_Descriptors },
                     { "TransitionsInTagHelperAttributes", null, DefaultPAndInputTagHelperDescriptors },
                     { "NestedScriptTagTagHelpers", null, DefaultPAndInputTagHelperDescriptors },
+                    { "SymbolBoundAttributes", null, SymbolBoundTagHelperDescriptors },
                 };
             }
         }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.DesignTime.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.DesignTime.cs
@@ -1,0 +1,65 @@
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class SymbolBoundAttributes
+    {
+        private static object @__o;
+        private void @__RazorDesignTimeHelpers__()
+        {
+            #pragma warning disable 219
+            string __tagHelperDirectiveSyntaxHelper = null;
+            __tagHelperDirectiveSyntaxHelper = 
+#line 1 "SymbolBoundAttributes.cshtml"
+              "*, nice"
+
+#line default
+#line hidden
+            ;
+            #pragma warning restore 219
+        }
+        #line hidden
+        private CatchAllTagHelper __CatchAllTagHelper = null;
+        #line hidden
+        public SymbolBoundAttributes()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+#line 12 "SymbolBoundAttributes.cshtml"
+__CatchAllTagHelper.ListItems = items;
+
+#line default
+#line hidden
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+#line 13 "SymbolBoundAttributes.cshtml"
+__CatchAllTagHelper.ArrayItems = items;
+
+#line default
+#line hidden
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+#line 14 "SymbolBoundAttributes.cshtml"
+__CatchAllTagHelper.Event1 = doSomething();
+
+#line default
+#line hidden
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+#line 15 "SymbolBoundAttributes.cshtml"
+__CatchAllTagHelper.Event2 = doSomething();
+
+#line default
+#line hidden
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __CatchAllTagHelper.StringProperty1 = "value";
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __CatchAllTagHelper.StringProperty2 = "value";
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
@@ -1,0 +1,175 @@
+#pragma checksum "SymbolBoundAttributes.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "65ef0c8f673481f5ab85bd4936f91f31e84c490c"
+namespace TestOutput
+{
+    using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+    using System;
+    using System.Threading.Tasks;
+
+    public class SymbolBoundAttributes
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private TagHelperContent __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private TagHelperRunner __tagHelperRunner = null;
+        private TagHelperScopeManager __tagHelperScopeManager = new TagHelperScopeManager();
+        private CatchAllTagHelper __CatchAllTagHelper = null;
+        #line hidden
+        public SymbolBoundAttributes()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __tagHelperRunner = __tagHelperRunner ?? new TagHelperRunner();
+            Instrumentation.BeginContext(25, 253, true);
+            WriteLiteral("\r\n<ul [item]=\"items\"></ul>\r\n<ul [(item)]=\"items\"></ul>\r\n<button (click)=\"doSometh" +
+"ing()\">Click Me</button>\r\n<button (^click)=\"doSomething()\">Click Me</button>\r\n<t" +
+"emplate *something=\"value\">\r\n</template>\r\n<div #local></div>\r\n<div #local=\"value" +
+"\"></div>\r\n\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("ul", TagMode.StartTagAndEndTag, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__CatchAllTagHelper);
+            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+#line 12 "SymbolBoundAttributes.cshtml"
+__CatchAllTagHelper.ListItems = items;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("[item]", __CatchAllTagHelper.ListItems);
+            __tagHelperExecutionContext.AddHtmlAttribute("[item]", Html.Raw("items"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(278, 45, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(323, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("ul", TagMode.StartTagAndEndTag, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__CatchAllTagHelper);
+            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+#line 13 "SymbolBoundAttributes.cshtml"
+__CatchAllTagHelper.ArrayItems = items;
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("[(item)]", __CatchAllTagHelper.ArrayItems);
+            __tagHelperExecutionContext.AddHtmlAttribute("[(item)]", Html.Raw("items"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(325, 49, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(374, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("button", TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(438, 8, true);
+                WriteLiteral("Click Me");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__CatchAllTagHelper);
+            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+#line 14 "SymbolBoundAttributes.cshtml"
+__CatchAllTagHelper.Event1 = doSomething();
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("(click)", __CatchAllTagHelper.Event1);
+            __tagHelperExecutionContext.AddHtmlAttribute("(click)", Html.Raw("doSomething()"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(376, 79, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(455, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("button", TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(521, 8, true);
+                WriteLiteral("Click Me");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__CatchAllTagHelper);
+            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+#line 15 "SymbolBoundAttributes.cshtml"
+__CatchAllTagHelper.Event2 = doSomething();
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("(^click)", __CatchAllTagHelper.Event2);
+            __tagHelperExecutionContext.AddHtmlAttribute("(^click)", Html.Raw("doSomething()"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(457, 81, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(538, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("template", TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(594, 2, true);
+                WriteLiteral("\r\n");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__CatchAllTagHelper);
+            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+            __CatchAllTagHelper.StringProperty1 = "value";
+            __tagHelperExecutionContext.AddTagHelperAttribute("*something", __CatchAllTagHelper.StringProperty1);
+            __tagHelperExecutionContext.AddHtmlAttribute("*something", Html.Raw("value"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(540, 67, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(607, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", TagMode.StartTagAndEndTag, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__CatchAllTagHelper);
+            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("#localminimized");
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(609, 33, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(642, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", TagMode.StartTagAndEndTag, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __CatchAllTagHelper = CreateTagHelper<CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__CatchAllTagHelper);
+            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+            __CatchAllTagHelper.StringProperty2 = "value";
+            __tagHelperExecutionContext.AddTagHelperAttribute("#local", __CatchAllTagHelper.StringProperty2);
+            __tagHelperExecutionContext.AddHtmlAttribute("#local", Html.Raw("value"));
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(644, 47, false);
+            await WriteTagHelperAsync(__tagHelperExecutionContext);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Source/SymbolBoundAttributes.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Source/SymbolBoundAttributes.cshtml
@@ -1,0 +1,19 @@
+﻿@addTagHelper "*, nice"
+
+<ul [item]="items"></ul>
+<ul [(item)]="items"></ul>
+<button (click)="doSomething()">Click Me</button>
+<button (^click)="doSomething()">Click Me</button>
+<template *something="value">
+</template>
+<div #local></div>
+<div #local="value"></div>
+
+<ul bound [item]="items" [item]="items"></ul>
+<ul bound [(item)]="items" [(item)]="items"></ul>
+<button bound (click)="doSomething()" (click)="doSomething()">Click Me</button>
+<button bound (^click)="doSomething()" (^click)="doSomething()">Click Me</button>
+<template bound *something="value" *something="value">
+</template>
+<div bound #localminimized></div>
+<div bound #local="value" #local="value"></div>


### PR DESCRIPTION
- Took the HTML5 spec approach of disallowing specific characters and accepting all others.
- Added several parser and code generation tests to cover both `TagHelper` and non-`TagHelper` variations of symbol bound attribute names.

#137