### PR TITLE
Fix nested C# blocks when combined with C# @ symbols.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor/Parser/CSharpCodeParser.Statements.cs
+++ b/src/Microsoft.AspNetCore.Razor/Parser/CSharpCodeParser.Statements.cs
@@ -654,7 +654,7 @@ namespace Microsoft.AspNetCore.Razor.Parser
                 {
                     Context.Source.Position = bookmark;
                     NextToken();
-                    AcceptUntil(CSharpSymbolType.LessThan, CSharpSymbolType.RightBrace);
+                    AcceptUntil(CSharpSymbolType.LessThan, CSharpSymbolType.LeftBrace, CSharpSymbolType.RightBrace);
                     return;
                 }
             }

--- a/test/Microsoft.AspNetCore.Razor.Test/Parser/CSharp/CSharpBlockTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Parser/CSharp/CSharpBlockTest.cs
@@ -16,6 +16,20 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.CSharp
     public class CSharpBlockTest : CsHtmlCodeParserTestBase
     {
         [Fact]
+        public void ParseBlock_NestedCodeBlockWithCSharpAt()
+        {
+            ParseBlockTest("{ if (true) { var val = @x; if (val != 3) { } } }",
+                new StatementBlock(
+                    Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                    Factory
+                        .Code(" if (true) { var val = @x; if (val != 3) { } } ")
+                        .AsStatement()
+                        .Accepts(AcceptedCharacters.Any)
+                        .AutoCompleteWith(autoCompleteString: null, atEndOfSpan: false),
+                    Factory.MetaCode("}").Accepts(AcceptedCharacters.None)));
+        }
+
+        [Fact]
         public void ParseBlock_NestedCodeBlockWithMarkupSetsDotAsMarkup()
         {
             ParseBlockTest("if (true) { @if(false) { <div>@something.</div> } }",


### PR DESCRIPTION
- We used to accept until markup or an ending brace which didn't allow the parser to balance nested braces.

#679