### PR TITLE
Expose `IsTagHelper` as an extensibility point.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperTypeResolver.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperTypeResolver.cs
@@ -83,9 +83,19 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             return assembly.ExportedTypes.Select(type => type.GetTypeInfo());
         }
 
-        // Internal for testing.
-        internal virtual bool IsTagHelper(TypeInfo typeInfo)
+        /// <summary>
+        /// Indicates if a <see cref="TypeInfo"/> should be treated as a tag helper.
+        /// </summary>
+        /// <param name="typeInfo">The <see cref="TypeInfo"/> to inspect.</param>
+        /// <returns><c>true</c> if <paramref name="typeInfo"/> should be treated as a tag helper; 
+        /// <c>false</c> otherwise</returns>
+        protected virtual bool IsTagHelper(TypeInfo typeInfo)
         {
+            if (typeInfo == null)
+            {
+                throw new ArgumentNullException(nameof(typeInfo));
+            }
+
             return
                 !typeInfo.IsNested &&
                 typeInfo.IsPublic &&


### PR DESCRIPTION
- This is required for the Razor tooling that determines `TagHelperDescriptor`s. 

Reason: In tooling you create an assembly load context that's based on a users project. `Type`s that you load from that project are not equivalent to the types that exist in the tooling project. Due to this limitation the current `IsTagHelper` implementation doesn't work in the tooling scenario due to the `ITagHelperTypeInfo.IsAssignableFrom(typeInfo)` line which assumes types are equivalent.

https://github.com/aspnet/RazorTooling/issues/43