### PR TITLE
CSS attribute selectors for `TagHelper` attributes.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Runtime/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Properties/Resources.Designer.cs
@@ -426,6 +426,86 @@ namespace Microsoft.AspNetCore.Razor.Runtime
             return string.Format(CultureInfo.CurrentCulture, GetString("ArgumentMustBeAnInstanceOf"), p0);
         }
 
+        /// <summary>
+        /// Could not find matching ']' for required attribute '{0}'.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_CouldNotFindMatchingEndBrace
+        {
+            get { return GetString("TagHelperDescriptorFactory_CouldNotFindMatchingEndBrace"); }
+        }
+
+        /// <summary>
+        /// Could not find matching ']' for required attribute '{0}'.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_CouldNotFindMatchingEndBrace(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_CouldNotFindMatchingEndBrace"), p0);
+        }
+
+        /// <summary>
+        /// Invalid required attribute character '{0}' in required attribute '{1}'. Separate required attributes with commas.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidRequiredAttributeCharacter
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidRequiredAttributeCharacter"); }
+        }
+
+        /// <summary>
+        /// Invalid required attribute character '{0}' in required attribute '{1}'. Separate required attributes with commas.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidRequiredAttributeCharacter(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidRequiredAttributeCharacter"), p0, p1);
+        }
+
+        /// <summary>
+        /// Required attribute '{0}' has mismatched quotes '{1}' around value.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidRequiredAttributeMismatchedQuotes
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidRequiredAttributeMismatchedQuotes"); }
+        }
+
+        /// <summary>
+        /// Required attribute '{0}' has mismatched quotes '{1}' around value.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidRequiredAttributeMismatchedQuotes(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidRequiredAttributeMismatchedQuotes"), p0, p1);
+        }
+
+        /// <summary>
+        /// Required attribute '{0}' has a partial CSS operator. '{1}' must be followed by an equals.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_PartialRequiredAttributeOperator
+        {
+            get { return GetString("TagHelperDescriptorFactory_PartialRequiredAttributeOperator"); }
+        }
+
+        /// <summary>
+        /// Required attribute '{0}' has a partial CSS operator. '{1}' must be followed by an equals.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_PartialRequiredAttributeOperator(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_PartialRequiredAttributeOperator"), p0, p1);
+        }
+
+        /// <summary>
+        /// Invalid character '{0}' in required attribute '{1}'. Expected supported CSS operator or ']'.
+        /// </summary>
+        internal static string TagHelperDescriptorFactory_InvalidRequiredAttributeOperator
+        {
+            get { return GetString("TagHelperDescriptorFactory_InvalidRequiredAttributeOperator"); }
+        }
+
+        /// <summary>
+        /// Invalid character '{0}' in required attribute '{1}'. Expected supported CSS operator or ']'.
+        /// </summary>
+        internal static string FormatTagHelperDescriptorFactory_InvalidRequiredAttributeOperator(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TagHelperDescriptorFactory_InvalidRequiredAttributeOperator"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Runtime/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Resources.resx
@@ -195,4 +195,19 @@
   <data name="ArgumentMustBeAnInstanceOf" xml:space="preserve">
     <value>Argument must be an instance of '{0}'.</value>
   </data>
+  <data name="TagHelperDescriptorFactory_CouldNotFindMatchingEndBrace" xml:space="preserve">
+    <value>Could not find matching ']' for required attribute '{0}'.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_InvalidRequiredAttributeCharacter" xml:space="preserve">
+    <value>Invalid required attribute character '{0}' in required attribute '{1}'. Separate required attributes with commas.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_InvalidRequiredAttributeMismatchedQuotes" xml:space="preserve">
+    <value>Required attribute '{0}' has mismatched quotes '{1}' around value.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_PartialRequiredAttributeOperator" xml:space="preserve">
+    <value>Required attribute '{0}' has a partial CSS operator. '{1}' must be followed by an equals.</value>
+  </data>
+  <data name="TagHelperDescriptorFactory_InvalidRequiredAttributeOperator" xml:space="preserve">
+    <value>Invalid character '{0}' in required attribute '{1}'. Expected supported CSS operator or ']'.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/HtmlTargetElementAttribute.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/HtmlTargetElementAttribute.cs
@@ -45,8 +45,10 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         public string Tag { get; }
 
         /// <summary>
-        /// A comma-separated <see cref="string"/> of attribute names the HTML element must contain for the
-        /// <see cref="ITagHelper"/> to run. <c>*</c> at the end of an attribute name acts as a prefix match.
+        /// A comma-separated <see cref="string"/> of attribute selectors the HTML element must match for the
+        /// <see cref="ITagHelper"/> to run. <c>*</c> at the end of an attribute name acts as a prefix match. A value
+        /// surrounded by square brackets is handled as a CSS attribute value selector. Operators <c>^=</c>, <c>$=</c> and
+        /// <c>=</c> are supported e.g. <c>"name"</c>, <c>"[name]"</c>, <c>"[name=value]"</c>, <c>"[ name ^= 'value' ]"</c>.
         /// </summary>
         public string Attributes { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Test.Sources/CaseSensitiveTagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Test.Sources/CaseSensitiveTagHelperDescriptorComparer.cs
@@ -33,7 +33,10 @@ namespace Microsoft.AspNetCore.Razor.Test.Internal
             // attributes or prefixes. In tests we do.
             Assert.Equal(descriptorX.TagName, descriptorY.TagName, StringComparer.Ordinal);
             Assert.Equal(descriptorX.Prefix, descriptorY.Prefix, StringComparer.Ordinal);
-            Assert.Equal(descriptorX.RequiredAttributes, descriptorY.RequiredAttributes, StringComparer.Ordinal);
+            Assert.Equal(
+                descriptorX.RequiredAttributes,
+                descriptorY.RequiredAttributes,
+                CaseSensitiveTagHelperRequiredAttributeDescriptorComparer.Default);
             Assert.Equal(descriptorX.RequiredParent, descriptorY.RequiredParent, StringComparer.Ordinal);
 
             if (descriptorX.AllowedChildren != descriptorY.AllowedChildren)
@@ -66,9 +69,10 @@ namespace Microsoft.AspNetCore.Razor.Test.Internal
                     TagHelperDesignTimeDescriptorComparer.Default.GetHashCode(descriptor.DesignTimeDescriptor));
             }
 
