### PR TITLE
Enable Razor templates inside of sections.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor/CodeGenerators/Visitors/CSharpCodeVisitor.cs
+++ b/src/Microsoft.AspNetCore.Razor/CodeGenerators/Visitors/CSharpCodeVisitor.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators.Visitors
         private const string ItemParameterName = "item";
         private const string ValueWriterName = "__razor_attribute_value_writer";
         private const string TemplateWriterName = "__razor_template_writer";
+        private const string SectionWriterName = "__razor_section_writer";
         private const int MaxStringLiteralLength = 1024;
 
         private CSharpPaddingBuilder _paddingBuilder;
@@ -377,9 +378,9 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators.Visitors
                    .WriteParameterSeparator();
 
             var currentTargetWriterName = Context.TargetWriterName;
-            Context.TargetWriterName = TemplateWriterName;
+            Context.TargetWriterName = SectionWriterName;
 
-            using (Writer.BuildAsyncLambda(endLine: false, parameterNames: TemplateWriterName))
+            using (Writer.BuildAsyncLambda(endLine: false, parameterNames: SectionWriterName))
             {
                 Accept(chunk.Children);
             }

--- a/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpRazorChunkGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpRazorChunkGeneratorTest.cs
@@ -397,7 +397,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                     documentAbsoluteIndex: 204,
                     documentLineIndex: 13,
                     documentCharacterOffsetIndex: 5,
