### PR TITLE
Change `DefaultTagHelperContent` to be smart about single content entries.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContent.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperContent.cs
@@ -19,14 +19,9 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         public abstract bool IsModified { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the content is empty.
+        /// Gets a value indicating whether the content is empty or whitespace.
         /// </summary>
-        public abstract bool IsEmpty { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the content is whitespace.
-        /// </summary>
-        public abstract bool IsWhiteSpace { get; }
+        public abstract bool IsEmptyOrWhiteSpace { get; }
 
         /// <summary>
         /// Sets the content.

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/DefaultTagHelperContentTest.cs
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             source.MoveTo(destination);
 
             // Assert
-            Assert.True(source.IsEmpty);
+            Assert.Equal(string.Empty, source.GetContent());
             Assert.Equal(3, items.Count);
 
             Assert.Equal("some-content", Assert.IsType<string>(items[0]));
@@ -191,8 +191,8 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             source.MoveTo(destination);
 
             // Assert
-            Assert.True(source.IsEmpty);
-            Assert.True(nested.IsEmpty);
+            Assert.Equal(string.Empty, source.GetContent());
+            Assert.Equal(string.Empty, nested.GetContent());
             Assert.Equal(3, items.Count);
 
             Assert.Equal("some-content", Assert.IsType<string>(items[0]));
@@ -362,7 +362,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         [InlineData("\n")]
         [InlineData("\t")]
         [InlineData("\r")]
-        public void CanIdentifyWhiteSpace(string data)
+        public void CanIdentifyEmptyOrWhiteSpace(string data)
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.Append(data);
 
             // Assert
-            Assert.True(tagHelperContent.IsWhiteSpace);
+            Assert.True(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
@@ -386,21 +386,22 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.Append("Hello");
 
             // Assert
-            Assert.False(tagHelperContent.IsWhiteSpace);
+            Assert.True(tagHelperContent.GetContent().Length > 0);
+            Assert.False(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
-        public void IsEmpty_InitiallyTrue()
+        public void IsEmptyOrWhiteSpace_InitiallyTrue()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
 
             // Act & Assert
-            Assert.True(tagHelperContent.IsEmpty);
+            Assert.True(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
-        public void IsEmpty_TrueAfterSetEmptyContent()
+        public void IsEmptyOrWhiteSpace_TrueAfterSetEmptyContent()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
@@ -409,11 +410,11 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.SetContent(string.Empty);
 
             // Assert
-            Assert.True(tagHelperContent.IsEmpty);
+            Assert.True(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
-        public void IsEmpty_TrueAfterAppendEmptyContent()
+        public void IsEmptyOrWhiteSpace_TrueAfterAppendEmptyContent()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
@@ -423,11 +424,11 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.Append(string.Empty);
 
             // Assert
-            Assert.True(tagHelperContent.IsEmpty);
+            Assert.True(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
-        public void IsEmpty_TrueAfterAppendEmptyTagHelperContent()
+        public void IsEmptyOrWhiteSpace_TrueAfterAppendEmptyTagHelperContent()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
@@ -438,11 +439,11 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.Append(string.Empty);
 
             // Assert
-            Assert.True(tagHelperContent.IsEmpty);
+            Assert.True(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
-        public void IsEmpty_TrueAfterClear()
+        public void IsEmptyOrWhiteSpace_TrueAfterClear()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
@@ -451,11 +452,12 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.Clear();
 
             // Assert
-            Assert.True(tagHelperContent.IsEmpty);
+            Assert.Equal(string.Empty, tagHelperContent.GetContent());
+            Assert.True(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
-        public void IsEmpty_FalseAfterSetContent()
+        public void IsEmptyOrWhiteSpace_FalseAfterSetContent()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
@@ -464,11 +466,11 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.SetContent("Hello");
 
             // Assert
-            Assert.False(tagHelperContent.IsEmpty);
+            Assert.False(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
-        public void IsEmpty_FalseAfterAppend()
+        public void IsEmptyOrWhiteSpace_FalseAfterAppend()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
@@ -477,11 +479,11 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.Append("Hello");
 
             // Assert
-            Assert.False(tagHelperContent.IsEmpty);
+            Assert.False(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
-        public void IsEmpty_FalseAfterAppendTagHelper()
+        public void IsEmptyOrWhiteSpace_FalseAfterAppendTagHelper()
         {
             // Arrange
             var tagHelperContent = new DefaultTagHelperContent();
@@ -492,7 +494,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.AppendHtml(copiedTagHelperContent);
 
             // Assert
-            Assert.False(tagHelperContent.IsEmpty);
+            Assert.False(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]
@@ -506,7 +508,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             tagHelperContent.Clear();
 
             // Assert
-            Assert.True(tagHelperContent.IsEmpty);
+            Assert.True(tagHelperContent.IsEmptyOrWhiteSpace);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -1079,11 +1079,11 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             // Assert
             buffer.WriteTo(writer, testEncoder);
 
-            Assert.True(output.PreElement.IsEmpty);
-            Assert.True(output.PreContent.IsEmpty);
-            Assert.True(output.Content.IsEmpty);
-            Assert.True(output.PostContent.IsEmpty);
-            Assert.True(output.PostElement.IsEmpty);
+            Assert.Equal(string.Empty, output.PreElement.GetContent());
+            Assert.Equal(string.Empty, output.PreContent.GetContent());
+            Assert.Equal(string.Empty, output.Content.GetContent());
+            Assert.Equal(string.Empty, output.PostContent.GetContent());
+            Assert.Equal(string.Empty, output.PostElement.GetContent());
             Assert.Empty(output.Attributes);
 
             Assert.Equal(expected, writer.ToString(), StringComparer.Ordinal);


### PR DESCRIPTION
- Today `TagHelperContent`s always allocate their underlying buffer even though they typically only ever have a single entry. Added a field to enable us to only allocate the backing buffer when we absolutely need to.
- Removed `IsEmpty` from `TagHelperContent` since it was not used in any of our `TagHelper`s for simplification. Changed `IsWhiteSpace` naming to be `IsEmptyOrWhiteSpace` since it can be used to indicate either state.
- Updated tests.

**Before:**
![image](https://cloud.githubusercontent.com/assets/2008729/14186561/d49d579c-f733-11e5-96fe-fd9591fd7c12.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/2008729/14186579/e9f67cae-f733-11e5-9a42-d50279417ac9.png)

**Result:** 4.1% overall reduction in allocations.

#621