-            foreach (var requiredAttribute in descriptor.RequiredAttributes.OrderBy(attribute => attribute))
+            foreach (var requiredAttribute in descriptor.RequiredAttributes.OrderBy(attribute => attribute.Name))
             {
-                hashCodeCombiner.Add(requiredAttribute, StringComparer.Ordinal);
+                hashCodeCombiner.Add(
+                    CaseSensitiveTagHelperRequiredAttributeDescriptorComparer.Default.GetHashCode(requiredAttribute));
             }
 
             if (descriptor.AllowedChildren != null)

--- a/src/Microsoft.AspNetCore.Razor.Test.Sources/CaseSensitiveTagHelperRequiredAttributeDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Test.Sources/CaseSensitiveTagHelperRequiredAttributeDescriptorComparer.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Compilation.TagHelpers;
+using Microsoft.Extensions.Internal;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Test.Internal
+{
+    internal class CaseSensitiveTagHelperRequiredAttributeDescriptorComparer : TagHelperRequiredAttributeDescriptorComparer
+    {
+        public new static readonly CaseSensitiveTagHelperRequiredAttributeDescriptorComparer Default =
+            new CaseSensitiveTagHelperRequiredAttributeDescriptorComparer();
+
+        private CaseSensitiveTagHelperRequiredAttributeDescriptorComparer()
+            : base()
+        {
+        }
+
+        public override bool Equals(TagHelperRequiredAttributeDescriptor descriptorX, TagHelperRequiredAttributeDescriptor descriptorY)
+        {
+            if (descriptorX == descriptorY)
+            {
+                return true;
+            }
+
+            Assert.True(base.Equals(descriptorX, descriptorY));
+            Assert.Equal(descriptorX.Name, descriptorY.Name, StringComparer.Ordinal);
+
+            return true;
+        }
+
+        public override int GetHashCode(TagHelperRequiredAttributeDescriptor descriptor)
+        {
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(base.GetHashCode(descriptor));
+            hashCodeCombiner.Add(descriptor.Name, StringComparer.Ordinal);
+
+            return hashCodeCombiner.CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperDescriptor.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
         private string _assemblyName;
         private IEnumerable<TagHelperAttributeDescriptor> _attributes =
             Enumerable.Empty<TagHelperAttributeDescriptor>();
-        private IEnumerable<string> _requiredAttributes = Enumerable.Empty<string>();
+        private IEnumerable<TagHelperRequiredAttributeDescriptor> _requiredAttributes = Enumerable.Empty<TagHelperRequiredAttributeDescriptor>();
 
         /// <summary>
         /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
         /// <remarks>
         /// <c>*</c> at the end of an attribute name acts as a prefix match.
         /// </remarks>
-        public IEnumerable<string> RequiredAttributes
+        public IEnumerable<TagHelperRequiredAttributeDescriptor> RequiredAttributes
         {
             get
             {

--- a/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperDescriptorComparer.cs
@@ -51,9 +51,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     descriptorY.RequiredParent,
                     StringComparison.OrdinalIgnoreCase) &&
                 Enumerable.SequenceEqual(
-                    descriptorX.RequiredAttributes.OrderBy(attribute => attribute, StringComparer.OrdinalIgnoreCase),
-                    descriptorY.RequiredAttributes.OrderBy(attribute => attribute, StringComparer.OrdinalIgnoreCase),
-                    StringComparer.OrdinalIgnoreCase) &&
+                    descriptorX.RequiredAttributes.OrderBy(attribute => attribute.Name, StringComparer.OrdinalIgnoreCase),
+                    descriptorY.RequiredAttributes.OrderBy(attribute => attribute.Name, StringComparer.OrdinalIgnoreCase),
+                    TagHelperRequiredAttributeDescriptorComparer.Default) &&
                 (descriptorX.AllowedChildren == descriptorY.AllowedChildren ||
                 (descriptorX.AllowedChildren != null &&
                 descriptorY.AllowedChildren != null &&
@@ -80,11 +80,11 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
             hashCodeCombiner.Add(descriptor.TagStructure);
 
             var attributes = descriptor.RequiredAttributes.OrderBy(
-                attribute => attribute,
+                attribute => attribute.Name,
                 StringComparer.OrdinalIgnoreCase);
             foreach (var attribute in attributes)
             {
-                hashCodeCombiner.Add(attribute, StringComparer.OrdinalIgnoreCase);
+                hashCodeCombiner.Add(TagHelperRequiredAttributeDescriptorComparer.Default.GetHashCode(attribute));
             }
 
             if (descriptor.AllowedChildren != null)

--- a/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperRequiredAttributeDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperRequiredAttributeDescriptor.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
+{
+    /// <summary>
+    /// A metadata class describing a required tag helper attribute.
+    /// </summary>
+    public class TagHelperRequiredAttributeDescriptor
+    {
+        /// <summary>
+        /// The HTML attribute name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The comparison method to use for <see cref="Name"/> when determining if an HTML attribute name matches.
+        /// </summary>
+        public TagHelperRequiredAttributeNameComparison NameComparison { get; set; }
+
+        /// <summary>
+        /// The HTML attribute value.
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// The comparison method to use for <see cref="Value"/> when determining if an HTML attribute value matches.
+        /// </summary>
+        public TagHelperRequiredAttributeValueComparison ValueComparison { get; set; }
+
+        /// <summary>
+        /// Determines if the current <see cref="TagHelperRequiredAttributeDescriptor"/> matches the given
+        /// <paramref name="attributeName"/> and <paramref name="attributeValue"/>.
+        /// </summary>
+        /// <param name="attributeName">An HTML attribute name.</param>
+        /// <param name="attributeValue">An HTML attribute value.</param>
+        /// <returns><c>true</c> if the current <see cref="TagHelperRequiredAttributeDescriptor"/> matches
+        /// <paramref name="attributeName"/> and <paramref name="attributeValue"/>; <c>false</c> otherwise.</returns>
+        public bool IsMatch(string attributeName, string attributeValue)
+        {
+            var nameMatches = false;
+            if (NameComparison == TagHelperRequiredAttributeNameComparison.FullMatch)
+            {
+                nameMatches = string.Equals(Name, attributeName, StringComparison.OrdinalIgnoreCase);
+            }
+            else if (NameComparison == TagHelperRequiredAttributeNameComparison.PrefixMatch)
+            {
+                // attributeName cannot equal the Name if comparing as a PrefixMatch.
+                nameMatches = attributeName.Length != Name.Length &&
+                    attributeName.StartsWith(Name, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                Debug.Assert(false, "Unknown name comparison.");
+            }
+
+            if (!nameMatches)
+            {
+                return false;
+            }
+
+            switch (ValueComparison)
+            {
+                case TagHelperRequiredAttributeValueComparison.None:
+                    return true;
+                case TagHelperRequiredAttributeValueComparison.PrefixMatch: // Value starts with
+                    return attributeValue.StartsWith(Value, StringComparison.Ordinal);
+                case TagHelperRequiredAttributeValueComparison.SuffixMatch: // Value ends with
+                    return attributeValue.EndsWith(Value, StringComparison.Ordinal);
+                case TagHelperRequiredAttributeValueComparison.FullMatch: // Value equals
+                    return string.Equals(attributeValue, Value, StringComparison.Ordinal);
+                default:
+                    Debug.Assert(false, "Unknown value comparison.");
+                    return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperRequiredAttributeDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperRequiredAttributeDescriptorComparer.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
+{
+    /// <summary>
+    /// An <see cref="IEqualityComparer{TagHelperRequiredAttributeDescriptor}"/> used to check equality between
+    /// two <see cref="TagHelperRequiredAttributeDescriptor"/>s.
+    /// </summary>
+    public class TagHelperRequiredAttributeDescriptorComparer : IEqualityComparer<TagHelperRequiredAttributeDescriptor>
+    {
+        /// <summary>
+        /// A default instance of the <see cref="TagHelperRequiredAttributeDescriptor"/>.
+        /// </summary>
+        public static readonly TagHelperRequiredAttributeDescriptorComparer Default =
+            new TagHelperRequiredAttributeDescriptorComparer();
+
+        /// <summary>
+        /// Initializes a new <see cref="TagHelperRequiredAttributeDescriptor"/> instance.
+        /// </summary>
+        protected TagHelperRequiredAttributeDescriptorComparer()
+        {
+        }
+
+        /// <inheritdoc />
+        public virtual bool Equals(
+            TagHelperRequiredAttributeDescriptor descriptorX,
+            TagHelperRequiredAttributeDescriptor descriptorY)
+        {
+            if (descriptorX == descriptorY)
+            {
+                return true;
+            }
+
+            return descriptorX != null &&
+                descriptorX.NameComparison == descriptorY.NameComparison &&
+                descriptorX.ValueComparison == descriptorY.ValueComparison &&
+                string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(descriptorX.Value, descriptorY.Value, StringComparison.Ordinal);
+        }
+
+        /// <inheritdoc />
+        public virtual int GetHashCode(TagHelperRequiredAttributeDescriptor descriptor)
+        {
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(descriptor.NameComparison);
+            hashCodeCombiner.Add(descriptor.ValueComparison);
+            hashCodeCombiner.Add(descriptor.Name, StringComparer.OrdinalIgnoreCase);
+            hashCodeCombiner.Add(descriptor.Value, StringComparer.Ordinal);
+
+            return hashCodeCombiner.CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperRequiredAttributeNameComparison.cs
+++ b/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperRequiredAttributeNameComparison.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
+{
+    /// <summary>
+    /// Acceptable <see cref="TagHelperRequiredAttributeDescriptor.Name"/> comparison modes.
+    /// </summary>
+    public enum TagHelperRequiredAttributeNameComparison
+    {
+        /// <summary>
+        /// HTML attribute name case insensitively matches <see cref="TagHelperRequiredAttributeDescriptor.Name"/>.
+        /// </summary>
+        FullMatch,
+
+        /// <summary>
+        /// HTML attribute name case insensitively starts with <see cref="TagHelperRequiredAttributeDescriptor.Name"/>.
+        /// </summary>
+        PrefixMatch,
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperRequiredAttributeValueComparison.cs
+++ b/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperRequiredAttributeValueComparison.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
+{
+    /// <summary>
+    /// Acceptable <see cref="TagHelperRequiredAttributeDescriptor.Value"/> comparison modes.
+    /// </summary>
+    public enum TagHelperRequiredAttributeValueComparison
+    {
+        /// <summary>
+        /// HTML attribute value always matches <see cref="TagHelperRequiredAttributeDescriptor.Value"/>.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// HTML attribute value case sensitively matches <see cref="TagHelperRequiredAttributeDescriptor.Value"/>.
+        /// </summary>
+        FullMatch,
+
+        /// <summary>
+        /// HTML attribute value case sensitively starts with <see cref="TagHelperRequiredAttributeDescriptor.Value"/>.
+        /// </summary>
+        PrefixMatch,
+
+        /// <summary>
+        /// HTML attribute value case sensitively ends with <see cref="TagHelperRequiredAttributeDescriptor.Value"/>.
+        /// </summary>
+        SuffixMatch,
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor/Parser/RazorParser.cs
+++ b/src/Microsoft.AspNetCore.Razor/Parser/RazorParser.cs
@@ -239,7 +239,8 @@ namespace Microsoft.AspNetCore.Razor.Parser
             return addOrRemoveTagHelperSpanVisitor.GetDescriptors(documentRoot);
         }
 
-        private static IEnumerable<ISyntaxTreeRewriter> GetDefaultRewriters(ParserBase markupParser)
+        // Internal for testing
+        internal static IEnumerable<ISyntaxTreeRewriter> GetDefaultRewriters(ParserBase markupParser)
         {
             return new ISyntaxTreeRewriter[]
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
@@ -21,6 +21,126 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
         private static IEnumerable<TagHelperDescriptor> PrefixedPAndInputTagHelperDescriptors { get; }
             = BuildPAndInputTagHelperDescriptors(prefix: "THS");
 
+        private static IEnumerable<TagHelperDescriptor> CssSelectorTagHelperDescriptors
+        {
+            get
+            {
+                var inputTypePropertyInfo = typeof(TestType).GetProperty("Type");
+                var inputCheckedPropertyInfo = typeof(TestType).GetProperty("Checked");
+
+                return new[]
+                {
+                    new TagHelperDescriptor
+                    {
+                        TagName = "a",
+                        TypeName = "TestNamespace.ATagHelper",
+                        AssemblyName = "SomeAssembly",
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor
+                            {
+                                Name = "href",
+                                NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                                Value = "~/",
+                                ValueComparison = TagHelperRequiredAttributeValueComparison.FullMatch,
+                            }
+                        },
+                    },
+                    new TagHelperDescriptor
+                    {
+                        TagName = "a",
+                        TypeName = "TestNamespace.ATagHelperMultipleSelectors",
+                        AssemblyName = "SomeAssembly",
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor
+                            {
+                                Name = "href",
+                                NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                                Value = "~/",
+                                ValueComparison = TagHelperRequiredAttributeValueComparison.PrefixMatch,
+                            },
+                            new TagHelperRequiredAttributeDescriptor
+                            {
+                                Name = "href",
+                                NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                                Value = "?hello=world",
+                                ValueComparison = TagHelperRequiredAttributeValueComparison.SuffixMatch,
+                            }
+                        },
+                    },
+                    new TagHelperDescriptor
+                    {
+                        TagName = "input",
+                        TypeName = "TestNamespace.InputTagHelper",
+                        AssemblyName = "SomeAssembly",
+                        Attributes = new TagHelperAttributeDescriptor[]
+                        {
+                            new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
+                        },
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor
+                            {
+                                Name = "type",
+                                NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                                Value = "text",
+                                ValueComparison = TagHelperRequiredAttributeValueComparison.FullMatch,
+                            }
+                        },
+                    },
+                    new TagHelperDescriptor
+                    {
+                        TagName = "input",
+                        TypeName = "TestNamespace.InputTagHelper2",
+                        AssemblyName = "SomeAssembly",
+                        Attributes = new TagHelperAttributeDescriptor[]
+                        {
+                            new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
+                        },
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor
+                            {
+                                Name = "ty",
+                                NameComparison = TagHelperRequiredAttributeNameComparison.PrefixMatch,
+                            }
+                        },
+                    },
+                    new TagHelperDescriptor
+                    {
+                        TagName = "*",
+                        TypeName = "TestNamespace.CatchAllTagHelper",
+                        AssemblyName = "SomeAssembly",
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor
+                            {
+                                Name = "href",
+                                NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                                Value = "~/",
+                                ValueComparison = TagHelperRequiredAttributeValueComparison.PrefixMatch,
+                            }
+                        },
+                    },
+                    new TagHelperDescriptor
+                    {
+                        TagName = "*",
+                        TypeName = "TestNamespace.CatchAllTagHelper2",
+                        AssemblyName = "SomeAssembly",
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor
+                            {
+                                Name = "type",
+                                NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                            }
+                        },
+                    }
+                };
+            }
+        }
+
         private static IEnumerable<TagHelperDescriptor> EnumTagHelperDescriptors
         {
             get
@@ -113,7 +233,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                                 TypeName = typeof(string).FullName
                             },
                         },
-                        RequiredAttributes = new[] { "bound" },
+                        RequiredAttributes = new[] { new TagHelperRequiredAttributeDescriptor { Name = "bound" } },
                     },
                 };
             }
@@ -140,7 +260,10 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                                 IsStringProperty = true
                             }
                         },
-                        RequiredAttributes = new[] { "catchall-unbound-required" },
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor { Name = "catchall-unbound-required" }
+                        },
                     },
                     new TagHelperDescriptor
                     {
@@ -164,7 +287,11 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                                 IsStringProperty = true
                             }
                         },
-                        RequiredAttributes = new[] { "input-bound-required-string", "input-unbound-required" },
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor { Name = "input-bound-required-string" },
+                            new TagHelperRequiredAttributeDescriptor { Name = "input-unbound-required" }
+                        },
                     }
                 };
             }
