### PR TITLE
Track `TagHelperAttribute` quotes.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -139,33 +139,19 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         }
 
         /// <summary>
-        /// Tracks the minimized HTML attribute.
-        /// </summary>
-        /// <param name="name">The minimized HTML attribute name.</param>
-        public void AddMinimizedHtmlAttribute(string name)
-        {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            var attribute = new TagHelperAttribute(name);
-            AddHtmlAttribute(attribute);
-        }
-
-        /// <summary>
         /// Tracks the HTML attribute.
         /// </summary>
         /// <param name="name">The HTML attribute name.</param>
         /// <param name="value">The HTML attribute value.</param>
-        public void AddHtmlAttribute(string name, object value)
+        /// <param name="valueStyle">The value style of the attribute.</param>
+        public void AddHtmlAttribute(string name, object value, HtmlAttributeValueStyle valueStyle)
         {
             if (name == null)
             {
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var attribute = new TagHelperAttribute(name, value);
+            var attribute = new TagHelperAttribute(name, value, valueStyle);
             AddHtmlAttribute(attribute);
         }
 
@@ -189,15 +175,16 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         /// </summary>
         /// <param name="name">The bound attribute name.</param>
         /// <param name="value">The attribute value.</param>
-        public void AddTagHelperAttribute(string name, object value)
+        /// <param name="valueStyle">The value style of the attribute.</param>
+        public void AddTagHelperAttribute(string name, object value, HtmlAttributeValueStyle valueStyle)
         {
             if (name == null)
             {
                 throw new ArgumentNullException(nameof(name));
             }
 
-
-            _allAttributes.Add(name, value);
+            var attribute = new TagHelperAttribute(name, value, valueStyle);
+            _allAttributes.Add(attribute);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/TagHelpers/TagHelperAttribute.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.TagHelpers
@@ -9,39 +12,40 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
     /// <summary>
     /// An HTML tag helper attribute.
     /// </summary>
-    public class TagHelperAttribute
+    public class TagHelperAttribute : IHtmlContentContainer
     {
         /// <summary>
         /// Instantiates a new instance of <see cref="TagHelperAttribute"/> with the specified <paramref name="name"/>.
-        /// <see cref="Minimized"/> is set to <c>true</c> and <see cref="Value"/> to <c>null</c>.
+        /// <see cref="ValueStyle"/> is set to <see cref="HtmlAttributeValueStyle.Minimized"/> and <see cref="Value"/> to
+        /// <c>null</c>.
         /// </summary>
         /// <param name="name">The <see cref="Name"/> of the attribute.</param>
         public TagHelperAttribute(string name)
-            : this(name, value: null, minimized: true)
+            : this(name, value: null, valueStyle: HtmlAttributeValueStyle.Minimized)
         {
         }
 
         /// <summary>
         /// Instantiates a new instance of <see cref="TagHelperAttribute"/> with the specified <paramref name="name"/>
-        /// and <paramref name="value"/>. <see cref="Minimized"/> is set to <c>false</c>.
+        /// and <paramref name="value"/>. <see cref="ValueStyle"/> is set to <see cref="HtmlAttributeValueStyle.DoubleQuotes"/>.
         /// </summary>
         /// <param name="name">The <see cref="Name"/> of the attribute.</param>
         /// <param name="value">The <see cref="Value"/> of the attribute.</param>
         public TagHelperAttribute(string name, object value)
-            : this(name, value, minimized: false)
+            : this(name, value, valueStyle: HtmlAttributeValueStyle.DoubleQuotes)
         {
         }
 
         /// <summary>
         /// Instantiates a new instance of <see cref="TagHelperAttribute"/> with the specified <paramref name="name"/>,
-        /// <paramref name="value"/> and <paramref name="minimized"/>.
+        /// <paramref name="value"/> and <paramref name="valueStyle"/>.
         /// </summary>
         /// <param name="name">The <see cref="Name"/> of the new instance.</param>
         /// <param name="value">The <see cref="Value"/> of the new instance.</param>
-        /// <param name="minimized">The <see cref="Minimized"/> value of the new instance.</param>
-        /// <remarks>If <paramref name="minimized"/> is <c>true</c>, <paramref name="value"/> is ignored when this
-        /// instance is rendered.</remarks>
-        public TagHelperAttribute(string name, object value, bool minimized)
+        /// <param name="valueStyle">The <see cref="ValueStyle"/> of the new instance.</param>
+        /// <remarks>If <paramref name="valueStyle"/> is <see cref="HtmlAttributeValueStyle.Minimized"/>,
+        /// <paramref name="value"/> is ignored when this instance is rendered.</remarks>
+        public TagHelperAttribute(string name, object value, HtmlAttributeValueStyle valueStyle)
         {
             if (name == null)
             {
@@ -50,7 +54,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
 
             Name = name;
             Value = value;
-            Minimized = minimized;
+            ValueStyle = valueStyle;
         }
 
         /// <summary>
@@ -64,11 +68,9 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         public object Value { get; }
 
         /// <summary>
-        /// Gets an indication whether the attribute is minimized or not.
+        /// Gets the value style of the attribute.
         /// </summary>
-        /// <remarks>If <c>true</c>, <see cref="Value"/> will be ignored.</remarks>
-        public bool Minimized { get; }
-
+        public HtmlAttributeValueStyle ValueStyle { get; }
 
         /// <inheritdoc />
         /// <remarks><see cref="Name"/> is compared case-insensitively.</remarks>
@@ -77,8 +79,147 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             return
                 other != null &&
                 string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) &&
-                Minimized == other.Minimized &&
-                (Minimized || Equals(Value, other.Value));
+                ValueStyle == other.ValueStyle &&
+                (ValueStyle == HtmlAttributeValueStyle.Minimized || Equals(Value, other.Value));
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            if (encoder == null)
+            {
+                throw new ArgumentNullException(nameof(encoder));
+            }
+
+            writer.Write(Name);
+
+            if (ValueStyle == HtmlAttributeValueStyle.Minimized)
+            {
+                return;
+            }
+
+            var valuePrefix = GetAttributeValuePrefix(ValueStyle);
+            if (valuePrefix != null)
+            {
+                writer.Write(valuePrefix);
+            }
+
+            var htmlContent = Value as IHtmlContent;
+            if (htmlContent != null)
+            {
+                htmlContent.WriteTo(writer, encoder);
+            }
+            else if (Value != null)
+            {
+                encoder.Encode(writer, Value.ToString());
+            }
+
+            var valueSuffix = GetAttributeValueSuffix(ValueStyle);
+            if (valueSuffix != null)
+            {
+                writer.Write(valueSuffix);
+            }
+        }
+
+        /// <inheritdoc />
+        public void CopyTo(IHtmlContentBuilder destination)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            destination.AppendHtml(Name);
+
+            if (ValueStyle == HtmlAttributeValueStyle.Minimized)
+            {
+                return;
+            }
+
+            var valuePrefix = GetAttributeValuePrefix(ValueStyle);
+            if (valuePrefix != null)
+            {
+                destination.AppendHtml(valuePrefix);
+            }
+
+            string valueAsString;
+            IHtmlContentContainer valueAsHtmlContainer;
+            IHtmlContent valueAsHtmlContent;
+            if ((valueAsString = Value as string) != null)
+            {
+                destination.Append(valueAsString);
+            }
+            else if ((valueAsHtmlContainer = Value as IHtmlContentContainer) != null)
+            {
+                valueAsHtmlContainer.CopyTo(destination);
+            }
+            else if ((valueAsHtmlContent = Value as IHtmlContent) != null)
+            {
+                destination.AppendHtml(valueAsHtmlContent);
+            }
+            else if (Value != null)
+            {
+                destination.Append(Value.ToString());
+            }
+
+            var valueSuffix = GetAttributeValueSuffix(ValueStyle);
+            if (valueSuffix != null)
+            {
+                destination.AppendHtml(valueSuffix);
+            }
+        }
+
+        /// <inheritdoc />
+        public void MoveTo(IHtmlContentBuilder destination)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            destination.AppendHtml(Name);
+
+            if (ValueStyle == HtmlAttributeValueStyle.Minimized)
+            {
+                return;
+            }
+
+            var valuePrefix = GetAttributeValuePrefix(ValueStyle);
+            if (valuePrefix != null)
+            {
+                destination.AppendHtml(valuePrefix);
+            }
+
+            string valueAsString;
+            IHtmlContentContainer valueAsHtmlContainer;
+            IHtmlContent valueAsHtmlContent;
+            if ((valueAsString = Value as string) != null)
+            {
+                destination.Append(valueAsString);
+            }
+            else if ((valueAsHtmlContainer = Value as IHtmlContentContainer) != null)
+            {
+                valueAsHtmlContainer.MoveTo(destination);
+            }
+            else if ((valueAsHtmlContent = Value as IHtmlContent) != null)
+            {
+                destination.AppendHtml(valueAsHtmlContent);
+            }
+            else if (Value != null)
+            {
+                destination.Append(Value.ToString());
+            }
+
+            var valueSuffix = GetAttributeValueSuffix(ValueStyle);
+            if (valueSuffix != null)
+            {
+                destination.AppendHtml(valueSuffix);
+            }
         }
 
         /// <inheritdoc />
@@ -94,10 +235,43 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
         {
             var hashCodeCombiner = HashCodeCombiner.Start();
             hashCodeCombiner.Add(Name, StringComparer.Ordinal);
-            hashCodeCombiner.Add(Value);
-            hashCodeCombiner.Add(Minimized);
+
+            if (ValueStyle != HtmlAttributeValueStyle.Minimized)
+            {
+                hashCodeCombiner.Add(Value);
+            }
+
+            hashCodeCombiner.Add(ValueStyle);
 
             return hashCodeCombiner.CombinedHash;
+        }
+
+        private static string GetAttributeValuePrefix(HtmlAttributeValueStyle valueStyle)
+        {
+            switch (valueStyle)
+            {
+                case HtmlAttributeValueStyle.DoubleQuotes:
+                    return "=\"";
+                case HtmlAttributeValueStyle.SingleQuotes:
+                    return "='";
+                case HtmlAttributeValueStyle.NoQuotes:
+                    return "=";
+            }
+
+            return null;
+        }
+
+        private static string GetAttributeValueSuffix(HtmlAttributeValueStyle valueStyle)
+        {
+            switch (valueStyle)
+            {
+                case HtmlAttributeValueStyle.DoubleQuotes:
+                    return "\"";
+                case HtmlAttributeValueStyle.SingleQuotes:
+                    return "'";
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor/Chunks/Generators/TagHelperChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor/Chunks/Generators/TagHelperChunkGenerator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Razor.Chunks.Generators
                 tagHelperBlock != null,
                 $"A {nameof(TagHelperChunkGenerator)} must only be used with {nameof(TagHelperBlock)}s.");
 
-            var attributes = new List<KeyValuePair<string, Chunk>>();
+            var attributes = new List<TagHelperAttributeTracker>();
 
             // We need to create a chunk generator to create chunks for each of the attributes.
             var chunkGenerator = context.Host.CreateChunkGenerator(
@@ -72,7 +72,12 @@ namespace Microsoft.AspNetCore.Razor.Chunks.Generators
                     };
                 }
 
-                attributes.Add(new KeyValuePair<string, Chunk>(attribute.Key, attributeChunkValue));
+                var attributeChunk = new TagHelperAttributeTracker(
+                    attribute.Name,
+                    attributeChunkValue,
+                    attribute.ValueStyle);
+
+                attributes.Add(attributeChunk);
 
                 // Reset the chunk tree builder so we can build a new one for the next attribute
                 chunkGenerator.Context.ChunkTreeBuilder = new ChunkTreeBuilder();

