### PR TITLE
Lazily initialize `TagHelperAttributeList`s.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -214,9 +214,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             _allAttributes.Add(name, value);
         }
 
-        /// <summary>
-        /// Internal for testing.
-        /// </summary>
+        // Internal for testing.
         internal async Task<TagHelperContent> GetChildContentAsync(bool useCachedResult, HtmlEncoder encoder)
         {
             // Get cached content for this encoder.

--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -14,12 +14,17 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
     /// </summary>
     public class TagHelperExecutionContext
     {
+        private readonly string _tagName;
+        private readonly string _uniqueId;
+        private readonly TagMode _tagMode;
         private readonly List<ITagHelper> _tagHelpers;
         private readonly Func<Task> _executeChildContentAsync;
         private readonly Action<HtmlEncoder> _startTagHelperWritingScope;
         private readonly Func<TagHelperContent> _endTagHelperWritingScope;
         private TagHelperContent _childContent;
         private Dictionary<HtmlEncoder, TagHelperContent> _perEncoderChildContent;
+        private TagHelperAttributeList _htmlAttributes;
+        private TagHelperAttributeList _allAttributes;
 
         /// <summary>
         /// Internal for testing purposes only.
@@ -93,18 +98,11 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             _startTagHelperWritingScope = startTagHelperWritingScope;
             _endTagHelperWritingScope = endTagHelperWritingScope;
 
-            TagMode = tagMode;
-            HtmlAttributes = new TagHelperAttributeList();
-            AllAttributes = new TagHelperAttributeList();
-            TagName = tagName;
+            _tagMode = tagMode;
+            _tagName = tagName;
             Items = items;
-            UniqueId = uniqueId;
+            _uniqueId = uniqueId;
         }
-
-        /// <summary>
-        /// Gets the HTML syntax of the element in the Razor source.
-        /// </summary>
-        public TagMode TagMode { get; }
 
         /// <summary>
         /// Indicates if <see cref="GetChildContentAsync"/> has been called.
@@ -123,21 +121,6 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         public IDictionary<object, object> Items { get; }
 
         /// <summary>
-        /// HTML attributes.
-        /// </summary>
-        public TagHelperAttributeList HtmlAttributes { get; }
-
-        /// <summary>
-        /// <see cref="ITagHelper"/> bound attributes and HTML attributes.
-        /// </summary>
-        public TagHelperAttributeList AllAttributes { get; }
-
-        /// <summary>
-        /// An identifier unique to the HTML element this context is for.
-        /// </summary>
-        public string UniqueId { get; }
-
-        /// <summary>
         /// <see cref="ITagHelper"/>s that should be run.
         /// </summary>
         public IList<ITagHelper> TagHelpers
@@ -149,14 +132,17 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         }
 
         /// <summary>
-        /// The HTML tag name in the Razor source.
-        /// </summary>
-        public string TagName { get; }
-
-        /// <summary>
         /// The <see cref="ITagHelper"/>s' output.
         /// </summary>
         public TagHelperOutput Output { get; set; }
+
+        public TagHelperContext CreateTagHelperContext() =>
+            new TagHelperContext(_allAttributes, Items, _uniqueId);
+        public TagHelperOutput CreateTagHelperOutput() =>
+            new TagHelperOutput(_tagName, _htmlAttributes, GetChildContentAsync)
+            {
+                TagMode = _tagMode
+            };
 
         /// <summary>
         /// Tracks the given <paramref name="tagHelper"/>.
@@ -183,9 +169,12 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 throw new ArgumentNullException(nameof(name));
             }
 
+            EnsureHtmlAttributes();
+            EnsureAllAttributes();
+
             var attribute = new TagHelperAttribute(name);
-            HtmlAttributes.Add(attribute);
-            AllAttributes.Add(attribute);
+            _htmlAttributes.Add(attribute);
+            _allAttributes.Add(attribute);
         }
 
         /// <summary>
@@ -200,8 +189,12 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 throw new ArgumentNullException(nameof(name));
             }
 
-            HtmlAttributes.Add(name, value);
-            AllAttributes.Add(name, value);
+            EnsureHtmlAttributes();
+            EnsureAllAttributes();
+
+            var attribute = new TagHelperAttribute(name, value);
+            _htmlAttributes.Add(attribute);
+            _allAttributes.Add(attribute);
         }
 
         /// <summary>
@@ -216,24 +209,15 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 throw new ArgumentNullException(nameof(name));
             }
 
-            AllAttributes.Add(name, value);
+            EnsureAllAttributes();
+
+            _allAttributes.Add(name, value);
         }
 
         /// <summary>
