### PR TITLE
React to changes in HTML abstractions

### DIFF
--- a/Razor.sln
+++ b/Razor.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.24711.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3C0D6505-79B3-49D0-B4C3-176F0F1836ED}"
 EndProject
@@ -16,6 +15,10 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Razor.Runtime.Test", "test\Microsoft.AspNetCore.Razor.Runtime.Test\Microsoft.AspNetCore.Razor.Runtime.Test.xproj", "{0535998A-E32C-4D1A-80D1-0B15A513C471}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Razor.Test.Sources", "src\Microsoft.AspNetCore.Razor.Test.Sources\Microsoft.AspNetCore.Razor.Test.Sources.xproj", "{E3A2A305-634D-4BA6-95DB-AA06D6C442B0}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.Html.Abstractions", "..\HtmlAbstractions\src\Microsoft.AspNetCore.Html.Abstractions\Microsoft.AspNetCore.Html.Abstractions.xproj", "{68A28E4A-3ADE-4187-9625-4FF185887CB3}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.WebEncoders", "..\HtmlAbstractions\src\Microsoft.Extensions.WebEncoders\Microsoft.Extensions.WebEncoders.xproj", "{DD2CE416-765E-4000-A03E-C2FF165DA1B6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -43,6 +46,14 @@ Global
 		{E3A2A305-634D-4BA6-95DB-AA06D6C442B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E3A2A305-634D-4BA6-95DB-AA06D6C442B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E3A2A305-634D-4BA6-95DB-AA06D6C442B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68A28E4A-3ADE-4187-9625-4FF185887CB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68A28E4A-3ADE-4187-9625-4FF185887CB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68A28E4A-3ADE-4187-9625-4FF185887CB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68A28E4A-3ADE-4187-9625-4FF185887CB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD2CE416-765E-4000-A03E-C2FF165DA1B6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-    "projects": ["src"]
+    "projects": ["src", "d:\\k\\HtmlAbstractions\\src"]
 }

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
@@ -149,6 +149,29 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         }
 
         /// <inheritdoc />
+        public override void CopyTo(IHtmlContentBuilder destination)
+        {
+            for (var i = 0; i < Buffer.Count; i++)
+            {
+                var entry = Buffer[i];
+                if (entry == null)
+                {
+                    continue;
+                }
+
+                var stringValue = entry as string;
+                if (stringValue != null)
+                {
+                    destination.Append(stringValue);
+                }
+                else
+                {
+                    destination.AppendHtml((IHtmlContent)entry);
+                }
+            }
+        }
+
+        /// <inheritdoc />
         public override TagHelperContent Clear()
         {
             Buffer.Clear();

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/DefaultTagHelperContent.cs
@@ -151,6 +151,16 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         /// <inheritdoc />
         public override void CopyTo(IHtmlContentBuilder destination)
         {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            if (_buffer == null)
+            {
+                return;
+            }
+
             for (var i = 0; i < Buffer.Count; i++)
             {
                 var entry = Buffer[i];
@@ -159,16 +169,61 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                     continue;
                 }
 
-                var stringValue = entry as string;
-                if (stringValue != null)
+                string entryAsString;
+                IHtmlContentContainer entryAsContainer;
+                if ((entryAsString = entry as string) != null)
                 {
-                    destination.Append(stringValue);
+                    destination.Append(entryAsString);
+                }
+                else if ((entryAsContainer = entry as IHtmlContentContainer) != null)
+                {
+                    entryAsContainer.CopyTo(destination);
                 }
                 else
                 {
                     destination.AppendHtml((IHtmlContent)entry);
                 }
             }
+        }
+
+        /// <inheritdoc />
+        public override void MoveTo(IHtmlContentBuilder destination)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            if (_buffer == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < Buffer.Count; i++)
+            {
+                var entry = Buffer[i];
+                if (entry == null)
+                {
+                    continue;
+                }
+
+                string entryAsString;
+                IHtmlContentContainer entryAsContainer;
+                if ((entryAsString = entry as string) != null)
+                {
+                    destination.Append(entryAsString);
+                }
+                else if ((entryAsContainer = entry as IHtmlContentContainer) != null)
+                {
+                    entryAsContainer.MoveTo(destination);
+                }
+                else
+                {
+                    destination.AppendHtml((IHtmlContent)entry);
+                }
+            }
+
+            Buffer.Clear();
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContent.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContent.cs
@@ -129,6 +129,12 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         public abstract TagHelperContent Clear();
 
         /// <summary>