--- a/src/Microsoft.AspNetCore.Razor/Chunks/TagHelperAttributeChunk.cs
+++ b/src/Microsoft.AspNetCore.Razor/Chunks/TagHelperAttributeChunk.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Microsoft.AspNetCore.Razor.Chunks
+{
+    public struct TagHelperAttributeTracker
+    {
+        public TagHelperAttributeTracker(string name, Chunk value, HtmlAttributeValueStyle valueStyle)
+        {
+            Name = name;
+            Value = value;
+            ValueStyle = valueStyle;
+        }
+
+        public string Name { get; }
+
+        public Chunk Value { get; }
+
+        public HtmlAttributeValueStyle ValueStyle { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor/Chunks/TagHelperChunk.cs
+++ b/src/Microsoft.AspNetCore.Razor/Chunks/TagHelperChunk.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Razor.Chunks
         public TagHelperChunk(
             string tagName,
             TagMode tagMode,
-            IList<KeyValuePair<string, Chunk>> attributes,
+            IList<TagHelperAttributeTracker> attributes,
             IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;
@@ -36,11 +36,7 @@ namespace Microsoft.AspNetCore.Razor.Chunks
         /// <summary>
         /// The HTML attributes.
         /// </summary>
-        /// <remarks>
-        /// These attributes are <see cref="string"/> => <see cref="Chunk"/> so attribute values can consist
-        /// of all sorts of Razor specific pieces.
-        /// </remarks>
-        public IList<KeyValuePair<string, Chunk>> Attributes { get; set; }
+        public IList<TagHelperAttributeTracker> Attributes { get; set; }
 
         /// <summary>
         /// The <see cref="TagHelperDescriptor"/>s that are associated with the tag helpers HTML element.

--- a/src/Microsoft.AspNetCore.Razor/CodeGenerators/GeneratedTagHelperContext.cs
+++ b/src/Microsoft.AspNetCore.Razor/CodeGenerators/GeneratedTagHelperContext.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators
             ScopeManagerEndMethodName = "End";
             ExecutionContextAddMethodName = "Add";
             ExecutionContextAddTagHelperAttributeMethodName = "AddTagHelperAttribute";
-            ExecutionContextAddMinimizedHtmlAttributeMethodName = "AddMinimizedHtmlAttribute";
             ExecutionContextAddHtmlAttributeMethodName = "AddHtmlAttribute";
             ExecutionContextOutputPropertyName = "Output";
             FormatInvalidIndexerAssignmentMethodName = "FormatInvalidIndexerAssignment";
@@ -112,11 +111,6 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators
         /// The name of the <see cref="ExecutionContextTypeName"/> method used to add tag helper attributes.
         /// </summary>
         public string ExecutionContextAddTagHelperAttributeMethodName { get; set; }
-
-        /// <summary>
-        /// The name of the <see cref="ExecutionContextTypeName"/> method used to add minimized HTML attributes.
-        /// </summary>
-        public string ExecutionContextAddMinimizedHtmlAttributeMethodName { get; set; }
 
         /// <summary>
         /// The name of the <see cref="ExecutionContextTypeName"/> method used to add HTML attributes.

--- a/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/TagHelperAttributeNode.cs
+++ b/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/TagHelperAttributeNode.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers
+{
+    public class TagHelperAttributeNode
+    {
+        public TagHelperAttributeNode(string name, SyntaxTreeNode value, HtmlAttributeValueStyle valueStyle)
+        {
+            Name = name;
+            Value = value;
+            ValueStyle = valueStyle;
+        }
+
+        // Internal for testing
+        internal TagHelperAttributeNode(string name, SyntaxTreeNode value)
+            : this(name, value, HtmlAttributeValueStyle.DoubleQuotes)
+        {
+        }
+
+        public string Name { get; }
+
+        public SyntaxTreeNode Value { get; }
+
+        public HtmlAttributeValueStyle ValueStyle { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/TagHelperBlock.cs
+++ b/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/TagHelperBlock.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers
         {
             TagName = source.TagName;
             Descriptors = source.Descriptors;
-            Attributes = new List<KeyValuePair<string, SyntaxTreeNode>>(source.Attributes);
+            Attributes = new List<TagHelperAttributeNode>(source.Attributes);
             _start = source.Start;
             TagMode = source.TagMode;
             SourceStartTag = source.SourceStartTag;
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers
         /// <summary>
         /// The HTML attributes.
         /// </summary>
-        public IList<KeyValuePair<string, SyntaxTreeNode>> Attributes { get; }
+        public IList<TagHelperAttributeNode> Attributes { get; }
 
         /// <inheritdoc />
         public override SourceLocation Start

--- a/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/TagHelperBlockBuilder.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers
         {
             TagName = original.TagName;
             Descriptors = original.Descriptors;
-            Attributes = new List<KeyValuePair<string, SyntaxTreeNode>>(original.Attributes);
+            Attributes = new List<TagHelperAttributeNode>(original.Attributes);
         }
 
         /// <summary>
@@ -41,14 +41,14 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers
             string tagName,
             TagMode tagMode,
             SourceLocation start,
-            IList<KeyValuePair<string, SyntaxTreeNode>> attributes,
+            IList<TagHelperAttributeNode> attributes,
             IEnumerable<TagHelperDescriptor> descriptors)
         {
             TagName = tagName;
             TagMode = tagMode;
             Start = start;
             Descriptors = descriptors;
-            Attributes = new List<KeyValuePair<string, SyntaxTreeNode>>(attributes);
+            Attributes = new List<TagHelperAttributeNode>(attributes);
             Type = BlockType.Tag;
             ChunkGenerator = new TagHelperChunkGenerator(descriptors);
         }
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers
         internal TagHelperBlockBuilder(
             string tagName,
             TagMode tagMode,
-            IList<KeyValuePair<string, SyntaxTreeNode>> attributes,
+            IList<TagHelperAttributeNode> attributes,
             IEnumerable<SyntaxTreeNode> children)
         {
             TagName = tagName;
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers
         /// <summary>
         /// The HTML attributes.
         /// </summary>
-        public IList<KeyValuePair<string, SyntaxTreeNode>> Attributes { get; }
+        public IList<TagHelperAttributeNode> Attributes { get; }
 
         /// <summary>
         /// The HTML tag name.

--- a/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/TagHelperBlockRewriter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
             return new TagHelperBlockBuilder(tagName, tagMode, start, attributes, descriptors);
         }
 
-        private static IList<KeyValuePair<string, SyntaxTreeNode>> GetTagAttributes(
+        private static IList<TagHelperAttributeNode> GetTagAttributes(
             string tagName,
             bool validStructure,
             Block tagBlock,
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
             // contained TagHelperAttributeDescriptor's.
             descriptors = descriptors.Distinct(TypeBasedTagHelperDescriptorComparer.Default);
 
-            var attributes = new List<KeyValuePair<string, SyntaxTreeNode>>();
+            var attributes = new List<TagHelperAttributeNode>();
 
             // We skip the first child "<tagname" and take everything up to the ending portion of the tag ">" or "/>".
             // The -2 accounts for both the start and end tags. If the tag does not have a valid structure then there's
@@ -102,8 +102,12 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                             result.AttributeName.Length);
                     }
 
-                    attributes.Add(
-                        new KeyValuePair<string, SyntaxTreeNode>(result.AttributeName, result.AttributeValueNode));
+                    var attributeNode = new TagHelperAttributeNode(
+                        result.AttributeName,
+                        result.AttributeValueNode,
+                        result.AttributeValueStyle);
+
+                    attributes.Add(attributeNode);
                 }
                 else
                 {
@@ -160,6 +164,10 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
             var htmlSymbols = span.Symbols.OfType<HtmlSymbol>().ToArray();
             var capturedAttributeValueStart = false;
             var attributeValueStartLocation = span.Start;
+
+            // Default to DoubleQuotes. We purposefully do not persist NoQuotes ValueStyle to stay consistent with the
+            // TryParseBlock() variation of attribute parsing.
+            var attributeValueStyle = HtmlAttributeValueStyle.DoubleQuotes;
 
             // The symbolOffset is initialized to 0 to expect worst case: "class=". If a quote is found later on for
             // the attribute value the symbolOffset is adjusted accordingly.
@@ -229,6 +237,11 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                     // Check for attribute start values, aka single or double quote
                     if (i < htmlSymbols.Length && IsQuote(htmlSymbols[i]))
                     {
+                        if (htmlSymbols[i].Type == HtmlSymbolType.SingleQuote)
+                        {
+                            attributeValueStyle = HtmlAttributeValueStyle.SingleQuotes;
+                        }
+
                         symbolStartLocation = htmlSymbols[i].Start;
 
                         // If there's a start quote then there must be an end quote to be valid, skip it.
@@ -290,8 +303,13 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
             {
                 attributeValue = CreateMarkupAttribute(builder, result.IsBoundNonStringAttribute);
             }
+            else
+            {
+                attributeValueStyle = HtmlAttributeValueStyle.Minimized;
+            }
 
             result.AttributeValueNode = attributeValue;
+            result.AttributeValueStyle = attributeValueStyle;
             return result;
         }
 
@@ -346,6 +364,30 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
 
             // Have a name now. Able to determine correct isBoundNonStringAttribute value.
             var result = CreateTryParseResult(name, descriptors);
+
+            var firstChild = builder.Children[0] as Span;
+            if (firstChild != null && firstChild.Symbols[0] is HtmlSymbol)
+            {
+                var htmlSymbol = firstChild.Symbols[firstChild.Symbols.Count - 1] as HtmlSymbol;
+                switch (htmlSymbol.Type)
+                {
+                    // Treat NoQuotes and DoubleQuotes equivalently. We purposefully do not persist NoQuotes
+                    // ValueStyles at code generation time to protect users from rendering dynamic content with spaces
+                    // that can break attributes.
+                    // Ex: <tag my-attribute=@value /> where @value results in the test "hello world".
+                    // This way, the above code would render <tag my-attribute="hello world" />.
+                    case HtmlSymbolType.Equals:
+                    case HtmlSymbolType.DoubleQuote:
+                        result.AttributeValueStyle = HtmlAttributeValueStyle.DoubleQuotes;
+                        break;
+                    case HtmlSymbolType.SingleQuote:
+                        result.AttributeValueStyle = HtmlAttributeValueStyle.SingleQuotes;
+                        break;
+                    default:
+                        result.AttributeValueStyle = HtmlAttributeValueStyle.Minimized;
+                        break;
+                }
+            }
 
             // Remove first child i.e. foo="
             builder.Children.RemoveAt(0);
@@ -663,6 +705,8 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
             public string AttributeName { get; set; }
 
             public SyntaxTreeNode AttributeValueNode { get; set; }
+
+            public HtmlAttributeValueStyle AttributeValueStyle { get; set; }
 
             public bool IsBoundAttribute { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor/TagHelpers/HtmlAttributeValueStyle.cs
+++ b/src/Microsoft.AspNetCore.Razor/TagHelpers/HtmlAttributeValueStyle.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.TagHelpers
+{
+    public enum HtmlAttributeValueStyle
+    {
+        DoubleQuotes,
+        SingleQuotes,
+        NoQuotes,
+        Minimized,
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/CaseSensitiveTagHelperAttributeComparer.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/CaseSensitiveTagHelperAttributeComparer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.TagHelpers
 {
@@ -25,13 +26,17 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
             // Normal comparer (TagHelperAttribute.Equals()) doesn't care about the Name case, in tests we do.
             return attributeX != null &&
                 string.Equals(attributeX.Name, attributeY.Name, StringComparison.Ordinal) &&
-                attributeX.Minimized == attributeY.Minimized &&
-                (attributeX.Minimized || Equals(attributeX.Value, attributeY.Value));
+                attributeX.ValueStyle == attributeY.ValueStyle &&
+                (attributeX.ValueStyle == HtmlAttributeValueStyle.Minimized || Equals(attributeX.Value, attributeY.Value));
         }
 
         public int GetHashCode(TagHelperAttribute attribute)
         {
-            return attribute.GetHashCode();
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(attribute.Name, StringComparer.Ordinal);
+            combiner.Add(attribute.GetHashCode());
+
+            return combiner.CombinedHash;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 updatedCallCount++;
                 return Task.FromResult(true);
             };
-            executionContext.AddMinimizedHtmlAttribute("something");
+            executionContext.AddHtmlAttribute(new TagHelperAttribute("something"));
 
             // Act - 1
             executionContext.Reinitialize(
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 items: new Dictionary<object, object>(),
                 uniqueId: string.Empty,
                 executeChildContentAsync: updatedExecuteChildContentAsync);
-            executionContext.AddMinimizedHtmlAttribute("Another attribute");
+            executionContext.AddHtmlAttribute(new TagHelperAttribute("Another attribute"));
 
             // Assert - 1
             var output = executionContext.Output;
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 endWritingScope);
             var updatedItems = new Dictionary<object, object>();
             var updatedUniqueId = "another unique id";
-            executionContext.AddMinimizedHtmlAttribute("something");
+            executionContext.AddHtmlAttribute(new TagHelperAttribute("something"));
 
             // Act
             executionContext.Reinitialize(
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 updatedItems,
                 updatedUniqueId,
                 executeChildContentAsync);
-            executionContext.AddMinimizedHtmlAttribute("Another attribute");
+            executionContext.AddHtmlAttribute(new TagHelperAttribute("Another attribute"));
 
             // Assert
             var context = executionContext.Context;
@@ -409,12 +409,12 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             var expectedAttributes = new TagHelperAttributeList
             {
                 { "class", "btn" },
-                { "foo", "bar" }
             };
+            expectedAttributes.Add(new TagHelperAttribute("type", "text", HtmlAttributeValueStyle.SingleQuotes));
 
             // Act
-            executionContext.AddHtmlAttribute("class", "btn");
-            executionContext.AddHtmlAttribute("foo", "bar");
+            executionContext.AddHtmlAttribute("class", "btn", HtmlAttributeValueStyle.DoubleQuotes);
+            executionContext.AddHtmlAttribute("type", "text", HtmlAttributeValueStyle.SingleQuotes);
             var output = executionContext.Output;
 
             // Assert
@@ -425,7 +425,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void AddMinimizedHtmlAttribute_MaintainsHtmlAttributes()
+        public void AddHtmlAttribute_MaintainsMinimizedHtmlAttributes()
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("input", tagMode: TagMode.StartTagOnly);
@@ -436,8 +436,8 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             };
 
             // Act
-            executionContext.AddMinimizedHtmlAttribute("checked");
-            executionContext.AddMinimizedHtmlAttribute("visible");
+            executionContext.AddHtmlAttribute(new TagHelperAttribute("checked"));
+            executionContext.AddHtmlAttribute(new TagHelperAttribute("visible"));
             var output = executionContext.Output;
 
             // Assert
@@ -448,7 +448,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
         }
 
         [Fact]
-        public void AddMinimizedHtmlAttribute_MaintainsHtmlAttributes_SomeMinimized()
+        public void AddHtmlAttribute_MaintainsHtmlAttributes_VariousStyles()
         {
             // Arrange
             var executionContext = new TagHelperExecutionContext("input", tagMode: TagMode.SelfClosing);
@@ -457,14 +457,18 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
                 { "class", "btn" },
                 { "foo", "bar" }
             };
+            expectedAttributes.Add(new TagHelperAttribute("valid", "true", HtmlAttributeValueStyle.NoQuotes));
+            expectedAttributes.Add(new TagHelperAttribute("type", "text", HtmlAttributeValueStyle.SingleQuotes));
             expectedAttributes.Add(new TagHelperAttribute(name: "checked"));
             expectedAttributes.Add(new TagHelperAttribute(name: "visible"));
 
             // Act
-            executionContext.AddHtmlAttribute("class", "btn");
-            executionContext.AddHtmlAttribute("foo", "bar");
-            executionContext.AddMinimizedHtmlAttribute("checked");
-            executionContext.AddMinimizedHtmlAttribute("visible");
+            executionContext.AddHtmlAttribute("class", "btn", HtmlAttributeValueStyle.DoubleQuotes);
+            executionContext.AddHtmlAttribute("foo", "bar", HtmlAttributeValueStyle.DoubleQuotes);
+            executionContext.AddHtmlAttribute("valid", "true", HtmlAttributeValueStyle.NoQuotes);
+            executionContext.AddHtmlAttribute("type", "text", HtmlAttributeValueStyle.SingleQuotes);
+            executionContext.AddHtmlAttribute(new TagHelperAttribute("checked"));
+            executionContext.AddHtmlAttribute(new TagHelperAttribute("visible"));
             var output = executionContext.Output;
 
             // Assert
@@ -482,14 +486,14 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             var expectedAttributes = new TagHelperAttributeList
             {
                 { "class", "btn" },
-                { "something", true },
-                { "foo", "bar" }
             };
+            expectedAttributes.Add(new TagHelperAttribute("something", true, HtmlAttributeValueStyle.SingleQuotes));
+            expectedAttributes.Add(new TagHelperAttribute("type", "text", HtmlAttributeValueStyle.NoQuotes));
 
             // Act
-            executionContext.AddHtmlAttribute("class", "btn");
-            executionContext.AddTagHelperAttribute("something", true);
-            executionContext.AddHtmlAttribute("foo", "bar");
+            executionContext.AddHtmlAttribute("class", "btn", HtmlAttributeValueStyle.DoubleQuotes);
+            executionContext.AddTagHelperAttribute("something", true, HtmlAttributeValueStyle.SingleQuotes);
+            executionContext.AddHtmlAttribute("type", "text", HtmlAttributeValueStyle.NoQuotes);
             var context = executionContext.Context;
 
             // Assert

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperRunnerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperRunnerTest.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             var tagHelper = new TagHelperContextTouchingTagHelper();
 
             executionContext.Add(tagHelper);
-            executionContext.AddTagHelperAttribute("foo", true);
+            executionContext.AddTagHelperAttribute("foo", true, HtmlAttributeValueStyle.DoubleQuotes);
 
             // Act
             await runner.RunAsync(executionContext);
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
 
             // Act
             executionContext.Add(executableTagHelper);
-            executionContext.AddHtmlAttribute("class", "btn");
+            executionContext.AddHtmlAttribute("class", "btn", HtmlAttributeValueStyle.DoubleQuotes);
             await runner.RunAsync(executionContext);
 
             // Assert
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
 
             // Act
             executionContext.Add(tagHelper);
-            executionContext.AddTagHelperAttribute("foo", true);
+            executionContext.AddTagHelperAttribute("foo", true, HtmlAttributeValueStyle.DoubleQuotes);
             await runner.RunAsync(executionContext);
 
             // Assert

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/TagHelpers/TagHelperOutputTest.cs
@@ -483,6 +483,22 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                             tagName:     "p",
                             attributes:  new TagHelperAttributeList()
                             {
+                                { new TagHelperAttribute("test", "testVal", HtmlAttributeValueStyle.NoQuotes) },
+                                { new TagHelperAttribute("something", "  spaced  ", HtmlAttributeValueStyle.SingleQuotes) },
+                            },
+                            tagMode: TagMode.StartTagAndEndTag,
+                            preElement:  null,
+                            preContent:  null,
+                            content:     "Hello World!",
+                            postContent: null,
+                            postElement: null),
+                        "<p test=HtmlEncode[[testVal]] something='HtmlEncode[[  spaced  ]]'>Hello World!</p>"
+                    },
+                    {
+                        GetTagHelperOutput(
+                            tagName:     "p",
+                            attributes:  new TagHelperAttributeList()
+                            {
                                 new TagHelperAttribute("test"),
                             },
                             tagMode: TagMode.StartTagAndEndTag,
@@ -531,7 +547,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                             attributes:  new TagHelperAttributeList()
                             {
                                 new TagHelperAttribute("test"),
-                                new TagHelperAttribute("last", "unminimized"),
+                                new TagHelperAttribute("last", "unminimized", HtmlAttributeValueStyle.NoQuotes),
                             },
                             tagMode: TagMode.StartTagAndEndTag,
                             preElement:  null,
@@ -539,7 +555,7 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                             content:     "Hello World!",
                             postContent: null,
                             postElement: null),
-                        "<p test last=\"HtmlEncode[[unminimized]]\">Hello World!</p>"
+                        "<p test last=HtmlEncode[[unminimized]]>Hello World!</p>"
                     },
                     {
                         GetTagHelperOutput(
@@ -572,14 +588,17 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                     {
                         GetTagHelperOutput(
                             tagName:     "p",
-                            attributes:  new TagHelperAttributeList() { { "test", "testVal" } },
+                            attributes:  new TagHelperAttributeList()
+                            {
+                                { new TagHelperAttribute("test", "testVal", HtmlAttributeValueStyle.SingleQuotes) }
+                            },
                             tagMode: TagMode.StartTagOnly,
                             preElement:  null,
                             preContent:  null,
                             content:     "Hello World!",
                             postContent: null,
                             postElement: null),
-                        "<p test=\"HtmlEncode[[testVal]]\">"
+                        "<p test='HtmlEncode[[testVal]]'>"
                     },
                     {
                         GetTagHelperOutput(
@@ -769,6 +788,21 @@ namespace Microsoft.AspNetCore.Razor.TagHelpers
                         GetTagHelperOutput(
                             tagName:     string.Empty,
                             attributes:  new TagHelperAttributeList { { "test", "testVal" } },
+                            tagMode: TagMode.StartTagOnly,
+                            preElement:  "Before",
+                            preContent:  null,
+                            content:     null,
+                            postContent: null,
+                            postElement: null),
+                        "Before"
+                    },
+                    {
+                        GetTagHelperOutput(
+                            tagName:     string.Empty,
+                            attributes:  new TagHelperAttributeList
+                            {
+                                { new TagHelperAttribute("test", "testVal", HtmlAttributeValueStyle.SingleQuotes) }
+                            },
                             tagMode: TagMode.StartTagOnly,
                             preElement:  "Before",
                             preContent:  null,

--- a/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpTagHelperRenderingTest.cs
@@ -1308,11 +1308,19 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
                                 generatedCharacterOffsetIndex: 42,
                                 contentLength: 4),
                             BuildLineMapping(
+                                documentAbsoluteIndex: 220,
+                                documentLineIndex: 5,
+                                documentCharacterOffsetIndex: 34,
+                                generatedAbsoluteIndex: 2234,
+                                generatedLineIndex: 45,
+                                generatedCharacterOffsetIndex: 42,
+                                contentLength: 4),
+                            BuildLineMapping(
                                 documentAbsoluteIndex: 41,
                                 documentLineIndex: 2,
                                 documentCharacterOffsetIndex: 8,
-                                generatedAbsoluteIndex: 1962,
-                                generatedLineIndex: 42,
+                                generatedAbsoluteIndex: 2447,
+                                generatedLineIndex: 51,
                                 generatedCharacterOffsetIndex: 33,
                                 contentLength: 1),
                         }

--- a/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpTagHelperRenderingUnitTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/CodeGenerators/CSharpTagHelperRenderingUnitTest.cs
@@ -241,14 +241,14 @@ namespace Microsoft.AspNetCore.Razor.Test.Generator
             return new TagHelperChunk(
                 tagName,
                 tagMode: TagMode.StartTagAndEndTag,
-                attributes: new List<KeyValuePair<string, Chunk>>(),
+                attributes: new List<TagHelperAttributeTracker>(),
                 descriptors: tagHelperDescriptors)
             {
                 Association = new TagHelperBlock(
                     new TagHelperBlockBuilder(
                         tagName,
                         tagMode: TagMode.StartTagAndEndTag,
-                        attributes: new List<KeyValuePair<string, SyntaxTreeNode>>(),
+                        attributes: new List<TagHelperAttributeNode>(),
                         children: Enumerable.Empty<SyntaxTreeNode>())),
                 Children = new List<Chunk>(),
             };

--- a/test/Microsoft.AspNetCore.Razor.Test/Framework/BlockFactory.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Framework/BlockFactory.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Framework
             var builder = new TagHelperBlockBuilder(
                 tagName,
                 tagMode,
-                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>(),
+                attributes: new List<TagHelperAttributeNode>(),
                 children: children)
             {
                 Start = start,

--- a/test/Microsoft.AspNetCore.Razor.Test/Framework/BlockTypes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Framework/BlockTypes.cs
@@ -132,18 +132,18 @@ namespace Microsoft.AspNetCore.Razor.Test.Framework
     public class MarkupTagHelperBlock : TagHelperBlock
     {
         public MarkupTagHelperBlock(string tagName)
-            : this(tagName, tagMode: TagMode.StartTagAndEndTag, attributes: new List<KeyValuePair<string, SyntaxTreeNode>>())
+            : this(tagName, tagMode: TagMode.StartTagAndEndTag, attributes: new List<TagHelperAttributeNode>())
         {
         }
 
         public MarkupTagHelperBlock(string tagName, TagMode tagMode)
-            : this(tagName, tagMode, new List<KeyValuePair<string, SyntaxTreeNode>>())
+            : this(tagName, tagMode, new List<TagHelperAttributeNode>())
         {
         }
 
         public MarkupTagHelperBlock(
             string tagName,
-            IList<KeyValuePair<string, SyntaxTreeNode>> attributes)
+            IList<TagHelperAttributeNode> attributes)
             : this(tagName, TagMode.StartTagAndEndTag, attributes, children: new SyntaxTreeNode[0])
         {
         }
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Framework
         public MarkupTagHelperBlock(
             string tagName,
             TagMode tagMode,
-            IList<KeyValuePair<string, SyntaxTreeNode>> attributes)
+            IList<TagHelperAttributeNode> attributes)
             : this(tagName, tagMode, attributes, new SyntaxTreeNode[0])
         {
         }
@@ -160,19 +160,19 @@ namespace Microsoft.AspNetCore.Razor.Test.Framework
             : this(
                   tagName,
                   TagMode.StartTagAndEndTag,
-                  attributes: new List<KeyValuePair<string, SyntaxTreeNode>>(),
+                  attributes: new List<TagHelperAttributeNode>(),
                   children: children)
         {
         }
 
         public MarkupTagHelperBlock(string tagName, TagMode tagMode, params SyntaxTreeNode[] children)
-            : this(tagName, tagMode, new List<KeyValuePair<string, SyntaxTreeNode>>(), children)
+            : this(tagName, tagMode, new List<TagHelperAttributeNode>(), children)
         {
         }
 
         public MarkupTagHelperBlock(
             string tagName,
-            IList<KeyValuePair<string, SyntaxTreeNode>> attributes,
+            IList<TagHelperAttributeNode> attributes,
             params SyntaxTreeNode[] children)
             : base(new TagHelperBlockBuilder(
                 tagName,
@@ -185,7 +185,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Framework
         public MarkupTagHelperBlock(
             string tagName,
             TagMode tagMode,
-            IList<KeyValuePair<string, SyntaxTreeNode>> attributes,
+            IList<TagHelperAttributeNode> attributes,
             params SyntaxTreeNode[] children)
             : base(new TagHelperBlockBuilder(tagName, tagMode, attributes, children))
         {

--- a/test/Microsoft.AspNetCore.Razor.Test/Framework/ParserTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Framework/ParserTestBase.cs
@@ -324,24 +324,30 @@ namespace Microsoft.AspNetCore.Razor.Test.Framework
             }
         }
 
-        private static void EvaluateTagHelperAttribute(ErrorCollector collector,
-                                                       KeyValuePair<string, SyntaxTreeNode> actual,
-                                                       KeyValuePair<string, SyntaxTreeNode> expected)
+        private static void EvaluateTagHelperAttribute(
+            ErrorCollector collector,
+            TagHelperAttributeNode actual,
+            TagHelperAttributeNode expected)
         {
-            if (actual.Key != expected.Key)
+            if (actual.Name != expected.Name)
             {
-                collector.AddError("{0} - FAILED :: Attribute names do not match", expected.Key);
+                collector.AddError("{0} - FAILED :: Attribute names do not match", expected.Name);
             }
             else
             {
-                collector.AddMessage("{0} - PASSED :: Attribute names match", expected.Key);
+                collector.AddMessage("{0} - PASSED :: Attribute names match", expected.Name);
             }
 
-            if (actual.Value == null && expected.Value == null)
+            if (actual.ValueStyle != expected.ValueStyle)
             {
-                collector.AddMessage("{0} - PASSED :: Minimized attribute values match", expected.Key);
+                collector.AddError("{0} - FAILED :: Attribute value styles do not match", expected.ValueStyle.ToString());
             }
             else
+            {
+                collector.AddMessage("{0} - PASSED :: Attribute value style match", expected.ValueStyle);
+            }
+
+            if (actual.ValueStyle != HtmlAttributeValueStyle.Minimized)
             {
                 EvaluateSyntaxTreeNode(collector, actual.Value, expected.Value);
             }
@@ -435,7 +441,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Framework
                 }
                 while (actualAttributes.MoveNext())
                 {
-                    collector.AddError("End of Attributes - FAILED :: Found Attribute: {0}", actualAttributes.Current.Key);
+                    collector.AddError("End of Attributes - FAILED :: Found Attribute: {0}", actualAttributes.Current.Name);
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperBlockRewriterTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Razor.Chunks.Generators;
 using Microsoft.AspNetCore.Razor.Parser;
 using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
+using Microsoft.AspNetCore.Razor.Parser.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.AspNetCore.Razor.Test.Framework;
 using Microsoft.AspNetCore.Razor.Test.TagHelpers;
@@ -30,32 +31,33 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<ul bound [item]='items'></ul>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("ul",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("[item]", factory.CodeMarkup("items"))
+                                    new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("[item]", factory.CodeMarkup("items"), HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                     {
                         "<ul bound [(item)]='items'></ul>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("ul",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("[(item)]", factory.CodeMarkup("items"))
+                                    new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("[(item)]", factory.CodeMarkup("items"), HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                     {
                         "<button bound (click)='doSomething()'>Click Me</button>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("button",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode(
                                         "(click)",
-                                        factory.CodeMarkup("doSomething()"))
+                                        factory.CodeMarkup("doSomething()"),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 },
                                 children: factory.Markup("Click Me")))
                     },
@@ -63,12 +65,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<button bound (^click)='doSomething()'>Click Me</button>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("button",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode(
                                         "(^click)",
-                                        factory.CodeMarkup("doSomething()"))
+                                        factory.CodeMarkup("doSomething()"),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 },
                                 children: factory.Markup("Click Me")))
                     },
@@ -76,30 +79,33 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<template bound *something='value'></template>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("template",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("*something", factory.Markup("value"))
+                                    new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode(
+                                        "*something",
+                                        factory.Markup("value"),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                     {
                         "<div bound #localminimized></div>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("div",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("#localminimized", null)
+                                    new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("#localminimized", null, HtmlAttributeValueStyle.Minimized)
                                 }))
                     },
                     {
                         "<div bound #local='value'></div>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("div",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("#local", factory.Markup("value"))
+                                    new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("#local", factory.Markup("value"), HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                 };
@@ -186,9 +192,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.StartTagOnly,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("type", factory.Markup("text"))
+                                    new TagHelperAttributeNode("type", factory.Markup("text"), HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                     {
@@ -203,9 +209,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.StartTagOnly,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("type", factory.Markup("text"))
+                                    new TagHelperAttributeNode("type", factory.Markup("text"), HtmlAttributeValueStyle.SingleQuotes)
                                 }),
                             new MarkupTagHelperBlock("input", TagMode.StartTagOnly))
                     },
@@ -272,9 +278,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.StartTagOnly,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("type", factory.Markup("text"))
+                                    new TagHelperAttributeNode("type", factory.Markup("text"), HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                     {
@@ -293,9 +299,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("type", factory.Markup("text"))
+                                    new TagHelperAttributeNode("type", factory.Markup("text"), HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                     {
@@ -380,11 +386,12 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class='",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "class",
-                                        factory.Markup(string.Empty).With(SpanChunkGenerator.Null))
+                                        factory.Markup(string.Empty).With(SpanChunkGenerator.Null),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new []
                         {
@@ -402,9 +409,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p bar=\"false\"\" <strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bar", factory.Markup("false"))
+                                    new TagHelperAttributeNode("bar", factory.Markup("false"))
                                 })),
                         new []
                         {
@@ -418,11 +425,12 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p bar='false  <strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "bar",
-                                        new MarkupBlock(factory.Markup("false"), factory.Markup("  <strong>")))
+                                        new MarkupBlock(factory.Markup("false"), factory.Markup("  <strong>")),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new []
                         {
@@ -440,13 +448,14 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p bar='false  <strong'",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "bar",
                                         new MarkupBlock(
                                             factory.Markup("false"),
-                                            factory.Markup("  <strong")))
+                                            factory.Markup("  <strong")),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new []
                         {
@@ -464,11 +473,12 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p bar=false'",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "bar",
-                                        factory.Markup("false"))
+                                        factory.Markup("false"),
+                                        HtmlAttributeValueStyle.DoubleQuotes)
                                 })),
                         new []
                         {
@@ -490,9 +500,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p bar=\"false'",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "bar",
                                         factory.Markup("false'"))
                                 })),