@@ -214,7 +341,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                             new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
                             new TagHelperAttributeDescriptor("checked", inputCheckedPropertyInfo)
                         },
-                        RequiredAttributes = new[] { "type" },
+                        RequiredAttributes = new[] { new TagHelperRequiredAttributeDescriptor { Name = "type" } },
                     },
                     new TagHelperDescriptor
                     {
@@ -226,7 +353,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                             new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
                             new TagHelperAttributeDescriptor("checked", inputCheckedPropertyInfo)
                         },
-                        RequiredAttributes = new[] { "checked" },
+                        RequiredAttributes = new[] { new TagHelperRequiredAttributeDescriptor { Name = "checked" } },
                     },
                     new TagHelperDescriptor
                     {
@@ -238,7 +365,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                             new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
                             new TagHelperAttributeDescriptor("checked", inputCheckedPropertyInfo)
                         },
-                        RequiredAttributes = new[] { "type" },
+                        RequiredAttributes = new[] { new TagHelperRequiredAttributeDescriptor { Name = "type" } },
                     },
                     new TagHelperDescriptor
                     {
@@ -250,7 +377,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                             new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
                             new TagHelperAttributeDescriptor("checked", inputCheckedPropertyInfo)
                         },
-                        RequiredAttributes = new[] { "checked" },
+                        RequiredAttributes = new[] { new TagHelperRequiredAttributeDescriptor { Name = "checked" } },
                     }
                 };
             }
