### PR TITLE
Add `ParentTag` to `[HtmlTargetElement]`.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Properties/Resources.Designer.cs
@@ -426,6 +426,22 @@ namespace Microsoft.AspNet.Razor.Runtime
             return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace"), p0, p1);
         }
 
+        /// <summary>
+        /// Parent Tag
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_ParentTag
+        {
+            get { return GetString("TagHelperDescriptorFactory_ParentTag"); }
+        }
+
+        /// <summary>
+        /// Parent Tag
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_ParentTag()
+        {
+            return GetString("TagHelperDescriptorFactory_ParentTag");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNet.Razor.Runtime/Resources.resx
@@ -195,4 +195,7 @@
   <data name="TagHelperDescriptorFactory_InvalidRestrictChildrenAttributeNameNullWhitespace" xml:space="preserve">
     <value>Invalid '{0}' tag name for tag helper '{1}'. Name cannot be null or whitespace.</value>
   </data>
+  <data name="TagHelperDescriptorFactory_ParentTag" xml:space="preserve">
+    <value>Parent Tag</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlTargetElementAttribute.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/HtmlTargetElementAttribute.cs
@@ -79,5 +79,11 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// </para>
         /// </remarks>
         public TagStructure TagStructure { get; set; }
+
+        /// <summary>
+        /// The required HTML element name of the direct parent.
+        /// </summary>
+        /// <remarks>A <c>null</c> value indicates any HTML element name is appropriate.</remarks>
+        public string ParentTag { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -142,6 +142,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         requiredAttributes: Enumerable.Empty<string>(),
                         allowedChildren: allowedChildren,
                         tagStructure: default(TagStructure),
+                        parentTag: null,
                         designTimeDescriptor: typeDesignTimeDescriptor)
                 };
             }
@@ -231,6 +232,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 attributeDescriptors,
                 requiredAttributes,
                 allowedChildren,
+                targetElementAttribute.ParentTag,
                 targetElementAttribute.TagStructure,
                 designTimeDescriptor);
         }
@@ -242,6 +244,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             IEnumerable<TagHelperAttributeDescriptor> attributeDescriptors,
             IEnumerable<string> requiredAttributes,
             IEnumerable<string> allowedChildren,
+            string parentTag,
             TagStructure tagStructure,
             TagHelperDesignTimeDescriptor designTimeDescriptor)
         {
@@ -253,6 +256,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 Attributes = attributeDescriptors,
                 RequiredAttributes = requiredAttributes,
                 AllowedChildren = allowedChildren,
+                RequiredParent = parentTag,
                 TagStructure = tagStructure,
                 DesignTimeDescriptor = designTimeDescriptor
             };
@@ -286,7 +290,27 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 }
             }
 
-            return validTagName && validAttributeNames;
+            var validParentTagName = ValidateParentTagName(attribute.ParentTag, errorSink);
+
+            return validTagName && validAttributeNames && validParentTagName;
+        }
+
+        /// <summary>
+        /// Internal for unit testing.
+        /// </summary>
+        internal static bool ValidateParentTagName(string parentTag, ErrorSink errorSink)
+        {
+            return parentTag == null ||
+                TryValidateName(
+                    parentTag,
+                    Resources.FormatHtmlTargetElementAttribute_NameCannotBeNullOrWhitespace(
+                        Resources.TagHelperDescriptorFactory_ParentTag),
+                    characterErrorBuilder: (invalidCharacter) =>
+                        Resources.FormatHtmlTargetElementAttribute_InvalidName(
+                            Resources.TagHelperDescriptorFactory_ParentTag.ToLower(),
+                            parentTag,
+                            invalidCharacter),
+                    errorSink: errorSink);
         }
 
         private static bool ValidateName(

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperDescriptorResolver.cs
@@ -161,6 +161,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         Attributes = descriptor.Attributes,
                         RequiredAttributes = descriptor.RequiredAttributes,
                         AllowedChildren = descriptor.AllowedChildren,
+                        RequiredParent = descriptor.RequiredParent,
                         TagStructure = descriptor.TagStructure,
                         DesignTimeDescriptor = descriptor.DesignTimeDescriptor
                     });

--- a/src/Microsoft.AspNet.Razor.Test.Sources/CaseSensitiveTagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor.Test.Sources/CaseSensitiveTagHelperDescriptorComparer.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNet.Razor.Test.Internal
             Assert.Equal(descriptorX.TagName, descriptorY.TagName, StringComparer.Ordinal);
             Assert.Equal(descriptorX.Prefix, descriptorY.Prefix, StringComparer.Ordinal);
             Assert.Equal(descriptorX.RequiredAttributes, descriptorY.RequiredAttributes, StringComparer.Ordinal);