@@ -512,9 +522,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p bar=\"false' ></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "bar",
                                         new MarkupBlock(
                                             factory.Markup("false'"),
@@ -536,10 +546,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p foo bar<strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("foo", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bar", null)
+                                    new TagHelperAttributeNode("foo", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("bar", null, HtmlAttributeValueStyle.Minimized)
                                 },
                                 new MarkupTagHelperBlock("strong"))),
                         new []
@@ -562,9 +572,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class=btn\" bar<strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         new []
                         {
@@ -578,9 +588,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class=btn\" bar=\"foo\"<strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         new []
                         {
@@ -594,12 +604,12 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class=\"btn bar=\"foo\"<strong>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "class",
                                         new MarkupBlock(factory.Markup("btn"), factory.Markup(" bar="))),
-                                    new KeyValuePair<string, SyntaxTreeNode>("foo", null)
+                                    new TagHelperAttributeNode("foo", null, HtmlAttributeValueStyle.Minimized)
                                 },
                                 new MarkupTagHelperBlock("strong"))),
                         new []
@@ -622,12 +632,12 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class=\"btn bar=\"foo\"></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "class",
                                         new MarkupBlock(factory.Markup("btn"), factory.Markup(" bar="))),
-                                    new KeyValuePair<string, SyntaxTreeNode>("foo", null),
+                                    new TagHelperAttributeNode("foo", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new RazorError[0]
                     },
