### PR TITLE
Allow for the TagHelperTypeDescriptorResolver to be injected

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/ITagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/ITagHelperDescriptorFactory.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Compilation.TagHelpers;
+
+namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// Factory for <see cref="TagHelperDescriptor"/> instances.
+    /// </summary>
+    public interface ITagHelperDescriptorFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="TagHelperDescriptor"/> from the given <paramref name="type"/>.
+        /// </summary>
+        /// <param name="assemblyName">The assembly name that contains <paramref name="type"/>.</param>
+        /// <param name="type">The <see cref="Type"/> to create a <see cref="TagHelperDescriptor"/> from.
+        /// </param>
+        /// <param name="errorSink">The <see cref="ErrorSink"/> used to collect <see cref="RazorError"/>s encountered
+        /// when creating <see cref="TagHelperDescriptor"/>s for the given <paramref name="type"/>.</param>
+        /// <returns>
+        /// A collection of <see cref="TagHelperDescriptor"/>s that describe the given <paramref name="type"/>.
+        /// </returns>
+        IEnumerable<TagHelperDescriptor> CreateDescriptors(string assemblyName, Type type, ErrorSink errorSink);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/ITagHelperTypeResolver.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/ITagHelperTypeResolver.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// Locates valid <see cref="ITagHelper"/>s within an assembly.
+    /// </summary>
+    public interface ITagHelperTypeResolver
+    {
+        /// <summary>
+        /// Locates valid <see cref="ITagHelper"/> types from the <see cref="Assembly"/> named <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The name of an <see cref="Assembly"/> to search.</param>
+        /// <param name="documentLocation">The <see cref="SourceLocation"/> of the associated
+        /// <see cref="Parser.SyntaxTree.SyntaxTreeNode"/> responsible for the current <see cref="Resolve"/> call.
+        /// </param>
+        /// <param name="errorSink">The <see cref="ErrorSink"/> used to record errors found when resolving
+        /// <see cref="ITagHelper"/> types.</param>
+        /// <returns>An <see cref="IEnumerable{Type}"/> of valid <see cref="ITagHelper"/> types.</returns>
+        IEnumerable<Type> Resolve(string name, SourceLocation documentLocation, ErrorSink errorSink);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperConventions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperConventions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
+{
+    /// <summary>
+    /// Default convention for determining if a type is a tag helper.
+    /// </summary>
+    public static class TagHelperConventions
+    {
+        private static readonly TypeInfo ITagHelperTypeInfo = typeof(ITagHelper).GetTypeInfo();
+
+        /// <summary>
+        /// Indicates whether or not the <see cref="TypeInfo"/> is a tag helper.
+        /// </summary>
+        /// <param name="typeInfo">The <see cref="TypeInfo"/>.</param>
+        /// <returns>true if <paramref name="typeInfo"/> is a tag helper; false otherwise.</returns>
+        public static bool IsTagHelper(TypeInfo typeInfo)
+        {
+            return !typeInfo.IsNested &&
+                typeInfo.IsPublic &&
+                !typeInfo.IsAbstract &&
+                !typeInfo.IsGenericType &&
+                ITagHelperTypeInfo.IsAssignableFrom(typeInfo);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperDescriptorFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperDescriptorFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
     /// <summary>
     /// Factory for <see cref="TagHelperDescriptor"/>s from <see cref="Type"/>s.
     /// </summary>
-    public class TagHelperDescriptorFactory
+    public class TagHelperDescriptorFactory : ITagHelperDescriptorFactory
     {
         private const string DataDashPrefix = "data-";
         private const string TagHelperNameEnding = "TagHelper";
@@ -59,17 +59,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             _designTime = designTime;
         }
 
-        /// <summary>
-        /// Creates a <see cref="TagHelperDescriptor"/> from the given <paramref name="type"/>.
-        /// </summary>
-        /// <param name="assemblyName">The assembly name that contains <paramref name="type"/>.</param>
-        /// <param name="type">The <see cref="Type"/> to create a <see cref="TagHelperDescriptor"/> from.
-        /// </param>
-        /// <param name="errorSink">The <see cref="ErrorSink"/> used to collect <see cref="RazorError"/>s encountered
-        /// when creating <see cref="TagHelperDescriptor"/>s for the given <paramref name="type"/>.</param>
-        /// <returns>
-        /// A collection of <see cref="TagHelperDescriptor"/>s that describe the given <paramref name="type"/>.
-        /// </returns>
+        /// <inheritdoc />
         public virtual IEnumerable<TagHelperDescriptor> CreateDescriptors(
             string assemblyName,
             Type type,

--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperDescriptorResolver.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperDescriptorResolver.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 { TagHelperDirectiveType.TagHelperPrefix, SyntaxConstants.CSharp.TagHelperPrefixKeyword },
             };
 
-        private readonly TagHelperTypeResolver _typeResolver;
-        private readonly TagHelperDescriptorFactory _descriptorFactory;
+        private readonly ITagHelperTypeResolver _typeResolver;
+        private readonly ITagHelperDescriptorFactory _descriptorFactory;
 
         /// <summary>
         /// Instantiates a new instance of the <see cref="TagHelperDescriptorResolver"/> class.
@@ -43,8 +43,8 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         /// <param name="typeResolver">The <see cref="TagHelperTypeResolver"/>.</param>
         /// <param name="descriptorFactory">The <see cref="TagHelperDescriptorFactory"/>.</param>
         public TagHelperDescriptorResolver(
-            TagHelperTypeResolver typeResolver,
-            TagHelperDescriptorFactory descriptorFactory)
+            ITagHelperTypeResolver typeResolver,
+            ITagHelperDescriptorFactory descriptorFactory)
         {
             _typeResolver = typeResolver;
             _descriptorFactory = descriptorFactory;

--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperTypeResolver.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperTypeResolver.cs
@@ -12,20 +12,11 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
     /// <summary>
     /// Class that locates valid <see cref="ITagHelper"/>s within an assembly.
     /// </summary>
-    public class TagHelperTypeResolver
+    public class TagHelperTypeResolver : ITagHelperTypeResolver
     {
         private static readonly TypeInfo ITagHelperTypeInfo = typeof(ITagHelper).GetTypeInfo();
 
-        /// <summary>
-        /// Locates valid <see cref="ITagHelper"/> types from the <see cref="Assembly"/> named <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name">The name of an <see cref="Assembly"/> to search.</param>
-        /// <param name="documentLocation">The <see cref="SourceLocation"/> of the associated
-        /// <see cref="Parser.SyntaxTree.SyntaxTreeNode"/> responsible for the current <see cref="Resolve"/> call.
-        /// </param>
-        /// <param name="errorSink">The <see cref="ErrorSink"/> used to record errors found when resolving
-        /// <see cref="ITagHelper"/> types.</param>
-        /// <returns>An <see cref="IEnumerable{Type}"/> of valid <see cref="ITagHelper"/> types.</returns>
+        /// <inheritdoc />
         public IEnumerable<Type> Resolve(
             string name,
             SourceLocation documentLocation,
@@ -96,12 +87,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 throw new ArgumentNullException(nameof(typeInfo));
             }
 
-            return
-                !typeInfo.IsNested &&
-                typeInfo.IsPublic &&
-                !typeInfo.IsAbstract &&
-                !typeInfo.IsGenericType &&
-                ITagHelperTypeInfo.IsAssignableFrom(typeInfo);
+            return TagHelperConventions.IsTagHelper(typeInfo);
         }
     }
 }


### PR DESCRIPTION
Changes required in Razor to support https://github.com/aspnet/Mvc/issues/4087
* Add an interface for ITagHelperTypeResolver and ITagHelperDescriptorFactory
* Extract the default convention for tag helper discovery into TagHelperConventions following the same  pattern we use for ViewComponents.