@@ -269,7 +396,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                         TagName = "p",
                         TypeName = "TestNamespace.PTagHelper",
                         AssemblyName = "SomeAssembly",
-                        RequiredAttributes = new[] { "class" },
+                        RequiredAttributes = new[] { new TagHelperRequiredAttributeDescriptor { Name = "class" } },
                     },
                     new TagHelperDescriptor
                     {
@@ -280,7 +407,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                         {
                             new TagHelperAttributeDescriptor("type", inputTypePropertyInfo)
                         },
-                        RequiredAttributes = new[] { "type" },
+                        RequiredAttributes = new[] { new TagHelperRequiredAttributeDescriptor { Name = "type" } },
                     },
                     new TagHelperDescriptor
                     {
@@ -292,14 +419,18 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                             new TagHelperAttributeDescriptor("type", inputTypePropertyInfo),
                             new TagHelperAttributeDescriptor("checked", inputCheckedPropertyInfo)
                         },
-                        RequiredAttributes = new[] { "type", "checked" },
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor { Name = "type" },
+                            new TagHelperRequiredAttributeDescriptor { Name = "checked" }
+                        },
                     },
                     new TagHelperDescriptor
                     {
                         TagName = "*",
                         TypeName = "TestNamespace.CatchAllTagHelper",
                         AssemblyName = "SomeAssembly",
-                        RequiredAttributes = new[] { "catchAll" },
+                        RequiredAttributes = new[] { new TagHelperRequiredAttributeDescriptor { Name = "catchAll" } },
                     }
                 };
             }
