### PR TITLE
Cache XML file information when creating design time based `TagHelperDescriptor`s.

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/Runtime/TagHelpers/TagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/Runtime/TagHelpers/TagHelperDescriptorResolver.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             };
 
         private readonly TagHelperTypeResolver _typeResolver;
-        private readonly bool _designTime;
+        private readonly TagHelperDescriptorFactory _descriptorFactory;
 
         /// <summary>
         /// Instantiates a new instance of the <see cref="TagHelperDescriptorResolver"/> class.
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// <param name="designTime">Indicates whether resolved <see cref="TagHelperDescriptor"/>s should include
         /// design time specific information.</param>
         public TagHelperDescriptorResolver(bool designTime)
-            : this(new TagHelperTypeResolver(), designTime)
+            : this(new TagHelperTypeResolver(), new TagHelperDescriptorFactory(designTime))
         {
         }
 
@@ -41,12 +41,13 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         /// specified <paramref name="typeResolver"/>.
         /// </summary>
         /// <param name="typeResolver">The <see cref="TagHelperTypeResolver"/>.</param>
-        /// <param name="designTime">Indicates whether resolved <see cref="TagHelperDescriptor"/>s should include
-        /// design time specific information.</param>
-        public TagHelperDescriptorResolver(TagHelperTypeResolver typeResolver, bool designTime)
+        /// <param name="descriptorFactory">The <see cref="TagHelperDescriptorFactory"/>.</param>
+        public TagHelperDescriptorResolver(
+            TagHelperTypeResolver typeResolver,
+            TagHelperDescriptorFactory descriptorFactory)
         {
             _typeResolver = typeResolver;
-            _designTime = designTime;
+            _descriptorFactory = descriptorFactory;
         }
 
         /// <inheritdoc />
@@ -137,7 +138,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
 
             // Convert types to TagHelperDescriptors
             var descriptors = tagHelperTypes.SelectMany(
-                type => TagHelperDescriptorFactory.CreateDescriptors(assemblyName, type, _designTime, errorSink));
+                type => _descriptorFactory.CreateDescriptors(assemblyName, type, errorSink));
 
             return descriptors;
         }

--- a/src/Microsoft.AspNet.Razor.Runtime/project.json
+++ b/src/Microsoft.AspNet.Razor.Runtime/project.json
@@ -26,6 +26,12 @@
       "frameworkAssemblies": {
         "System.Xml": "4.0.0.0",
         "System.Xml.Linq": "4.0.0.0"
+      },
+      "dependencies": {
+        "Microsoft.Extensions.HashCodeCombiner.Sources": {
+          "type": "build",
+          "version": "1.0.0-*"
+        }
       }
     },
     "dotnet5.4": {

--- a/test/Microsoft.AspNet.Razor.Runtime.Precompilation.Test/PrecompilationTagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Precompilation.Test/PrecompilationTagHelperDescriptorFactoryTest.cs
@@ -37,12 +37,12 @@ namespace Microsoft.AspNet.Razor.Runtime.Precompilation
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/Runtime/TagHelpers/RuntimeTagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/Runtime/TagHelpers/RuntimeTagHelperDescriptorFactoryTest.cs
@@ -25,12 +25,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
             var objectAssemblyName = typeof(object).GetTypeInfo().Assembly.GetName().Name;
             var expectedDescriptor =
                 CreateTagHelperDescriptor("object", "System.Object", objectAssemblyName);
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 objectAssemblyName,
                 GetTypeInfo(typeof(object)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -48,12 +48,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -137,12 +137,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: true);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime: true,
                 errorSink: errorSink);
 
             // Assert

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperDescriptorFactoryTest.cs
@@ -88,12 +88,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -177,12 +177,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -262,12 +262,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -351,12 +351,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -587,12 +587,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime,
                 errorSink);
 
             // Assert
