### PR TITLE
Pre-allocate unbound `TagHelper` attributes.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -146,12 +146,8 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 throw new ArgumentNullException(nameof(name));
             }
 
-            EnsureHtmlAttributes();
-            EnsureAllAttributes();
-
             var attribute = new TagHelperAttribute(name);
-            _htmlAttributes.Add(attribute);
-            _allAttributes.Add(attribute);
+            AddHtmlAttribute(attribute);
         }
 
         /// <summary>
@@ -166,10 +162,24 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 throw new ArgumentNullException(nameof(name));
             }
 
+            var attribute = new TagHelperAttribute(name, value);
+            AddHtmlAttribute(attribute);
+        }
+
+        /// <summary>
+        /// Tracks the HTML attribute.
+        /// </summary>
+        /// <param name="attribute">The <see cref="TagHelperAttribute"/> to track.</param>
+        public void AddHtmlAttribute(TagHelperAttribute attribute)
+        {
+            if (attribute == null)
+            {
+                throw new ArgumentNullException(nameof(attribute));
+            }
+
             EnsureHtmlAttributes();
             EnsureAllAttributes();
 
-            var attribute = new TagHelperAttribute(name, value);
             _htmlAttributes.Add(attribute);
             _allAttributes.Add(attribute);
         }

--- a/src/Microsoft.AspNetCore.Razor/Chunks/PreallocatedTagHelperAttributeChunk.cs
+++ b/src/Microsoft.AspNetCore.Razor/Chunks/PreallocatedTagHelperAttributeChunk.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Chunks
+{
+    /// <summary>
+    /// A <see cref="Chunk"/> that represents a pre-allocated tag helper attribute.
+    /// </summary>
+    public class PreallocatedTagHelperAttributeChunk : Chunk
+    {
+        /// <summary>
+        /// The variable holding the pre-allocated attribute.
+        /// </summary>
+        public string AttributeVariableAccessor { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor/CodeGenerators/GeneratedTagHelperContext.cs
+++ b/src/Microsoft.AspNetCore.Razor/CodeGenerators/GeneratedTagHelperContext.cs
@@ -38,6 +38,8 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators
             TagHelperOutputIsContentModifiedPropertyName = "IsContentModified";
             TagHelperOutputContentPropertyName = "Content";
             TagHelperOutputGetChildContentAsyncMethodName = "GetChildContentAsync";
+            TagHelperAttributeTypeName = "Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute";
+            EncodedHtmlStringTypeName = "Microsoft.AspNetCore.Html.HtmlEncodedString";
         }
 
         /// <summary>
@@ -211,5 +213,15 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators
         /// tag helper child content.
         /// </summary>
         public string TagHelperOutputGetChildContentAsyncMethodName { get; set; }
+
+        /// <summary>
+        /// The name of the type used to represent tag helper attributes.
+        /// </summary>
+        public string TagHelperAttributeTypeName { get; set; }
+
+        /// <summary>
+        /// The name of the type used to represent encoded content.
+        /// </summary>
+        public string EncodedHtmlStringTypeName { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor/CodeGenerators/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
+++ b/src/Microsoft.AspNetCore.Razor/CodeGenerators/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
@@ -3,18 +3,23 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Chunks;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.CodeGenerators.Visitors
 {
     public class CSharpTagHelperFieldDeclarationVisitor : CodeVisitor<CSharpCodeWriter>
     {
+        private const string _preAllocatedAttributeVariablePrefix = "__tagHelperAttribute_";
         private readonly HashSet<string> _declaredTagHelpers;
+        private readonly Dictionary<TagHelperAttributeKey, string> _preAllocatedAttributes;
         private readonly GeneratedTagHelperContext _tagHelperContext;
         private bool _foundTagHelpers;
 
-        public CSharpTagHelperFieldDeclarationVisitor(CSharpCodeWriter writer,
-                                                      CodeGeneratorContext context)
+        public CSharpTagHelperFieldDeclarationVisitor(
+            CSharpCodeWriter writer,
+            CodeGeneratorContext context)
             : base(writer, context)
         {
             if (writer == null)
@@ -29,6 +34,7 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators.Visitors
 
             _declaredTagHelpers = new HashSet<string>(StringComparer.Ordinal);
             _tagHelperContext = Context.Host.GeneratedClassContext.GeneratedTagHelperContext;
+            _preAllocatedAttributes = new Dictionary<TagHelperAttributeKey, string>();
         }
 
         protected override void Visit(TagHelperChunk chunk)
@@ -86,8 +92,81 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators.Visitors
                 }
             }
 
+            if (!Context.Host.DesignTimeMode)
+            {
+                PreAllocateUnboundTagHelperAttributes(chunk);
+            }
+
             // We need to dive deeper to ensure we pick up any nested tag helpers.
             Accept(chunk.Children);
+        }
+
+        private void PreAllocateUnboundTagHelperAttributes(TagHelperChunk chunk)
+        {
+            var boundAttributes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < chunk.Attributes.Count; i++)
+            {
+                var attribute = chunk.Attributes[i];
+                var hasAssociatedDescriptors = chunk.Descriptors.Any(descriptor =>
+                    descriptor.Attributes.Any(attributeDescriptor => attributeDescriptor.IsNameMatch(attribute.Key)));
+
+                // If there's no descriptors associated or we're hitting a bound attribute a second time.
+                if (!hasAssociatedDescriptors || !boundAttributes.Add(attribute.Key))
+                {
+                    string preAllocatedAttributeVariableName = null;
+
+                    if (attribute.Value == null)
+                    {
+                        var preAllocatedAttributeKey = new TagHelperAttributeKey(attribute.Key, value: null);
+                        if (TryCachePreallocatedVariableName(preAllocatedAttributeKey, out preAllocatedAttributeVariableName))
+                        {
+                            Writer
+                                .Write("private static readonly global::")
+                                .Write(_tagHelperContext.TagHelperAttributeTypeName)
+                                .Write(" ")
+                                .Write(preAllocatedAttributeVariableName)
+                                .Write(" = ")
+                                .WriteStartNewObject(_tagHelperContext.TagHelperAttributeTypeName)
+                                .WriteStringLiteral(attribute.Key)
+                                .WriteEndMethodInvocation();
+                        }
+                    }
+                    else
+                    {
+                        string plainText;
+                        if (CSharpTagHelperCodeRenderer.TryGetPlainTextValue(attribute.Value, out plainText))
+                        {
+                            var preAllocatedAttributeKey = new TagHelperAttributeKey(attribute.Key, plainText);
+                            if (TryCachePreallocatedVariableName(preAllocatedAttributeKey, out preAllocatedAttributeVariableName))
+                            {
+                                Writer
+                                    .Write("private static readonly global::")
+                                    .Write(_tagHelperContext.TagHelperAttributeTypeName)
+                                    .Write(" ")
+                                    .Write(preAllocatedAttributeVariableName)
+                                    .Write(" = ")
+                                    .WriteStartNewObject("global::" + _tagHelperContext.TagHelperAttributeTypeName)
+                                    .WriteStringLiteral(attribute.Key)
+                                    .WriteParameterSeparator()
+                                    .WriteStartNewObject("global::" + _tagHelperContext.EncodedHtmlStringTypeName)
+                                    .WriteStringLiteral(plainText)
+                                    .WriteEndMethodInvocation(endLine: false)
+                                    .WriteEndMethodInvocation();
+                            }
+                        }
+                    }
+
+                    if (preAllocatedAttributeVariableName != null)
+                    {
+                        chunk.Attributes[i] = new KeyValuePair<string, Chunk>(
+                            attribute.Key,
+                            new PreallocatedTagHelperAttributeChunk
+                            {
+                                AttributeVariableAccessor = preAllocatedAttributeVariableName
+                            });
+                    }
+                }
+            }
         }
 
         public override void Accept(Chunk chunk)
@@ -116,11 +195,63 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators.Visitors
             }
         }
 