@@ -657,9 +667,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class=@DateTime.Now\"></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "class",
                                         new MarkupBlock(
                                             new MarkupBlock(
@@ -672,7 +682,8 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                                     factory.CodeTransition(),
                                                         factory.Code("DateTime.Now")
                                                             .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                            .Accepts(AcceptedCharacters.NonWhiteSpace)))))
+                                                            .Accepts(AcceptedCharacters.NonWhiteSpace)))),
+                                        HtmlAttributeValueStyle.DoubleQuotes)
                                 })),
                         new []
                         {
@@ -686,9 +697,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class=\"@do {",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "class",
                                         createInvalidDoBlock(string.Empty))
                                 })),
@@ -711,9 +722,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class=\"@do {\"></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", createInvalidDoBlock("\"></p>"))
+                                    new TagHelperAttributeNode("class", createInvalidDoBlock("\"></p>"))
                                 })),
                         new []
                         {
@@ -762,9 +773,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class=some=thing attr=\"@value\"></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("some"))
+                                    new TagHelperAttributeNode("class", factory.Markup("some"))
                                 })),
                         new []
                         {
@@ -972,9 +983,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("age", factory.CodeMarkup("12"))
+                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12"))
                                 }))
                     },
                     {
@@ -982,9 +993,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "birthday",
                                         factory.CodeMarkup("DateTime.Now"))
                                 }))
@@ -994,9 +1005,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "age",
                                         new MarkupBlock(
                                             new MarkupBlock(
@@ -1013,9 +1024,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "age",
                                         new MarkupBlock(
                                             new MarkupBlock(
@@ -1036,9 +1047,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("name", factory.Markup("John"))
+                                    new TagHelperAttributeNode("name", factory.Markup("John"))
                                 }))
                     },
                     {
@@ -1046,9 +1057,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "name",
                                         new MarkupBlock(factory.Markup("Time:"), dateTimeNow))
                                 }))
@@ -1058,9 +1069,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "age",
                                         new MarkupBlock(
                                             factory.CodeMarkup("1"),
@@ -1078,7 +1089,7 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                                         .Accepts(AcceptedCharacters.NonWhiteSpace))),
                                             factory.CodeMarkup(" +"),
                                             factory.CodeMarkup(" 2"))),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "birthday",
                                         new MarkupBlock(
                                             factory.CodeMarkup("(bool)"),
@@ -1110,8 +1121,8 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                                     factory
                                                         .Code("DateTime.Now")
                                                         .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace)))
-                                        ))
+                                                        .Accepts(AcceptedCharacters.NonWhiteSpace)))),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                     {
@@ -1119,13 +1130,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("age", factory.CodeMarkup("12")),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12")),
+                                    new TagHelperAttributeNode(
                                         "birthday",
                                         factory.CodeMarkup("DateTime.Now")),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "name",
                                         new MarkupBlock(factory.Markup("Time:"), dateTimeNow))
                                 }))
@@ -1135,13 +1146,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("age", factory.CodeMarkup("12")),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12")),
+                                    new TagHelperAttributeNode(
                                         "birthday",
                                         factory.CodeMarkup("DateTime.Now")),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "name",
                                         new MarkupBlock(
                                             factory.Markup("Time:"),
@@ -1158,13 +1169,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("age", factory.CodeMarkup("12")),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12")),
+                                    new TagHelperAttributeNode(
                                         "birthday",
                                         factory.CodeMarkup("DateTime.Now")),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "name",
                                         new MarkupBlock(
                                              new MarkupBlock(
@@ -1180,9 +1191,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("person",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "age",
                                         new MarkupBlock(
                                             new MarkupBlock(
@@ -1207,10 +1218,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                                         .Accepts(AcceptedCharacters.None)
                                                         .As(SpanKind.Code)
                                                         .With(new MarkupChunkGenerator()))))),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "birthday",
                                         factory.CodeMarkup("DateTime.Now")),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "name",
                                         new MarkupBlock(factory.Markup("Time:"), dateTimeNow))
                                 }))
@@ -1280,10 +1291,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now style=color:red;><strong></p></strong>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>(
+                                new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                new TagHelperAttributeNode(
                                     "dynamic",
                                     new MarkupBlock(
                                         new MarkupBlock(
@@ -1296,8 +1307,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                                 factory.CodeTransition(),
                                                     factory.Code("DateTime.Now")
                                                         .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace))))),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                                        .Accepts(AcceptedCharacters.NonWhiteSpace)))),
+                                    HtmlAttributeValueStyle.DoubleQuotes),
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                             },
                             new MarkupTagHelperBlock("strong")),
                             blockFactory.MarkupTagBlock("</strong>")),
@@ -1353,15 +1365,15 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=\"foo\">Hello <p style=\"color:red;\">World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo"))
+                                new TagHelperAttributeNode("class", factory.Markup("foo"))
                             },
                             factory.Markup("Hello "),
                             new MarkupTagHelperBlock("p",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                    new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                                 },
                                 factory.Markup("World")))),
                     new RazorError[]
@@ -1397,10 +1409,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p      class=\"     foo\"    style=\"   color :  red  ;   \"    ></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new List<KeyValuePair<string, SyntaxTreeNode>>
+                        new List<TagHelperAttributeNode>
                         {
-                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("     foo")),
-                            new KeyValuePair<string, SyntaxTreeNode>(
+                            new TagHelperAttributeNode("class", factory.Markup("     foo")),
+                            new TagHelperAttributeNode(
                                 "style",
                                 new MarkupBlock(
                                     factory.Markup("   color"),
@@ -1415,10 +1427,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p      class=\"     foo\"    style=\"   color :  red  ;   \"    >Hello World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("     foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>(
+                                new TagHelperAttributeNode("class", factory.Markup("     foo")),
+                                new TagHelperAttributeNode(
                                     "style",
                                     new MarkupBlock(
                                         factory.Markup("   color"),
@@ -1434,18 +1446,18 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p     class=\"   foo  \" >Hello</p> <p    style=\"  color:red; \" >World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>(
+                                new TagHelperAttributeNode(
                                     "class",
                                     new MarkupBlock(factory.Markup("   foo"), factory.Markup("  ")))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>(
+                                new TagHelperAttributeNode(
                                     "style",
                                     new MarkupBlock(factory.Markup("  color:red;"), factory.Markup(" ")))
                             },
@@ -1512,10 +1524,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     string.Format(currentFormattedString, dateTimeNowString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new List<KeyValuePair<string, SyntaxTreeNode>>
+                        new List<TagHelperAttributeNode>
                         {
-                            new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow(10)),
-                            new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow(32))
+                            new TagHelperAttributeNode("class", dateTimeNow(10)),
+                            new TagHelperAttributeNode("style", dateTimeNow(32), HtmlAttributeValueStyle.SingleQuotes)
                         }))
                 };
                 yield return new object[]
@@ -1523,10 +1535,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     string.Format(currentFormattedString, doWhileString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new List<KeyValuePair<string, SyntaxTreeNode>>
+                        new List<TagHelperAttributeNode>
                         {
-                            new KeyValuePair<string, SyntaxTreeNode>("class", doWhile(10)),
-                            new KeyValuePair<string, SyntaxTreeNode>("style", doWhile(83))
+                            new TagHelperAttributeNode("class", doWhile(10)),
+                            new TagHelperAttributeNode("style", doWhile(83), HtmlAttributeValueStyle.SingleQuotes)
                         }))
                 };
 
@@ -1536,10 +1548,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     string.Format(currentFormattedString, dateTimeNowString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow(10)),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow(32))
+                                new TagHelperAttributeNode("class", dateTimeNow(10)),
+                                new TagHelperAttributeNode("style", dateTimeNow(32), HtmlAttributeValueStyle.SingleQuotes)
                             },
                             factory.Markup("Hello World")))
                 };
@@ -1548,10 +1560,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     string.Format(currentFormattedString, doWhileString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", doWhile(10)),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", doWhile(83))
+                                new TagHelperAttributeNode("class", doWhile(10)),
+                                new TagHelperAttributeNode("style", doWhile(83), HtmlAttributeValueStyle.SingleQuotes)
                             },
                             factory.Markup("Hello World")))
                 };
@@ -1562,16 +1574,16 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     string.Format(currentFormattedString, dateTimeNowString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow(10))
+                                new TagHelperAttributeNode("class", dateTimeNow(10))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow(45))
+                                new TagHelperAttributeNode("style", dateTimeNow(45), HtmlAttributeValueStyle.SingleQuotes)
                             },
                             factory.Markup("World")))
                 };
@@ -1580,16 +1592,16 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     string.Format(currentFormattedString, doWhileString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", doWhile(10))
+                                new TagHelperAttributeNode("class", doWhile(10))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("style", doWhile(96))
+                                new TagHelperAttributeNode("style", doWhile(96), HtmlAttributeValueStyle.SingleQuotes)
                             },
                             factory.Markup("World")))
                 };
@@ -1601,10 +1613,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     string.Format(currentFormattedString, dateTimeNowString),
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow(10)),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow(32))
+                                new TagHelperAttributeNode("class", dateTimeNow(10)),
+                                new TagHelperAttributeNode("style", dateTimeNow(32), HtmlAttributeValueStyle.SingleQuotes)
                             },
                             factory.Markup("Hello World "),
                             new MarkupTagBlock(
@@ -1894,31 +1906,32 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         "<p class=\"\"></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class",  new MarkupBlock())
+                                new TagHelperAttributeNode("class",  new MarkupBlock())
                             }))
                     },
                     {
                         "<p class=''></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class",  new MarkupBlock())
+                                new TagHelperAttributeNode("class",  new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes)
                             }))
                     },
                     {
                         "<p class=></p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
                                 // We expected a markup node here because attribute values without quotes can only ever
                                 // be a single item, hence don't need to be enclosed by a block.
-                                new KeyValuePair<string, SyntaxTreeNode>(
+                                new TagHelperAttributeNode(
                                     "class",
-                                    factory.Markup("").With(SpanChunkGenerator.Null)),
+                                    factory.Markup("").With(SpanChunkGenerator.Null),
+                                    HtmlAttributeValueStyle.DoubleQuotes),
                             }))
                     },
                     {
@@ -1926,13 +1939,14 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class1", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("class1", new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode(
                                         "class2",
-                                        factory.Markup(string.Empty).With(SpanChunkGenerator.Null)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class3", new MarkupBlock()),
+                                        factory.Markup(string.Empty).With(SpanChunkGenerator.Null),
+                                        HtmlAttributeValueStyle.DoubleQuotes),
+                                    new TagHelperAttributeNode("class3", new MarkupBlock()),
                                 }))
                     },
                     {
@@ -1940,13 +1954,14 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class1",  new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class2",  new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("class1",  new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("class2",  new MarkupBlock()),
+                                    new TagHelperAttributeNode(
                                         "class3",
-                                        factory.Markup(string.Empty).With(SpanChunkGenerator.Null)),
+                                        factory.Markup(string.Empty).With(SpanChunkGenerator.Null),
+                                        HtmlAttributeValueStyle.DoubleQuotes),
                                 }))
                     },
                 };
@@ -1979,9 +1994,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", new MarkupBlock())
+                                    new TagHelperAttributeNode("bound", new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new[]
                         {
@@ -1996,9 +2011,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("    true"))
+                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("    true"), HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new RazorError[0]
                     },
@@ -2008,9 +2023,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("    "))
+                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("    "), HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new[]
                         {
@@ -2025,10 +2040,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", new MarkupBlock())
+                                    new TagHelperAttributeNode("bound", new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound", new MarkupBlock())
                                 })),
                         new[]
                         {
@@ -2046,10 +2061,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup(" ")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("  "))
+                                    new TagHelperAttributeNode("bound", factory.CodeMarkup(" "), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("  "))
                                 })),
                         new[]
                         {
@@ -2067,12 +2082,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("true")),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("true"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode(
                                         "bound",
-                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null))
+                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null),
+                                        HtmlAttributeValueStyle.DoubleQuotes)
                                 })),
                         new[]
                         {
@@ -2087,12 +2103,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "bound",
-                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("name", new MarkupBlock())
+                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null),
+                                        HtmlAttributeValueStyle.DoubleQuotes),
+                                    new TagHelperAttributeNode("name", new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new[]
                         {
@@ -2107,12 +2124,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "bound",
-                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("name", factory.Markup("  "))
+                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null),
+                                        HtmlAttributeValueStyle.DoubleQuotes),
+                                    new TagHelperAttributeNode("name", factory.Markup("  "), HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new[]
                         {
@@ -2127,16 +2145,18 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound", factory.CodeMarkup("true")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("name", factory.Markup("john")),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("true"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("name", factory.Markup("john"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode(
                                         "bound",
-                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null)),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null),
+                                        HtmlAttributeValueStyle.DoubleQuotes),
+                                    new TagHelperAttributeNode(
                                         "name",
-                                        factory.Markup(string.Empty).With(SpanChunkGenerator.Null))
+                                        factory.Markup(string.Empty).With(SpanChunkGenerator.Null),
+                                        HtmlAttributeValueStyle.DoubleQuotes)
                                 })),
                         new[]
                         {
@@ -2151,9 +2171,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("BouND", new MarkupBlock())
+                                    new TagHelperAttributeNode("BouND", new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new[]
                         {
@@ -2168,10 +2188,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("BOUND", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bOUnd", new MarkupBlock())
+                                    new TagHelperAttributeNode("BOUND", new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bOUnd", new MarkupBlock())
                                 })),
                         new[]
                         {
@@ -2188,12 +2208,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "myth",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "BOUND",
-                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("nAMe", factory.Markup("john"))
+                                        factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null),
+                                        HtmlAttributeValueStyle.DoubleQuotes),
+                                    new TagHelperAttributeNode("nAMe", factory.Markup("john"), HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new[]
                         {
@@ -2208,10 +2229,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>(
+                                        new TagHelperAttributeNode(
                                             "bound",
                                             new MarkupBlock(
                                                 new MarkupBlock(
@@ -2223,7 +2244,8 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                                     factory.Code("true")
                                                         .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
                                                         .Accepts(AcceptedCharacters.NonWhiteSpace))),
-                                                factory.CodeMarkup("  ")))
+                                                factory.CodeMarkup("  ")),
+                                            HtmlAttributeValueStyle.SingleQuotes)
                                     }
                                 })),
                         new RazorError[0]