@@ -789,12 +789,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -838,12 +838,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(tagHelperType),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -875,12 +875,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         CreateTagHelperAttributeDescriptor("Something-Else", validProperty2)
                     })
             };
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(OverriddenAttributeTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -909,12 +909,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         CreateTagHelperAttributeDescriptor("Something-Else", validProperty2)
                     })
             };
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(InheritedOverriddenAttributeTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -943,12 +943,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         CreateTagHelperAttributeDescriptor("Something-Else", validProperty2)
                     })
             };
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(InheritedNotOverriddenAttributeTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
             // Assert
             Assert.Empty(errorSink.Errors);
@@ -973,12 +973,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         TypeName = typeof(int).FullName
                     }
                 });
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(InheritedSingleAttributeTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -1001,12 +1001,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 {
                     CreateTagHelperAttributeDescriptor("int-attribute", intProperty)
                 });
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(SingleAttributeTagHelper)),
-                designTime: false,
                 errorSink: new ErrorSink());
 
             // Assert
@@ -1030,12 +1030,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 {
                     CreateTagHelperAttributeDescriptor("valid-attribute", validProperty)
                 });
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(MissingAccessorTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -1059,12 +1059,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                 {
                     CreateTagHelperAttributeDescriptor("valid-attribute", validProperty)
                 });
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(NonPublicAccessorTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -1091,12 +1091,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         TypeName = typeof(object).FullName
                     }
                 });
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(NotBoundAttributeTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -1110,12 +1110,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(DuplicateAttributeNameTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -1159,12 +1159,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                         }
                     })
             };
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(MultiTagTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -1191,12 +1191,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     {
                         CreateTagHelperAttributeDescriptor("valid-attribute", validProp)
                     });
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(InheritedMultiTagTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -1221,12 +1221,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     typeof(DuplicateTagNameTagHelper).FullName,
                     AssemblyName)
             };
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(DuplicateTagNameTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -1251,12 +1251,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
                     typeof(OverrideNameTagHelper).FullName,
                     AssemblyName),
             };
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(typeof(OverrideNameTagHelper)),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert
@@ -1439,12 +1439,12 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         {
             // Arrange
             var errorSink = new ErrorSink();
+            var factory = new TagHelperDescriptorFactory(designTime: false);
 
             // Act
-            var descriptors = TagHelperDescriptorFactory.CreateDescriptors(
+            var descriptors = factory.CreateDescriptors(
                 AssemblyName,
                 GetTypeInfo(type),
-                designTime: false,
                 errorSink: errorSink);
 
             // Assert

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperDescriptorResolverTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperDescriptorResolverTest.cs
@@ -1381,7 +1381,7 @@ namespace Microsoft.AspNet.Razor.Runtime.TagHelpers
         private class TestTagHelperDescriptorResolver : TagHelperDescriptorResolver
         {
             public TestTagHelperDescriptorResolver(TagHelperTypeResolver typeResolver)
-                : base(typeResolver, designTime: false)
+                : base(typeResolver, new TagHelperDescriptorFactory(designTime: false))
             {
             }
 

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/project.json
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/project.json
@@ -11,10 +11,6 @@
       "type": "build"
     },
     "Microsoft.AspNet.Testing": "1.0.0-*",
-    "Microsoft.Extensions.HashCodeCombiner.Sources": {
-      "type": "build",
-      "version": "1.0.0-*"
-    },
     "Microsoft.Extensions.WebEncoders": "1.0.0-*",
     "xunit.runner.aspnet": "2.0.0-aspnet-*"
   },
@@ -27,6 +23,13 @@
         "Moq": "4.2.1312.1622"
       }
     },
-    "dnxcore50": {}
+    "dnxcore50": {
+      "dependencies": {
+        "Microsoft.Extensions.HashCodeCombiner.Sources": {
+          "type": "build",
+          "version": "1.0.0-*"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- Prior to this change we'd hit the disk every time we'd create a `TagHelperDesignTimeDescriptor` to locate an assemblies XML files.
- Did not want to tie the XML cache to a static member in-case a user updates their XML information between parses. Therefore, changed `TagHelperDescriptorFactory` and `TagHelperDesignTimeDescriptorFactory` to no longer be static.
- Put the same `TagHeleprDescriptorFactory` extensibility point as we had for its counterpart `TagHelperTypeResolver` to stay consistent. This involved making `CreateDescriptors` virtual and allowing it to be provided in the `TagHelperDescriptorResolver` constructor.

#630