### PR TITLE
Change missing section end brace error to work at EOF.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.Directives.cs
@@ -114,6 +114,8 @@ namespace Microsoft.AspNet.Razor.Parser
                 Accept(whitespace);
             }
 
+            var startingBraceLocation = CurrentLocation;
+
             // Set up edit handler
             var editHandler = new AutoCompleteEditHandler(Language.TokenizeString, autoCompleteAtEndOfSpan: true);
 
@@ -130,8 +132,11 @@ namespace Microsoft.AspNet.Razor.Parser
             {
                 editHandler.AutoCompleteString = "}";
                 Context.OnError(
-                    CurrentLocation,
-                    RazorResources.FormatParseError_Expected_X(Language.GetSample(CSharpSymbolType.RightBrace)),
+                    startingBraceLocation,
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
+                        SyntaxConstants.CSharp.SectionKeyword,
+                        Language.GetSample(CSharpSymbolType.RightBrace),
+                        Language.GetSample(CSharpSymbolType.LeftBrace)),
                     length: 1 /* } */);
             }
             else

--- a/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpAutoCompleteTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Parser/CSharp/CSharpAutoCompleteTest.cs
@@ -46,8 +46,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                            .Accepts(AcceptedCharacters.Any),
                     new MarkupBlock()),
                 new RazorError(
-                    RazorResources.FormatParseError_Expected_X("}"),
-                    new SourceLocation(17, 0, 17),
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("section", "}", "{"),
+                    new SourceLocation(16, 0, 16),
                     length: 1));
         }
 
@@ -109,8 +109,8 @@ namespace Microsoft.AspNet.Razor.Test.Parser.CSharp
                         new MarkupTagBlock(
                             Factory.Markup("</p>")))),
                 new RazorError(
-                    RazorResources.FormatParseError_Expected_X("}"),
-                    new SourceLocation(27 + Environment.NewLine.Length, 1, 10),
+                    RazorResources.FormatParseError_Expected_EndOfBlock_Before_EOF("section", "}", "{"),
+                    new SourceLocation(16, 0, 16),
                     length: 1));
         }
 


### PR DESCRIPTION
- Updated existing tests and added a new case to understand `@section {....` scenarios.
- Instead of trying to guess 1 character prior to EOF decided to log error on opening brace since we know its position. Updated error to account for change in location.

#625