-                    generatedAbsoluteIndex: 1197,
+                    generatedAbsoluteIndex: 1196,
                     generatedLineIndex: 60,
                     generatedCharacterOffsetIndex: 6,
                     contentLength: 3),

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DesignTime.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DesignTime.cs
@@ -56,7 +56,7 @@ __o = Foo(item => new Template(async(__razor_template_writer) => {
 
 #line default
 #line hidden
-            DefineSection("Footer", async(__razor_template_writer) => {
+            DefineSection("Footer", async(__razor_section_writer) => {
 #line 14 "DesignTime.cshtml"
 __o = bar;
 

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/InlineBlocks.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/InlineBlocks.cs
@@ -14,7 +14,7 @@ namespace TestOutput
         #pragma warning disable 1998
         public override async Task ExecuteAsync()
         {
-            DefineSection("Link", async(__razor_template_writer) => {
+            DefineSection("Link", async(__razor_section_writer) => {
             }
             );
             Instrumentation.BeginContext(13, 23, true);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/Sections.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/Sections.cs
@@ -1,4 +1,4 @@
-#pragma checksum "Sections.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "19b065ba387522fb8b9b4aea4820b3752d898d0a"
+#pragma checksum "Sections.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "bf45c2508895b4b9b3579bc193e7a0167ccdbdfb"
 namespace TestOutput
 {
     using System;
@@ -24,19 +24,62 @@ namespace TestOutput
             Instrumentation.BeginContext(49, 31, true);
             WriteLiteral("\r\n<div>This is in the Body>\r\n\r\n");
             Instrumentation.EndContext();
-            DefineSection("Section2", async(__razor_template_writer) => {
+            DefineSection("Section2", async(__razor_section_writer) => {
                 Instrumentation.BeginContext(99, 39, true);
-                WriteLiteralTo(__razor_template_writer, "\r\n    <div>This is in Section 2</div>\r\n");
+                WriteLiteralTo(__razor_section_writer, "\r\n    <div>This is in Section 2</div>\r\n");
                 Instrumentation.EndContext();
             }
             );
             Instrumentation.BeginContext(141, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
-            DefineSection("Section1", async(__razor_template_writer) => {
+            DefineSection("Section1", async(__razor_section_writer) => {
                 Instrumentation.BeginContext(162, 39, true);
-                WriteLiteralTo(__razor_template_writer, "\r\n    <div>This is in Section 1</div>\r\n");
+                WriteLiteralTo(__razor_section_writer, "\r\n    <div>This is in Section 1</div>\r\n");
                 Instrumentation.EndContext();
+            }
+            );
+            Instrumentation.BeginContext(204, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            DefineSection("NestedDelegates", async(__razor_section_writer) => {
+                Instrumentation.BeginContext(232, 2, true);
+                WriteLiteralTo(__razor_section_writer, "\r\n");
+                Instrumentation.EndContext();
+#line 16 "Sections.cshtml"
+    
+
+#line default
+#line hidden
+
+#line 16 "Sections.cshtml"
+       Func<dynamic, object> f = 
+
+#line default
+#line hidden
+
+                item => new Template(async(__razor_template_writer) => {
+                    Instrumentation.BeginContext(268, 6, true);
+                    WriteLiteralTo(__razor_template_writer, "<span>");
+                    Instrumentation.EndContext();
+                    Instrumentation.BeginContext(275, 4, false);
+#line 16 "Sections.cshtml"
+        WriteTo(__razor_template_writer, item);
+
+#line default
+#line hidden
+                    Instrumentation.EndContext();
+                    Instrumentation.BeginContext(279, 7, true);
+                    WriteLiteralTo(__razor_template_writer, "</span>");
+                    Instrumentation.EndContext();
+                }
+                )
+#line 16 "Sections.cshtml"
+                                                    ; 
+
+#line default
+#line hidden
+
             }
             );
         }

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/StringLiterals.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/StringLiterals.cs
@@ -103,9 +103,9 @@ namespace TestOutput
 
 ");
             Instrumentation.EndContext();
-            DefineSection("WriteLiteralsToInHere", async(__razor_template_writer) => {
+            DefineSection("WriteLiteralsToInHere", async(__razor_section_writer) => {
                 Instrumentation.BeginContext(2045, 2618, true);
-                WriteLiteralTo(__razor_template_writer, @"
+                WriteLiteralTo(__razor_section_writer, @"
     <p>This is line 1 nested</p>
     <p>This is line 2 nested</p>
     <p>This is line 3 nested</p>
@@ -136,7 +136,7 @@ namespace TestOutput
     <p>This is line 28 nested</p>
     <p>This is line 29 nested</p>
     <p>This is l");
-                WriteLiteralTo(__razor_template_writer, @"ine 30 nested</p>
+                WriteLiteralTo(__razor_section_writer, @"ine 30 nested</p>
     <p>This is line 31 nested</p>
     <p>This is line 32 nested</p>
     <p>This is line 33 nested</p>
@@ -166,7 +166,7 @@ namespace TestOutput
     <p>This is line 57 nested</p>
     <p>This is line 58 nested</p>
     <p>This is line 59 ne");
-                WriteLiteralTo(__razor_template_writer, @"sted</p>
+                WriteLiteralTo(__razor_section_writer, @"sted</p>
     <p>This is line 60 nested</p>
     <p>This is line 61 nested</p>
     <p>This is line 62 nested</p>
@@ -233,9 +233,9 @@ namespace TestOutput
 <p>This is line 43</p>hi!");
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
-            DefineSection("WriteLiteralsToInHereAlso", async(__razor_template_writer) => {
+            DefineSection("WriteLiteralsToInHereAlso", async(__razor_section_writer) => {
                 Instrumentation.BeginContext(5728, 1023, true);
-                WriteLiteralTo(__razor_template_writer, @"
+                WriteLiteralTo(__razor_section_writer, @"
     <p>This is line 1 nested</p>
     <p>This is line 2 nested</p>
     <p>This is line 3 nested</p>

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
@@ -37,9 +37,9 @@ namespace TestOutput
             Instrumentation.BeginContext(69, 2, true);
             WriteLiteral("\r\n");
             Instrumentation.EndContext();
-            DefineSection("MySection", async(__razor_template_writer) => {
+            DefineSection("MySection", async(__razor_section_writer) => {
                 Instrumentation.BeginContext(91, 21, true);
-                WriteLiteralTo(__razor_template_writer, "\r\n    <div>\r\n        ");
+                WriteLiteralTo(__razor_section_writer, "\r\n    <div>\r\n        ");
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                     Instrumentation.BeginContext(215, 52, true);
@@ -101,11 +101,11 @@ AddHtmlAttributeValue(" ", 199, DateTime.Now, 200, 14, false);
                     __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
                 }
                 Instrumentation.BeginContext(112, 245, false);
-                WriteTo(__razor_template_writer, __tagHelperExecutionContext.Output);
+                WriteTo(__razor_section_writer, __tagHelperExecutionContext.Output);
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 Instrumentation.BeginContext(357, 14, true);
-                WriteLiteralTo(__razor_template_writer, "\r\n    </div>\r\n");
+                WriteLiteralTo(__razor_section_writer, "\r\n    </div>\r\n");
                 Instrumentation.EndContext();
             }
             );

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Source/Sections.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Source/Sections.cshtml
@@ -11,3 +11,7 @@
 @section Section1 {
     <div>This is in Section 1</div>
 }
+
+@section NestedDelegates {
+    @{ Func<dynamic, object> f = @<span>@item</span>; }
+}


### PR DESCRIPTION
- Changed the variable used to render templates (`HelperResult`s) so they can be used inside of sections.
- Updated section test file to showcase nested scenario. Also Regenerated existing test files.

#572