### PR TITLE
Fix: Newline at the end of text tag in code block is rendered as markup

### DIFF
--- a/src/Microsoft.AspNetCore.Razor/Parser/HtmlMarkupParser.Block.cs
+++ b/src/Microsoft.AspNetCore.Razor/Parser/HtmlMarkupParser.Block.cs
@@ -1118,7 +1118,9 @@ namespace Microsoft.AspNetCore.Razor.Parser
                     }
                 }
 
-                if (!EndOfFile && CurrentSymbol.Type == HtmlSymbolType.NewLine)
+                if (!EndOfFile &&
+                    At(HtmlSymbolType.NewLine) &&
+                    Context.LastSpan.Kind != SpanKind.Transition)
                 {
                     AcceptAndMoveNext();
                 }

--- a/test/Microsoft.AspNetCore.Razor.Test/Parser/CSharp/CSharpToMarkupSwitchTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Parser/CSharp/CSharpToMarkupSwitchTest.cs
@@ -685,10 +685,8 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.CSharp
                                        Factory.Code("p").AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)
                                        ),
                                    new MarkupTagBlock(
-                                        Factory.MarkupTransition("</text>").Accepts(AcceptedCharacters.None)),
-                                   Factory.Markup(Environment.NewLine).Accepts(AcceptedCharacters.None)
-                                   ),
-                               Factory.Code($"    }}{Environment.NewLine}    if(!false) {{{Environment.NewLine}").AsStatement(),
+                                        Factory.MarkupTransition("</text>").Accepts(AcceptedCharacters.None))),
+                               Factory.Code($"{Environment.NewLine}    }}{Environment.NewLine}    if(!false) {{{Environment.NewLine}").AsStatement(),
                                new MarkupBlock(
                                    Factory.Markup("        "),
                                    new MarkupTagBlock(

--- a/test/Microsoft.AspNetCore.Razor.Test/Parser/Html/HtmlDocumentTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Parser/Html/HtmlDocumentTest.cs
@@ -321,6 +321,26 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.Html
         }
 
         [Fact]
+        public void ParseDocumentDoesNotRenderExtraNewlineAtTheEndTextTagInVerbatimBlock()
+        {
+            ParseDocumentTest("@{<text>Blah</text>\r\n\r\n}<html>",
+                new MarkupBlock(
+                    Factory.EmptyHtml(),
+                    new StatementBlock(
+                        Factory.CodeTransition(),
+                        Factory.MetaCode("{").Accepts(AcceptedCharacters.None),
+                        new MarkupBlock(
+                            new MarkupTagBlock(
+                                Factory.MarkupTransition("<text>")),
+                            Factory.Markup("Blah").Accepts(AcceptedCharacters.None),
+                            new MarkupTagBlock(
+                                Factory.MarkupTransition("</text>"))),
+                        Factory.Code("\r\n\r\n").AsStatement(),
+                        Factory.MetaCode("}").Accepts(AcceptedCharacters.None)),
+                    BlockFactory.MarkupTagBlock("<html>")));
+        }
+
+        [Fact]
         public void ParseDocumentDoesNotIgnoreNewLineAtTheEndOfMarkupBlock()
         {
             ParseDocumentTest("@{\r\n}\r\n<html>\r\n",

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/CodeBlockWithTextElement.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/CodeBlockWithTextElement.cs
@@ -49,10 +49,8 @@ namespace TestOutput
 #line default
 #line hidden
             Instrumentation.EndContext();
-            Instrumentation.BeginContext(80, 2, true);
-            WriteLiteral("\r\n");
-            Instrumentation.EndContext();
-#line 4 "CodeBlockWithTextElement.cshtml"
+#line 3 "CodeBlockWithTextElement.cshtml"
+                                     
 
 #line default
 #line hidden


### PR DESCRIPTION
Fixes issue https://github.com/aspnet/Razor/issues/485#issuecomment-214654609

@NTaylorMullen 