### PR TITLE
Change string rendering to be chunked.

### DIFF
--- a/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpCodeWriter.cs
+++ b/src/Microsoft.AspNet.Razor/CodeGenerators/CSharpCodeWriter.cs
@@ -498,23 +498,6 @@ namespace Microsoft.AspNet.Razor.CodeGenerators
                         Write(literal[i].ToString());
                         break;
                 }
-                if (i > 0 && i % 80 == 0)
-                {
-                    // If current character is a high surrogate and the following
-                    // character is a low surrogate, don't break them.
-                    // Otherwise when we write the string to a file, we might lose
-                    // the characters.
-                    if (Char.IsHighSurrogate(literal[i])
-                        && (i < literal.Length - 1)
-                        && Char.IsLowSurrogate(literal[i + 1]))
-                    {
-                        Write(literal[++i].ToString());
-                    }
-
-                    Write("\" +");
-                    Write(NewLine);
-                    Write("\"");
-                }
             }
             Write("\"");
         }

--- a/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpRazorChunkGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/CodeGenerators/CSharpRazorChunkGeneratorTest.cs
@@ -52,6 +52,7 @@ namespace Microsoft.AspNet.Razor.Test.Generator
         }
 
         [Theory]
+        [InlineData("StringLiterals")]
         [InlineData("NestedCSharp")]
         [InlineData("NullConditionalExpressions")]
         [InlineData("NestedCodeBlocks")]

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Await.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/Await.cs
@@ -24,8 +24,7 @@ namespace TestOutput
         public override async Task ExecuteAsync()
         {
             Instrumentation.BeginContext(91, 100, true);
-            WriteLiteral("\r\n<section>\r\n    <h1>Basic Asynchronous Expression Test</h1>\r\n    <p>Basic Asynch" +
-"ronous Expression: ");
+            WriteLiteral("\r\n<section>\r\n    <h1>Basic Asynchronous Expression Test</h1>\r\n    <p>Basic Asynchronous Expression: ");
             Instrumentation.EndContext();
             Instrumentation.BeginContext(192, 11, false);
 #line 10 "Await.cshtml"
@@ -83,8 +82,7 @@ namespace TestOutput
 #line hidden
             Instrumentation.EndContext();
             Instrumentation.BeginContext(453, 124, true);
-            WriteLiteral("</p>\r\n</section>\r\n\r\n<section>\r\n    <h1>Advanced Asynchronous Expression Test</h1>" +
-"\r\n    <p>Advanced Asynchronous Expression: ");
+            WriteLiteral("</p>\r\n</section>\r\n\r\n<section>\r\n    <h1>Advanced Asynchronous Expression Test</h1>\r\n    <p>Advanced Asynchronous Expression: ");
             Instrumentation.EndContext();
             Instrumentation.BeginContext(578, 15, false);
 #line 19 "Await.cshtml"

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.RemoveTagHelper.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.RemoveTagHelper.cs
@@ -15,9 +15,7 @@ namespace TestOutput
         public override async Task ExecuteAsync()
         {
             Instrumentation.BeginContext(70, 187, true);
-            WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    <p class=\"Hello World\">\r\n       " +
-" <p></p>\r\n        <input type=\"text\" />\r\n        <input type=\"checkbox\" checked=" +
-"\"true\"/>\r\n    </p>\r\n</div>");
+            WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    <p class=\"Hello World\">\r\n        <p></p>\r\n        <input type=\"text\" />\r\n        <input type=\"checkbox\" checked=\"true\"/>\r\n    </p>\r\n</div>");
             Instrumentation.EndContext();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ConditionalAttributes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/ConditionalAttributes.cs
