### PR TITLE
Avoid GetContent and ToString in TagHelperContent tests

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using Microsoft.AspNet.Html.Abstractions;
@@ -13,6 +14,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
     /// <summary>
     /// Default concrete <see cref="TagHelperContent"/>.
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public class DefaultTagHelperContent : TagHelperContent
     {
         private BufferedHtmlContent _buffer;
@@ -279,6 +281,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <inheritdoc />
         public override string GetContent()
         {
+            return GetContent(HtmlEncoder.Default);
+        }
+
+        /// <inheritdoc />
+        public override string GetContent(IHtmlEncoder encoder)
+        {
             if (_buffer == null)
             {
                 return string.Empty;
@@ -286,7 +294,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             using (var writer = new StringWriter())
             {
-                WriteTo(writer, HtmlEncoder.Default);
+                WriteTo(writer, encoder);
                 return writer.ToString();
             }
         }
@@ -307,8 +315,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Buffer.WriteTo(writer, encoder);
         }
 
-        /// <inheritdoc />
-        public override string ToString()
+        private string DebuggerToString()
         {
             return GetContent();
         }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContent.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContent.cs
@@ -202,6 +202,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <returns>A <see cref="string"/> containing the content.</returns>
         public abstract string GetContent();
 
+        /// <summary>
+        /// Gets the content.
+        /// </summary>
+        /// <param name="encoder">The <see cref="IHtmlEncoder"/>.</param>
+        /// <returns>A <see cref="string"/> containing the content.</returns>
+        public abstract string GetContent(IHtmlEncoder encoder);
+
         /// <inheritdoc />
         public abstract void WriteTo(TextWriter writer, IHtmlEncoder encoder);
     }

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using Microsoft.AspNet.Testing;
-using Microsoft.Framework.WebEncoders;
 using Microsoft.Framework.WebEncoders.Testing;
 using Xunit;
 
@@ -19,13 +17,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
-            var expected = "Hello World!";
+            var expected = "HtmlEncode[[Hello World!]]";
 
             // Act
-            tagHelperContent.SetContent(expected);
+            tagHelperContent.SetContent("Hello World!");
 
             // Assert