@@ -1774,6 +1905,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                 // Note: The baseline resource name is equivalent to the test resource name.
                 return new TheoryData<string, string, IEnumerable<TagHelperDescriptor>>
                 {
+                    { "CssSelectorTagHelperAttributes", null, CssSelectorTagHelperDescriptors },
                     { "IncompleteTagHelper", null, DefaultPAndInputTagHelperDescriptors },
                     { "SingleTagHelper", null, DefaultPAndInputTagHelperDescriptors },
                     { "SingleTagHelperWithNewlineBeforeAttributes", null, DefaultPAndInputTagHelperDescriptors },

--- a/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             TypeName = typeof(string).FullName
                         },
                     },
-                    RequiredAttributes = new[] { "bound" },
+                    RequiredAttributes = new[] { new TagHelperRequiredAttributeDescriptor { Name = "bound" } },
                 },
             };
             var descriptorProvider = new TagHelperDescriptorProvider(descriptors);
@@ -3940,7 +3940,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                 IsStringProperty = true
                             }
                         },
-                        RequiredAttributes = new[] { "unbound-required" }
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor { Name = "unbound-required" }
+                        }
                     },
                     new TagHelperDescriptor
                     {
@@ -3957,7 +3960,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                 IsStringProperty = true
                             }
                         },
