### PR TITLE
Fix aspnet/Mvc#3196 Razor Compilation Allocations

### DIFF
--- a/src/Microsoft.AspNet.Razor/Chunks/ChunkTreeBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Chunks/ChunkTreeBuilder.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Razor.Chunks
         {
             _lastChunk = chunk;
 
-            chunk.Start = association?.Start ?? default(SourceLocation);
+            chunk.Start = association.Start;
             chunk.Association = association;
 
             // If we're not in the middle of a parent chunk
@@ -72,8 +72,12 @@ namespace Microsoft.AspNet.Razor.Chunks
         {
             ParentLiteralChunk parentLiteralChunk;
 
-            // We try to join literal chunks where possible, so that we have fewer 'writes' in the generated
-            // code.
+            // We try to join literal chunks where possible, so that we have fewer 'writes' in the generated code.
+            //
+            // Possible cases here:
+            //  - We just added a LiteralChunk and we need to add another - so merge them into ParentLiteralChunk.
+            //  - We have a ParentLiteralChunk - merge the new chunk into it.
+            //  - We just added something <else> - just add the LiteralChunk like normal.
             if (_lastChunk is LiteralChunk)
             {
                 parentLiteralChunk = new ParentLiteralChunk()

--- a/src/Microsoft.AspNet.Razor/Chunks/ChunkTreeBuilder.cs
+++ b/src/Microsoft.AspNet.Razor/Chunks/ChunkTreeBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.AspNet.Razor.Parser.SyntaxTree;
 
 namespace Microsoft.AspNet.Razor.Chunks
@@ -26,7 +27,7 @@ namespace Microsoft.AspNet.Razor.Chunks
         {
             _lastChunk = chunk;
 
-            chunk.Start = association.Start;
+            chunk.Start = association?.Start ?? default(SourceLocation);
             chunk.Association = association;
 
             // If we're not in the middle of a parent chunk
@@ -69,22 +70,39 @@ namespace Microsoft.AspNet.Razor.Chunks
 
         public void AddLiteralChunk(string literal, SyntaxTreeNode association)
         {
-            // If the previous chunk was also a LiteralChunk, append the content of the current node to the previous one.
-            var literalChunk = _lastChunk as LiteralChunk;
-            if (literalChunk != null)
+            ParentLiteralChunk parentLiteralChunk;
+
+            // We try to join literal chunks where possible, so that we have fewer 'writes' in the generated
+            // code.
+            if (_lastChunk is LiteralChunk)
             {
-                // Literal chunks are always associated with Spans
-                var lastSpan = (Span)literalChunk.Association;
-                var currentSpan = (Span)association;
-
-                var builder = new SpanBuilder(lastSpan);
-                foreach (var symbol in currentSpan.Symbols)
+                parentLiteralChunk = new ParentLiteralChunk()
                 {
-                    builder.Accept(symbol);
-                }
+                    Start = _lastChunk.Start,
+                };
 
-                literalChunk.Association = builder.Build();
-                literalChunk.Text += literal;
+                parentLiteralChunk.Children.Add(_lastChunk);
+                parentLiteralChunk.Children.Add(new LiteralChunk
+                {
+                    Association = association,
+                    Start = association.Start,
+                    Text = literal,
+                });
+
+                Debug.Assert(Current.Children[Current.Children.Count - 1] == _lastChunk);
+                Current.Children.RemoveAt(Current.Children.Count - 1);
+                Current.Children.Add(parentLiteralChunk);
+                _lastChunk = parentLiteralChunk;
+            }
+            else if ((parentLiteralChunk = _lastChunk as ParentLiteralChunk) != null)
+            {
+                parentLiteralChunk.Children.Add(new LiteralChunk
+                {
+                    Association = association,
+                    Start = association.Start,
+                    Text = literal,
+                });
+                _lastChunk = parentLiteralChunk;
             }
             else
             {

--- a/src/Microsoft.AspNet.Razor/Chunks/ParentLiteralChunk.cs
+++ b/src/Microsoft.AspNet.Razor/Chunks/ParentLiteralChunk.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+
+namespace Microsoft.AspNet.Razor.Chunks
+{
+    public class ParentLiteralChunk : ParentChunk
+    {
+        public string GetText()
+        {
+            var builder = new StringBuilder();
+            for (var i = 0; i < Children.Count; i++)
+            {
+                builder.Append(((LiteralChunk)Children[i]).Text);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpCodeWriter.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpCodeWriter.cs
@@ -505,19 +505,18 @@ namespace Microsoft.AspNet.Razor.CodeGenerators
 
         public CSharpCodeWriter WriteStartInstrumentationContext(
             ChunkGeneratorContext context,
-            int start,
+            int absoluteIndex,
             int length,
             bool isLiteral)
         {
             WriteStartMethodInvocation(context.Host.GeneratedClassContext.BeginContextMethodName);
-            Write(start.ToString(CultureInfo.InvariantCulture));
+            Write(absoluteIndex.ToString(CultureInfo.InvariantCulture));
             WriteParameterSeparator();
             Write(length.ToString(CultureInfo.InvariantCulture));
             WriteParameterSeparator();
             Write(isLiteral ? "true" : "false");
             return WriteEndMethodInvocation();
         }
-
 
         public CSharpCodeWriter WriteEndInstrumentationContext(ChunkGeneratorContext context)
         {

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpCodeWriter.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpCodeWriter.cs
@@ -496,14 +496,28 @@ namespace Microsoft.AspNet.Razor.CodeGenerators
             SyntaxTreeNode syntaxNode,
             bool isLiteral)
         {
+            return WriteStartInstrumentationContext(
+                context,
+                syntaxNode.Start.AbsoluteIndex,
+                syntaxNode.Length,
+                isLiteral);
+        }
+
+        public CSharpCodeWriter WriteStartInstrumentationContext(
+            ChunkGeneratorContext context,
+            int start,
+            int length,
+            bool isLiteral)
+        {
             WriteStartMethodInvocation(context.Host.GeneratedClassContext.BeginContextMethodName);
-            Write(syntaxNode.Start.AbsoluteIndex.ToString(CultureInfo.InvariantCulture));
+            Write(start.ToString(CultureInfo.InvariantCulture));
             WriteParameterSeparator();
-            Write(syntaxNode.Length.ToString(CultureInfo.InvariantCulture));
+            Write(length.ToString(CultureInfo.InvariantCulture));
             WriteParameterSeparator();
             Write(isLiteral ? "true" : "false");
             return WriteEndMethodInvocation();
         }
+
 
         public CSharpCodeWriter WriteEndInstrumentationContext(ChunkGeneratorContext context)
         {

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpTagHelperCodeRenderer.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpTagHelperCodeRenderer.cs
@@ -397,7 +397,7 @@ namespace Microsoft.AspNet.Razor.CodeGenerators
                 // statement together and the #line pragma correct to make debugging possible.
                 using (var lineMapper = new CSharpLineMappingWriter(
                     _writer,
-                    attributeValueChunk.Association.Start,
+                    attributeValueChunk.Start,
                     _context.SourceFile))
                 {
                     // Place the assignment LHS to align RHS with original attribute value's indentation.
@@ -710,16 +710,21 @@ namespace Microsoft.AspNet.Razor.CodeGenerators
                 return false;
             }
 
-            var literalChildChunk = parentChunk.Children[0] as LiteralChunk;
-
-            if (literalChildChunk == null)
+            LiteralChunk literalChildChunk;
+            if ((literalChildChunk = parentChunk.Children[0] as LiteralChunk) != null)
             {
-                return false;
+                plainText = literalChildChunk.Text;
+                return true;
             }
 
-            plainText = literalChildChunk.Text;
+            ParentLiteralChunk parentLiteralChunk;
+            if ((parentLiteralChunk = parentChunk.Children[0] as ParentLiteralChunk) != null)
+            {
+                plainText = parentLiteralChunk.GetText();
+                return true;
+            }
 
-            return true;
+            return false;
         }
 
         // A CSharpCodeVisitor which does not HTML encode values. Used when rendering bound string attribute values.

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpCodeVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpCodeVisitor.cs
@@ -119,23 +119,20 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
 
         protected override void Visit(ParentLiteralChunk chunk)
         {
+            Debug.Assert(chunk.Children.Count > 1);
+
             if (Context.Host.DesignTimeMode)
             {
                 // Skip generating the chunk if we're in design time or if the chunk is empty.
                 return;
             }
-            
+
+            var text = chunk.GetText();
+
             if (Context.Host.EnableInstrumentation)
             {
-                var start = chunk.Children[0].Association.Start.AbsoluteIndex;
-
-                var length = 0;
-                for (var i = 0; i < chunk.Children.Count; i++)
-                {
-                    length += chunk.Children[i].Association.Length;
-                }
-
-                Writer.WriteStartInstrumentationContext(Context, start, length, isLiteral: true);
+                var start = chunk.Start.AbsoluteIndex;
+                Writer.WriteStartInstrumentationContext(Context, start, text.Length, isLiteral: true);
             }
 
             if (Context.ExpressionRenderingMode == ExpressionRenderingMode.WriteToOutput)
@@ -143,7 +140,7 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
                 RenderPreWriteStart();
             }
 
-            Writer.WriteStringLiteral(chunk.GetText());
+            Writer.WriteStringLiteral(text);
 
             if (Context.ExpressionRenderingMode == ExpressionRenderingMode.WriteToOutput)
             {

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpTagHelperAttributeValueVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpTagHelperAttributeValueVisitor.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
         /// <param name="chunk">The <see cref="ExpressionChunk"/> to render.</param>
         protected override void Visit(ExpressionChunk chunk)
         {
-            RenderCode(chunk.Code, (Span)chunk.Association);
+            RenderCode(chunk.Code, chunk.Start);
         }
 
         /// <summary>
@@ -99,12 +99,12 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
         /// <param name="chunk">The <see cref="LiteralChunk"/> to render.</param>
         protected override void Visit(LiteralChunk chunk)
         {
-            RenderCode(chunk.Text, (Span)chunk.Association);
+            RenderCode(chunk.Text, chunk.Start);
         }
 
         protected override void Visit(ParentLiteralChunk chunk)
         {
-            RenderCode(chunk.GetText(), (Span)chunk.Children[0].Association);
+            RenderCode(chunk.GetText(), chunk.Start);
         }
 
         /// <summary>
@@ -155,10 +155,10 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
         }
 
         // Tracks the code mapping and writes code for a leaf node in the attribute value Chunk tree.
-        private void RenderCode(string code, Span association)
+        private void RenderCode(string code, SourceLocation start)
         {
             _firstChild = false;
-            using (new CSharpLineMappingWriter(Writer, association.Start, code.Length))
+            using (new CSharpLineMappingWriter(Writer, start, code.Length))
             {
                 Writer.Write(code);
             }

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpTagHelperAttributeValueVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CSharpTagHelperAttributeValueVisitor.cs
@@ -102,6 +102,11 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
             RenderCode(chunk.Text, (Span)chunk.Association);
         }
 
+        protected override void Visit(ParentLiteralChunk chunk)
+        {
+            RenderCode(chunk.GetText(), (Span)chunk.Children[0].Association);
+        }
+
         /// <summary>
         /// Writes code for the given <paramref name="chunk"/>.
         /// </summary>

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/ChunkVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/ChunkVisitor.cs
@@ -53,6 +53,10 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
             {
                 Visit((LiteralChunk)chunk);
             }
+            else if (chunk is ParentLiteralChunk)
+            {
+                Visit((ParentLiteralChunk)chunk);
+            }
             else if (chunk is ExpressionBlockChunk)
             {
                 Visit((ExpressionBlockChunk)chunk);
@@ -120,6 +124,7 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
         }
 
         protected abstract void Visit(LiteralChunk chunk);
+        protected abstract void Visit(ParentLiteralChunk chunk);
         protected abstract void Visit(ExpressionChunk chunk);
         protected abstract void Visit(StatementChunk chunk);
         protected abstract void Visit(TagHelperChunk chunk);

--- a/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CodeVisitor.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/Visitors/CodeVisitor.cs
@@ -26,6 +26,9 @@ namespace Microsoft.AspNet.Razor.CodeGenerators.Visitors
         protected override void Visit(LiteralChunk chunk)
         {
         }
+        protected override void Visit(ParentLiteralChunk chunk)
+        {
+        }
         protected override void Visit(ExpressionBlockChunk chunk)
         {
         }


### PR DESCRIPTION
This change significantly reduces the amount of string and List<ISymbol>
allocations that occur during compilation by changing the way
LiteralChunks are combined.

This is a low impact fix that addresses the performance issue, the design
issues that caused it still exist.

The problem here lies in what Razor fundamentally does - it parses HTML/C#
into tokens, and then combines them back into 'chunks' a representation
friendly to code generation. When presenting with a large block of static
HTML, Razor parses it into individual HTML tokens, and then tries to join
them in back into a single chunk for rendering. Due to details of Razor's
representation of chunks/tokens, the process of combining literals is too
expensive.

Mainly, what's done here is to not try to combine instances of
LiteralChunk. The process of merging them is too expensive and requires
lots of interm List<ISymbol> and string allocations.

Instead we produce a new 'chunk' ParentLiteralChunk, which doesn't do so
much up-front computing. Various pieces of the code that deal with
LiteralChunk need to be updated to deal with ParentLiteralChunk also,
which is the bulk of the changes here.

Note that we still have the potential for LOH allocations to occur during
codegen, but it's likely to occur O(1) for each large block of HTML
instead of O(N) as it did in the old code.