### PR TITLE
Fix TagHelper directive tests to fail when expected.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ project.lock.json
 *.*sdf
 *.ipch
 .build/
+.vs/

--- a/src/Microsoft.AspNetCore.Razor/Chunks/Generators/AddTagHelperChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor/Chunks/Generators/AddTagHelperChunkGenerator.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Chunks.Generators
 {
@@ -34,6 +36,24 @@ namespace Microsoft.AspNetCore.Razor.Chunks.Generators
         public override void GenerateChunk(Span target, ChunkGeneratorContext context)
         {
             context.ChunkTreeBuilder.AddAddTagHelperChunk(_lookupText, target);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            var other = obj as AddTagHelperChunkGenerator;
+            return base.Equals(other) &&
+                string.Equals(_lookupText, other._lookupText, StringComparison.Ordinal);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(base.GetHashCode());
+            combiner.Add(_lookupText, StringComparer.Ordinal);
+
+            return combiner.CombinedHash;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor/Chunks/Generators/RemoveTagHelperChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor/Chunks/Generators/RemoveTagHelperChunkGenerator.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Chunks.Generators
 {
@@ -34,6 +36,24 @@ namespace Microsoft.AspNetCore.Razor.Chunks.Generators
         public override void GenerateChunk(Span target, ChunkGeneratorContext context)
         {
             context.ChunkTreeBuilder.AddRemoveTagHelperChunk(_lookupText, target);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            var other = obj as RemoveTagHelperChunkGenerator;
+            return base.Equals(other) &&
+                string.Equals(_lookupText, other._lookupText, StringComparison.Ordinal);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(base.GetHashCode());
+            combiner.Add(_lookupText, StringComparer.Ordinal);
+
+            return combiner.CombinedHash;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor/Chunks/Generators/TagHelperPrefixDirectiveChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor/Chunks/Generators/TagHelperPrefixDirectiveChunkGenerator.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Chunks.Generators
 {
@@ -35,6 +37,24 @@ namespace Microsoft.AspNetCore.Razor.Chunks.Generators
         public override void GenerateChunk(Span target, ChunkGeneratorContext context)
         {
             context.ChunkTreeBuilder.AddTagHelperPrefixDirectiveChunk(_prefix, target);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            var other = obj as TagHelperPrefixDirectiveChunkGenerator;
+            return base.Equals(other) &&
+                string.Equals(_prefix, other._prefix, StringComparison.Ordinal);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(base.GetHashCode());
+            combiner.Add(_prefix, StringComparer.Ordinal);
+
+            return combiner.CombinedHash;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Parser/CSharp/CSharpDirectivesTest.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.CSharp
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharacters.None),
                     Factory.Code("\"Foo")
-                        .AsTagHelperPrefixDirective("Foo")),
+                        .AsTagHelperPrefixDirective("\"Foo")),
                 new RazorError(
                     RazorResources.ParseError_Unterminated_String_Literal,
                     absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.CSharp
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharacters.None),
                     Factory.Code("Foo   \"")
-                        .AsTagHelperPrefixDirective("Foo")),
+                        .AsTagHelperPrefixDirective("Foo   \"")),
                 new RazorError(
                     RazorResources.ParseError_Unterminated_String_Literal,
                     absoluteIndex: 23, lineIndex: 0, columnIndex: 23, length: 1),
@@ -183,7 +183,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.CSharp
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
                     Factory.Code("\"Foo")
-                        .AsRemoveTagHelper("Foo")),
+                        .AsRemoveTagHelper("\"Foo")),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
                      absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.CSharp
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
                     Factory.Code("Foo\"")
-                        .AsRemoveTagHelper("Foo")
+                        .AsRemoveTagHelper("Foo\"")
                         .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.CSharp
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + "     ")
                            .Accepts(AcceptedCharacters.None),
                     Factory.Code("Foo,   Bar    ")
-                        .AsAddTagHelper("Foo,  Bar")));
+                        .AsAddTagHelper("Foo,   Bar")));
         }
 
         [Fact]
@@ -286,7 +286,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.CSharp
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
                     Factory.Code("\"Foo")
-                        .AsAddTagHelper("Foo")),
+                        .AsAddTagHelper("\"Foo")),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,
                      absoluteIndex: 14, lineIndex: 0, columnIndex: 14, length: 1),
@@ -305,7 +305,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Parser.CSharp
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharacters.None),
                     Factory.Code("Foo\"")
-                        .AsAddTagHelper("Foo")
+                        .AsAddTagHelper("Foo\"")
                         .Accepts(AcceptedCharacters.AnyExceptNewline)),
                  new RazorError(
                      RazorResources.ParseError_Unterminated_String_Literal,


### PR DESCRIPTION
- Prior to this change the equals bits were falling back to the type comparison that `ChunkGenerator` exposes.