-        /// Executes children asynchronously with the given <paramref name="encoder"/> in scope and returns their
-        /// rendered content.
+        /// Internal for testing.
         /// </summary>
-        /// <param name="useCachedResult">
-        /// If <c>true</c>, multiple calls with the same <see cref="HtmlEncoder"/> will not cause children to
-        /// re-execute; returns cached content.
-        /// </param>
-        /// <param name="encoder">
-        /// The <see cref="HtmlEncoder"/> to use when the page handles
-        /// non-<see cref="Microsoft.AspNetCore.Html.IHtmlContent"/> C# expressions. If <c>null</c>, executes children with
-        /// the page's current <see cref="HtmlEncoder"/>.
-        /// </param>
-        /// <returns>A <see cref="Task"/> that on completion returns the rendered child content.</returns>
-        public async Task<TagHelperContent> GetChildContentAsync(bool useCachedResult, HtmlEncoder encoder)
+        internal async Task<TagHelperContent> GetChildContentAsync(bool useCachedResult, HtmlEncoder encoder)
         {
             // Get cached content for this encoder.
             TagHelperContent childContent;
@@ -271,6 +255,22 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             }
 
             return new DefaultTagHelperContent().SetContent(childContent);
+        }
+
+        private void EnsureHtmlAttributes()
+        {
+            if (_htmlAttributes == null)
+            {
+                _htmlAttributes = new TagHelperAttributeList();
+            }
+        }
+
+        private void EnsureAllAttributes()
+        {
+            if (_allAttributes == null)
+            {
+                _allAttributes = new TagHelperAttributeList();
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperRunner.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperRunner.cs
@@ -27,10 +27,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 throw new ArgumentNullException(nameof(executionContext));
             }
 
-            var tagHelperContext = new TagHelperContext(
-                executionContext.AllAttributes,
-                executionContext.Items,
-                executionContext.UniqueId);
+            var tagHelperContext = executionContext.CreateTagHelperContext();
 
             OrderTagHelpers(executionContext.TagHelpers);
 
@@ -39,13 +36,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 executionContext.TagHelpers[i].Init(tagHelperContext);
             }
 
