### PR TITLE
Add support for `@tagHelperPrefix` and `[RestrictChildren]`.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperParseTreeRewriter.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TagHelpers/TagHelperParseTreeRewriter.cs
@@ -567,9 +567,14 @@ namespace Microsoft.AspNet.Razor.Parser.TagHelpers.Internal
 
                 if (Builder.Descriptors.Any(descriptor => descriptor.AllowedChildren != null))
                 {
+                    Debug.Assert(Builder.Descriptors.Count() >= 1);
+
+                    var tagHelperPrefix = Builder.Descriptors.First().Prefix;
+
                     AllowedChildren = Builder.Descriptors
                         .SelectMany(descriptor => descriptor.AllowedChildren)
-                        .Distinct(StringComparer.OrdinalIgnoreCase);
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .Select(allowedChild => tagHelperPrefix + allowedChild);
                 }
             }
 

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -18,6 +18,44 @@ namespace Microsoft.AspNet.Razor.Test.TagHelpers
 {
     public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
+        [Fact]
+        public void Rewrite_UnderstandsTagHelperPrefixAndRestrictedChildren()
+        {
+            // Arrange
+            var factory = CreateDefaultSpanFactory();
+            var blockFactory = new BlockFactory(factory);
+            var documentContent = "<th:p><th:strong></th:strong></th:p>";
+            var expectedOutput = new MarkupBlock(
+                new MarkupTagHelperBlock("th:p",
+                    new MarkupTagHelperBlock("th:strong")));
+            var descriptors = new TagHelperDescriptor[]
+                {
+                    new TagHelperDescriptor
+                    {
+                        TagName = "p",
+                        TypeName = "PTagHelper",
+                        AssemblyName = "SomeAssembly",
+                        AllowedChildren = new[] { "strong" },
+                        Prefix = "th:"
+                    },
+                    new TagHelperDescriptor
+                    {
+                        TagName = "strong",
+                        TypeName = "StrongTagHelper",
+                        AssemblyName = "SomeAssembly",
+                        Prefix = "th:"
+                    }
+                };
+            var descriptorProvider = new TagHelperDescriptorProvider(descriptors);
+
+            // Act & Assert
+            EvaluateData(
+                descriptorProvider,
+                documentContent,
+                expectedOutput,
+                expectedErrors: Enumerable.Empty<RazorError>());
+        }
+
         public static TheoryData InvalidHtmlScriptBlockData
         {
             get


### PR DESCRIPTION
- Added a test to validate prefixed `TagHelper`s can have children with `TagHelper` prefixes.

#532