### PR TITLE
Order `TagHelperExecutionContext.TagHelpers` without `.OrderBy`.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <summary>
         /// <see cref="ITagHelper"/>s that should be run.
         /// </summary>
-        public IEnumerable<ITagHelper> TagHelpers
+        public IList<ITagHelper> TagHelpers
         {
             get
             {


### PR DESCRIPTION
- By using linq we created several `OrderedEnumerable` allocations.

**Before:**
![image](https://cloud.githubusercontent.com/assets/2008729/11286889/89a022f8-8ecc-11e5-80b4-aebf6fc648ad.png)


**After:**
![image](https://cloud.githubusercontent.com/assets/2008729/11286895/90c73cf6-8ecc-11e5-89f6-91d621f4102d.png)

**Result:** Roughly a 2.3% reduction in overall allocations.

#601