-            var tagHelperOutput = new TagHelperOutput(
-                executionContext.TagName,
-                executionContext.HtmlAttributes,
-                executionContext.GetChildContentAsync)
-            {
-                TagMode = executionContext.TagMode,
-            };
+            var tagHelperOutput = executionContext.CreateTagHelperOutput();
 
             for (var i = 0; i < executionContext.TagHelpers.Count; i++)
             {

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/ReadOnlyTagHelperAttributeList.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/ReadOnlyTagHelperAttributeList.cs
@@ -31,8 +31,8 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         /// <paramref name="attributes"/>.
         /// </summary>
         /// <param name="attributes">The collection to wrap.</param>
-        public ReadOnlyTagHelperAttributeList(IEnumerable<TagHelperAttribute> attributes)
-            : base(new List<TagHelperAttribute>(attributes))
+        public ReadOnlyTagHelperAttributeList(IList<TagHelperAttribute> attributes)
+            : base(attributes)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperAttributeList.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperAttributeList.cs
@@ -25,6 +25,20 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         /// </summary>
         /// <param name="attributes">The collection to wrap.</param>
         public TagHelperAttributeList(IEnumerable<TagHelperAttribute> attributes)
+            : base (new List<TagHelperAttribute>(attributes))
+        {
+            if (attributes == null)
+            {
+                throw new ArgumentNullException(nameof(attributes));
+            }
+        }
+
+        /// <summary>
+        /// Instantiates a new instance of <see cref="TagHelperAttributeList"/> with the specified
+        /// <paramref name="attributes"/>.
+        /// </summary>
+        /// <param name="attributes">The collection to wrap.</param>
+        public TagHelperAttributeList(List<TagHelperAttribute> attributes)
             : base(attributes)
         {
             if (attributes == null)

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.AspNetCore.Razor.TagHelpers
 {

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Razor.TagHelpers
 {
@@ -11,8 +12,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
     /// </summary>
     public class TagHelperContext
     {
-        private ReadOnlyTagHelperAttributeList _allAttributes;
-        private IEnumerable<TagHelperAttribute> _allAttributesData;
+        private static ReadOnlyTagHelperAttributeList EmptyAttributes = new TagHelperAttributeList();
 
         /// <summary>
         /// Instantiates a new <see cref="TagHelperContext"/>.
@@ -22,15 +22,10 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         /// <param name="uniqueId">The unique identifier for the source element this <see cref="TagHelperContext" />
         /// applies to.</param>
         public TagHelperContext(
-            IEnumerable<TagHelperAttribute> allAttributes,
+            ReadOnlyTagHelperAttributeList allAttributes,
             IDictionary<object, object> items,
             string uniqueId)
         {
-            if (allAttributes == null)
-            {
-                throw new ArgumentNullException(nameof(allAttributes));
-            }
-
             if (items == null)
             {
                 throw new ArgumentNullException(nameof(items));
@@ -41,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                 throw new ArgumentNullException(nameof(uniqueId));
             }
 
-            _allAttributesData = allAttributes;
+            AllAttributes = allAttributes ?? EmptyAttributes;
             Items = items;
             UniqueId = uniqueId;
         }
@@ -49,18 +44,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         /// <summary>
         /// Every attribute associated with the current HTML element.
         /// </summary>
-        public ReadOnlyTagHelperAttributeList AllAttributes
-        {
-            get
-            {
-                if (_allAttributes == null)
-                {
-                    _allAttributes = new TagHelperAttributeList(_allAttributesData);
-                }
-
-                return _allAttributes;
-            }
-        }
+        public ReadOnlyTagHelperAttributeList AllAttributes { get; }
 
         /// <summary>
         /// Gets the collection of items used to communicate with other <see cref="ITagHelper"/>s.

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
@@ -18,13 +18,16 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         [InlineData(TagMode.SelfClosing)]
         [InlineData(TagMode.StartTagAndEndTag)]
         [InlineData(TagMode.StartTagOnly)]
-        public void TagMode_ReturnsExpectedValue(TagMode tagMode)
+        public void ExecutionContext_CreateTagHelperOutput_ReturnsExpectedTagMode(TagMode tagMode)
         {
-            // Arrange & Act
+            // Arrange
             var executionContext = new TagHelperExecutionContext("p", tagMode);
 
+            // Act
+            var output = executionContext.CreateTagHelperOutput();
+
             // Assert
-            Assert.Equal(tagMode, executionContext.TagMode);
+            Assert.Equal(tagMode, output.TagMode);
         }
 
         [Fact]
@@ -270,51 +273,6 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             Assert.NotSame(content1, content2);
         }
 
-        public static TheoryData<string, string> DictionaryCaseTestingData
-        {
-            get
-            {
-                return new TheoryData<string, string>
-                {
-                    { "class", "CLaSS" },
-                    { "Class", "class" },
-                    { "Class", "claSS" }
-                };
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(DictionaryCaseTestingData))]
-        public void HtmlAttributes_IgnoresCase(string originalName, string updatedName)
-        {
-            // Arrange
-            var executionContext = new TagHelperExecutionContext("p", TagMode.StartTagAndEndTag);
-            executionContext.HtmlAttributes.SetAttribute(originalName, "hello");
-
-            // Act
-            executionContext.HtmlAttributes.SetAttribute(updatedName, "something else");
-
-            // Assert
-            var attribute = Assert.Single(executionContext.HtmlAttributes);
-            Assert.Equal(new TagHelperAttribute(originalName, "something else"), attribute);
-        }
-
-        [Theory]
-        [MemberData(nameof(DictionaryCaseTestingData))]
-        public void AllAttributes_IgnoresCase(string originalName, string updatedName)
-        {
-            // Arrange
-            var executionContext = new TagHelperExecutionContext("p", tagMode: TagMode.StartTagAndEndTag);
-            executionContext.AllAttributes.SetAttribute(originalName, value: false);
-
-            // Act
-            executionContext.AllAttributes.SetAttribute(updatedName, true);
-
-            // Assert
-            var attribute = Assert.Single(executionContext.AllAttributes);
-            Assert.Equal(new TagHelperAttribute(originalName, true), attribute);
-        }
-
         [Fact]
         public void AddHtmlAttribute_MaintainsHtmlAttributes()
         {
@@ -329,11 +287,12 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             // Act
             executionContext.AddHtmlAttribute("class", "btn");
             executionContext.AddHtmlAttribute("foo", "bar");
+            var output = executionContext.CreateTagHelperOutput();
 
             // Assert
             Assert.Equal(
                 expectedAttributes,
-                executionContext.HtmlAttributes,
+                output.Attributes,
                 CaseSensitiveTagHelperAttributeComparer.Default);
         }
 
@@ -351,11 +310,12 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             // Act
             executionContext.AddMinimizedHtmlAttribute("checked");
             executionContext.AddMinimizedHtmlAttribute("visible");
+            var output = executionContext.CreateTagHelperOutput();
 
             // Assert
             Assert.Equal(
                 expectedAttributes,
-                executionContext.HtmlAttributes,
+                output.Attributes,
                 CaseSensitiveTagHelperAttributeComparer.Default);
         }
 
@@ -377,11 +337,12 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             executionContext.AddHtmlAttribute("foo", "bar");
             executionContext.AddMinimizedHtmlAttribute("checked");
             executionContext.AddMinimizedHtmlAttribute("visible");
+            var output = executionContext.CreateTagHelperOutput();
 
             // Assert
             Assert.Equal(
                 expectedAttributes,
-                executionContext.HtmlAttributes,
+                output.Attributes,
                 CaseSensitiveTagHelperAttributeComparer.Default);
         }
 
@@ -401,11 +362,12 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             executionContext.AddHtmlAttribute("class", "btn");
             executionContext.AddTagHelperAttribute("something", true);
             executionContext.AddHtmlAttribute("foo", "bar");
+            var context = executionContext.CreateTagHelperContext();
 
             // Assert
             Assert.Equal(
                 expectedAttributes,
-                executionContext.AllAttributes,
+                context.AllAttributes,
                 CaseSensitiveTagHelperAttributeComparer.Default);
         }
 

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperScopeManagerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperScopeManagerTest.cs
@@ -125,16 +125,17 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void Begin_CreatesContextWithAppropriateTagName()
+        public void Begin_CreatesContexts_TagHelperOutput_WithAppropriateTagName()
         {
             // Arrange
             var scopeManager = new TagHelperScopeManager();
 
             // Act
             var executionContext = BeginDefaultScope(scopeManager, tagName: "p");
+            var output = executionContext.CreateTagHelperOutput();
 
             // Assert
-            Assert.Equal("p", executionContext.TagName);
+            Assert.Equal("p", output.TagName);
         }
 
         [Fact]
@@ -146,25 +147,27 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             // Act
             var executionContext = BeginDefaultScope(scopeManager, tagName: "p");
             executionContext = BeginDefaultScope(scopeManager, tagName: "div");
+            var output = executionContext.CreateTagHelperOutput();
 
             // Assert
-            Assert.Equal("div", executionContext.TagName);
+            Assert.Equal("div", output.TagName);
         }
 
         [Theory]
         [InlineData(TagMode.SelfClosing)]
         [InlineData(TagMode.StartTagAndEndTag)]
         [InlineData(TagMode.StartTagOnly)]
