### PR TITLE
Generate `async` lambda for template attributes.

### DIFF
--- a/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpCodeVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpCodeVisitor.cs
@@ -236,7 +236,7 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
                     .WriteParameterSeparator()
                     .WriteStartNewObject(Context.Host.GeneratedClassContext.TemplateTypeName);
 
-                using (Writer.BuildLambda(endLine: false, parameterNames: ValueWriterName))
+                using (Writer.BuildAsyncLambda(endLine: false, parameterNames: ValueWriterName))
                 {
                     Accept(chunk.Children);
                 }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ConditionalAttributes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ConditionalAttributes.cs
@@ -79,7 +79,7 @@ WriteAttributeValue(" ", 232, ch, 233, 4, false);
             WriteLiteral(" />\r\n    <p");
             Instrumentation.EndContext();
             BeginWriteAttribute("class", " class=\"", 248, "\"", 281, 1);
-            WriteAttributeValue("", 256, new Template((__razor_attribute_value_writer) => {
+            WriteAttributeValue("", 256, new Template(async(__razor_attribute_value_writer) => {
 #line 10 "ConditionalAttributes.cshtml"
                if(cls != null) { 
 

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.cs
@@ -53,7 +53,7 @@ AddHtmlAttributeValue(" ", 57, DateTime.Now, 58, 14, false);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
             BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 2);
-            AddHtmlAttributeValue("", 95, new Template((__razor_attribute_value_writer) => {
+            AddHtmlAttributeValue("", 95, new Template(async(__razor_attribute_value_writer) => {
 #line 5 "DynamicAttributeTagHelpers.cshtml"
                  if (true) { 
 
@@ -186,7 +186,7 @@ AddHtmlAttributeValue("", 347, long.MinValue, 347, 14, false);
 
 #line default
 #line hidden
-            AddHtmlAttributeValue(" ", 361, new Template((__razor_attribute_value_writer) => {
+            AddHtmlAttributeValue(" ", 361, new Template(async(__razor_attribute_value_writer) => {
 #line 10 "DynamicAttributeTagHelpers.cshtml"
                                 if (true) { 
 
@@ -273,7 +273,7 @@ AddHtmlAttributeValue(" ", 490, int.MaxValue, 491, 14, false);
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
             BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 1);
-            AddHtmlAttributeValue("", 528, new Template((__razor_attribute_value_writer) => {
+            AddHtmlAttributeValue("", 528, new Template(async(__razor_attribute_value_writer) => {
 #line 14 "DynamicAttributeTagHelpers.cshtml"
                  if (true) { 
 

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/InlineBlocks.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/InlineBlocks.cs
@@ -21,7 +21,7 @@ namespace TestOutput
             WriteLiteral("(string link) {\r\n    <a");
             Instrumentation.EndContext();
             BeginWriteAttribute("href", " href=\"", 36, "\"", 94, 1);
-            WriteAttributeValue("", 43, new Template((__razor_attribute_value_writer) => {
+            WriteAttributeValue("", 43, new Template(async(__razor_attribute_value_writer) => {
 #line 2 "InlineBlocks.cshtml"
               if(link != null) { 
 

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
@@ -43,7 +43,7 @@ namespace TestOutput
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
             BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "class", 1);
-            AddHtmlAttributeValue("", 109, new Template((__razor_attribute_value_writer) => {
+            AddHtmlAttributeValue("", 109, new Template(async(__razor_attribute_value_writer) => {
             }
             ), 109, 6, false);
             EndAddHtmlAttributeValues(__tagHelperExecutionContext);


### PR DESCRIPTION
- Template attributes should be of type `Func<TextWriter, Task>`. We weren't generating an `async` lambda for attributes prior to this change resulting in a compilation failure when used at runtime and the inability to `@await` code (unless a user returns some sort of `Task`).
- Updated code generation files to reflect the new code generation behavior.

#594