@@ -2234,10 +2256,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "myth",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>(
+                                        new TagHelperAttributeNode(
                                             "bound",
                                             new MarkupBlock(
                                                 new MarkupBlock(
@@ -2255,7 +2277,8 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                                         .Accepts(AcceptedCharacters.None)
                                                         .As(SpanKind.Code)
                                                         .With(new MarkupChunkGenerator()))),
-                                                factory.CodeMarkup("  ")))
+                                                factory.CodeMarkup("  ")),
+                                            HtmlAttributeValueStyle.SingleQuotes)
                                     }
                                 })),
                         new RazorError[0]
@@ -2350,10 +2373,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     new MarkupBlock(
                         new MarkupTagHelperBlock("script",
                             TagMode.SelfClosing,
-                            attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                            attributes: new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                             }))
                 };
                 yield return new object[]
@@ -2363,10 +2386,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupTagHelperBlock("p",
                             factory.Markup("Hello "),
                             new MarkupTagHelperBlock("script",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                    new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                    new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                                 }),
                             factory.Markup(" World")))
                 };
@@ -2377,16 +2400,16 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         new MarkupTagHelperBlock("p",
                             factory.Markup("Hello "),
                             new MarkupTagHelperBlock("script",
-                                new List<KeyValuePair<string, SyntaxTreeNode>>
+                                new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "class",
                                         new MarkupBlock(
                                             new MarkupBlock(
                                                 factory.Markup("@").Accepts(AcceptedCharacters.None),
                                                 factory.Markup("@").With(SpanChunkGenerator.Null).Accepts(AcceptedCharacters.None)),
                                             factory.Markup("foo@bar.com"))),
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                    new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                                 }),
                             factory.Markup(" World")))
                 };
@@ -2414,10 +2437,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
                             TagMode.SelfClosing,
-                            attributes:  new List<KeyValuePair<string, SyntaxTreeNode>>
+                            attributes:  new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                             }))
                 };
                 yield return new object[]
@@ -2433,10 +2456,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                 new MarkupTagHelperBlock(
                                     "p",
                                     TagMode.SelfClosing,
-                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                    attributes: new List<TagHelperAttributeNode>
                                         {
-                                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                            new KeyValuePair<string, SyntaxTreeNode>(
+                                            new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                            new TagHelperAttributeNode(
                                                 "style",
                                                 factory.Markup("color:red;"))
                                         }),
@@ -2450,16 +2473,16 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                         factory.Markup("Hello"),
                         new MarkupTagHelperBlock("p",
                             TagMode.SelfClosing,
-                            attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                            attributes: new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo"))
+                                new TagHelperAttributeNode("class", factory.Markup("foo"))
                             }),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
                             TagMode.SelfClosing,
-                            attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                            attributes: new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                             }),
                         factory.Markup("World"))
                 };
@@ -2500,11 +2523,11 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now style=color:red;></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new List<KeyValuePair<string, SyntaxTreeNode>>
+                        new List<TagHelperAttributeNode>
                         {
-                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                            new KeyValuePair<string, SyntaxTreeNode>("dynamic", dateTimeNow(21)),
-                            new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                            new TagHelperAttributeNode("class", factory.Markup("foo")),
+                            new TagHelperAttributeNode("dynamic", dateTimeNow(21)),
+                            new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                         }))
                 };
                 yield return new object[]
@@ -2512,11 +2535,11 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now style=color:red;>Hello World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", dateTimeNow(21)),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                new TagHelperAttributeNode("dynamic", dateTimeNow(21)),
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("Hello World")))
                 };
@@ -2525,18 +2548,19 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now style=color@@:red;>Hello World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", dateTimeNow(21)),
-                                new KeyValuePair<string, SyntaxTreeNode>(
+                                new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                new TagHelperAttributeNode("dynamic", dateTimeNow(21)),
+                                new TagHelperAttributeNode(
                                     "style",
                                     new MarkupBlock(
                                         factory.Markup("color"),
                                          new MarkupBlock(
                                             factory.Markup("@").Accepts(AcceptedCharacters.None),
                                             factory.Markup("@").With(SpanChunkGenerator.Null).Accepts(AcceptedCharacters.None)),
-                                        factory.Markup(":red;")))
+                                        factory.Markup(":red;")),
+                                    HtmlAttributeValueStyle.DoubleQuotes)
                             },
                             factory.Markup("Hello World")))
                 };
@@ -2545,18 +2569,18 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now>Hello</p> <p style=color:red; dynamic=@DateTime.Now>World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", dateTimeNow(21))
+                                new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                new TagHelperAttributeNode("dynamic", dateTimeNow(21))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;")),
-                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", dateTimeNow(73))
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;")),
+                                new TagHelperAttributeNode("dynamic", dateTimeNow(73))
                             },
                             factory.Markup("World")))
                 };
@@ -2565,11 +2589,11 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=foo dynamic=@DateTime.Now style=color:red;>Hello World <strong class=\"foo\">inside of strong tag</strong></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>("dynamic", dateTimeNow(21)),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                new TagHelperAttributeNode("dynamic", dateTimeNow(21)),
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("Hello World "),
                             new MarkupTagBlock(
@@ -2609,10 +2633,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=\"foo\" style=\"color:red;\"></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                        new List<KeyValuePair<string, SyntaxTreeNode>>
+                        new List<TagHelperAttributeNode>
                         {
-                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                            new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                            new TagHelperAttributeNode("class", factory.Markup("foo")),
+                            new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                         }))
                 };
                 yield return new object[]
@@ -2620,10 +2644,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=\"foo\" style=\"color:red;\">Hello World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("Hello World")))
                 };
@@ -2632,16 +2656,16 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=\"foo\">Hello</p> <p style=\"color:red;\">World</p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo"))
+                                new TagHelperAttributeNode("class", factory.Markup("foo"))
                             },
                             factory.Markup("Hello")),
                         factory.Markup(" "),
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("World")))
                 };
@@ -2650,10 +2674,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                     "<p class=\"foo\" style=\"color:red;\">Hello World <strong class=\"foo\">inside of strong tag</strong></p>",
                     new MarkupBlock(
                         new MarkupTagHelperBlock("p",
-                            new List<KeyValuePair<string, SyntaxTreeNode>>
+                            new List<TagHelperAttributeNode>
                             {
-                                new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("foo")),
-                                new KeyValuePair<string, SyntaxTreeNode>("style", factory.Markup("color:red;"))
+                                new TagHelperAttributeNode("class", factory.Markup("foo")),
+                                new TagHelperAttributeNode("style", factory.Markup("color:red;"))
                             },
                             factory.Markup("Hello World "),
                             new MarkupTagBlock(
@@ -2754,11 +2778,12 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "data-required",
-                                        new MarkupBlock(dateTimeNow)),
+                                        new MarkupBlock(dateTimeNow),
+                                        HtmlAttributeValueStyle.SingleQuotes),
                                 }))
                     },
                     {
@@ -2767,9 +2792,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("data-required", factory.Markup("value")),
+                                    new TagHelperAttributeNode("data-required", factory.Markup("value"), HtmlAttributeValueStyle.SingleQuotes),
                                 }))
                     },
                     {
@@ -2778,11 +2803,12 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "data-required",
-                                        new MarkupBlock(factory.Markup("prefix "), dateTimeNow)),
+                                        new MarkupBlock(factory.Markup("prefix "), dateTimeNow),
+                                        HtmlAttributeValueStyle.SingleQuotes),
                                 }))
                     },
                     {
@@ -2791,11 +2817,12 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "data-required",
-                                        new MarkupBlock(dateTimeNow, factory.Markup(" suffix"))),
+                                        new MarkupBlock(dateTimeNow, factory.Markup(" suffix")),
+                                        HtmlAttributeValueStyle.SingleQuotes),
                                 }))
                     },
                     {
@@ -2804,14 +2831,15 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "data-required",
                                         new MarkupBlock(
                                             factory.Markup("prefix "),
                                             dateTimeNow,
-                                            factory.Markup(" suffix"))),
+                                            factory.Markup(" suffix")),
+                                        HtmlAttributeValueStyle.SingleQuotes),
                                 }))
                     },
                     {
@@ -2820,16 +2848,17 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("pre-attribute", value: null),
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode("pre-attribute", value: null, valueStyle: HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode(
                                         "data-required",
                                         new MarkupBlock(
                                             factory.Markup("prefix "),
                                             dateTimeNow,
-                                            factory.Markup(" suffix"))),
-                                    new KeyValuePair<string, SyntaxTreeNode>("post-attribute", value: null),
+                                            factory.Markup(" suffix")),
+                                        HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("post-attribute", value: null, valueStyle: HtmlAttributeValueStyle.Minimized),
                                 }))
                     },
                     {
@@ -2838,14 +2867,15 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>(
+                                    new TagHelperAttributeNode(
                                         "data-required",
                                         new MarkupBlock(
                                             dateTimeNow,
                                             factory.Markup(" middle "),
-                                            dateTimeNow)),
+                                            dateTimeNow),
+                                        HtmlAttributeValueStyle.SingleQuotes),
                                 }))
                     },
                 };
@@ -2936,9 +2966,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("unbound-required", null),
+                                    new TagHelperAttributeNode("unbound-required", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         noErrors
                     },
@@ -2948,9 +2978,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -2964,9 +2994,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-string", null),
+                                    new TagHelperAttributeNode("bound-required-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -2980,9 +3010,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-int", null),
+                                    new TagHelperAttributeNode("bound-required-int", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -2996,9 +3026,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
+                                    new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[] { new RazorError(string.Format(errorFormat, "bound-int", "p", intType), 3, 0, 3, 9) }
                     },
@@ -3008,9 +3038,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("int-dictionary", null),
+                                    new TagHelperAttributeNode("int-dictionary", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3028,9 +3058,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("string-dictionary", null),
+                                    new TagHelperAttributeNode("string-dictionary", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3048,9 +3078,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("int-prefix-", null),
+                                    new TagHelperAttributeNode("int-prefix-", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3074,9 +3104,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("string-prefix-", null),
+                                    new TagHelperAttributeNode("string-prefix-", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3100,9 +3130,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("int-prefix-value", null),
+                                    new TagHelperAttributeNode("int-prefix-value", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3120,9 +3150,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("string-prefix-value", null),
+                                    new TagHelperAttributeNode("string-prefix-value", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3140,9 +3170,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("int-prefix-value", new MarkupBlock()),
+                                    new TagHelperAttributeNode("int-prefix-value", new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         new[]
                         {
@@ -3160,9 +3190,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("string-prefix-value", new MarkupBlock()),
+                                    new TagHelperAttributeNode("string-prefix-value", new MarkupBlock(), HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         new RazorError[0]
                     },
@@ -3172,9 +3202,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("int-prefix-value", factory.CodeMarkup("3")),
+                                    new TagHelperAttributeNode("int-prefix-value", factory.CodeMarkup("3"), HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         new RazorError[0]
                     },
@@ -3184,11 +3214,14 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("string-prefix-value", new MarkupBlock(
-                                        factory.Markup("some"),
-                                        factory.Markup(" string"))),
+                                    new TagHelperAttributeNode(
+                                        "string-prefix-value",
+                                        new MarkupBlock(
+                                            factory.Markup("some"),
+                                            factory.Markup(" string")),
+                                        HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         new RazorError[0]
                     },
@@ -3198,10 +3231,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("unbound-required", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-string", null),
+                                    new TagHelperAttributeNode("unbound-required", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("bound-required-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3219,10 +3252,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
+                                    new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3236,11 +3269,11 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("unbound-required", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-string", null),
+                                    new TagHelperAttributeNode("bound-required-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("unbound-required", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("bound-required-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3260,11 +3293,11 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
+                                    new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3279,10 +3312,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("unbound-required", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("unbound-required", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         noErrors
                     },
@@ -3292,10 +3325,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         new[]
                         {
@@ -3313,10 +3346,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("unbound-required", null),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("unbound-required", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         noErrors
                     },
@@ -3326,10 +3359,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3347,10 +3380,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-string", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("bound-required-string", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         new[]
                         {
@@ -3368,10 +3401,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-string", null),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound-required-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3389,10 +3422,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("bound-required-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         new[]
                         {
@@ -3406,10 +3439,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         new[]
                         {
@@ -3422,10 +3455,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-int", null),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound-required-int", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3438,10 +3471,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3454,10 +3487,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", expression(14)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-int", null),
+                                    new TagHelperAttributeNode("class", expression(14), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound-required-int", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3471,10 +3504,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", expression(10)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
+                                    new TagHelperAttributeNode("class", expression(10), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3488,13 +3521,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", expression(36)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-string", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", expression(86)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("unbound-required", null),
+                                    new TagHelperAttributeNode("bound-required-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("class", expression(36), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound-required-string", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("class", expression(86), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("unbound-required", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3515,13 +3548,13 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", expression(23)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", expression(64)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
+                                    new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("class", expression(23), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("class", expression(64), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3617,9 +3650,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                                     }
                                 }
 
-                                tagHelperBlock.Attributes[i] = new KeyValuePair<string, SyntaxTreeNode>(
-                                    attribute.Key,
-                                    blockBuilder.Build());
+                                tagHelperBlock.Attributes[i] = new TagHelperAttributeNode(
+                                    attribute.Name,
+                                    blockBuilder.Build(),
+                                    attribute.ValueStyle);
                             }
                         }
                     }
@@ -3669,9 +3703,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("unbound-required", null),
+                                    new TagHelperAttributeNode("unbound-required", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3691,9 +3725,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-string", null),
+                                    new TagHelperAttributeNode("bound-required-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3719,9 +3753,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-int", null),
+                                    new TagHelperAttributeNode("bound-required-int", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3747,11 +3781,11 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("unbound-required", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-string", null),
+                                    new TagHelperAttributeNode("bound-required-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("unbound-required", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("bound-required-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3783,9 +3817,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3807,9 +3841,9 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
+                                    new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3830,10 +3864,10 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
+                                    new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
                                 })),
                         new[]
                         {
@@ -3856,19 +3890,19 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
                             new MarkupTagHelperBlock(
                                 "input",
                                 TagMode.StartTagAndEndTag,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                attributes: new List<TagHelperAttributeNode>()
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-int", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("unbound-required", null),
-                                    new KeyValuePair<string, SyntaxTreeNode>("bound-required-string", null),
+                                    new TagHelperAttributeNode("bound-required-int", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("unbound-required", null, HtmlAttributeValueStyle.Minimized),
+                                    new TagHelperAttributeNode("bound-required-string", null, HtmlAttributeValueStyle.Minimized),
                                 },
                                 children: new MarkupTagHelperBlock(
                                     "p",
                                     TagMode.StartTagAndEndTag,
-                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>()
+                                    attributes: new List<TagHelperAttributeNode>()
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>("bound-int", null),
-                                        new KeyValuePair<string, SyntaxTreeNode>("bound-string", null),
+                                        new TagHelperAttributeNode("bound-int", null, HtmlAttributeValueStyle.Minimized),
+                                        new TagHelperAttributeNode("bound-string", null, HtmlAttributeValueStyle.Minimized),
                                     }))),
                         new[]
                         {

--- a/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TagHelpers/TagHelperParseTreeRewriterTest.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Razor.Test.Framework;
 using Microsoft.AspNetCore.Razor.Text;
 using Xunit;
 using Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal;
+using Microsoft.AspNetCore.Razor.Parser.TagHelpers;
 
 namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
 {
@@ -766,9 +767,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
             };
             var expectedOutput = new MarkupBlock(
                 new MarkupTagHelperBlock("strong",
-                    new List<KeyValuePair<string, SyntaxTreeNode>>
+                    new List<TagHelperAttributeNode>
                     {
-                        new KeyValuePair<string, SyntaxTreeNode>("required", null)
+                        new TagHelperAttributeNode("required", null, HtmlAttributeValueStyle.Minimized)
                     },
                     blockFactory.MarkupTagBlock("<strong>"),
                     blockFactory.MarkupTagBlock("</strong>")));
@@ -1351,9 +1352,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -1362,9 +1363,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow(10))
+                                    new TagHelperAttributeNode("class", dateTimeNow(10))
                                 }))
                     },
                     {
@@ -1372,9 +1373,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1383,9 +1384,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow(10))
+                                    new TagHelperAttributeNode("class", dateTimeNow(10))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1394,9 +1395,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -1413,9 +1414,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "strong",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 }))
                     },
                     {
@@ -1424,9 +1425,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "strong",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", dateTimeNow(18))
+                                    new TagHelperAttributeNode("catchAll", dateTimeNow(18))
                                 }))
                     },
                     {
@@ -1434,9 +1435,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1445,9 +1446,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", dateTimeNow(18))
+                                    new TagHelperAttributeNode("catchAll", dateTimeNow(18))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1494,10 +1495,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("a")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("notRequired", factory.Markup("a")),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -1506,10 +1507,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", dateTimeNow(16)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("notRequired", dateTimeNow(16)),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -1517,10 +1518,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("a")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("notRequired", factory.Markup("a")),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1530,10 +1531,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "div",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("style", new MarkupBlock()),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -1542,10 +1543,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "div",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow(12)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("style", dateTimeNow(12)),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 }))
                     },
                     {
@@ -1553,10 +1554,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("style", new MarkupBlock()),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1565,10 +1566,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow(12)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow(34))
+                                    new TagHelperAttributeNode("style", dateTimeNow(12)),
+                                    new TagHelperAttributeNode("class", dateTimeNow(34))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1577,10 +1578,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("style", new MarkupBlock()),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -1597,10 +1598,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "p",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 }))
                     },
                     {
@@ -1608,10 +1609,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1621,11 +1622,11 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "div",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("style", new MarkupBlock()),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 }))
                     },
                     {
@@ -1633,11 +1634,11 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("style", new MarkupBlock()),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1646,11 +1647,11 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll",
+                                    new TagHelperAttributeNode("style", new MarkupBlock()),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("catchAll",
                                         new MarkupBlock(
                                             new MarkupBlock(
                                                 factory.Markup("@").Accepts(AcceptedCharacters.None),
@@ -1665,11 +1666,11 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", dateTimeNow(12)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", dateTimeNow(34)),
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", dateTimeNow(59))
+                                    new TagHelperAttributeNode("style", dateTimeNow(12)),
+                                    new TagHelperAttributeNode("class", dateTimeNow(34)),
+                                    new TagHelperAttributeNode("catchAll", dateTimeNow(59))
                                 },
                                 children: factory.Markup("words and spaces")))
                     },