+        /// Copies the content to another <see cref="IHtmlContentBuilder"/>.
+        /// </summary>
+        /// <param name="destination">The destination <see cref="IHtmlContentBuilder"/>.</param>
+        public abstract void CopyTo(IHtmlContentBuilder destination);
+
+        /// <summary>
         /// Gets the content.
         /// </summary>
         /// <returns>A <see cref="string"/> containing the content.</returns>
@@ -166,6 +172,18 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         IHtmlContentBuilder IHtmlContentBuilder.Clear()
         {
             return Clear();
+        }
+
+        /// <inheritdoc />
+        void IHtmlContentContainer.MoveTo(IHtmlContentBuilder destination)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            CopyTo(destination);
+            Clear();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContent.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContent.cs
@@ -128,11 +128,11 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         /// <returns>A reference to this instance after the clear operation has completed.</returns>
         public abstract TagHelperContent Clear();
 
-        /// <summary>
-        /// Copies the content to another <see cref="IHtmlContentBuilder"/>.
-        /// </summary>
-        /// <param name="destination">The destination <see cref="IHtmlContentBuilder"/>.</param>
+        /// <inheritdoc />
         public abstract void CopyTo(IHtmlContentBuilder destination);
+
+        /// <inheritdoc />
+        public abstract void MoveTo(IHtmlContentBuilder destination);
 
         /// <summary>
         /// Gets the content.
