### PR TITLE
Remove allocations from lookahead

### DIFF
--- a/src/Microsoft.AspNet.Razor/Text/LookaheadToken.cs
+++ b/src/Microsoft.AspNet.Razor/Text/LookaheadToken.cs
@@ -5,14 +5,19 @@ using System;
 
 namespace Microsoft.AspNet.Razor.Text
 {
-    public class LookaheadToken : IDisposable
+    public struct LookaheadToken : IDisposable
     {
-        private Action _cancelAction;
+        private readonly ITextBuffer _buffer;
+        private readonly int _position;
+
         private bool _accepted;
 
-        public LookaheadToken(Action cancelAction)
+        public LookaheadToken(ITextBuffer buffer)
         {
-            _cancelAction = cancelAction;
+            _buffer = buffer;
+            _position = buffer.Position;
+
+            _accepted = false;
         }
 
         public void Accept()
@@ -22,15 +27,9 @@ namespace Microsoft.AspNet.Razor.Text
 
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
             if (!_accepted)
             {
-                _cancelAction();
+                _buffer.Position = _position;
             }
         }
     }

--- a/src/Microsoft.AspNet.Razor/Text/TextExtensions.cs
+++ b/src/Microsoft.AspNet.Razor/Text/TextExtensions.cs
@@ -25,10 +25,7 @@ namespace Microsoft.AspNet.Razor.Text
         public static LookaheadToken BeginLookahead(this ITextBuffer self)
         {
             var start = self.Position;
-            return new LookaheadToken(() =>
-            {
-                self.Position = start;
-            });
+            return new LookaheadToken(self);
         }
 
         public static string ReadToEnd(this ITextBuffer self)

--- a/src/Microsoft.AspNet.Razor/Tokenizer/Tokenizer.cs
+++ b/src/Microsoft.AspNet.Razor/Tokenizer/Tokenizer.cs
@@ -165,7 +165,7 @@ namespace Microsoft.AspNet.Razor.Tokenizer
 
         protected char Peek()
         {
-            using (LookaheadToken lookahead = Source.BeginLookahead())
+            using (var lookahead = Source.BeginLookahead())
             {
                 MoveNext();
                 return CurrentCharacter;
@@ -250,7 +250,7 @@ namespace Microsoft.AspNet.Razor.Tokenizer
                 oldBuffer = Buffer.ToString();
             }
 
-            using (LookaheadToken lookahead = Source.BeginLookahead())
+            using (var lookahead = Source.BeginLookahead())
             {
                 for (int i = 0; i < expected.Length; i++)
                 {

--- a/test/Microsoft.AspNet.Razor.Test/Tokenizer/TokenizerLookaheadTest.cs
+++ b/test/Microsoft.AspNet.Razor.Test/Tokenizer/TokenizerLookaheadTest.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.Razor.Test.Tokenizer
         public void After_Accepting_Lookahead_Tokenizer_Returns_Next_Token()
         {
             var tokenizer = new HtmlTokenizer(new SeekableTextReader(new StringReader("<foo>")));
-            using (LookaheadToken lookahead = tokenizer.Source.BeginLookahead())
+            using (var lookahead = tokenizer.Source.BeginLookahead())
             {
                 Assert.Equal(new HtmlSymbol(0, 0, 0, "<", HtmlSymbolType.OpenAngle), tokenizer.NextSymbol());
                 Assert.Equal(new HtmlSymbol(1, 0, 1, "foo", HtmlSymbolType.Text), tokenizer.NextSymbol());


### PR DESCRIPTION
This makes lookahead allocation-free, saving about 15MB in our current
benchmark.