### PR TITLE
Rename TagHelperContent.Append(IHtmlContent` overload to be `TagHelpe…

### DIFF
--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         }
 
         /// <inheritdoc />
-        public override TagHelperContent Append(IHtmlContent htmlContent)
+        public override TagHelperContent AppendHtml(IHtmlContent htmlContent)
         {
             Buffer.Add(htmlContent);
             return this;

--- a/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContent.cs
+++ b/src/Microsoft.AspNet.Razor.Runtime/TagHelpers/TagHelperContent.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         /// </summary>
         /// <param name="htmlContent">The <see cref="IHtmlContent"/> to be appended.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        public abstract TagHelperContent Append(IHtmlContent htmlContent);
+        public abstract TagHelperContent AppendHtml(IHtmlContent htmlContent);
 
         /// <summary>
         /// Appends <paramref name="encoded"/> to the existing content. <paramref name="encoded"/> is assumed
@@ -145,9 +145,9 @@ namespace Microsoft.AspNet.Razor.TagHelpers
         public abstract void WriteTo(TextWriter writer, HtmlEncoder encoder);
 
         /// <inheritdoc />
-        IHtmlContentBuilder IHtmlContentBuilder.Append(IHtmlContent content)
+        IHtmlContentBuilder IHtmlContentBuilder.AppendHtml(IHtmlContent content)
         {
-            return Append(content);
+            return AppendHtml(content);
         }
 
         /// <inheritdoc />

--- a/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
+++ b/test/Microsoft.AspNet.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             tagHelperContent.Append(text2);
 
             // Act
-            copiedTagHelperContent.Append(tagHelperContent);
+            copiedTagHelperContent.AppendHtml(tagHelperContent);
 
             // Assert
             Assert.Equal(expected, copiedTagHelperContent.GetContent(new HtmlTestEncoder()));
@@ -233,7 +233,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             TagHelperContent NullContent = null;
 
             // Act
-            tagHelperContent.Append(NullContent);
+            tagHelperContent.AppendHtml(NullContent);
 
             // Assert
             Assert.True(tagHelperContent.IsModified);
@@ -317,7 +317,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             var copiedTagHelperContent = new DefaultTagHelperContent();
 
             // Act
-            tagHelperContent.Append(copiedTagHelperContent);
+            tagHelperContent.AppendHtml(copiedTagHelperContent);
             tagHelperContent.Append(string.Empty);
 
             // Assert
@@ -372,7 +372,7 @@ namespace Microsoft.AspNet.Razor.TagHelpers
             copiedTagHelperContent.SetContent("Hello");
 
             // Act
-            tagHelperContent.Append(copiedTagHelperContent);
+            tagHelperContent.AppendHtml(copiedTagHelperContent);
 
             // Assert
             Assert.False(tagHelperContent.IsEmpty);


### PR DESCRIPTION
…rContent.AppendHtml(IHtmlContent)`

Fixes #634