-        public void Begin_SetsExecutionContextTagMode(TagMode tagMode)
+        public void Begin_SetsExecutionContexts_TagHelperOutputTagMode(TagMode tagMode)
         {
             // Arrange
             var scopeManager = new TagHelperScopeManager();
 
             // Act
             var executionContext = BeginDefaultScope(scopeManager, "p", tagMode);
+            var output = executionContext.CreateTagHelperOutput();
 
             // Assert
-            Assert.Equal(tagMode, executionContext.TagMode);
+            Assert.Equal(tagMode, output.TagMode);
         }
 
         [Fact]
@@ -177,9 +180,10 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             var executionContext = BeginDefaultScope(scopeManager, tagName: "p");
             executionContext = BeginDefaultScope(scopeManager, tagName: "div");
             executionContext = scopeManager.End();
+            var output = executionContext.CreateTagHelperOutput();
 
             // Assert
-            Assert.Equal("p", executionContext.TagName);
+            Assert.Equal("p", output.TagName);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/ReadOnlyTagHelperAttributeListTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/ReadOnlyTagHelperAttributeListTest.cs
@@ -730,7 +730,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         private class TestableReadOnlyTagHelperAttributes : ReadOnlyTagHelperAttributeList
         {
             public TestableReadOnlyTagHelperAttributes(IEnumerable<TagHelperAttribute> attributes)
-                : base(attributes)
+                : base(new List<TagHelperAttribute>(attributes))
             {
             }
 


### PR DESCRIPTION
- Not all `TagHelper`s have unbound HTML attributes or any attributes at all. A great example of this is MVC's input `TagHelper` which usually takes the format of `<input asp-for="..." />`. By lazily initializing we don't build extra attribute lists where not needed.

**Before:**
![image](https://cloud.githubusercontent.com/assets/2008729/12692346/9b361660-c6aa-11e5-85be-968001194fda.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/2008729/12692350/ad9f5cbc-c6aa-11e5-8d4b-596cb5eb7db0.png)


**Result:** 1.4% reduction in overall allocations

#604