@@ -172,18 +172,6 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         IHtmlContentBuilder IHtmlContentBuilder.Clear()
         {
             return Clear();
-        }
-
-        /// <inheritdoc />
-        void IHtmlContentContainer.MoveTo(IHtmlContentBuilder destination)
-        {
-            if (destination == null)
-            {
-                throw new ArgumentNullException(nameof(destination));
-            }
-
-            CopyTo(destination);
-            Clear();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -278,6 +278,11 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
 
         void IHtmlContentContainer.CopyTo(IHtmlContentBuilder destination)
         {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
             _preElement?.CopyTo(destination);
 
             var isTagNameNullOrWhitespace = string.IsNullOrWhiteSpace(TagName);
@@ -288,7 +293,6 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                 destination.AppendHtml(TagName);
 
                 CopyAttributesTo(destination);
-                _attributes?.Clear();
 
                 if (TagMode == TagMode.SelfClosing)
                 {
@@ -319,6 +323,11 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
 
         void IHtmlContentContainer.MoveTo(IHtmlContentBuilder destination)
         {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
             _preElement?.MoveTo(destination);
 
             var isTagNameNullOrWhitespace = string.IsNullOrWhiteSpace(TagName);
@@ -329,6 +338,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                 destination.AppendHtml(TagName);
                 
                 CopyAttributesTo(destination);
+                _attributes?.Clear();
 
                 if (TagMode == TagMode.SelfClosing)
                 {
@@ -357,6 +367,16 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
 
         public void WriteTo(TextWriter writer, HtmlEncoder encoder)
         {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            if (encoder == null)
+            {
+                throw new ArgumentNullException(nameof(encoder));
+            }
+
             _preElement?.WriteTo(writer, encoder);
 
             var isTagNameNullOrWhitespace = string.IsNullOrWhiteSpace(TagName);

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -338,7 +338,6 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                 destination.AppendHtml(TagName);
                 
                 CopyAttributesTo(destination);
-                _attributes?.Clear();
 
                 if (TagMode == TagMode.SelfClosing)
                 {
@@ -363,6 +362,12 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             }
 
             _postElement?.MoveTo(destination);
+
+            // Depending on the code path we took, these might need to be cleared.
+            _preContent?.Clear();
+            _content?.Clear();
+            _postContent?.Clear();
+            _attributes?.Clear();
         }
 
         public void WriteTo(TextWriter writer, HtmlEncoder encoder)

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperOutput.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperOutput.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
     /// <summary>
     /// Class used to represent the output of an <see cref="ITagHelper"/>.
     /// </summary>
-    public class TagHelperOutput : IHtmlContent
+    public class TagHelperOutput : IHtmlContentContainer
     {
         private readonly Func<bool, HtmlEncoder, Task<TagHelperContent>> _getChildContentAsync;
         private TagHelperAttributeList _attributes;
@@ -276,14 +276,154 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             return _getChildContentAsync(useCachedResult, encoder);
         }
 
-        /// <inheritdoc />
-        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        void IHtmlContentContainer.CopyTo(IHtmlContentBuilder destination)
         {
-            if (writer == null)
+            _preElement?.CopyTo(destination);
+
+            var isTagNameNullOrWhitespace = string.IsNullOrWhiteSpace(TagName);
+
+            if (!isTagNameNullOrWhitespace)
             {
-                throw new ArgumentNullException(nameof(writer));
+                destination.AppendHtml("<");
+                destination.AppendHtml(TagName);
+
+                // Perf: Avoid allocating enumerator
+                for (var i = 0; i < (_attributes?.Count ?? 0); i++)
+                {
+                    var attribute = _attributes[i];
+                    destination.AppendHtml(" ");
+                    destination.AppendHtml(attribute.Name);
+
+                    if (attribute.Minimized)
+                    {
+                        continue;
+                    }
+
+                    destination.AppendHtml("=\"");
+                    var value = attribute.Value;
+                    var htmlContent = value as IHtmlContent;
+                    if (htmlContent != null)
+                    {
+                        // Perf: static text in a bound attribute go down this path. Avoid allocating if possible (common case).
+                        var htmlEncodedString = value as HtmlEncodedString;
+                        if (htmlEncodedString != null && !htmlEncodedString.Value.Contains("\""))
+                        {
+                            destination.AppendHtml(htmlEncodedString);
+                        }
+                        else
+                        {
+                            destination.AppendHtml(new AttributeContent(htmlContent));
+                        }
+                    }
+                    else if (value != null)
+                    {
+                        destination.Append(value.ToString());
+                    }
+
+                    destination.AppendHtml("\"");
+                }
+
+                if (TagMode == TagMode.SelfClosing)
+                {
+                    destination.AppendHtml(" /");
+                }
+
+                destination.AppendHtml(">");
             }
 
+            if (isTagNameNullOrWhitespace || TagMode == TagMode.StartTagAndEndTag)
+            {
+                _preContent?.CopyTo(destination);
+
+                _content?.CopyTo(destination);
+
+                _postContent?.CopyTo(destination);
+            }
+
+            if (!isTagNameNullOrWhitespace && TagMode == TagMode.StartTagAndEndTag)
+            {
+                destination.AppendHtml("</");
+                destination.AppendHtml(TagName);
+                destination.AppendHtml(">");
+            }
+
+            _postElement?.CopyTo(destination);
+        }
+
+        void IHtmlContentContainer.MoveTo(IHtmlContentBuilder destination)
+        {
+            ((IHtmlContentBuilder)_preContent)?.MoveTo(destination);
+
+            var isTagNameNullOrWhitespace = string.IsNullOrWhiteSpace(TagName);
+
+            if (!isTagNameNullOrWhitespace)
+            {
+                destination.AppendHtml("<");
+                destination.AppendHtml(TagName);
+
+                // Perf: Avoid allocating enumerator
+                for (var i = 0; i < (_attributes?.Count ?? 0); i++)
+                {
+                    var attribute = _attributes[i];
+                    destination.AppendHtml(" ");
+                    destination.AppendHtml(attribute.Name);
+
+                    if (attribute.Minimized)
+                    {
+                        continue;
+                    }
+
+                    destination.AppendHtml("=\"");
+                    var value = attribute.Value;
+                    var htmlContent = value as IHtmlContent;
+                    if (htmlContent != null)
+                    {
+                        // Perf: static text in a bound attribute go down this path. Avoid allocating if possible (common case).
+                        var htmlEncodedString = value as HtmlEncodedString;
+                        if (htmlEncodedString != null && !htmlEncodedString.Value.Contains("\""))
+                        {
+                            destination.AppendHtml(htmlEncodedString);
+                        }
+                        else
+                        {
+                            destination.AppendHtml(new AttributeContent(htmlContent));
+                        }
+                    }
+                    else if (value != null)
+                    {
+                        destination.Append(value.ToString());
+                    }
+
+                    destination.AppendHtml("\"");
+                }
+
+                if (TagMode == TagMode.SelfClosing)
+                {
+                    destination.AppendHtml(" /");
+                }
+
+                destination.AppendHtml(">");
+            }
+
+            if (isTagNameNullOrWhitespace || TagMode == TagMode.StartTagAndEndTag)
+            {
+                ((IHtmlContentBuilder)_preContent)?.MoveTo(destination);
+                ((IHtmlContentBuilder)_content)?.MoveTo(destination);
+                ((IHtmlContentBuilder)_postContent)?.MoveTo(destination);
+            }
+
+            if (!isTagNameNullOrWhitespace && TagMode == TagMode.StartTagAndEndTag)
+            {
+                destination.AppendHtml("</");
+                destination.AppendHtml(TagName);
+                destination.AppendHtml(">");
+            }
+
+            ((IHtmlContentBuilder)_postElement)?.MoveTo(destination);
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
             _preElement?.WriteTo(writer, encoder);
 
             var isTagNameNullOrWhitespace = string.IsNullOrWhiteSpace(TagName);
@@ -310,21 +450,30 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                     var htmlContent = value as IHtmlContent;
                     if (htmlContent != null)
                     {
-                        // There's no way of tracking the attribute value quotations in the Razor source. Therefore, we
-                        // must escape any IHtmlContent double quote values in the case that a user wrote:
-                        // <p name='A " is valid in single quotes'></p>
-                        using (var stringWriter = new StringWriter())
+                        // Perf: static text in a bound attribute go down this path. Avoid allocating if possible (common case).
+                        var htmlEncodedString = value as HtmlEncodedString;
+                        if (htmlEncodedString != null && !htmlEncodedString.Value.Contains("\""))
                         {
-                            htmlContent.WriteTo(stringWriter, encoder);
-                            stringWriter.GetStringBuilder().Replace("\"", "&quot;");
+                            writer.Write(htmlEncodedString.Value);
+                        }
+                        else
+                        {
+                            // There's no way of tracking the attribute value quotations in the Razor source. Therefore, we
+                            // must escape any IHtmlContent double quote values in the case that a user wrote:
+                            // <p name='A " is valid in single quotes'></p>
+                            using (var stringWriter = new StringWriter())
+                            {
+                                htmlContent.WriteTo(stringWriter, encoder);
+                                stringWriter.GetStringBuilder().Replace("\"", "&quot;");
 
-                            var stringValue = stringWriter.ToString();
-                            writer.Write(stringValue);
+                                var stringValue = stringWriter.ToString();
+                                writer.Write(stringValue);
+                            }
                         }
                     }
                     else if (value != null)
                     {
-                        encoder.Encode(writer, value.ToString());
+                        writer.Write(value.ToString());
                     }
 
                     writer.Write("\"");
@@ -355,6 +504,31 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             }
 
             _postElement?.WriteTo(writer, encoder);
+        }
+
+        private class AttributeContent : IHtmlContent
+        {
+            public AttributeContent(IHtmlContent inner)
+            {
+                Inner = inner;
+            }
+
+            public IHtmlContent Inner { get; }
+
+            public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+            {
+                // There's no way of tracking the attribute value quotations in the Razor source. Therefore, we
+                // must escape any IHtmlContent double quote values in the case that a user wrote:
+                // <p name='A " is valid in single quotes'></p>
+                using (var stringWriter = new StringWriter())
+                {
+                    Inner.WriteTo(stringWriter, encoder);
+                    stringWriter.GetStringBuilder().Replace("\"", "&quot;");
+
+                    var stringValue = stringWriter.ToString();
+                    writer.Write(stringValue);
+                }
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -972,17 +972,14 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             Assert.Equal(expected, writer.ToString(), StringComparer.Ordinal);
         }
 
-        // This tests a separate code path that's used by THO when the writer is an HtmlTextWriter.
-        // The output should be the same, but we do some specific perf optimizations on this path.
         [Theory]
         [MemberData(nameof(WriteTagHelper_InputData))]
-        public void WriteTo_WritesFormattedTagHelper_HtmlTextWriter(TagHelperOutput output, string expected)
+        public void CopyTo_CopiesToBuilder(TagHelperOutput output, string expected)
         {
             // Arrange
-            var inner = new StringWriter();
+            var writer = new StringWriter();
             var testEncoder = new HtmlTestEncoder();
 
-            var writer = new StringWriter();
             var buffer = new HtmlContentBuilder();
 
             var tagHelperExecutionContext = new TagHelperExecutionContext(
@@ -996,10 +993,48 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperExecutionContext.Output = output;
 
             // Act
-            output.WriteTo(writer, testEncoder);
+            ((IHtmlContentContainer)output).CopyTo(buffer);
 
             // Assert
-            Assert.Equal(expected, inner.ToString(), StringComparer.Ordinal);
+            buffer.WriteTo(writer, testEncoder);
+
+            Assert.Equal(expected, writer.ToString(), StringComparer.Ordinal);
+        }
+
+        [Theory]
+        [MemberData(nameof(WriteTagHelper_InputData))]
+        public void MoveTo_MovesToBuilder(TagHelperOutput output, string expected)
+        {
+            // Arrange
+            var writer = new StringWriter();
+            var testEncoder = new HtmlTestEncoder();
+
+            var buffer = new HtmlContentBuilder();
+
+            var tagHelperExecutionContext = new TagHelperExecutionContext(
+                tagName: output.TagName,
+                tagMode: output.TagMode,
+                items: new Dictionary<object, object>(),
+                uniqueId: string.Empty,
+                executeChildContentAsync: () => Task.FromResult(result: true),
+                startTagHelperWritingScope: _ => { },
+                endTagHelperWritingScope: () => new DefaultTagHelperContent());
+            tagHelperExecutionContext.Output = output;
+
+            // Act
+            ((IHtmlContentContainer)output).MoveTo(buffer);
+
+            // Assert
+            buffer.WriteTo(writer, testEncoder);
+
+            Assert.True(output.PreElement.IsEmpty);
+            Assert.True(output.PreContent.IsEmpty);
+            Assert.True(output.Content.IsEmpty);
+            Assert.True(output.PostContent.IsEmpty);
+            Assert.True(output.PostElement.IsEmpty);
+            Assert.Empty(output.Attributes);
+
+            Assert.Equal(expected, writer.ToString(), StringComparer.Ordinal);
         }
 
         private static TagHelperOutput GetTagHelperOutput(

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -981,7 +981,9 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             // Arrange
             var inner = new StringWriter();
             var testEncoder = new HtmlTestEncoder();
-            var writer = new MockHtmlTextWriter(inner, testEncoder);
+
+            var writer = new StringWriter();
+            var buffer = new HtmlContentBuilder();
 
             var tagHelperExecutionContext = new TagHelperExecutionContext(
                 tagName: output.TagName,
@@ -1045,30 +1047,6 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             }
 
             return output;
-        }
-
-        private class MockHtmlTextWriter : HtmlTextWriter
-        {
-            private readonly HtmlEncoder _encoder;
-            private readonly TextWriter _inner;
-
-            public MockHtmlTextWriter(TextWriter inner, HtmlEncoder encoder)
-            {
-                _inner = inner;
-                _encoder = encoder;
-            }
-
-            public override Encoding Encoding => _inner.Encoding;
-
-            public override void Write(IHtmlContent value)
-            {
-                value.WriteTo(_inner, _encoder);
-            }
-
-            public override void Write(char value)
-            {
-                _inner.Write(value);
-            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -977,6 +977,8 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         public void CopyTo_CopiesToBuilder(TagHelperOutput output, string expected)
         {
             // Arrange
+            var attributeCount = output.Attributes.Count;
+
             var writer = new StringWriter();
             var testEncoder = new HtmlTestEncoder();
 
@@ -998,6 +1000,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             // Assert
             buffer.WriteTo(writer, testEncoder);
 
+            Assert.Equal(attributeCount, output.Attributes.Count);
             Assert.Equal(expected, writer.ToString(), StringComparer.Ordinal);
         }
 


### PR DESCRIPTION
This change implements the new API for flattening content in Razor.

Also, some optimizations to avoid allocations on paths where we need
to encode HTML attribute values.