-                        RequiredAttributes = new[] { "bound-required-string" }
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor { Name = "bound-required-string" }
+                        }
                     },
                     new TagHelperDescriptor
                     {
@@ -3973,7 +3979,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                 TypeName = typeof(int).FullName
                             }
                         },
-                        RequiredAttributes = new[] { "bound-required-int" }
+                        RequiredAttributes = new[]
+                        {
+                            new TagHelperRequiredAttributeDescriptor { Name = "bound-required-int" }
+                        }
                     },
                     new TagHelperDescriptor
                     {

--- a/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperDescriptorTest.cs
@@ -21,8 +21,22 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                 Prefix = "prefix:",
                 TagName = "tag name",
                 TypeName = "type name",
-                AssemblyName =  "assembly name",
-                RequiredAttributes = new[] { "required attribute one", "required attribute two" },
+                AssemblyName = "assembly name",
+                RequiredAttributes = new[]
+                {
+                    new TagHelperRequiredAttributeDescriptor
+                    {
+                        Name = "required attribute one",
+                        NameComparison = TagHelperRequiredAttributeNameComparison.PrefixMatch
+                    },
+                    new TagHelperRequiredAttributeDescriptor
+                    {
+                        Name = "required attribute two",
+                        NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                        Value = "something",
+                        ValueComparison = TagHelperRequiredAttributeValueComparison.PrefixMatch,
+                    }
+                },
                 AllowedChildren = new[] { "allowed child one" },
                 RequiredParent = "parent name",
                 DesignTimeDescriptor = new TagHelperDesignTimeDescriptor
@@ -41,7 +55,14 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                 $"\"{ nameof(TagHelperDescriptor.AssemblyName) }\":\"assembly name\"," +
                 $"\"{ nameof(TagHelperDescriptor.Attributes) }\":[]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":" +
-                "[\"required attribute one\",\"required attribute two\"]," +
+                $"[{{\"{ nameof(TagHelperRequiredAttributeDescriptor.Name)}\":\"required attribute one\"," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.NameComparison) }\":1," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.Value) }\":null," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.ValueComparison) }\":0}}," +
+                $"{{\"{ nameof(TagHelperRequiredAttributeDescriptor.Name)}\":\"required attribute two\"," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.NameComparison) }\":0," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.Value) }\":\"something\"," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.ValueComparison) }\":2}}]," +
                 $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":[\"allowed child one\"]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredParent) }\":\"parent name\"," +
                 $"\"{ nameof(TagHelperDescriptor.TagStructure) }\":0," +
@@ -200,8 +221,15 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                 $"\"{nameof(TagHelperDescriptor.TypeName)}\":\"type name\"," +
                 $"\"{nameof(TagHelperDescriptor.AssemblyName)}\":\"assembly name\"," +
                 $"\"{nameof(TagHelperDescriptor.Attributes)}\":[]," +
-                $"\"{nameof(TagHelperDescriptor.RequiredAttributes)}\":" +
-                "[\"required attribute one\",\"required attribute two\"]," +
+                $"\"{ nameof(TagHelperDescriptor.RequiredAttributes) }\":" +
+                $"[{{\"{ nameof(TagHelperRequiredAttributeDescriptor.Name)}\":\"required attribute one\"," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.NameComparison) }\":1," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.Value) }\":null," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.ValueComparison) }\":0}}," +
+                $"{{\"{ nameof(TagHelperRequiredAttributeDescriptor.Name)}\":\"required attribute two\"," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.NameComparison) }\":0," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.Value) }\":\"something\"," +
+                $"\"{ nameof(TagHelperRequiredAttributeDescriptor.ValueComparison) }\":2}}]," +
                 $"\"{ nameof(TagHelperDescriptor.AllowedChildren) }\":[\"allowed child one\",\"allowed child two\"]," +
                 $"\"{ nameof(TagHelperDescriptor.RequiredParent) }\":\"parent name\"," +
                 $"\"{nameof(TagHelperDescriptor.TagStructure)}\":2," +
@@ -215,7 +243,21 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                 TagName = "tag name",
                 TypeName = "type name",
                 AssemblyName = "assembly name",
-                RequiredAttributes = new[] { "required attribute one", "required attribute two" },
+                RequiredAttributes = new[]
+                {
+                    new TagHelperRequiredAttributeDescriptor
+                    {
+                        Name = "required attribute one",
+                        NameComparison = TagHelperRequiredAttributeNameComparison.PrefixMatch
+                    },
+                    new TagHelperRequiredAttributeDescriptor
+                    {
+                        Name = "required attribute two",
+                        NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                        Value = "something",
+                        ValueComparison = TagHelperRequiredAttributeValueComparison.PrefixMatch,
+                    }
+                },
                 AllowedChildren = new[] { "allowed child one", "allowed child two" },
                 RequiredParent = "parent name",
                 DesignTimeDescriptor = new TagHelperDesignTimeDescriptor