+        private bool TryCachePreallocatedVariableName(TagHelperAttributeKey key, out string preAllocatedAttributeVariableName)
+        {
+            if (!_preAllocatedAttributes.TryGetValue(key, out preAllocatedAttributeVariableName))
+            {
+                preAllocatedAttributeVariableName = _preAllocatedAttributeVariablePrefix + _preAllocatedAttributes.Count;
+                _preAllocatedAttributes[key] = preAllocatedAttributeVariableName;
+                return true;
+            }
+
+            return false;
+        }
+
         private void WritePrivateField(string type, string name, string value)
         {
             Writer
                 .Write("private ")
                 .WriteVariableDeclaration(type, name, value);
+        }
+
+        private struct TagHelperAttributeKey : IEquatable<TagHelperAttributeKey>
+        {
+            public TagHelperAttributeKey(string name, string value)
+            {
+                Name = name;
+                Value = value;
+            }
+
+            public string Name { get; }
+
+            public string Value { get; }
+
+            public override int GetHashCode()
+            {
+                var hashCodeCombiner = HashCodeCombiner.Start();
+                hashCodeCombiner.Add(Name, StringComparer.Ordinal);
+                hashCodeCombiner.Add(Value, StringComparer.Ordinal);
+
+                return hashCodeCombiner.CombinedHash;
+            }
+
+            public override bool Equals(object obj)
+            {
+                var other = obj as TagHelperAttributeKey?;
+
+                if (other != null)
+                {
+                    return Equals(other.Value);
+                }
+
+                return false;
+            }
+
+            public bool Equals(TagHelperAttributeKey other)
+            {
+                return string.Equals(Name, other.Name, StringComparison.Ordinal) &&
+                    string.Equals(Value, other.Value, StringComparison.Ordinal);
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
@@ -582,14 +582,14 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                                 generatedCharacterOffsetIndex: 47,
                                 contentLength: 17),
                             BuildLineMapping(
-                                documentAbsoluteIndex: 202,
+                                documentAbsoluteIndex: 220,
                                 documentLineIndex: 5,
                                 generatedAbsoluteIndex: 1293,
                                 generatedLineIndex: 31,
                                 characterOffsetIndex: 38,
                                 contentLength: 23),
                             BuildLineMapping(
-                                documentAbsoluteIndex: 285,
+                                documentAbsoluteIndex: 303,
                                 documentLineIndex: 6,
                                 documentCharacterOffsetIndex: 40,
                                 generatedAbsoluteIndex: 1934,

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/AttributeTargetingTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/AttributeTargetingTagHelpers.cs
@@ -14,7 +14,9 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("btn"));
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("catchAll", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("hi"));
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -41,7 +43,7 @@ namespace TestOutput
                 , StartTagHelperWritingScope, EndTagHelperWritingScope);
                 __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
                 __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-                __tagHelperExecutionContext.AddHtmlAttribute("catchAll", Html.Raw("hi"));
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 if (!__tagHelperExecutionContext.Output.IsContentModified)
                 {
@@ -96,7 +98,7 @@ __TestNamespace_InputTagHelper2.Checked = true;
 #line default
 #line hidden
                 __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
-                __tagHelperExecutionContext.AddHtmlAttribute("catchAll", Html.Raw("hi"));
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(198, 54, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -109,7 +111,7 @@ __TestNamespace_InputTagHelper2.Checked = true;
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("btn"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
@@ -1,4 +1,4 @@
-#pragma checksum "BasicTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "3cdbdfa1515b87565e2f00812f0093dbe8e49667"
+#pragma checksum "BasicTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "02f53fe4a386cdc0885235e5fd3f5d6d317dd4d6"
 namespace TestOutput
 {
     using System.Threading.Tasks;
@@ -13,6 +13,9 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("Hello World"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("1000"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("-delay1000"));
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -36,12 +39,13 @@ namespace TestOutput
                 , StartTagHelperWritingScope, EndTagHelperWritingScope);
                 __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
                 __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
-                Instrumentation.BeginContext(155, 7, false);
+                Instrumentation.BeginContext(155, 25, false);
                 Write(__tagHelperExecutionContext.Output);
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                Instrumentation.BeginContext(162, 10, true);
+                Instrumentation.BeginContext(180, 10, true);
                 WriteLiteral("\r\n        ");
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
@@ -65,11 +69,11 @@ namespace TestOutput
                 __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
-                Instrumentation.BeginContext(172, 71, false);
+                Instrumentation.BeginContext(190, 71, false);
                 Write(__tagHelperExecutionContext.Output);
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                Instrumentation.BeginContext(243, 10, true);
+                Instrumentation.BeginContext(261, 10, true);
                 WriteLiteral("\r\n        ");
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
@@ -89,29 +93,29 @@ __TestNamespace_InputTagHelper2.Checked = **From custom attribute code renderer*
 #line hidden
                 __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
-                Instrumentation.BeginContext(253, 39, false);
+                Instrumentation.BeginContext(271, 39, false);
                 Write(__tagHelperExecutionContext.Output);
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                Instrumentation.BeginContext(292, 6, true);
+                Instrumentation.BeginContext(310, 6, true);
                 WriteLiteral("\r\n    ");
                 Instrumentation.EndContext();
             }
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
-            __tagHelperExecutionContext.AddHtmlAttribute("data-delay", Html.Raw("1000"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
                 __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
             }
-            Instrumentation.BeginContext(104, 198, false);
+            Instrumentation.BeginContext(104, 216, false);
             Write(__tagHelperExecutionContext.Output);
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(302, 8, true);
+            Instrumentation.BeginContext(320, 8, true);
             WriteLiteral("\r\n</div>");
             Instrumentation.EndContext();
         }

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.Prefixed.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.Prefixed.cs
@@ -14,6 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("Hello World"));
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -60,7 +61,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.cs
@@ -1,4 +1,4 @@
-#pragma checksum "BasicTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "3cdbdfa1515b87565e2f00812f0093dbe8e49667"
+#pragma checksum "BasicTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "02f53fe4a386cdc0885235e5fd3f5d6d317dd4d6"
 namespace TestOutput
 {
     using System;
@@ -14,6 +14,9 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("Hello World"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("1000"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("-delay1000"));
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -37,12 +40,13 @@ namespace TestOutput
                 , StartTagHelperWritingScope, EndTagHelperWritingScope);
                 __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
                 __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
-                Instrumentation.BeginContext(155, 7, false);
+                Instrumentation.BeginContext(155, 25, false);
                 Write(__tagHelperExecutionContext.Output);
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                Instrumentation.BeginContext(162, 10, true);
+                Instrumentation.BeginContext(180, 10, true);
                 WriteLiteral("\r\n        ");
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
@@ -66,11 +70,11 @@ namespace TestOutput
                 __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
-                Instrumentation.BeginContext(172, 71, false);
+                Instrumentation.BeginContext(190, 71, false);
                 Write(__tagHelperExecutionContext.Output);
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                Instrumentation.BeginContext(243, 10, true);
+                Instrumentation.BeginContext(261, 10, true);
                 WriteLiteral("\r\n        ");
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
@@ -90,29 +94,29 @@ __TestNamespace_InputTagHelper2.Checked = true;
 #line hidden
                 __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
-                Instrumentation.BeginContext(253, 39, false);
+                Instrumentation.BeginContext(271, 39, false);
                 Write(__tagHelperExecutionContext.Output);
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                Instrumentation.BeginContext(292, 6, true);
+                Instrumentation.BeginContext(310, 6, true);
                 WriteLiteral("\r\n    ");
                 Instrumentation.EndContext();
             }
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
-            __tagHelperExecutionContext.AddHtmlAttribute("data-delay", Html.Raw("1000"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
                 __tagHelperExecutionContext.Output.Content = await __tagHelperExecutionContext.Output.GetChildContentAsync();
             }
-            Instrumentation.BeginContext(104, 198, false);
+            Instrumentation.BeginContext(104, 216, false);
             Write(__tagHelperExecutionContext.Output);
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            Instrumentation.BeginContext(302, 8, true);
+            Instrumentation.BeginContext(320, 8, true);
             WriteLiteral("\r\n</div>");
             Instrumentation.EndContext();
         }

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
@@ -16,6 +16,13 @@ namespace TestOutput
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", new global::Microsoft.AspNetCore.Html.HtmlEncodedString(""));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("placeholder", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("Enter in a new time..."));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("first value"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("second value"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("hello"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("world"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("hello"));
         #line hidden
         public ComplexTagHelpers()
         {
@@ -74,8 +81,8 @@ namespace TestOutput
                     __TestNamespace_InputTagHelper.Type = "text";
                     __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
                     __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
-                    __tagHelperExecutionContext.AddHtmlAttribute("value", Html.Raw(""));
-                    __tagHelperExecutionContext.AddHtmlAttribute("placeholder", Html.Raw("Enter in a new time..."));
+                    __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+                    __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
                     __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                     Instrumentation.BeginContext(278, 66, false);
                     Write(__tagHelperExecutionContext.Output);
@@ -311,14 +318,14 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("unbound", Html.Raw("first value"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
 #line 21 "ComplexTagHelpers.cshtml"
      __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
-            __tagHelperExecutionContext.AddHtmlAttribute("unbound", Html.Raw("second value"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
@@ -342,8 +349,8 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-                __tagHelperExecutionContext.AddHtmlAttribute("unbound", Html.Raw("hello"));
-                __tagHelperExecutionContext.AddHtmlAttribute("unbound", Html.Raw("world"));
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_4);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_5);
 #line 26 "ComplexTagHelpers.cshtml"
                   __TestNamespace_InputTagHelper2.Checked = (DateTimeOffset.Now.Year > 2014);
 
@@ -506,7 +513,7 @@ __TestNamespace_PTagHelper.Age = 123;
 #line default
 #line hidden
     __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
-    __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("hello"));
+    __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_6);
     __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
     if (!__tagHelperExecutionContext.Output.IsContentModified)
     {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.cs
@@ -14,8 +14,13 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("AGE", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("40"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("Age", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("500"));
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("TYPE", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("checkbox"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("checkbox"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("checked", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("false"));
         #line hidden
         public DuplicateAttributeTagHelpers()
         {
@@ -42,7 +47,7 @@ namespace TestOutput
                 __TestNamespace_InputTagHelper.Type = "button";
                 __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
-                __tagHelperExecutionContext.AddHtmlAttribute("TYPE", Html.Raw("checkbox"));
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(69, 39, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -67,8 +72,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
 #line default
 #line hidden
                 __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
-                __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("checkbox"));
-                __tagHelperExecutionContext.AddHtmlAttribute("checked", Html.Raw("false"));
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_4);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(114, 70, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -87,8 +92,8 @@ __TestNamespace_PTagHelper.Age = 3;
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
-            __tagHelperExecutionContext.AddHtmlAttribute("AGE", Html.Raw("40"));
-            __tagHelperExecutionContext.AddHtmlAttribute("Age", Html.Raw("500"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EmptyAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EmptyAttributeTagHelpers.cs
@@ -15,6 +15,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString(""));
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
         #line hidden
         public EmptyAttributeTagHelpers()
@@ -44,7 +45,7 @@ __TestNamespace_InputTagHelper2.Checked = ;
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw(""));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(38, 34, false);
             Write(__tagHelperExecutionContext.Output);
@@ -73,7 +74,7 @@ __TestNamespace_InputTagHelper2.Checked = ;
 #line default
 #line hidden
                 __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
-                __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw(""));
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(98, 34, false);
                 Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/IncompleteTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/IncompleteTagHelper.cs
@@ -14,6 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString(""));
         #line hidden
         public IncompleteTagHelper()
         {
@@ -31,7 +32,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw(""));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(33, 10, false);
             Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/MinimizedTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/MinimizedTagHelpers.cs
@@ -14,7 +14,12 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("catchall-unbound-required");
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("btn"));
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("input-unbound-required");
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("catchall-unbound-required", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("hello"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("input-unbound-required", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("hello2"));
         #line hidden
         public MinimizedTagHelpers()
         {
@@ -36,8 +41,8 @@ namespace TestOutput
                 , StartTagHelperWritingScope, EndTagHelperWritingScope);
                 __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
                 __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-                __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("btn"));
-                __tagHelperExecutionContext.AddMinimizedHtmlAttribute("catchall-unbound-required");
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(96, 59, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -53,9 +58,9 @@ namespace TestOutput
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
                 __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-                __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("btn"));
-                __tagHelperExecutionContext.AddMinimizedHtmlAttribute("catchall-unbound-required");
-                __tagHelperExecutionContext.AddMinimizedHtmlAttribute("input-unbound-required");
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
                 __TestNamespace_InputTagHelper.BoundRequiredString = "hello";
                 __tagHelperExecutionContext.AddTagHelperAttribute("input-bound-required-string", __TestNamespace_InputTagHelper.BoundRequiredString);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
@@ -73,9 +78,9 @@ namespace TestOutput
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
                 __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-                __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("btn"));
-                __tagHelperExecutionContext.AddMinimizedHtmlAttribute("catchall-unbound-required");
-                __tagHelperExecutionContext.AddMinimizedHtmlAttribute("input-unbound-required");
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
                 __TestNamespace_CatchAllTagHelper.BoundRequiredString = "world";
                 __tagHelperExecutionContext.AddTagHelperAttribute("catchall-bound-string", __TestNamespace_CatchAllTagHelper.BoundRequiredString);
                 __TestNamespace_InputTagHelper.BoundRequiredString = "hello2";
@@ -95,10 +100,10 @@ namespace TestOutput
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
                 __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-                __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("btn"));
-                __tagHelperExecutionContext.AddHtmlAttribute("catchall-unbound-required", Html.Raw("hello"));
-                __tagHelperExecutionContext.AddHtmlAttribute("input-unbound-required", Html.Raw("hello2"));
-                __tagHelperExecutionContext.AddMinimizedHtmlAttribute("catchall-unbound-required");
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_4);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
                 __TestNamespace_InputTagHelper.BoundRequiredString = "world";
                 __tagHelperExecutionContext.AddTagHelperAttribute("input-bound-required-string", __TestNamespace_InputTagHelper.BoundRequiredString);
                 __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
@@ -113,7 +118,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("catchall-unbound-required");
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
@@ -14,6 +14,8 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("Hello World"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("1000"));
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -94,8 +96,8 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
-            __tagHelperExecutionContext.AddHtmlAttribute("data-delay", Html.Raw("1000"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
@@ -15,6 +15,10 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         private global::TestNamespace.InputTagHelper1 __TestNamespace_InputTagHelper1 = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("checkbox"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("password"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("radio"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("int-prefix-salt", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("8"));
         #line hidden
         public PrefixedAttributeTagHelpers()
         {
@@ -52,7 +56,7 @@ namespace TestOutput
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
             __TestNamespace_InputTagHelper1 = CreateTagHelper<global::TestNamespace.InputTagHelper1>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper1);
-            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("checkbox"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 16 "PrefixedAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.IntDictionaryProperty = intDictionary;
 
@@ -90,7 +94,7 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty = intDictionary;
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-garlic", "TestNamespace.InputTagHelper1", "IntDictionaryProperty"));
             }
-            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("password"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
 #line 17 "PrefixedAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.IntDictionaryProperty = intDictionary;
 
@@ -143,7 +147,7 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty = intDictionary;
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-paprika", "TestNamespace.InputTagHelper1", "StringDictionaryProperty"));
             }
-            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("radio"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
 #line 19 "PrefixedAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
 
@@ -165,7 +169,7 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty["salt"] = 37;
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-pepper", __TestNamespace_InputTagHelper2.IntDictionaryProperty["pepper"]);
             __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"] = __TestNamespace_InputTagHelper2.IntDictionaryProperty["pepper"];
-            __tagHelperExecutionContext.AddHtmlAttribute("int-prefix-salt", Html.Raw("8"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["grabber"] = "string";
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __TestNamespace_InputTagHelper2.StringDictionaryProperty["grabber"]);
             __TestNamespace_InputTagHelper1.StringProperty = __TestNamespace_InputTagHelper2.StringDictionaryProperty["grabber"];

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
@@ -15,6 +15,10 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.InputTagHelper1 __TestNamespace_InputTagHelper1 = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("checkbox"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("password"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("radio"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("int-prefix-salt", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("8"));
         #line hidden
         public PrefixedAttributeTagHelpers()
         {
@@ -52,7 +56,7 @@ namespace TestOutput
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper1);
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("checkbox"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 16 "PrefixedAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper1.IntDictionaryProperty = intDictionary;
 
@@ -90,7 +94,7 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty = intDictionary;
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("int-prefix-garlic", "TestNamespace.InputTagHelper2", "IntDictionaryProperty"));
             }
-            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("password"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
 #line 17 "PrefixedAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper1.IntDictionaryProperty = intDictionary;
 
@@ -143,7 +147,7 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty = intDictionary;
             {
                 throw new InvalidOperationException(FormatInvalidIndexerAssignment("string-prefix-grabber", "TestNamespace.InputTagHelper2", "StringDictionaryProperty"));
             }
-            __tagHelperExecutionContext.AddHtmlAttribute("type", Html.Raw("radio"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
 #line 19 "PrefixedAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper1.IntProperty = 42;
 
@@ -165,7 +169,7 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"] = 37;
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-pepper", __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"]);
             __TestNamespace_InputTagHelper2.IntDictionaryProperty["pepper"] = __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"];
-            __tagHelperExecutionContext.AddHtmlAttribute("int-prefix-salt", Html.Raw("8"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             __TestNamespace_InputTagHelper1.StringProperty = "string";
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __TestNamespace_InputTagHelper1.StringProperty);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["grabber"] = __TestNamespace_InputTagHelper1.StringProperty;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelper.cs
@@ -14,6 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("Hello World"));
         #line hidden
         public SingleTagHelper()
         {
@@ -34,7 +35,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 3 "SingleTagHelper.cshtml"
 __TestNamespace_PTagHelper.Age = 1337;
 

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelperWithNewlineBeforeAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelperWithNewlineBeforeAttributes.cs
@@ -14,6 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("Hello World"));
         #line hidden
         public SingleTagHelperWithNewlineBeforeAttributes()
         {
@@ -34,7 +35,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 4 "SingleTagHelperWithNewlineBeforeAttributes.cshtml"
 __TestNamespace_PTagHelper.Age = 1337;
 

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
@@ -14,6 +14,14 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("bound");
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("[item]", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("items"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("[(item)]", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("items"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("(click)", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("doSomething()"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("(^click)", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("doSomething()"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("*something", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("value"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("#localminimized");
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("#local", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("value"));
         #line hidden
         public SymbolBoundAttributes()
         {
@@ -31,14 +39,14 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 12 "SymbolBoundAttributes.cshtml"
 __TestNamespace_CatchAllTagHelper.ListItems = items;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("[item]", __TestNamespace_CatchAllTagHelper.ListItems);
-            __tagHelperExecutionContext.AddHtmlAttribute("[item]", Html.Raw("items"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(276, 45, false);
             Write(__tagHelperExecutionContext.Output);
@@ -52,14 +60,14 @@ __TestNamespace_CatchAllTagHelper.ListItems = items;
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 13 "SymbolBoundAttributes.cshtml"
 __TestNamespace_CatchAllTagHelper.ArrayItems = items;
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("[(item)]", __TestNamespace_CatchAllTagHelper.ArrayItems);
-            __tagHelperExecutionContext.AddHtmlAttribute("[(item)]", Html.Raw("items"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(323, 49, false);
             Write(__tagHelperExecutionContext.Output);
@@ -76,14 +84,14 @@ __TestNamespace_CatchAllTagHelper.ArrayItems = items;
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 14 "SymbolBoundAttributes.cshtml"
 __TestNamespace_CatchAllTagHelper.Event1 = doSomething();
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("(click)", __TestNamespace_CatchAllTagHelper.Event1);
-            __tagHelperExecutionContext.AddHtmlAttribute("(click)", Html.Raw("doSomething()"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
@@ -104,14 +112,14 @@ __TestNamespace_CatchAllTagHelper.Event1 = doSomething();
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 15 "SymbolBoundAttributes.cshtml"
 __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
 
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("(^click)", __TestNamespace_CatchAllTagHelper.Event2);
-            __tagHelperExecutionContext.AddHtmlAttribute("(^click)", Html.Raw("doSomething()"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_4);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
@@ -132,10 +140,10 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __TestNamespace_CatchAllTagHelper.StringProperty1 = "value";
             __tagHelperExecutionContext.AddTagHelperAttribute("*something", __TestNamespace_CatchAllTagHelper.StringProperty1);
-            __tagHelperExecutionContext.AddHtmlAttribute("*something", Html.Raw("value"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_5);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
@@ -153,8 +161,8 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
-            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("#localminimized");
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_6);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(607, 33, false);
             Write(__tagHelperExecutionContext.Output);
@@ -168,10 +176,10 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-            __tagHelperExecutionContext.AddMinimizedHtmlAttribute("bound");
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __TestNamespace_CatchAllTagHelper.StringProperty2 = "value";
             __tagHelperExecutionContext.AddTagHelperAttribute("#local", __TestNamespace_CatchAllTagHelper.StringProperty2);
-            __tagHelperExecutionContext.AddHtmlAttribute("#local", Html.Raw("value"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_7);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(642, 47, false);
             Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersWithWeirdlySpacedAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersWithWeirdlySpacedAttributes.cs
@@ -14,8 +14,12 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("Hello World"));
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("hello"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("hello2"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("blah"));
         #line hidden
         public TagHelpersWithWeirdlySpacedAttributes()
         {
@@ -36,7 +40,7 @@ namespace TestOutput
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("Hello World"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 6 "TagHelpersWithWeirdlySpacedAttributes.cshtml"
 __TestNamespace_PTagHelper.Age = 1337;
 
@@ -73,7 +77,7 @@ __TestNamespace_PTagHelper.Age = 1337;
             __TestNamespace_InputTagHelper.Type = "text";
             __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
-            __tagHelperExecutionContext.AddHtmlAttribute("data-content", Html.Raw("hello"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(122, 47, false);
             Write(__tagHelperExecutionContext.Output);
@@ -93,7 +97,7 @@ __TestNamespace_PTagHelper.Age = 1234;
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
-            __tagHelperExecutionContext.AddHtmlAttribute("data-content", Html.Raw("hello2"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(173, 46, false);
             Write(__tagHelperExecutionContext.Output);
@@ -112,7 +116,7 @@ __TestNamespace_PTagHelper.Age = 1234;
             __TestNamespace_InputTagHelper.Type = "password";
             __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
-            __tagHelperExecutionContext.AddHtmlAttribute("data-content", Html.Raw("blah"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             __tagHelperExecutionContext.Output = await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(223, 51, false);
             Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
@@ -14,6 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager();
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlEncodedString("test"));
         #line hidden
         public TransitionsInTagHelperAttributes()
         {
@@ -96,7 +97,7 @@ __TestNamespace_PTagHelper.Age = 42;
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("test"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 9 "TransitionsInTagHelperAttributes.cshtml"
 __TestNamespace_PTagHelper.Age = 42 + @int;
 
@@ -116,7 +117,7 @@ __TestNamespace_PTagHelper.Age = 42 + @int;
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("test"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 10 "TransitionsInTagHelperAttributes.cshtml"
 __TestNamespace_PTagHelper.Age = int;
 
@@ -136,7 +137,7 @@ __TestNamespace_PTagHelper.Age = int;
             , StartTagHelperWritingScope, EndTagHelperWritingScope);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw("test"));
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
 #line 11 "TransitionsInTagHelperAttributes.cshtml"
 __TestNamespace_PTagHelper.Age = (@int);
 

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Source/BasicTagHelpers.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Source/BasicTagHelpers.cshtml
@@ -2,7 +2,7 @@
 
 <div data-animation="fade" class="randomNonTagHelperAttribute">
     <p class="Hello World" data-delay="1000">
-        <p></p>
+        <p data="-delay1000"></p>
         <input data-interval="2000 + @ViewBag.DefaultInterval + 1" type="text">
         <input type="checkbox" checked="true"/>
     </p>


### PR DESCRIPTION
- Hoist `TagHelperAttribute` creation into `private static readonly` fields to avoid allocations on every request. With the recent `TagHelperAttribute` change that made them immutable we can now pre-allocate them without worry of them being modified.
- Added two extra class configuration pieces to enable pre-allocation.
- Updated test files to showcase new pre-allocations.

**Before:**
![image](https://cloud.githubusercontent.com/assets/2008729/13414254/0a1676ba-df06-11e5-9802-9b4f829f353c.png)


**After:**
![image](https://cloud.githubusercontent.com/assets/2008729/13414272/1d7c5120-df06-11e5-8218-948212dc42d3.png)

**Result:** 5.7% reduction in allocations overall.

#600 