### PR TITLE
Execute `dnu restore` with .NET Core and use Mono 4.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
 language: csharp
-sudo: false
-mono:
-  - beta
+sudo: required
+dist: trusty
+addons:
+  apt:
+    packages:
+    - gettext
+    - libcurl4-openssl-dev
+    - libicu-dev
+    - libssl-dev
+    - libunwind8
+    - zlib1g
+before_install:
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; fi
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew install icu4c; fi
 env:
-  - MONO_THREADS_PER_CPU=2000
+  - KOREBUILD_DNU_RESTORE_CORECLR=true MONO_THREADS_PER_CPU=2000
+mono:
+  - 4.0.5
 os:
   - linux
   - osx


### PR DESCRIPTION
- upgrade Linux to Trusty (Ubuntu 14.04) distribution, where .NET Core is supported
- Mono beta is now 4.2.1 which doesn't work with `nuget.exe`
  - see also aspnet/External#48

Note: cannot use `KOREBUILD_TEST_DNXCORE=true` due to #577