+            Assert.Equal(descriptorX.RequiredParent, descriptorY.RequiredParent, StringComparer.Ordinal);
 
             if (descriptorX.AllowedChildren != descriptorY.AllowedChildren)
             {

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptor.cs
@@ -164,6 +164,12 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         public IEnumerable<string> AllowedChildren { get; set; }
 
         /// <summary>
+        /// Get the name of the HTML element required as the immediate parent.
+        /// </summary>
+        /// <remarks><c>null</c> indicates no restriction on parent tag.</remarks>
+        public string RequiredParent { get; set; }
+
+        /// <summary>
         /// The expected tag structure.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorComparer.cs
@@ -46,6 +46,10 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal) &&
                 string.Equals(descriptorX.TagName, descriptorY.TagName, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(descriptorX.AssemblyName, descriptorY.AssemblyName, StringComparison.Ordinal) &&
+                string.Equals(
+                    descriptorX.RequiredParent,
+                    descriptorY.RequiredParent,
+                    StringComparison.OrdinalIgnoreCase) &&
                 Enumerable.SequenceEqual(
                     descriptorX.RequiredAttributes.OrderBy(attribute => attribute, StringComparer.OrdinalIgnoreCase),
                     descriptorY.RequiredAttributes.OrderBy(attribute => attribute, StringComparer.OrdinalIgnoreCase),
@@ -72,6 +76,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             hashCodeCombiner.Add(descriptor.TypeName, StringComparer.Ordinal);
             hashCodeCombiner.Add(descriptor.TagName, StringComparer.OrdinalIgnoreCase);
             hashCodeCombiner.Add(descriptor.AssemblyName, StringComparer.Ordinal);
+            hashCodeCombiner.Add(descriptor.RequiredParent, StringComparer.OrdinalIgnoreCase);
             hashCodeCombiner.Add(descriptor.TagStructure);
 
             var attributes = descriptor.RequiredAttributes.OrderBy(

--- a/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.Razor/TagHelpers/TagHelperDescriptorProvider.cs
@@ -40,10 +40,14 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// <param name="tagName">The name of the HTML tag to match. Providing a '*' tag name
         /// retrieves catch-all <see cref="TagHelperDescriptor"/>s (descriptors that target every tag).</param>
         /// <param name="attributeNames">Attributes the HTML element must contain to match.</param>
+        /// <param name="parentTagName">The parent tag name of the given <paramref name="tagName"/> tag.</param>
         /// <returns><see cref="TagHelperDescriptor"/>s that apply to the given <paramref name="tagName"/>.
         /// Will return an empty <see cref="Enumerable" /> if no <see cref="TagHelperDescriptor"/>s are
         /// found.</returns>
-        public IEnumerable<TagHelperDescriptor> GetDescriptors(string tagName, IEnumerable<string> attributeNames)
+        public IEnumerable<TagHelperDescriptor> GetDescriptors(
+            string tagName,
+            IEnumerable<string> attributeNames,
+            string parentTagName)
         {
             if (!string.IsNullOrEmpty(_tagHelperPrefix) &&
                 (tagName.Length <= _tagHelperPrefix.Length ||
@@ -75,8 +79,18 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             }
 
             var applicableDescriptors = ApplyRequiredAttributes(descriptors, attributeNames);
+            applicableDescriptors = ApplyParentTagFilter(applicableDescriptors, parentTagName);
 
             return applicableDescriptors;
+        }
+
+        private IEnumerable<TagHelperDescriptor> ApplyParentTagFilter(
+            IEnumerable<TagHelperDescriptor> descriptors,
+            string parentTagName)
+        {
+            return descriptors.Where(descriptor =>
+                descriptor.RequiredParent == null ||
+                string.Equals(parentTagName, descriptor.RequiredParent, StringComparison.OrdinalIgnoreCase));
         }
 
         private IEnumerable<TagHelperDescriptor> ApplyRequiredAttributes(

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TestTagHelpers/TagHelperDescriptorFactoryTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/TestTagHelpers/TagHelperDescriptorFactoryTagHelpers.cs
@@ -9,6 +9,23 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 
 namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 {
+    [HtmlTargetElement("input", ParentTag = "div")]
+    public class RequiredParentTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("p", ParentTag = "div")]
+    [HtmlTargetElement("input", ParentTag = "section")]
+    public class MultiSpecifiedRequiredParentTagHelper : TagHelper
+    {
+    }
+
+    [HtmlTargetElement("p")]
+    [HtmlTargetElement("input", ParentTag = "div")]
+    public class MultiWithUnspecifiedRequiredParentTagHelper : TagHelper
+    {
+    }
+
 
     [RestrictChildren("p")]
     public class RestrictChildrenTagHelper

--- a/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
@@ -24,12 +24,13 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 AssemblyName =  "assembly name",
                 RequiredAttributes = new[] { "required attribute one", "required attribute two" },
                 AllowedChildren = new[] { "allowed child one" },
+                RequiredParent = "parent name",
                 DesignTimeDescriptor = new TagHelperDesignTimeDescriptor
                 {
                     Summary = "usage summary",
                     Remarks = "usage remarks",
                     OutputElementHint = "some-tag"
-                }
+                },
             };
 
             var expectedSerializedDescriptor =
@@ -42,6 +43,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":" +
                 "[\"required attribute one\",\"required attribute two\"]," +
                 $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":[\"allowed child one\"]," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredParent) }\":\"parent name\"," +
                 $"\"{ nameof(TagHelperDescriptor.TagStructure) }\":0," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":{{"+
                 $"\"{ nameof(TagHelperDesignTimeDescriptor.Summary) }\":\"usage summary\"," +
@@ -105,6 +107,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperAttributeDescriptor.DesignTimeDescriptor) }\":null}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]," +
                 $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":null," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredParent) }\":null," +
                 $"\"{ nameof(TagHelperDescriptor.TagStructure) }\":1," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":null}}";
 