@@ -123,8 +123,7 @@ WriteAttributeValue("", 426, Url.Content("~/Scripts/modernizr-2.0.6-development-
 #line hidden
             EndWriteAttribute();
             Instrumentation.BeginContext(488, 152, true);
-            WriteLiteral(" type=\"text/javascript\"></script>\r\n    <script src=\"http://ajax.aspnetcdn.com/aja" +
-"x/jquery.ui/1.8.16/jquery-ui.min.js\" type=\"text/javascript\"></script>\r\n");
+            WriteLiteral(" type=\"text/javascript\"></script>\r\n    <script src=\"http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.16/jquery-ui.min.js\" type=\"text/javascript\"></script>\r\n");
             Instrumentation.EndContext();
 #line 15 "ConditionalAttributes.cshtml"
 

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
@@ -26,8 +26,7 @@ namespace TestOutput
         {
             __tagHelperRunner = __tagHelperRunner ?? new global::Microsoft.AspNet.Razor.Runtime.TagHelperRunner();
             Instrumentation.BeginContext(31, 106, true);
-            WriteLiteral("\r\n<script type=\"text/html\">\r\n    <div data-animation=\"fade\" class=\"randomNonTagHe" +
-"lperAttribute\">\r\n        ");
+            WriteLiteral("\r\n<script type=\"text/html\">\r\n    <div data-animation=\"fade\" class=\"randomNonTagHelperAttribute\">\r\n        ");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNet.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 Instrumentation.BeginContext(178, 2, true);
@@ -46,8 +45,7 @@ namespace TestOutput
 #line hidden
 
                 Instrumentation.BeginContext(223, 84, true);
-                WriteLiteral("                <script id=\"nestedScriptTag\" type=\"text/html\">\r\n                 " +
-"   ");
+                WriteLiteral("                <script id=\"nestedScriptTag\" type=\"text/html\">\r\n                    ");
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNet.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
                 }
@@ -90,8 +88,7 @@ namespace TestOutput
 #line hidden
 
                 Instrumentation.BeginContext(437, 129, true);
-                WriteLiteral("            <script type=\"text/javascript\">\r\n                var tag = \'<input ch" +
-"ecked=\"true\">\';\r\n            </script>\r\n        ");
+                WriteLiteral("            <script type=\"text/javascript\">\r\n                var tag = \'<input checked=\"true\">\';\r\n            </script>\r\n        ");
                 Instrumentation.EndContext();
             }
             , StartTagHelperWritingScope, EndTagHelperWritingScope);

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/StringLiterals.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/StringLiterals.cs
@@ -1,0 +1,279 @@
+#pragma checksum "StringLiterals.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "3c21118a6113e76e4f71d17e3ae081f13d451427"
+namespace TestOutput
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public class StringLiterals
+    {
+        #line hidden
+        public StringLiterals()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            Instrumentation.BeginContext(0, 2013, true);
+            WriteLiteral(@"<p>This is line 1</p>
+<p>This is line 2</p>
+<p>This is line 3</p>
+<p>This is line 4</p>
+<p>This is line 5</p>
+<p>This is line 6</p>
+<p>This is line 7</p>
+<p>This is line 8</p>
+<p>This is line 9</p>
+<p>This is line 10</p>
+<p>This is line 11</p>
+<p>This is line 12</p>
+<p>This is line 13</p>
+<p>This is line 14</p>
+<p>This is line 15</p>
+<p>This is line 16</p>
+<p>This is line 17</p>
+<p>This is line 18</p>
+<p>This is line 19</p>
+<p>This is line 20</p>
+<p>This is line 21</p>
+<p>This is line 22</p>
+<p>This is line 23</p>
+<p>This is line 24</p>
+<p>This is line 25</p>
+<p>This is line 26</p>
+<p>This is line 27</p>
+<p>This is line 28</p>
+<p>This is line 29</p>
+<p>This is line 30</p>
+<p>This is line 31</p>
+<p>This is line 32</p>
+<p>This is line 33</p>
+<p>This is line 34</p>
+<p>This is line 35</p>
+<p>This is line 36</p>
+<p>This is line 37</p>
+<p>This is line 38</p>
+<p>This is line 39</p>
+<p>This is line 40</p>
+<p>This is line 41</p>
+<p>This is line 42</p>
+<p>This is line 43</p>
+<");
+            WriteLiteral(@"p>This is line 44</p>
+<p>This is line 45</p>
+<p>This is line 46</p>
+<p>This is line 47</p>
+<p>This is line 48</p>
+<p>This is line 49</p>
+<p>This is line 50</p>
+<p>This is line 51</p>
+<p>This is line 52</p>
+<p>This is line 53</p>
+<p>This is line 54</p>
+<p>This is line 55</p>
+<p>This is line 56</p>
+<p>This is line 57</p>
+<p>This is line 58</p>
+<p>This is line 59</p>
+<p>This is line 60</p>
+<p>This is line 61</p>
+<p>This is line 62</p>
+<p>This is line 63</p>
+<p>This is line 64</p>
+<p>This is line 65</p>
+<p>This is line 66</p>
+<p>This is line 67</p>
+<p>This is line 68</p>
+<p>This is line 69</p>
+<p>This is line 70</p>
+<p>This is line 71</p>
+<p>This is line 72</p>
+<p>This is line 73</p>
+<p>This is line 74</p>
+<p>This is line 75</p>
+<p>This is line 76</p>
+<p>This is line 77</p>
+<p>This is line 78</p>
+<p>This is line 79</p>
+<p>This is line 80</p>
+<p>This is line 81</p>
+<p>This is line 82</p>
+<p>This is line 83</p>
+<p>This is line 84</p><br>
+
+");
+            Instrumentation.EndContext();
+            DefineSection("WriteLiteralsToInHere", async(__razor_template_writer) => {
+                Instrumentation.BeginContext(2045, 2618, true);
+                WriteLiteralTo(__razor_template_writer, @"
+    <p>This is line 1 nested</p>
+    <p>This is line 2 nested</p>
+    <p>This is line 3 nested</p>
+    <p>This is line 4 nested</p>
+    <p>This is line 5 nested</p>
+    <p>This is line 6 nested</p>
+    <p>This is line 7 nested</p>
+    <p>This is line 8 nested</p>
+    <p>This is line 9 nested</p>
+    <p>This is line 10 nested</p>
+    <p>This is line 11 nested</p>
+    <p>This is line 12 nested</p>
+    <p>This is line 13 nested</p>
+    <p>This is line 14 nested</p>
+    <p>This is line 15 nested</p>
+    <p>This is line 16 nested</p>
+    <p>This is line 17 nested</p>
+    <p>This is line 18 nested</p>
+    <p>This is line 19 nested</p>
+    <p>This is line 20 nested</p>
+    <p>This is line 21 nested</p>
+    <p>This is line 22 nested</p>
+    <p>This is line 23 nested</p>
+    <p>This is line 24 nested</p>
+    <p>This is line 25 nested</p>
+    <p>This is line 26 nested</p>
+    <p>This is line 27 nested</p>
+    <p>This is line 28 nested</p>
+    <p>This is line 29 nested</p>
+    <p>This is l");
+                WriteLiteralTo(__razor_template_writer, @"ine 30 nested</p>
+    <p>This is line 31 nested</p>
+    <p>This is line 32 nested</p>
+    <p>This is line 33 nested</p>
+    <p>This is line 34 nested</p>
+    <p>This is line 35 nested</p>
+    <p>This is line 36 nested</p>
+    <p>This is line 37 nested</p>
+    <p>This is line 38 nested</p>
+    <p>This is line 39 nested</p>
+    <p>This is line 40 nested</p>
+    <p>This is line 41 nested</p>
+    <p>This is line 42 nested</p>
+    <p>This is line 43 nested</p>
+    <p>This is line 44 nested</p>
+    <p>This is line 45 nested</p>
+    <p>This is line 46 nested</p>
+    <p>This is line 47 nested</p>
+    <p>This is line 48 nested</p>
+    <p>This is line 49 nested</p>
+    <p>This is line 50 nested</p>
+    <p>This is line 51 nested</p>
+    <p>This is line 52 nested</p>
+    <p>This is line 53 nested</p>
+    <p>This is line 54 nested</p>
+    <p>This is line 55 nested</p>
+    <p>This is line 56 nested</p>
+    <p>This is line 57 nested</p>
+    <p>This is line 58 nested</p>
+    <p>This is line 59 ne");
+                WriteLiteralTo(__razor_template_writer, @"sted</p>
+    <p>This is line 60 nested</p>
+    <p>This is line 61 nested</p>
+    <p>This is line 62 nested</p>
+    <p>This is line 63 nested</p>
+    <p>This is line 64 nested</p>
+    <p>This is line 65 nested</p>
+    <p>This is line 66 nested</p>
+    <p>This is line 67 nested</p>
+    <p>This is line 68 nested</p>
+    <p>This is line 69 nested</p>
+    <p>This is line 70 nested</p>
+    <p>This is line 71 nested</p>
+    <p>This is line 72 nested</p>
+    <p>This is line 73 nested</p>
+    <p>This is line 74 nested</p>
+    <p>This is line 75 nested</p>
+");
+                Instrumentation.EndContext();
+            }
+            );
+            Instrumentation.BeginContext(4666, 1026, true);
+            WriteLiteral(@"<p>This is line 1</p>
+<p>This is line 2</p>
+<p>This is line 3</p>
+<p>This is line 4</p>
+<p>This is line 5</p>
+<p>This is line 6</p>
+<p>This is line 7</p>
+<p>This is line 8</p>
+<p>This is line 9</p>
+<p>This is line 10</p>
+<p>This is line 11</p>
+<p>This is line 12</p>
+<p>This is line 13</p>
+<p>This is line 14</p>
+<p>This is line 15</p>
+<p>This is line 16</p>
+<p>This is line 17</p>
+<p>This is line 18</p>
+<p>This is line 19</p>
+<p>This is line 20</p>
+<p>This is line 21</p>
+<p>This is line 22</p>
+<p>This is line 23</p>
+<p>This is line 24</p>
+<p>This is line 25</p>
+<p>This is line 26</p>
+<p>This is line 27</p>
+<p>This is line 28</p>
+<p>This is line 29</p>
+<p>This is line 30</p>
+<p>This is line 31</p>
+<p>This is line 32</p>
+<p>This is line 33</p>
+<p>This is line 34</p>
+<p>This is line 35</p>
+<p>This is line 36</p>
+<p>This is line 37</p>
+<p>This is line 38</p>
+<p>This is line 39</p>
+<p>This is line 40</p>
+<p>This is line 41</p>
+<p>This is line 42</p>
+<p>This is line 43</p>hi!");
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            DefineSection("WriteLiteralsToInHereAlso", async(__razor_template_writer) => {
+                Instrumentation.BeginContext(5728, 1023, true);
+                WriteLiteralTo(__razor_template_writer, @"
+    <p>This is line 1 nested</p>
+    <p>This is line 2 nested</p>
+    <p>This is line 3 nested</p>
+    <p>This is line 4 nested</p>
+    <p>This is line 5 nested</p>
+    <p>This is line 6 nested</p>
+    <p>This is line 7 nested</p>
+    <p>This is line 8 nested</p>
+    <p>This is line 9 nested</p>
+    <p>This is line 10 nested</p>
+    <p>This is line 11 nested</p>
+    <p>This is line 12 nested</p>
+    <p>This is line 13 nested</p>
+    <p>This is line 14 nested</p>
+    <p>This is line 15 nested</p>
+    <p>This is line 16 nested</p>
+    <p>This is line 17 nested</p>
+    <p>This is line 18 nested</p>
+    <p>This is line 19 nested</p>
+    <p>This is line 20 nested</p>
+    <p>This is line 21 nested</p>
+    <p>This is line 22 nested</p>
+    <p>This is line 23 nested</p>
+    <p>This is line 24 nested</p>
+    <p>This is line 25 nested</p>
+    <p>This is line 26 nested</p>
+    <p>This is line 27 nested</p>
+    <p>This is line 28 nested</p>
+    <p>This is line 29 nested</p>
+    <p>30</p>
+");
+                Instrumentation.EndContext();
+            }
+            );
+            Instrumentation.BeginContext(6752, 1, true);
+            WriteLiteral("!");
+            Instrumentation.EndContext();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
@@ -24,10 +24,7 @@ namespace TestOutput
         {
             __tagHelperRunner = __tagHelperRunner ?? new global::Microsoft.AspNet.Razor.Runtime.TagHelperRunner();
             Instrumentation.BeginContext(23, 253, true);
-            WriteLiteral("\r\n<ul [item]=\"items\"></ul>\r\n<ul [(item)]=\"items\"></ul>\r\n<button (click)=\"doSometh" +
-"ing()\">Click Me</button>\r\n<button (^click)=\"doSomething()\">Click Me</button>\r\n<t" +
-"emplate *something=\"value\">\r\n</template>\r\n<div #local></div>\r\n<div #local=\"value" +
-"\"></div>\r\n\r\n");
+            WriteLiteral("\r\n<ul [item]=\"items\"></ul>\r\n<ul [(item)]=\"items\"></ul>\r\n<button (click)=\"doSomething()\">Click Me</button>\r\n<button (^click)=\"doSomething()\">Click Me</button>\r\n<template *something=\"value\">\r\n</template>\r\n<div #local></div>\r\n<div #local=\"value\"></div>\r\n\r\n");
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("ul", global::Microsoft.AspNet.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }

--- a/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Source/StringLiterals.cshtml
+++ b/test/Microsoft.AspNet.Razor.Test/TestFiles/CodeGenerator/Source/StringLiterals.cshtml
@@ -1,0 +1,237 @@
+﻿<p>This is line 1</p>
+<p>This is line 2</p>
+<p>This is line 3</p>
+<p>This is line 4</p>
+<p>This is line 5</p>
+<p>This is line 6</p>
+<p>This is line 7</p>
+<p>This is line 8</p>
+<p>This is line 9</p>
+<p>This is line 10</p>
+<p>This is line 11</p>
+<p>This is line 12</p>
+<p>This is line 13</p>
+<p>This is line 14</p>
+<p>This is line 15</p>
+<p>This is line 16</p>
+<p>This is line 17</p>
+<p>This is line 18</p>
+<p>This is line 19</p>
+<p>This is line 20</p>
+<p>This is line 21</p>
+<p>This is line 22</p>
+<p>This is line 23</p>
+<p>This is line 24</p>
+<p>This is line 25</p>
+<p>This is line 26</p>
+<p>This is line 27</p>
+<p>This is line 28</p>
+<p>This is line 29</p>
+<p>This is line 30</p>
+<p>This is line 31</p>
+<p>This is line 32</p>
+<p>This is line 33</p>
+<p>This is line 34</p>
+<p>This is line 35</p>
+<p>This is line 36</p>
+<p>This is line 37</p>
+<p>This is line 38</p>
+<p>This is line 39</p>
+<p>This is line 40</p>
+<p>This is line 41</p>
+<p>This is line 42</p>
+<p>This is line 43</p>
+<p>This is line 44</p>
+<p>This is line 45</p>
+<p>This is line 46</p>
+<p>This is line 47</p>
+<p>This is line 48</p>
+<p>This is line 49</p>
+<p>This is line 50</p>
+<p>This is line 51</p>
+<p>This is line 52</p>
+<p>This is line 53</p>
+<p>This is line 54</p>
+<p>This is line 55</p>
+<p>This is line 56</p>
+<p>This is line 57</p>
+<p>This is line 58</p>
+<p>This is line 59</p>
+<p>This is line 60</p>
+<p>This is line 61</p>
+<p>This is line 62</p>
+<p>This is line 63</p>
+<p>This is line 64</p>
+<p>This is line 65</p>
+<p>This is line 66</p>
+<p>This is line 67</p>
+<p>This is line 68</p>
+<p>This is line 69</p>
+<p>This is line 70</p>
+<p>This is line 71</p>
+<p>This is line 72</p>
+<p>This is line 73</p>
+<p>This is line 74</p>
+<p>This is line 75</p>
+<p>This is line 76</p>
+<p>This is line 77</p>
+<p>This is line 78</p>
+<p>This is line 79</p>
+<p>This is line 80</p>
+<p>This is line 81</p>
+<p>This is line 82</p>
+<p>This is line 83</p>
+<p>This is line 84</p><br>
+
+@section WriteLiteralsToInHere {
+    <p>This is line 1 nested</p>
+    <p>This is line 2 nested</p>
+    <p>This is line 3 nested</p>
+    <p>This is line 4 nested</p>
+    <p>This is line 5 nested</p>
+    <p>This is line 6 nested</p>
+    <p>This is line 7 nested</p>
+    <p>This is line 8 nested</p>
+    <p>This is line 9 nested</p>
+    <p>This is line 10 nested</p>
+    <p>This is line 11 nested</p>
+    <p>This is line 12 nested</p>
+    <p>This is line 13 nested</p>
+    <p>This is line 14 nested</p>
+    <p>This is line 15 nested</p>
+    <p>This is line 16 nested</p>
+    <p>This is line 17 nested</p>
+    <p>This is line 18 nested</p>
+    <p>This is line 19 nested</p>
+    <p>This is line 20 nested</p>
+    <p>This is line 21 nested</p>
+    <p>This is line 22 nested</p>
+    <p>This is line 23 nested</p>
+    <p>This is line 24 nested</p>
+    <p>This is line 25 nested</p>
+    <p>This is line 26 nested</p>
+    <p>This is line 27 nested</p>
+    <p>This is line 28 nested</p>
+    <p>This is line 29 nested</p>
+    <p>This is line 30 nested</p>
+    <p>This is line 31 nested</p>
+    <p>This is line 32 nested</p>
+    <p>This is line 33 nested</p>
+    <p>This is line 34 nested</p>
+    <p>This is line 35 nested</p>
+    <p>This is line 36 nested</p>
+    <p>This is line 37 nested</p>
+    <p>This is line 38 nested</p>
+    <p>This is line 39 nested</p>
+    <p>This is line 40 nested</p>
+    <p>This is line 41 nested</p>
+    <p>This is line 42 nested</p>
+    <p>This is line 43 nested</p>
+    <p>This is line 44 nested</p>
+    <p>This is line 45 nested</p>
+    <p>This is line 46 nested</p>
+    <p>This is line 47 nested</p>
+    <p>This is line 48 nested</p>
+    <p>This is line 49 nested</p>
+    <p>This is line 50 nested</p>
+    <p>This is line 51 nested</p>
+    <p>This is line 52 nested</p>
+    <p>This is line 53 nested</p>
+    <p>This is line 54 nested</p>
+    <p>This is line 55 nested</p>
+    <p>This is line 56 nested</p>
+    <p>This is line 57 nested</p>
+    <p>This is line 58 nested</p>
+    <p>This is line 59 nested</p>
+    <p>This is line 60 nested</p>
+    <p>This is line 61 nested</p>
+    <p>This is line 62 nested</p>
+    <p>This is line 63 nested</p>
+    <p>This is line 64 nested</p>
+    <p>This is line 65 nested</p>
+    <p>This is line 66 nested</p>
+    <p>This is line 67 nested</p>
+    <p>This is line 68 nested</p>
+    <p>This is line 69 nested</p>
+    <p>This is line 70 nested</p>
+    <p>This is line 71 nested</p>
+    <p>This is line 72 nested</p>
+    <p>This is line 73 nested</p>
+    <p>This is line 74 nested</p>
+    <p>This is line 75 nested</p>
+}
+<p>This is line 1</p>
+<p>This is line 2</p>
+<p>This is line 3</p>
+<p>This is line 4</p>
+<p>This is line 5</p>
+<p>This is line 6</p>
+<p>This is line 7</p>
+<p>This is line 8</p>
+<p>This is line 9</p>
+<p>This is line 10</p>
+<p>This is line 11</p>
+<p>This is line 12</p>
+<p>This is line 13</p>
+<p>This is line 14</p>
+<p>This is line 15</p>
+<p>This is line 16</p>
+<p>This is line 17</p>
+<p>This is line 18</p>
+<p>This is line 19</p>
+<p>This is line 20</p>
+<p>This is line 21</p>
+<p>This is line 22</p>
+<p>This is line 23</p>
+<p>This is line 24</p>
+<p>This is line 25</p>
+<p>This is line 26</p>
+<p>This is line 27</p>
+<p>This is line 28</p>
+<p>This is line 29</p>
+<p>This is line 30</p>
+<p>This is line 31</p>
+<p>This is line 32</p>
+<p>This is line 33</p>
+<p>This is line 34</p>
+<p>This is line 35</p>
+<p>This is line 36</p>
+<p>This is line 37</p>
+<p>This is line 38</p>
+<p>This is line 39</p>
+<p>This is line 40</p>
+<p>This is line 41</p>
+<p>This is line 42</p>
+<p>This is line 43</p>hi!
+@section WriteLiteralsToInHereAlso {
+    <p>This is line 1 nested</p>
+    <p>This is line 2 nested</p>
+    <p>This is line 3 nested</p>
+    <p>This is line 4 nested</p>
+    <p>This is line 5 nested</p>
+    <p>This is line 6 nested</p>
+    <p>This is line 7 nested</p>
+    <p>This is line 8 nested</p>
+    <p>This is line 9 nested</p>
+    <p>This is line 10 nested</p>
+    <p>This is line 11 nested</p>
+    <p>This is line 12 nested</p>
+    <p>This is line 13 nested</p>
+    <p>This is line 14 nested</p>
+    <p>This is line 15 nested</p>
+    <p>This is line 16 nested</p>
+    <p>This is line 17 nested</p>
+    <p>This is line 18 nested</p>
+    <p>This is line 19 nested</p>
+    <p>This is line 20 nested</p>
+    <p>This is line 21 nested</p>
+    <p>This is line 22 nested</p>
+    <p>This is line 23 nested</p>
+    <p>This is line 24 nested</p>
+    <p>This is line 25 nested</p>
+    <p>This is line 26 nested</p>
+    <p>This is line 27 nested</p>
+    <p>This is line 28 nested</p>
+    <p>This is line 29 nested</p>
+    <p>30</p>
+}!


### PR DESCRIPTION
- Roslyn currently has an issue where too large of strings result in out of memory exceptions at compile time. To combat this I broke down literal strings into 1k pieces each resulting in their own `WriteLiteral`/`WriteLiteralTo` calls.
- Added tests to validate large string rendering.

#614