@@ -1678,11 +1679,11 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "div",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("style", new MarkupBlock()),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("style", new MarkupBlock()),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn")),
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -1760,9 +1761,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: new[]
                                 {
@@ -1775,9 +1776,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -1790,9 +1791,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: new[]
                                 {
@@ -1807,9 +1808,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 },
                                 children: new SyntaxTreeNode[]
                                 {
@@ -1824,15 +1825,15 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: new MarkupTagHelperBlock(
                                     "strong",
-                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                    attributes: new List<TagHelperAttributeNode>
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                        new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                     },
                                     children: new[]
                                     {
@@ -1845,15 +1846,15 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 },
                                 children: new MarkupTagHelperBlock(
                                     "p",
-                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                    attributes: new List<TagHelperAttributeNode>
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                        new TagHelperAttributeNode("class", factory.Markup("btn"))
                                     },
                                     children: new[]
                                     {
@@ -1866,15 +1867,15 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: new MarkupTagHelperBlock(
                                     "p",
-                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                    attributes: new List<TagHelperAttributeNode>
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                        new TagHelperAttributeNode("class", factory.Markup("btn"))
                                     },
                                     children: new[]
                                     {
@@ -1887,15 +1888,15 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 },
                                 children: new MarkupTagHelperBlock(
                                     "strong",
-                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                    attributes: new List<TagHelperAttributeNode>
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                        new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                     },
                                     children: new[]
                                     {
@@ -1908,9 +1909,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: new[]
                                 {
@@ -1918,9 +1919,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                                     blockFactory.MarkupTagBlock("<p>"),
                                     new MarkupTagHelperBlock(
                                         "p",
-                                        attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                        attributes: new List<TagHelperAttributeNode>
                                         {
-                                            new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                            new TagHelperAttributeNode("class", factory.Markup("btn"))
                                         },
                                         children: new[]
                                         {
@@ -1937,9 +1938,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "strong",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                    new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                 },
                                 children: new[]
                                 {
@@ -1947,9 +1948,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                                     blockFactory.MarkupTagBlock("<strong>"),
                                     new MarkupTagHelperBlock(
                                     "strong",
-                                    attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                    attributes: new List<TagHelperAttributeNode>
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>("catchAll", factory.Markup("hi"))
+                                        new TagHelperAttributeNode("catchAll", factory.Markup("hi"))
                                     },
                                     children: new[]
                                     {
@@ -2017,9 +2018,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -2038,10 +2039,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("hi")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("notRequired", factory.Markup("hi")),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -2067,9 +2068,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -2084,10 +2085,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("hi")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("notRequired", factory.Markup("hi")),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -2101,9 +2102,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         "<p class=\"btn\" <p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: blockFactory.MarkupTagBlock("<p>"))),
                         new[]
@@ -2122,10 +2123,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         "<p notRequired=\"hi\" class=\"btn\" <p>",
                         new MarkupBlock(
                             new MarkupTagHelperBlock("p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("hi")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("notRequired", factory.Markup("hi")),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: blockFactory.MarkupTagBlock("<p>"))),
                         new[]
@@ -2145,9 +2146,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -2166,10 +2167,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "p",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("notRequired", factory.Markup("hi")),
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("notRequired", factory.Markup("hi")),
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         new[]
                         {
@@ -2370,9 +2371,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "th:myth",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         availableDescriptorsColon
                     },
@@ -2382,9 +2383,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "PREFIXmyth",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         availableDescriptorsText
                     },
@@ -2394,9 +2395,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "th:myth2",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         availableDescriptorsColon
                     },
@@ -2406,9 +2407,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "PREFIXmyth2",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 })),
                         availableDescriptorsText
                     },
@@ -2417,9 +2418,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "th:myth",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces"))),
                         availableDescriptorsColon
@@ -2429,9 +2430,9 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                         new MarkupBlock(
                             new MarkupTagHelperBlock(
                                 "PREFIXmyth",
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new KeyValuePair<string, SyntaxTreeNode>("class", factory.Markup("btn"))
+                                    new TagHelperAttributeNode("class", factory.Markup("btn"))
                                 },
                                 children: factory.Markup("words and spaces"))),
                         availableDescriptorsText
@@ -2442,10 +2443,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "th:myth2",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>(
+                                        new TagHelperAttributeNode(
                                             "bound",
                                             new MarkupBlock(
                                                 new MarkupBlock(
@@ -2464,10 +2465,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "PREFIXmyth2",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>(
+                                        new TagHelperAttributeNode(
                                             "bound",
                                             new MarkupBlock(
                                                 new MarkupBlock(
@@ -2486,10 +2487,10 @@ namespace Microsoft.AspNetCore.Razor.Test.TagHelpers
                             new MarkupTagHelperBlock(
                                 "PREFIXmyth2",
                                 tagMode: TagMode.SelfClosing,
-                                attributes: new List<KeyValuePair<string, SyntaxTreeNode>>
+                                attributes: new List<TagHelperAttributeNode>
                                 {
                                     {
-                                        new KeyValuePair<string, SyntaxTreeNode>(
+                                        new TagHelperAttributeNode(
                                             "bound",
                                             new MarkupBlock(
                                                 new MarkupBlock(

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/AttributeTargetingTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/AttributeTargetingTagHelpers.cs
@@ -14,9 +14,9 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("btn"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("btn"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("catchAll", new global::Microsoft.AspNetCore.Html.HtmlString("hi"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("catchAll", new global::Microsoft.AspNetCore.Html.HtmlString("hi"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -65,14 +65,14 @@ namespace TestOutput
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 __TestNamespace_InputTagHelper.Type = "checkbox";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 6 "AttributeTargetingTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(152, 40, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -91,14 +91,14 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
                 __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
                 __TestNamespace_InputTagHelper.Type = "checkbox";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 7 "AttributeTargetingTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(198, 54, false);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
@@ -13,9 +13,9 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data", new global::Microsoft.AspNetCore.Html.HtmlString("-delay1000"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data", new global::Microsoft.AspNetCore.Html.HtmlString("-delay1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -65,9 +65,9 @@ namespace TestOutput
 #line hidden
                 WriteLiteral(" + 1");
                 __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
-                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer));
+                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper.Type = **From custom attribute code renderer**: "text";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(190, 71, false);
@@ -85,14 +85,14 @@ namespace TestOutput
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 __TestNamespace_InputTagHelper.Type = **From custom attribute code renderer**: "checkbox";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 7 "BasicTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = **From custom attribute code renderer**: true;
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(271, 39, false);
                 Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.Prefixed.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.Prefixed.cs
@@ -14,7 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -42,14 +42,14 @@ namespace TestOutput
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 __TestNamespace_InputTagHelper.Type = "checkbox";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 8 "BasicTagHelpers.Prefixed.cshtml"
  __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(189, 41, false);
                 Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.cs
@@ -14,9 +14,9 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data", new global::Microsoft.AspNetCore.Html.HtmlString("-delay1000"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data", new global::Microsoft.AspNetCore.Html.HtmlString("-delay1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -66,9 +66,9 @@ namespace TestOutput
 #line hidden
                 WriteLiteral(" + 1");
                 __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
-                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer));
+                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper.Type = "text";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(190, 71, false);
@@ -86,14 +86,14 @@ namespace TestOutput
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 __TestNamespace_InputTagHelper.Type = "checkbox";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 7 "BasicTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(271, 39, false);
                 Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
@@ -16,13 +16,13 @@ namespace TestOutput
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", new global::Microsoft.AspNetCore.Html.HtmlString(""));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("placeholder", new global::Microsoft.AspNetCore.Html.HtmlString("Enter in a new time..."));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("first value"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("second value"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("hello"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("world"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("hello"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("placeholder", new global::Microsoft.AspNetCore.Html.HtmlString("Enter in a new time..."), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("first value"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("second value"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("hello"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("world"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("hello"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public ComplexTagHelpers()
         {
@@ -80,7 +80,7 @@ namespace TestOutput
                     __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                     __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                     __TestNamespace_InputTagHelper.Type = "text";
-                    __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                    __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                     __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                     __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
                     __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
@@ -135,14 +135,14 @@ namespace TestOutput
 #line hidden
                     __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
                     __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer;
-                    __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                    __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                     __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 16 "ComplexTagHelpers.cshtml"
                      __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
-                    __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                    __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                     await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                     Instrumentation.BeginContext(431, 37, false);
                     Write(__tagHelperExecutionContext.Output);
@@ -179,7 +179,7 @@ namespace TestOutput
 #line hidden
                 __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
                 __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer;
-                __tagHelperExecutionContext.AddTagHelperAttribute("tYPe", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("tYPe", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(490, 50, false);
@@ -219,7 +219,7 @@ namespace TestOutput
 
                 __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
                 __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer;
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(558, 79, false);
@@ -242,7 +242,7 @@ namespace TestOutput
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "time", 3);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "time", 3, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             AddHtmlAttributeValue("", 146, "Current", 146, 7, true);
             AddHtmlAttributeValue(" ", 153, "Time:", 154, 6, true);
 #line 8 "ComplexTagHelpers.cshtml"
@@ -294,7 +294,7 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("ChecKED", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("ChecKED", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(817, 28, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -313,7 +313,7 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
@@ -345,7 +345,7 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(925, 85, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -363,7 +363,7 @@ __TestNamespace_PTagHelper.Age = -1970 + @DateTimeOffset.Now.Year;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
@@ -392,7 +392,7 @@ __TestNamespace_InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(1088, 48, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -410,7 +410,7 @@ __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
@@ -439,7 +439,7 @@ __TestNamespace_InputTagHelper2.Checked =    @(  DateTimeOffset.Now.Year  ) > 20
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(1216, 63, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -457,7 +457,7 @@ __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
@@ -486,7 +486,7 @@ __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
 
 #line default
 #line hidden
-        __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+        __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
         Instrumentation.BeginContext(1343, 26, false);
         Write(__tagHelperExecutionContext.Output);
@@ -501,7 +501,7 @@ __TestNamespace_PTagHelper.Age = 123;
 
 #line default
 #line hidden
-    __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+    __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
     __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_6);
     await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
     if (!__tagHelperExecutionContext.Output.IsContentModified)

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.DesignTime.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.DesignTime.cs
@@ -38,6 +38,15 @@ __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
+            __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
+            __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
+            __TestNamespace_InputTagHelper.Type = "button";
+            __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+#line 6 "DuplicateAttributeTagHelpers.cshtml"
+__TestNamespace_InputTagHelper2.Checked = true;
+
+#line default
+#line hidden
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
 #line 3 "DuplicateAttributeTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = 3;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.cs
@@ -1,4 +1,4 @@
-#pragma checksum "DuplicateAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "84ecb9053de09ef4f2a69927fed3e41e188c730b"
+#pragma checksum "DuplicateAttributeTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "b7cbc77774bfe558f4548cc5b3760f88754a329e"
 namespace TestOutput
 {
     using System;
@@ -14,13 +14,15 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("AGE", new global::Microsoft.AspNetCore.Html.HtmlString("40"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("Age", new global::Microsoft.AspNetCore.Html.HtmlString("500"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("AGE", new global::Microsoft.AspNetCore.Html.HtmlString("40"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("Age", new global::Microsoft.AspNetCore.Html.HtmlString("500"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("TYPE", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("checked", new global::Microsoft.AspNetCore.Html.HtmlString("false"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("TYPE", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("checked", new global::Microsoft.AspNetCore.Html.HtmlString("false"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("checked", new global::Microsoft.AspNetCore.Html.HtmlString("true"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("checked", new global::Microsoft.AspNetCore.Html.HtmlString("true"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public DuplicateAttributeTagHelpers()
         {
@@ -46,7 +48,7 @@ namespace TestOutput
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 __TestNamespace_InputTagHelper.Type = "button";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
@@ -65,14 +67,14 @@ namespace TestOutput
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 __TestNamespace_InputTagHelper.Type = "button";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 5 "DuplicateAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_4);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
@@ -80,7 +82,35 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 Write(__tagHelperExecutionContext.Output);
                 Instrumentation.EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                Instrumentation.BeginContext(184, 2, true);
+                Instrumentation.BeginContext(184, 6, true);
+                WriteLiteral("\r\n    ");
+                Instrumentation.EndContext();
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
+                }
+                );
+                __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
+                __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
+                __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
+                __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
+                __TestNamespace_InputTagHelper.Type = "button";
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
+                __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+#line 6 "DuplicateAttributeTagHelpers.cshtml"
+__TestNamespace_InputTagHelper2.Checked = true;
+
+#line default
+#line hidden
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_5);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
+                __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_6);
+                await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+                Instrumentation.BeginContext(190, 96, false);
+                Write(__tagHelperExecutionContext.Output);
+                Instrumentation.EndContext();
+                __tagHelperExecutionContext = __tagHelperScopeManager.End();
+                Instrumentation.BeginContext(286, 2, true);
                 WriteLiteral("\r\n");
                 Instrumentation.EndContext();
             }
@@ -92,7 +122,7 @@ __TestNamespace_PTagHelper.Age = 3;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
@@ -100,7 +130,7 @@ __TestNamespace_PTagHelper.Age = 3;
             {
                 await __tagHelperExecutionContext.SetOutputContentAsync();
             }
-            Instrumentation.BeginContext(33, 157, false);
+            Instrumentation.BeginContext(33, 259, false);
             Write(__tagHelperExecutionContext.Output);
             Instrumentation.EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.End();

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateTargetTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateTargetTagHelper.cs
@@ -36,14 +36,14 @@ namespace TestOutput
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
             __TestNamespace_InputTagHelper.Type = "checkbox";
-            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_CatchAllTagHelper.Type = __TestNamespace_InputTagHelper.Type;
 #line 3 "DuplicateTargetTagHelper.cshtml"
 __TestNamespace_InputTagHelper.Checked = true;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper.Checked);
+            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_CatchAllTagHelper.Checked = __TestNamespace_InputTagHelper.Checked;
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(33, 40, false);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.cs
@@ -32,7 +32,7 @@ namespace TestOutput
             );
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 2);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 2, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             AddHtmlAttributeValue("", 49, "prefix", 49, 6, true);
 #line 3 "DynamicAttributeTagHelpers.cshtml"
 AddHtmlAttributeValue(" ", 55, DateTime.Now, 56, 14, false);
@@ -53,7 +53,7 @@ AddHtmlAttributeValue(" ", 55, DateTime.Now, 56, 14, false);
             );
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 2);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 2, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             AddHtmlAttributeValue("", 93, new Template(async(__razor_attribute_value_writer) => {
 #line 5 "DynamicAttributeTagHelpers.cshtml"
                  if (true) { 
@@ -114,8 +114,8 @@ WriteTo(__razor_attribute_value_writer, string.Empty);
             WriteLiteral(" suffix");
             __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
             __TestNamespace_InputTagHelper.Bound = __tagHelperStringValueBuffer;
-            __tagHelperExecutionContext.AddTagHelperAttribute("bound", __TestNamespace_InputTagHelper.Bound);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 3);
+            __tagHelperExecutionContext.AddTagHelperAttribute("bound", __TestNamespace_InputTagHelper.Bound, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 3, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             AddHtmlAttributeValue("", 204, "prefix", 204, 6, true);
 #line 7 "DynamicAttributeTagHelpers.cshtml"
 AddHtmlAttributeValue(" ", 210, DateTime.Now, 211, 14, false);
@@ -180,8 +180,8 @@ AddHtmlAttributeValue(" ", 210, DateTime.Now, 211, 14, false);
 #line hidden
             __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
             __TestNamespace_InputTagHelper.Bound = __tagHelperStringValueBuffer;
-            __tagHelperExecutionContext.AddTagHelperAttribute("bound", __TestNamespace_InputTagHelper.Bound);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 3);
+            __tagHelperExecutionContext.AddTagHelperAttribute("bound", __TestNamespace_InputTagHelper.Bound, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 3, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
 #line 10 "DynamicAttributeTagHelpers.cshtml"
 AddHtmlAttributeValue("", 345, long.MinValue, 345, 14, false);
 
@@ -241,7 +241,7 @@ AddHtmlAttributeValue(" ", 404, int.MaxValue, 405, 14, false);
             );
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 5);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 5, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
 #line 12 "DynamicAttributeTagHelpers.cshtml"
 AddHtmlAttributeValue("", 442, long.MinValue, 442, 14, false);
 
@@ -273,7 +273,7 @@ AddHtmlAttributeValue(" ", 488, int.MaxValue, 489, 14, false);
             );
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 1);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 1, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             AddHtmlAttributeValue("", 526, new Template(async(__razor_attribute_value_writer) => {
 #line 14 "DynamicAttributeTagHelpers.cshtml"
                  if (true) { 

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EmptyAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EmptyAttributeTagHelpers.cs
@@ -15,7 +15,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString(""));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
         #line hidden
         public EmptyAttributeTagHelpers()
@@ -38,14 +38,14 @@ namespace TestOutput
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
             __TestNamespace_InputTagHelper.Type = "";
-            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 4 "EmptyAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = ;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(38, 34, false);
@@ -67,14 +67,14 @@ __TestNamespace_InputTagHelper2.Checked = ;
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 __TestNamespace_InputTagHelper.Type = "";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 6 "EmptyAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = ;
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(98, 34, false);
@@ -93,7 +93,7 @@ __TestNamespace_PTagHelper.Age = ;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EnumTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EnumTagHelpers.cs
@@ -50,7 +50,7 @@ __TestNamespace_InputTagHelper.Value = MyEnum.MyValue;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("value", __TestNamespace_InputTagHelper.Value);
+            __tagHelperExecutionContext.AddTagHelperAttribute("value", __TestNamespace_InputTagHelper.Value, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(79, 33, false);
             Write(__tagHelperExecutionContext.Output);
@@ -66,7 +66,7 @@ __TestNamespace_InputTagHelper.Value = MyEnum.MyValue;
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "class", 1);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "class", 1, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
 #line 8 "EnumTagHelpers.cshtml"
 AddHtmlAttributeValue("", 128, MyEnum.MySecondValue, 128, 21, false);
 
@@ -93,7 +93,7 @@ __TestNamespace_InputTagHelper.Value = global::Microsoft.AspNetCore.Razor.Test.G
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("value", __TestNamespace_InputTagHelper.Value);
+            __tagHelperExecutionContext.AddTagHelperAttribute("value", __TestNamespace_InputTagHelper.Value, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(155, 25, false);
             Write(__tagHelperExecutionContext.Output);
@@ -114,13 +114,13 @@ __TestNamespace_InputTagHelper.Value = global::Microsoft.AspNetCore.Razor.Test.G
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("value", __TestNamespace_InputTagHelper.Value);
+            __tagHelperExecutionContext.AddTagHelperAttribute("value", __TestNamespace_InputTagHelper.Value, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
 #line 10 "EnumTagHelpers.cshtml"
 __TestNamespace_CatchAllTagHelper.CatchAll = global::Microsoft.AspNetCore.Razor.Test.Generator.MyEnum.MyValue;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("catch-all", __TestNamespace_CatchAllTagHelper.CatchAll);
+            __tagHelperExecutionContext.AddTagHelperAttribute("catch-all", __TestNamespace_CatchAllTagHelper.CatchAll, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(182, 50, false);
             Write(__tagHelperExecutionContext.Output);
@@ -141,13 +141,13 @@ __TestNamespace_InputTagHelper.Value = enumValue;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("value", __TestNamespace_InputTagHelper.Value);
+            __tagHelperExecutionContext.AddTagHelperAttribute("value", __TestNamespace_InputTagHelper.Value, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
 #line 11 "EnumTagHelpers.cshtml"
 __TestNamespace_CatchAllTagHelper.CatchAll = enumValue;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("catch-all", __TestNamespace_CatchAllTagHelper.CatchAll);
+            __tagHelperExecutionContext.AddTagHelperAttribute("catch-all", __TestNamespace_CatchAllTagHelper.CatchAll, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(234, 51, false);
             Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EscapedTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EscapedTagHelpers.cs
@@ -53,14 +53,14 @@ namespace TestOutput
 #line hidden
             __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
             __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer;
-            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 6 "EscapedTagHelpers.cshtml"
                                 __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(184, 45, false);
             Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/IncompleteTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/IncompleteTagHelper.cs
@@ -14,7 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString(""));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public IncompleteTagHelper()
         {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/MinimizedTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/MinimizedTagHelpers.cs
@@ -15,11 +15,11 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper = null;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("catchall-unbound-required");
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("btn"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("btn"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("input-unbound-required");
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("catchall-unbound-required", new global::Microsoft.AspNetCore.Html.HtmlString("hello"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("input-unbound-required", new global::Microsoft.AspNetCore.Html.HtmlString("hello2"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("catchall-unbound-required", new global::Microsoft.AspNetCore.Html.HtmlString("hello"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("input-unbound-required", new global::Microsoft.AspNetCore.Html.HtmlString("hello2"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public MinimizedTagHelpers()
         {
@@ -63,7 +63,7 @@ namespace TestOutput
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
                 __TestNamespace_InputTagHelper.BoundRequiredString = "hello";
-                __tagHelperExecutionContext.AddTagHelperAttribute("input-bound-required-string", __TestNamespace_InputTagHelper.BoundRequiredString);
+                __tagHelperExecutionContext.AddTagHelperAttribute("input-bound-required-string", __TestNamespace_InputTagHelper.BoundRequiredString, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(161, 119, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -83,9 +83,9 @@ namespace TestOutput
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
                 __TestNamespace_CatchAllTagHelper.BoundRequiredString = "world";
-                __tagHelperExecutionContext.AddTagHelperAttribute("catchall-bound-string", __TestNamespace_CatchAllTagHelper.BoundRequiredString);
+                __tagHelperExecutionContext.AddTagHelperAttribute("catchall-bound-string", __TestNamespace_CatchAllTagHelper.BoundRequiredString, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper.BoundRequiredString = "hello2";
-                __tagHelperExecutionContext.AddTagHelperAttribute("input-bound-required-string", __TestNamespace_InputTagHelper.BoundRequiredString);
+                __tagHelperExecutionContext.AddTagHelperAttribute("input-bound-required-string", __TestNamespace_InputTagHelper.BoundRequiredString, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(286, 176, false);
                 Write(__tagHelperExecutionContext.Output);
@@ -106,7 +106,7 @@ namespace TestOutput
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_4);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
                 __TestNamespace_InputTagHelper.BoundRequiredString = "world";
-                __tagHelperExecutionContext.AddTagHelperAttribute("input-bound-required-string", __TestNamespace_InputTagHelper.BoundRequiredString);
+                __tagHelperExecutionContext.AddTagHelperAttribute("input-bound-required-string", __TestNamespace_InputTagHelper.BoundRequiredString, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(468, 206, false);
                 Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
@@ -14,8 +14,8 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         #line hidden
@@ -66,16 +66,16 @@ namespace TestOutput
 #line hidden
                 WriteLiteral(" + 1");
                 __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
-                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer));
+                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper.Type = "text";
-                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+                __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 8 "NestedScriptTagTagHelpers.cshtml"
                                                           __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked);
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 Instrumentation.BeginContext(307, 86, false);
                 Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
@@ -15,10 +15,10 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
         private global::TestNamespace.InputTagHelper1 __TestNamespace_InputTagHelper1 = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("password"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("radio"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("int-prefix-salt", new global::Microsoft.AspNetCore.Html.HtmlString("8"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("password"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("radio"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("int-prefix-salt", new global::Microsoft.AspNetCore.Html.HtmlString("8"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public PrefixedAttributeTagHelpers()
         {
@@ -63,14 +63,14 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty = intDictionary;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __TestNamespace_InputTagHelper2.IntDictionaryProperty);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __TestNamespace_InputTagHelper2.IntDictionaryProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.IntDictionaryProperty = __TestNamespace_InputTagHelper2.IntDictionaryProperty;
 #line 16 "PrefixedAttributeTagHelpers.cshtml"
                   __TestNamespace_InputTagHelper2.StringDictionaryProperty = stringDictionary;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-dictionary", __TestNamespace_InputTagHelper2.StringDictionaryProperty);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-dictionary", __TestNamespace_InputTagHelper2.StringDictionaryProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.StringDictionaryProperty = __TestNamespace_InputTagHelper2.StringDictionaryProperty;
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(329, 92, false);
@@ -101,21 +101,21 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty = intDictionary;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __TestNamespace_InputTagHelper2.IntDictionaryProperty);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __TestNamespace_InputTagHelper2.IntDictionaryProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.IntDictionaryProperty = __TestNamespace_InputTagHelper2.IntDictionaryProperty;
 #line 17 "PrefixedAttributeTagHelpers.cshtml"
            __TestNamespace_InputTagHelper2.IntDictionaryProperty["garlic"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-garlic", __TestNamespace_InputTagHelper2.IntDictionaryProperty["garlic"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-garlic", __TestNamespace_InputTagHelper2.IntDictionaryProperty["garlic"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.IntDictionaryProperty["garlic"] = __TestNamespace_InputTagHelper2.IntDictionaryProperty["garlic"];
 #line 17 "PrefixedAttributeTagHelpers.cshtml"
                                   __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.IntProperty = __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"];
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(427, 103, false);
@@ -154,28 +154,28 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"] = 42;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.IntProperty = __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"];
 #line 19 "PrefixedAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.IntDictionaryProperty["salt"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-salt", __TestNamespace_InputTagHelper2.IntDictionaryProperty["salt"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-salt", __TestNamespace_InputTagHelper2.IntDictionaryProperty["salt"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"] = __TestNamespace_InputTagHelper2.IntDictionaryProperty["salt"];
 #line 19 "PrefixedAttributeTagHelpers.cshtml"
          __TestNamespace_InputTagHelper2.IntDictionaryProperty["pepper"] = 98;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-pepper", __TestNamespace_InputTagHelper2.IntDictionaryProperty["pepper"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-pepper", __TestNamespace_InputTagHelper2.IntDictionaryProperty["pepper"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"] = __TestNamespace_InputTagHelper2.IntDictionaryProperty["pepper"];
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["grabber"] = "string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __TestNamespace_InputTagHelper2.StringDictionaryProperty["grabber"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __TestNamespace_InputTagHelper2.StringDictionaryProperty["grabber"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.StringProperty = __TestNamespace_InputTagHelper2.StringDictionaryProperty["grabber"];
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["paprika"] = "another string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __TestNamespace_InputTagHelper2.StringDictionaryProperty["paprika"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __TestNamespace_InputTagHelper2.StringDictionaryProperty["paprika"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["paprika"] = __TestNamespace_InputTagHelper2.StringDictionaryProperty["paprika"];
             BeginWriteTagHelperAttribute();
             WriteLiteral("literate ");
@@ -187,7 +187,7 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty["salt"] = 37;
             WriteLiteral("?");
             __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"] = __tagHelperStringValueBuffer;
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-cumin", __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-cumin", __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"] = __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"];
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(536, 257, false);
@@ -225,10 +225,10 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty["value"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-value", __TestNamespace_InputTagHelper2.IntDictionaryProperty["value"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-value", __TestNamespace_InputTagHelper2.IntDictionaryProperty["value"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.IntDictionaryProperty["value"] = __TestNamespace_InputTagHelper2.IntDictionaryProperty["value"];
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["thyme"] = "string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-thyme", __TestNamespace_InputTagHelper2.StringDictionaryProperty["thyme"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-thyme", __TestNamespace_InputTagHelper2.StringDictionaryProperty["thyme"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["thyme"] = __TestNamespace_InputTagHelper2.StringDictionaryProperty["thyme"];
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(799, 60, false);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
@@ -15,10 +15,10 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.InputTagHelper1 __TestNamespace_InputTagHelper1 = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("password"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("radio"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("int-prefix-salt", new global::Microsoft.AspNetCore.Html.HtmlString("8"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("password"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("radio"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("int-prefix-salt", new global::Microsoft.AspNetCore.Html.HtmlString("8"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public PrefixedAttributeTagHelpers()
         {
@@ -63,14 +63,14 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty = intDictionary;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __TestNamespace_InputTagHelper1.IntDictionaryProperty);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __TestNamespace_InputTagHelper1.IntDictionaryProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.IntDictionaryProperty = __TestNamespace_InputTagHelper1.IntDictionaryProperty;
 #line 16 "PrefixedAttributeTagHelpers.cshtml"
                   __TestNamespace_InputTagHelper1.StringDictionaryProperty = stringDictionary;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-dictionary", __TestNamespace_InputTagHelper1.StringDictionaryProperty);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-dictionary", __TestNamespace_InputTagHelper1.StringDictionaryProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty = __TestNamespace_InputTagHelper1.StringDictionaryProperty;
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(329, 92, false);
@@ -101,21 +101,21 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty = intDictionary;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __TestNamespace_InputTagHelper1.IntDictionaryProperty);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-dictionary", __TestNamespace_InputTagHelper1.IntDictionaryProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.IntDictionaryProperty = __TestNamespace_InputTagHelper1.IntDictionaryProperty;
 #line 17 "PrefixedAttributeTagHelpers.cshtml"
            __TestNamespace_InputTagHelper1.IntDictionaryProperty["garlic"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-garlic", __TestNamespace_InputTagHelper1.IntDictionaryProperty["garlic"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-garlic", __TestNamespace_InputTagHelper1.IntDictionaryProperty["garlic"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.IntDictionaryProperty["garlic"] = __TestNamespace_InputTagHelper1.IntDictionaryProperty["garlic"];
 #line 17 "PrefixedAttributeTagHelpers.cshtml"
                                                        __TestNamespace_InputTagHelper1.IntProperty = 42;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __TestNamespace_InputTagHelper1.IntProperty);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __TestNamespace_InputTagHelper1.IntProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"] = __TestNamespace_InputTagHelper1.IntProperty;
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(427, 103, false);
@@ -154,28 +154,28 @@ __TestNamespace_InputTagHelper1.IntProperty = 42;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __TestNamespace_InputTagHelper1.IntProperty);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-grabber", __TestNamespace_InputTagHelper1.IntProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.IntDictionaryProperty["grabber"] = __TestNamespace_InputTagHelper1.IntProperty;
 #line 19 "PrefixedAttributeTagHelpers.cshtml"
 __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-salt", __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-salt", __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.IntDictionaryProperty["salt"] = __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"];
 #line 19 "PrefixedAttributeTagHelpers.cshtml"
          __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"] = 98;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-pepper", __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-pepper", __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.IntDictionaryProperty["pepper"] = __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"];
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             __TestNamespace_InputTagHelper1.StringProperty = "string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __TestNamespace_InputTagHelper1.StringProperty);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-grabber", __TestNamespace_InputTagHelper1.StringProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["grabber"] = __TestNamespace_InputTagHelper1.StringProperty;
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["paprika"] = "another string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __TestNamespace_InputTagHelper1.StringDictionaryProperty["paprika"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __TestNamespace_InputTagHelper1.StringDictionaryProperty["paprika"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["paprika"] = __TestNamespace_InputTagHelper1.StringDictionaryProperty["paprika"];
             BeginWriteTagHelperAttribute();
             WriteLiteral("literate ");
@@ -187,7 +187,7 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"] = 37;
             WriteLiteral("?");
             __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"] = __tagHelperStringValueBuffer;
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-cumin", __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-cumin", __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"] = __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"];
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(536, 257, false);
@@ -225,10 +225,10 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["value"] = 37;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-value", __TestNamespace_InputTagHelper1.IntDictionaryProperty["value"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("int-prefix-value", __TestNamespace_InputTagHelper1.IntDictionaryProperty["value"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.IntDictionaryProperty["value"] = __TestNamespace_InputTagHelper1.IntDictionaryProperty["value"];
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["thyme"] = "string";
-            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-thyme", __TestNamespace_InputTagHelper1.StringDictionaryProperty["thyme"]);
+            __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-thyme", __TestNamespace_InputTagHelper1.StringDictionaryProperty["thyme"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["thyme"] = __TestNamespace_InputTagHelper1.StringDictionaryProperty["thyme"];
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(799, 60, false);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelper.cs
@@ -14,7 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public SingleTagHelper()
         {
@@ -42,7 +42,7 @@ __TestNamespace_PTagHelper.Age = 1337;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelperWithNewlineBeforeAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelperWithNewlineBeforeAttributes.cs
@@ -14,7 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public SingleTagHelperWithNewlineBeforeAttributes()
         {
@@ -42,7 +42,7 @@ __TestNamespace_PTagHelper.Age = 1337;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
@@ -15,13 +15,13 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.CatchAllTagHelper __TestNamespace_CatchAllTagHelper = null;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("bound");
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("[item]", new global::Microsoft.AspNetCore.Html.HtmlString("items"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("[(item)]", new global::Microsoft.AspNetCore.Html.HtmlString("items"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("(click)", new global::Microsoft.AspNetCore.Html.HtmlString("doSomething()"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("(^click)", new global::Microsoft.AspNetCore.Html.HtmlString("doSomething()"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("*something", new global::Microsoft.AspNetCore.Html.HtmlString("value"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("[item]", new global::Microsoft.AspNetCore.Html.HtmlString("items"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("[(item)]", new global::Microsoft.AspNetCore.Html.HtmlString("items"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("(click)", new global::Microsoft.AspNetCore.Html.HtmlString("doSomething()"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("(^click)", new global::Microsoft.AspNetCore.Html.HtmlString("doSomething()"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("*something", new global::Microsoft.AspNetCore.Html.HtmlString("value"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("#localminimized");
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("#local", new global::Microsoft.AspNetCore.Html.HtmlString("value"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("#local", new global::Microsoft.AspNetCore.Html.HtmlString("value"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public SymbolBoundAttributes()
         {
@@ -46,7 +46,7 @@ __TestNamespace_CatchAllTagHelper.ListItems = items;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("[item]", __TestNamespace_CatchAllTagHelper.ListItems);
+            __tagHelperExecutionContext.AddTagHelperAttribute("[item]", __TestNamespace_CatchAllTagHelper.ListItems, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(276, 45, false);
@@ -67,7 +67,7 @@ __TestNamespace_CatchAllTagHelper.ArrayItems = items;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("[(item)]", __TestNamespace_CatchAllTagHelper.ArrayItems);
+            __tagHelperExecutionContext.AddTagHelperAttribute("[(item)]", __TestNamespace_CatchAllTagHelper.ArrayItems, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(323, 49, false);
@@ -91,7 +91,7 @@ __TestNamespace_CatchAllTagHelper.Event1 = doSomething();
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("(click)", __TestNamespace_CatchAllTagHelper.Event1);
+            __tagHelperExecutionContext.AddTagHelperAttribute("(click)", __TestNamespace_CatchAllTagHelper.Event1, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
@@ -119,7 +119,7 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("(^click)", __TestNamespace_CatchAllTagHelper.Event2);
+            __tagHelperExecutionContext.AddTagHelperAttribute("(^click)", __TestNamespace_CatchAllTagHelper.Event2, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_4);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
@@ -143,7 +143,7 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __TestNamespace_CatchAllTagHelper.StringProperty1 = "value";
-            __tagHelperExecutionContext.AddTagHelperAttribute("*something", __TestNamespace_CatchAllTagHelper.StringProperty1);
+            __tagHelperExecutionContext.AddTagHelperAttribute("*something", __TestNamespace_CatchAllTagHelper.StringProperty1, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_5);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
@@ -179,7 +179,7 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
             __TestNamespace_CatchAllTagHelper.StringProperty2 = "value";
-            __tagHelperExecutionContext.AddTagHelperAttribute("#local", __TestNamespace_CatchAllTagHelper.StringProperty2);
+            __tagHelperExecutionContext.AddTagHelperAttribute("#local", __TestNamespace_CatchAllTagHelper.StringProperty2, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_7);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(642, 47, false);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
@@ -86,8 +86,8 @@ namespace TestOutput
 #line hidden
                 __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
                 __TestNamespace_MyTagHelper.BoundProperty = __tagHelperStringValueBuffer;
-                __tagHelperExecutionContext.AddTagHelperAttribute("boundproperty", __TestNamespace_MyTagHelper.BoundProperty);
-                BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unboundproperty", 3);
+                __tagHelperExecutionContext.AddTagHelperAttribute("boundproperty", __TestNamespace_MyTagHelper.BoundProperty, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+                BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unboundproperty", 3, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 AddHtmlAttributeValue("", 186, "Current", 186, 7, true);
                 AddHtmlAttributeValue(" ", 193, "Time:", 194, 6, true);
 #line 9 "TagHelpersInSection.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersWithWeirdlySpacedAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersWithWeirdlySpacedAttributes.cs
@@ -14,12 +14,12 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private global::TestNamespace.InputTagHelper __TestNamespace_InputTagHelper = null;
         private global::TestNamespace.InputTagHelper2 __TestNamespace_InputTagHelper2 = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlString("hello"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlString("hello2"));
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlString("blah"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlString("hello"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlString("hello2"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlString("blah"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public TagHelpersWithWeirdlySpacedAttributes()
         {
@@ -47,7 +47,7 @@ __TestNamespace_PTagHelper.Age = 1337;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             BeginWriteTagHelperAttribute();
 #line 7 "TagHelpersWithWeirdlySpacedAttributes.cshtml"
              Write(true);
@@ -55,7 +55,7 @@ __TestNamespace_PTagHelper.Age = 1337;
 #line default
 #line hidden
             __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
-            __tagHelperExecutionContext.AddHtmlAttribute("data-content", Html.Raw(__tagHelperStringValueBuffer));
+            __tagHelperExecutionContext.AddHtmlAttribute("data-content", Html.Raw(__tagHelperStringValueBuffer), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
@@ -76,7 +76,7 @@ __TestNamespace_PTagHelper.Age = 1337;
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
             __TestNamespace_InputTagHelper.Type = "text";
-            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
@@ -97,7 +97,7 @@ __TestNamespace_PTagHelper.Age = 1234;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(173, 46, false);
@@ -115,7 +115,7 @@ __TestNamespace_PTagHelper.Age = 1234;
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
             __TestNamespace_InputTagHelper.Type = "password";
-            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
+            __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
@@ -14,7 +14,7 @@ namespace TestOutput
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager __tagHelperScopeManager = null;
         private global::TestNamespace.PTagHelper __TestNamespace_PTagHelper = null;
-        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("test"));
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("test"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
         public TransitionsInTagHelperAttributes()
         {
@@ -44,7 +44,7 @@ namespace TestOutput
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "class", 1);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "class", 1, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             AddHtmlAttributeValue("", 107, new Template(async(__razor_attribute_value_writer) => {
             }
             ), 107, 6, false);
@@ -54,7 +54,7 @@ __TestNamespace_PTagHelper.Age = 1337;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {
@@ -72,7 +72,7 @@ __TestNamespace_PTagHelper.Age = 1337;
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "class", 1);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "class", 1, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
 #line 8 "TransitionsInTagHelperAttributes.cshtml"
 AddHtmlAttributeValue("", 153, @class, 153, 9, false);
 
@@ -84,7 +84,7 @@ __TestNamespace_PTagHelper.Age = 42;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(143, 34, false);
             Write(__tagHelperExecutionContext.Output);
@@ -104,7 +104,7 @@ __TestNamespace_PTagHelper.Age = 42 + @int;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(179, 36, false);
             Write(__tagHelperExecutionContext.Output);
@@ -124,7 +124,7 @@ __TestNamespace_PTagHelper.Age = int;
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(217, 31, false);
             Write(__tagHelperExecutionContext.Output);
@@ -144,7 +144,7 @@ __TestNamespace_PTagHelper.Age = (@int);
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(250, 34, false);
             Write(__tagHelperExecutionContext.Output);
@@ -158,7 +158,7 @@ __TestNamespace_PTagHelper.Age = (@int);
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "class", 2);
+            BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "class", 2, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             AddHtmlAttributeValue("", 296, "custom-", 296, 7, true);
 #line 12 "TransitionsInTagHelperAttributes.cshtml"
 AddHtmlAttributeValue("", 303, @class, 303, 9, false);
@@ -171,7 +171,7 @@ __TestNamespace_PTagHelper.Age = 4 * @(@int + 2);
 
 #line default
 #line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             Instrumentation.BeginContext(286, 54, false);
             Write(__tagHelperExecutionContext.Output);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Source/DuplicateAttributeTagHelpers.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Source/DuplicateAttributeTagHelpers.cshtml
@@ -3,4 +3,5 @@
 <p age="3" AGE="40" Age="500">
     <input type="button" TYPE="checkbox" />
     <input type="button" checked="true" type="checkbox" checked="false" />
+    <input type='button' checked="true" type=checkbox checked='true' type="checkbox" checked=true />
 </p>


### PR DESCRIPTION
- Removed `Minimized` from `TagHelperAttribute` and replaced it with `HtmlAttributeStructure`.
- Removed `AddMinimizedTagHelperAttribute` method from `TagHelperExecutionContext` since we always provide a `HtmlAttributeStructure` now.
- Stopped manually escaping double quotes because we now know how an attribute was originally written.
- Updated tests to account for new attribute format (from kvp).

#705

/cc @dougbu @pranavkm @ajaybhargavb 