@@ -237,7 +279,7 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
             Assert.Equal(expectedDescriptor.TypeName, descriptor.TypeName, StringComparer.Ordinal);
             Assert.Equal(expectedDescriptor.AssemblyName, descriptor.AssemblyName, StringComparer.Ordinal);
             Assert.Empty(descriptor.Attributes);
-            Assert.Equal(expectedDescriptor.RequiredAttributes, descriptor.RequiredAttributes, StringComparer.Ordinal);
+            Assert.Equal(expectedDescriptor.RequiredAttributes, descriptor.RequiredAttributes, TagHelperRequiredAttributeDescriptorComparer.Default);
             Assert.Equal(
                 expectedDescriptor.DesignTimeDescriptor,
                 descriptor.DesignTimeDescriptor,

--- a/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperRequiredAttributeDescriptorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperRequiredAttributeDescriptorTest.cs
@@ -1,0 +1,173 @@
+﻿using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
+{
+    public class TagHelperRequiredAttributeDescriptorTest
+    {
+        public static TheoryData RequiredAttributeDescriptorData
+        {
+            get
+            {
+                // requiredAttributeDescriptor, attributeName, attributeValue, expectedResult
+                return new TheoryData<TagHelperRequiredAttributeDescriptor, string, string, bool>
+                {
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "key"
+                        },
+                        "KeY",
+                        "value",
+                        true
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "key"
+                        },
+                        "keys",
+                        "value",
+                        false
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "route-",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.PrefixMatch,
+                        },
+                        "ROUTE-area",
+                        "manage",
+                        true
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "route-",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.PrefixMatch,
+                        },
+                        "routearea",
+                        "manage",
+                        false
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "route-",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.PrefixMatch,
+                        },
+                        "route-",
+                        "manage",
+                        false
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "key",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                        },
+                        "KeY",
+                        "value",
+                        true
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "key",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                        },
+                        "keys",
+                        "value",
+                        false
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "key",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                            Value = "value",
+                            ValueComparison = TagHelperRequiredAttributeValueComparison.FullMatch,
+                        },
+                        "key",
+                        "value",
+                        true
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "key",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                            Value = "value",
+                            ValueComparison = TagHelperRequiredAttributeValueComparison.FullMatch,
+                        },
+                        "key",
+                        "Value",
+                        false
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "class",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                            Value = "btn",
+                            ValueComparison = TagHelperRequiredAttributeValueComparison.PrefixMatch,
+                        },
+                        "class",
+                        "btn btn-success",
+                        true
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "class",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                            Value = "btn",
+                            ValueComparison = TagHelperRequiredAttributeValueComparison.PrefixMatch,
+                        },
+                        "class",
+                        "BTN btn-success",
+                        false
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "href",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                            Value = "#navigate",
+                            ValueComparison = TagHelperRequiredAttributeValueComparison.SuffixMatch,
+                        },
+                        "href",
+                        "/home/index#navigate",
+                        true
+                    },
+                    {
+                        new TagHelperRequiredAttributeDescriptor
+                        {
+                            Name = "href",
+                            NameComparison = TagHelperRequiredAttributeNameComparison.FullMatch,
+                            Value = "#navigate",
+                            ValueComparison = TagHelperRequiredAttributeValueComparison.SuffixMatch,
+                        },
+                        "href",
+                        "/home/index#NAVigate",
+                        false
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RequiredAttributeDescriptorData))]
+        public void Matches_ReturnsExpectedResult(
+            TagHelperRequiredAttributeDescriptor requiredAttributeDescriptor,
+            string attributeName,
+            string attributeValue,
+            bool expectedResult)
+        {
+            // Act
+            var result = requiredAttributeDescriptor.IsMatch(attributeName, attributeValue);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/CssSelectorTagHelperAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/CssSelectorTagHelperAttributes.cs
@@ -1,0 +1,272 @@
+#pragma checksum "CssSelectorTagHelperAttributes.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "7c9072aeb0075e207732cb34646d54529eade9f0"
+namespace TestOutput
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public class CssSelectorTagHelperAttributes
+    {
+        #line hidden
+        #pragma warning disable 0414
+        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
+        private global::TestNamespace.ATagHelper __TestNamespace_ATagHelper = null;
+        private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("href", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("~/"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("href", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("~/hello"));
+        private global::TestNamespace.ATagHelperMultipleSelectors __TestNamespace_ATagHelperMultipleSelectors = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("href", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("~/?hello=world"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("href", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("~/?hello=world@false"));
+        private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
+        private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
+        private global::TestNamespace.CatchAllTagHelper2 __TestNamespace_CatchAllTagHelper2 = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("3 TagHelpers"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("2 TagHelper"));
+        #line hidden
+        public CssSelectorTagHelperAttributes()
+        {
+        }
+
+        #pragma warning disable 1998
+        public override async Task ExecuteAsync()
+        {
+            __tagHelperRunner = __tagHelperRunner ?? new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner();
+            Instrumentation.BeginContext(30, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(45, 13, true);
+                WriteLiteral("2 TagHelpers.");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_ATagHelper = CreateTagHelper<global::TestNamespace.ATagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_ATagHelper);
+            __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
+            }
+            Instrumentation.BeginContext(32, 30, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(62, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(80, 12, true);
+                WriteLiteral("1 TagHelper.");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
+            }
+            Instrumentation.BeginContext(64, 32, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(96, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(123, 12, true);
+                WriteLiteral("2 TagHelpers");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_ATagHelperMultipleSelectors = CreateTagHelper<global::TestNamespace.ATagHelperMultipleSelectors>();
+            __tagHelperExecutionContext.Add(__TestNamespace_ATagHelperMultipleSelectors);
+            __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
+            }
+            Instrumentation.BeginContext(98, 41, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(139, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(172, 12, true);
+                WriteLiteral("2 TagHelpers");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_ATagHelperMultipleSelectors = CreateTagHelper<global::TestNamespace.ATagHelperMultipleSelectors>();
+            __tagHelperExecutionContext.Add(__TestNamespace_ATagHelperMultipleSelectors);
+            __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "href", 3);
+            AddHtmlAttributeValue("", 150, "~/", 150, 2, true);
+#line 6 "CssSelectorTagHelperAttributes.cshtml"
+AddHtmlAttributeValue("", 152, false, 152, 6, false);
+
+#line default
+#line hidden
+            AddHtmlAttributeValue("", 158, "?hello=world", 158, 12, true);
+            EndAddHtmlAttributeValues(__tagHelperExecutionContext);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
+            }
+            Instrumentation.BeginContext(141, 47, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(188, 35, true);
+            WriteLiteral("\r\n<a href=\' ~/\'>0 TagHelpers.</a>\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(240, 11, true);
+                WriteLiteral("1 TagHelper");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "href", 2);
+            AddHtmlAttributeValue("", 231, "~/", 231, 2, true);
+#line 8 "CssSelectorTagHelperAttributes.cshtml"
+AddHtmlAttributeValue("", 233, false, 233, 6, false);
+
+#line default
+#line hidden
+            EndAddHtmlAttributeValues(__tagHelperExecutionContext);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
+            }
+            Instrumentation.BeginContext(223, 32, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(255, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(288, 11, true);
+                WriteLiteral("1 TagHelper");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
+            }
+            Instrumentation.BeginContext(257, 46, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(303, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+                Instrumentation.BeginContext(337, 11, true);
+                WriteLiteral("1 TagHelper");
+                Instrumentation.EndContext();
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "href", 2);
+            AddHtmlAttributeValue("", 314, "~/?hello=world", 314, 14, true);
+#line 10 "CssSelectorTagHelperAttributes.cshtml"
+AddHtmlAttributeValue(" ", 328, false, 329, 7, false);
+
+#line default
+#line hidden
+            EndAddHtmlAttributeValues(__tagHelperExecutionContext);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
+            }
+            Instrumentation.BeginContext(305, 47, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(352, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
+            __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
+            __TestNamespace_CatchAllTagHelper2 = CreateTagHelper<global::TestNamespace.CatchAllTagHelper2>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper2);
+            __TestNamespace_InputTagHelper.Type = "text";
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+            __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_4);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(354, 42, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(396, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
+            __TestNamespace_CatchAllTagHelper2 = CreateTagHelper<global::TestNamespace.CatchAllTagHelper2>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper2);
+            __TestNamespace_InputTagHelper2.Type = "texty";
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper2.Type);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_4);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(398, 43, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            Instrumentation.BeginContext(441, 2, true);
+            WriteLiteral("\r\n");
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
+            }
+            , StartTagHelperWritingScope, EndTagHelperWritingScope);
+            __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
+            __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
+            __TestNamespace_CatchAllTagHelper2 = CreateTagHelper<global::TestNamespace.CatchAllTagHelper2>();
+            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper2);
+            __TestNamespace_InputTagHelper2.Type = "checkbox";
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper2.Type);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_5);
+            __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            Instrumentation.BeginContext(443, 45, false);
+            Write(__tagHelperExecutionContext.Output);
+            Instrumentation.EndContext();
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Source/CssSelectorTagHelperAttributes.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Source/CssSelectorTagHelperAttributes.cshtml
@@ -1,0 +1,13 @@
+﻿@addTagHelper "*, something"
+
+<a href="~/">2 TagHelpers.</a>
+<a href=~/hello>1 TagHelper.</a>
+<a href="~/?hello=world">2 TagHelpers</a>
+<a href="~/@false?hello=world">2 TagHelpers</a>
+<a href=' ~/'>0 TagHelpers.</a>
+<a href=~/@false>1 TagHelper</a>
+<a href="~/?hello=world@false">1 TagHelper</a>
+<a href='~/?hello=world @false'>1 TagHelper</a>
+<input type="text" value="3 TagHelpers" />
+<input type='texty' value="3 TagHelpers" />
+<input type="checkbox" value="2 TagHelper" />


### PR DESCRIPTION
- Added the ability for users to opt into CSS `TagHelper` selectors in their required attributes by surrounding the value with `[` and `]`. Added selectors `^=`, `$=` and `=`.