-            Assert.Equal(expected, tagHelperContent.GetContent());
+            Assert.Equal(expected, tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -33,34 +31,34 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
-            var expected = "Hello World!";
+            var expected = "HtmlEncode[[Hello World!]]";
             tagHelperContent.SetContent("Contoso");
 
             // Act
-            tagHelperContent.SetContent(expected);
+            tagHelperContent.SetContent("Hello World!");
 
             // Assert
-            Assert.Equal(expected, tagHelperContent.GetContent());
+            Assert.Equal(expected, tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Theory]
-        [InlineData("HelloWorld!")]
-        [InlineData("  ")]
-        public void SetContent_WithTagHelperContent_WorksAsExpected(string expected)
+        [InlineData("HelloWorld!", "HtmlEncode[[HelloWorld!]]")]
+        [InlineData("  ", "HtmlEncode[[  ]]")]
+        public void SetContent_WithTagHelperContent_WorksAsExpected(string content, string expected)
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
             var copiedTagHelperContent = new DefaultTagHelperContent();
-            tagHelperContent.SetContent(expected);
+            tagHelperContent.SetContent(content);
 
             // Act
             copiedTagHelperContent.SetContent(tagHelperContent);
 
             // Assert
-            Assert.Equal(expected, copiedTagHelperContent.GetContent());
+            Assert.Equal(expected, copiedTagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
-        // GetContent
+        // GetContent - this one relies on the default encoder.
         [Fact]
         public void CanGetContent()
         {
@@ -81,13 +79,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
-            var expected = "Hello World!";
+            var expected = "HtmlEncode[[Hello World!]]";
 
             // Act
-            tagHelperContent.Append(expected);
+            tagHelperContent.Append("Hello World!");
 
             // Assert
-            Assert.Equal(expected, tagHelperContent.GetContent());
+            Assert.Equal(expected, tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         // Overload with args array is called.
@@ -101,7 +99,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             tagHelperContent.AppendFormat("{0} {1} {2} {3}!", "First", "Second", "Third", "Fourth");
 
             // Assert
-            Assert.Equal("First Second Third Fourth!", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[First Second Third Fourth!]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -114,7 +114,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             tagHelperContent.AppendFormat("0x{0, -5:X} - hex equivalent for 50.", 50);
 
             // Assert
-            Assert.Equal("0x32    - hex equivalent for 50.", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[0x32    - hex equivalent for 50.]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -127,7 +129,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             tagHelperContent.AppendFormat("0x{0, -5:X} - hex equivalent for {1}.", 50, 50);
 
             // Assert
-            Assert.Equal("0x32    - hex equivalent for 50.", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[0x32    - hex equivalent for 50.]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -140,7 +144,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             tagHelperContent.AppendFormat("0x{0, -5:X} - {1} equivalent for {2}.", 50, "hex", 50);
 
             // Assert
-            Assert.Equal("0x32    - hex equivalent for 50.", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[0x32    - hex equivalent for 50.]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -153,7 +159,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             tagHelperContent.AppendFormat("{0, -10} World!", "Hello");
 
             // Assert
-            Assert.Equal("Hello      World!", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Hello      World!]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -166,7 +174,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             tagHelperContent.AppendFormat("0x{0:X}", 50);
 
             // Assert
-            Assert.Equal("0x32", tagHelperContent.GetContent());
+            Assert.Equal("HtmlEncode[[0x32]]", tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         // Overload with args array is called.
@@ -186,7 +194,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 32.86);
 
             // Assert
-            Assert.Equal("Numbers in InvariantCulture - 1.10  2.98 145.82 32.86!", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Numbers in InvariantCulture - 1.10  2.98 145.82 32.86!]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -202,7 +212,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 1.1);
 
             // Assert
-            Assert.Equal("Numbers in InvariantCulture - 1.10 !", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Numbers in InvariantCulture - 1.10 !]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -219,7 +231,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 2.98);
 
             // Assert
-            Assert.Equal("Numbers in InvariantCulture - 1.10  2.98!", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Numbers in InvariantCulture - 1.10  2.98!]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -237,7 +251,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 3.12);
 
             // Assert
-            Assert.Equal("Numbers in InvariantCulture - 1.10  2.98 3.12!", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Numbers in InvariantCulture - 1.10  2.98 3.12!]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -251,7 +267,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             tagHelperContent.AppendFormat(culture, "{0} in french!", 1.21);
 
             // Assert
-            Assert.Equal("1,21 in french!", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[1,21 in french!]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -265,23 +283,25 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             tagHelperContent.AppendFormat(CultureInfo.CurrentCulture, "{0:D}", DateTime.Parse("01/02/2015"));
 
             // Assert
-            Assert.Equal("01 February 2015", tagHelperContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[01 February 2015]]",
+                tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
-        [Fact]
+        [Fact(Skip = "Blocked by #526")]
         public void CanAppendDefaultTagHelperContent()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
             var helloWorldContent = new DefaultTagHelperContent();
             helloWorldContent.SetContent("HelloWorld");
-            var expected = "Content was HelloWorld";
+            var expected = "HtmlEncode[[Content was HelloWorld]]";
 
             // Act
             tagHelperContent.AppendFormat("Content was {0}", helloWorldContent);
 
             // Assert
-            Assert.Equal(expected, tagHelperContent.GetContent());
+            Assert.Equal(expected, tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -292,7 +312,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var copiedTagHelperContent = new DefaultTagHelperContent();
             var text1 = "Hello";
             var text2 = " World!";
-            var expected = text1 + text2;
+            var expected = "HtmlEncode[[Hello]]HtmlEncode[[ World!]]";
             tagHelperContent.Append(text1);
             tagHelperContent.Append(text2);
 
@@ -300,7 +320,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             copiedTagHelperContent.Append(tagHelperContent);
 
             // Assert
-            Assert.Equal(expected, copiedTagHelperContent.GetContent());
+            Assert.Equal(expected, copiedTagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -511,32 +531,17 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void ToString_ReturnsExpectedValue()
-        {
-            // Arrange
-            var tagHelperContent = new DefaultTagHelperContent();
-            var expected = "Hello World!";
-            tagHelperContent.SetContent(expected);
-
-            // Act
-            var actual = tagHelperContent.ToString();
-
-            // Assert
-            Assert.Equal(expected, actual, StringComparer.Ordinal);
-        }
-
-        [Fact]
         public void Fluent_SetContent_Append_WritesExpectedContent()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
-            var expected = "Hello World!";
+            var expected = "HtmlEncode[[Hello ]]HtmlEncode[[World!]]";
 
             // Act
             tagHelperContent.SetContent("Hello ").Append("World!");
 
             // Assert
-            Assert.Equal(expected, tagHelperContent.GetContent());
+            Assert.Equal(expected, tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -544,13 +549,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
-            var expected = "First Second Third";
+            var expected = "HtmlEncode[[First ]]HtmlEncode[[Second Third]]";
 
             // Act
             tagHelperContent.SetContent("First ").AppendFormat("{0} Third", "Second");
 
             // Assert
-            Assert.Equal(expected, tagHelperContent.GetContent());
+            Assert.Equal(expected, tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -558,7 +563,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
-            var expected = "First Second Third Fourth";
+            var expected = "HtmlEncode[[First ]]HtmlEncode[[Second Third ]]HtmlEncode[[Fourth]]";
 
             // Act
             tagHelperContent
@@ -567,7 +572,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 .Append("Fourth");
 
             // Assert
-            Assert.Equal(expected, tagHelperContent.GetContent());
+            Assert.Equal(expected, tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -575,14 +580,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
-            var expected = "Hello World!";
+            var expected = "HtmlEncode[[Hello World]]";
             tagHelperContent.SetContent("Some Random Content");
 
             // Act
-            tagHelperContent.Clear().SetContent(expected);
+            tagHelperContent.Clear().SetContent("Hello World");
 
             // Assert
-            Assert.Equal(expected, tagHelperContent.GetContent());
+            Assert.Equal(expected, tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -590,14 +595,14 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
-            var expected = "Hello World!";
+            var expected = "HtmlEncode[[Hello ]]HtmlEncode[[World!]]";
             tagHelperContent.SetContent("Some Random Content");
 
             // Act
             tagHelperContent.Clear().SetContent("Hello ").Append("World!");
 
             // Assert
-            Assert.Equal(expected, tagHelperContent.GetContent());
+            Assert.Equal(expected, tagHelperContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperExecutionContextTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Framework.WebEncoders.Testing;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
@@ -54,6 +55,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var defaultTagHelperContent = new DefaultTagHelperContent();
+            var content = string.Empty;
             var expectedContent = string.Empty;
             var executionContext = new TagHelperExecutionContext(
                 "p",
@@ -64,10 +66,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 {
                     if (string.IsNullOrEmpty(expectedContent))
                     {
-                        expectedContent = "Hello from child content: " + Guid.NewGuid().ToString();
+                        content = "Hello from child content: " + Guid.NewGuid().ToString();
+                        expectedContent = $"HtmlEncode[[{content}]]";
                     }
 
-                    defaultTagHelperContent.SetContent(expectedContent);
+                    defaultTagHelperContent.SetContent(content);
 
                     return Task.FromResult(result: true);
                 },
@@ -79,8 +82,8 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var content2 = await executionContext.GetChildContentAsync(useCachedResult: true);
 
             // Assert
-            Assert.Equal(expectedContent, content1.GetContent());
-            Assert.Equal(expectedContent, content2.GetContent());
+            Assert.Equal(expectedContent, content1.GetContent(new CommonTestEncoder()));
+            Assert.Equal(expectedContent, content2.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -134,7 +137,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.NotSame(content1, content2);
-            Assert.Empty((await executionContext.GetChildContentAsync(useCachedResult)).GetContent());
+
+            var content3 = await executionContext.GetChildContentAsync(useCachedResult);
+            Assert.Empty(content3.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Framework.WebEncoders.Testing;
 using Xunit;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
@@ -20,7 +21,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Assert.NotNull(tagHelperOutput.Content);
             Assert.NotNull(tagHelperOutput.PostContent);
             Assert.NotNull(tagHelperOutput.PostElement);
-            Assert.Equal("Hello World", tagHelperOutput.PreElement.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Hello World]]",
+                tagHelperOutput.PreElement.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -36,7 +39,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Assert.NotNull(tagHelperOutput.Content);
             Assert.NotNull(tagHelperOutput.PostContent);
             Assert.NotNull(tagHelperOutput.PostElement);
-            Assert.Equal("Hello World", tagHelperOutput.PostElement.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Hello World]]",
+                tagHelperOutput.PostElement.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -75,7 +80,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Assert.NotNull(tagHelperOutput.Content);
             Assert.NotNull(tagHelperOutput.PostContent);
             Assert.NotNull(tagHelperOutput.PostElement);
-            Assert.Equal("Hello World", tagHelperOutput.PreContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Hello World]]",
+                tagHelperOutput.PreContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -91,7 +98,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Assert.NotNull(tagHelperOutput.Content);
             Assert.NotNull(tagHelperOutput.PostContent);
             Assert.NotNull(tagHelperOutput.PostElement);
-            Assert.Equal("Hello World", tagHelperOutput.Content.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Hello World]]",
+                tagHelperOutput.Content.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -107,7 +116,9 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             Assert.NotNull(tagHelperOutput.Content);
             Assert.NotNull(tagHelperOutput.PostContent);
             Assert.NotNull(tagHelperOutput.PostElement);
-            Assert.Equal("Hello World", tagHelperOutput.PostContent.GetContent());
+            Assert.Equal(
+                "HtmlEncode[[Hello World]]",
+                tagHelperOutput.PostContent.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -125,15 +136,15 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             // Assert
             Assert.Null(tagHelperOutput.TagName);
             Assert.NotNull(tagHelperOutput.PreElement);
-            Assert.Empty(tagHelperOutput.PreElement.GetContent());
+            Assert.Empty(tagHelperOutput.PreElement.GetContent(new CommonTestEncoder()));
             Assert.NotNull(tagHelperOutput.PreContent);
-            Assert.Empty(tagHelperOutput.PreContent.GetContent());
+            Assert.Empty(tagHelperOutput.PreContent.GetContent(new CommonTestEncoder()));
             Assert.NotNull(tagHelperOutput.Content);
-            Assert.Empty(tagHelperOutput.Content.GetContent());
+            Assert.Empty(tagHelperOutput.Content.GetContent(new CommonTestEncoder()));
             Assert.NotNull(tagHelperOutput.PostContent);
-            Assert.Empty(tagHelperOutput.PostContent.GetContent());
+            Assert.Empty(tagHelperOutput.PostContent.GetContent(new CommonTestEncoder()));
             Assert.NotNull(tagHelperOutput.PostElement);
-            Assert.Empty(tagHelperOutput.PostElement.GetContent());
+            Assert.Empty(tagHelperOutput.PostElement.GetContent(new CommonTestEncoder()));
         }
 
         [Fact]
@@ -155,15 +166,15 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Assert
             Assert.NotNull(tagHelperOutput.PreElement);
-            Assert.Empty(tagHelperOutput.PreElement.GetContent());
+            Assert.Empty(tagHelperOutput.PreElement.GetContent(new CommonTestEncoder()));
             Assert.NotNull(tagHelperOutput.PreContent);
-            Assert.Empty(tagHelperOutput.PreContent.GetContent());
+            Assert.Empty(tagHelperOutput.PreContent.GetContent(new CommonTestEncoder()));
             Assert.NotNull(tagHelperOutput.Content);
-            Assert.Empty(tagHelperOutput.Content.GetContent());
+            Assert.Empty(tagHelperOutput.Content.GetContent(new CommonTestEncoder()));
             Assert.NotNull(tagHelperOutput.PostContent);
-            Assert.Empty(tagHelperOutput.PostContent.GetContent());
+            Assert.Empty(tagHelperOutput.PostContent.GetContent(new CommonTestEncoder()));
             Assert.NotNull(tagHelperOutput.PostElement);
-            Assert.Empty(tagHelperOutput.PostElement.GetContent());
+            Assert.Empty(tagHelperOutput.PostElement.GetContent(new CommonTestEncoder()));
         }
 
         [Theory]


### PR DESCRIPTION
In preparation for changing the encoding behavior of `AppendFormat(...)`...