### PR TITLE
Remove boxing of symbol types.

### DIFF
--- a/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/CSharpCodeParser.cs
@@ -62,6 +62,8 @@ namespace Microsoft.AspNet.Razor.Parser
             get { return CSharpLanguageCharacteristics.Instance; }
         }
 
+        protected override bool SymbolTypeEquals(CSharpSymbolType x, CSharpSymbolType y) => x == y;
+
         protected void MapDirectives(Action handler, params string[] directives)
         {
             foreach (string directive in directives)

--- a/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.Document.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.Document.cs
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.Razor.Parser
                     // Whitespace here is invalid (according to the spec)
                     OptionalBangEscape();
                     Optional(HtmlSymbolType.Text);
-                    AcceptAll(HtmlSymbolType.WhiteSpace);
+                    Optional(HtmlSymbolType.WhiteSpace);
                     Optional(HtmlSymbolType.CloseAngle);
                 }
 

--- a/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/HtmlMarkupParser.cs
@@ -48,6 +48,8 @@ namespace Microsoft.AspNet.Razor.Parser
             get { return HtmlLanguageCharacteristics.Instance; }
         }
 
+        protected override bool SymbolTypeEquals(HtmlSymbolType x, HtmlSymbolType y) => x == y;
+
         public override void BuildSpan(SpanBuilder span, SourceLocation start, string content)
         {
             span.Kind = SpanKind.Markup;

--- a/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.Helpers.cs
+++ b/src/Microsoft.AspNet.Razor/Parser/TokenizerBackedParser.Helpers.cs
@@ -23,8 +23,10 @@ namespace Microsoft.AspNet.Razor.Parser
         [Conditional("DEBUG")]
         internal void Assert(TSymbolType expectedType)
         {
-            Debug.Assert(!EndOfFile && Equals(CurrentSymbol.Type, expectedType));
+            Debug.Assert(!EndOfFile && SymbolTypeEquals(CurrentSymbol.Type, expectedType));
         }
+
+        abstract protected bool SymbolTypeEquals(TSymbolType x, TSymbolType y);
 
         protected internal void PutBack(TSymbol symbol)
         {
@@ -147,12 +149,12 @@ namespace Microsoft.AspNet.Razor.Parser
 
         protected internal bool NextIs(TSymbolType type)
         {
-            return NextIs(sym => sym != null && Equals(type, sym.Type));
+            return NextIs(sym => sym != null && SymbolTypeEquals(type, sym.Type));
         }
 
         protected internal bool NextIs(params TSymbolType[] types)
         {
-            return NextIs(sym => sym != null && types.Any(t => Equals(t, sym.Type)));
+            return NextIs(sym => sym != null && types.Any(t => SymbolTypeEquals(t, sym.Type)));
         }
 
         protected internal bool NextIs(Func<TSymbol, bool> condition)
@@ -168,12 +170,12 @@ namespace Microsoft.AspNet.Razor.Parser
 
         protected internal bool Was(TSymbolType type)
         {
-            return PreviousSymbol != null && Equals(PreviousSymbol.Type, type);
+            return PreviousSymbol != null && SymbolTypeEquals(PreviousSymbol.Type, type);
         }
 
         protected internal bool At(TSymbolType type)
         {
-            return !EndOfFile && CurrentSymbol != null && Equals(CurrentSymbol.Type, type);
+            return !EndOfFile && CurrentSymbol != null && SymbolTypeEquals(CurrentSymbol.Type, type);
         }
 
         protected internal bool AcceptAndMoveNext()
@@ -219,7 +221,7 @@ namespace Microsoft.AspNet.Razor.Parser
         {
             foreach (TSymbolType type in types)
             {
-                if (CurrentSymbol == null || !Equals(CurrentSymbol.Type, type))
+                if (CurrentSymbol == null || !SymbolTypeEquals(CurrentSymbol.Type, type))
                 {
                     return false;
                 }
@@ -380,44 +382,44 @@ namespace Microsoft.AspNet.Razor.Parser
 
         protected internal void AcceptWhile(TSymbolType type)
         {
-            AcceptWhile(sym => Equals(type, sym.Type));
+            AcceptWhile(sym => SymbolTypeEquals(type, sym.Type));
         }
 
         // We want to avoid array allocations and enumeration where possible, so we use the same technique as string.Format
         protected internal void AcceptWhile(TSymbolType type1, TSymbolType type2)
         {
-            AcceptWhile(sym => Equals(type1, sym.Type) || Equals(type2, sym.Type));
+            AcceptWhile(sym => SymbolTypeEquals(type1, sym.Type) || SymbolTypeEquals(type2, sym.Type));
         }
 
         protected internal void AcceptWhile(TSymbolType type1, TSymbolType type2, TSymbolType type3)
         {
-            AcceptWhile(sym => Equals(type1, sym.Type) || Equals(type2, sym.Type) || Equals(type3, sym.Type));
+            AcceptWhile(sym => SymbolTypeEquals(type1, sym.Type) || SymbolTypeEquals(type2, sym.Type) || SymbolTypeEquals(type3, sym.Type));
         }
 
         protected internal void AcceptWhile(params TSymbolType[] types)
         {
-            AcceptWhile(sym => types.Any(expected => Equals(expected, sym.Type)));
+            AcceptWhile(sym => types.Any(expected => SymbolTypeEquals(expected, sym.Type)));
         }
 
         protected internal void AcceptUntil(TSymbolType type)
         {
-            AcceptWhile(sym => !Equals(type, sym.Type));
+            AcceptWhile(sym => !SymbolTypeEquals(type, sym.Type));
         }
 
         // We want to avoid array allocations and enumeration where possible, so we use the same technique as string.Format
         protected internal void AcceptUntil(TSymbolType type1, TSymbolType type2)
         {
-            AcceptWhile(sym => !Equals(type1, sym.Type) && !Equals(type2, sym.Type));
+            AcceptWhile(sym => !SymbolTypeEquals(type1, sym.Type) && !SymbolTypeEquals(type2, sym.Type));
         }
 
         protected internal void AcceptUntil(TSymbolType type1, TSymbolType type2, TSymbolType type3)
         {
-            AcceptWhile(sym => !Equals(type1, sym.Type) && !Equals(type2, sym.Type) && !Equals(type3, sym.Type));
+            AcceptWhile(sym => !SymbolTypeEquals(type1, sym.Type) && !SymbolTypeEquals(type2, sym.Type) && !SymbolTypeEquals(type3, sym.Type));
         }
 
         protected internal void AcceptUntil(params TSymbolType[] types)
         {
-            AcceptWhile(sym => types.All(expected => !Equals(expected, sym.Type)));
+            AcceptWhile(sym => types.All(expected => !SymbolTypeEquals(expected, sym.Type)));
         }
 
         protected internal void AcceptWhile(Func<TSymbol, bool> condition)


### PR DESCRIPTION
- The Equals operators were boxing the symbol types like crazy, added an abstract `SymbolTypeEquals` to avoid this.

**Before:**
![image](https://cloud.githubusercontent.com/assets/2008729/12342720/114298f8-bae2-11e5-8d4a-2fe69eb07492.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/2008729/12342728/23d2cc04-bae2-11e5-9813-f4a723a0f219.png)


#635