### PR TITLE
Update `TagHelperDesignTimeDescriptorFactory` to work in CoreCLR.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -34,9 +34,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 RegexOptions.None,
                 Constants.RegexMatchTimeout);
 
-#if !NETSTANDARD1_3
         private readonly TagHelperDesignTimeDescriptorFactory _designTimeDescriptorFactory;
-#endif
         private readonly bool _designTime;
 
         // TODO: Investigate if we should cache TagHelperDescriptors for types:
@@ -53,12 +51,10 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         /// </param>
         public TagHelperDescriptorFactory(bool designTime)
         {
-#if !NETSTANDARD1_3
             if (designTime)
             {
                 _designTimeDescriptorFactory = new TagHelperDesignTimeDescriptorFactory();
             }
-#endif
 
             _designTime = designTime;
         }
@@ -129,12 +125,10 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         {
             TagHelperDesignTimeDescriptor typeDesignTimeDescriptor = null;
 
-#if !NETSTANDARD1_3
             if (_designTime)
             {
                 typeDesignTimeDescriptor = _designTimeDescriptorFactory.CreateDescriptor(type);
             }
-#endif
 
             var typeName = type.FullName;
 
@@ -689,12 +683,10 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         {
             TagHelperAttributeDesignTimeDescriptor propertyDesignTimeDescriptor = null;
 
-#if !NETSTANDARD1_3
             if (_designTime)
             {
                 propertyDesignTimeDescriptor = _designTimeDescriptorFactory.CreateAttributeDescriptor(property);
             }
-#endif
 
             return new TagHelperAttributeDescriptor
             {

--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/XmlDocumentationProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/XmlDocumentationProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if !NETSTANDARD1_3
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -126,4 +125,3 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         }
     }
 }
-#endif

--- a/src/Microsoft.AspNetCore.Razor.Runtime/project.json
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/project.json
@@ -56,9 +56,12 @@
     },
     "netstandard1.3": {
       "dependencies": {
+        "System.Collections.Concurrent": "4.0.12-*",
+        "System.Reflection": "4.1.0-*",
         "System.Reflection.Extensions": "4.0.1-*",
         "System.Reflection.TypeExtensions": "4.1.0-*",
-        "System.Text.RegularExpressions": "4.0.12-*"
+        "System.Text.RegularExpressions": "4.0.12-*",
+        "System.Xml.XDocument": "4.0.11-*"
       },
       "imports": [
         "dotnet5.4"

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/project.json
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/project.json
@@ -23,7 +23,8 @@
         "portable-net451+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-*"
+        "dotnet-test-xunit": "1.0.0-dev-*",
+        "moq.netcore": "4.4.0-beta8"
       }
     },
     "net451": {


### PR DESCRIPTION
- After discussion offline to maintain consistency we decided to also remove `CodeBase` fallback in the net451 scenario. This will keep CoreCLR and net451 scenarios more consistent.
- Removed `CodeBase` validation tests.
- Added `GetAssemblyLocation` extensibility point to enable proper testing of the `TagHelperDesignTimeDescriptorFactory`.

#709