@@ -143,7 +146,8 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                         IsStringProperty = true
                     },
                 },
-                AllowedChildren = new[] { "allowed child one", "allowed child two" }
+                AllowedChildren = new[] { "allowed child one", "allowed child two" },
+                RequiredParent = "parent name"
             };
 
             var expectedSerializedDescriptor =
@@ -167,6 +171,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperAttributeDescriptor.DesignTimeDescriptor) }\":null}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]," +
                 $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":[\"allowed child one\",\"allowed child two\"]," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredParent) }\":\"parent name\"," +
                 $"\"{ nameof(TagHelperDescriptor.TagStructure) }\":0," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":null}}";
 
@@ -191,6 +196,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{nameof(TagHelperDescriptor.RequiredAttributes)}\":" +
                 "[\"required attribute one\",\"required attribute two\"]," +
                 $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":[\"allowed child one\",\"allowed child two\"]," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredParent) }\":\"parent name\"," +
                 $"\"{nameof(TagHelperDescriptor.TagStructure)}\":2," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":{{" +
                 $"\"{ nameof(TagHelperDesignTimeDescriptor.Summary) }\":\"usage summary\"," +
@@ -204,6 +210,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 AssemblyName = "assembly name",
                 RequiredAttributes = new[] { "required attribute one", "required attribute two" },
                 AllowedChildren = new[] { "allowed child one", "allowed child two" },
+                RequiredParent = "parent name",
                 DesignTimeDescriptor = new TagHelperDesignTimeDescriptor
                 {
                     Summary = "usage summary",
@@ -255,6 +262,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperAttributeDescriptor.DesignTimeDescriptor) }\":null}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]," +
                 $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":null," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredParent) }\":null," +
                 $"\"{nameof(TagHelperDescriptor.TagStructure)}\":0," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":null}}";
             var expectedDescriptor = new TagHelperDescriptor
@@ -321,6 +329,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
                 $"\"{ nameof(TagHelperAttributeDescriptor.DesignTimeDescriptor) }\":null}}]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":[]," +
                 $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":null," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredParent) }\":null," +
                 $"\"{nameof(TagHelperDescriptor.TagStructure)}\":1," +
                 $"\"{ nameof(TagHelperDescriptor.DesignTimeDescriptor) }\":null}}";
             var expectedDescriptor = new TagHelperDescriptor


### PR DESCRIPTION
- `ParentTag` allows `TagHelper`s to restrict where they apply based on their immediate parent tag.
- Changed the `TagHelperParseTreeRewriter` to understand non-`TagHelper` HTML elements to properly determine a parent tag when applying `TagHelperDescriptor.RequiredParent`. This change will also enable `[RestrictChildren]` to apply to more than just `TagHelper`s.
- Added tests to validate that partial and well formed tags properly discover `TagHelper`s. Also added tests that validate that descriptors are properly created based on `TagHelper` types.

#474