### PR TITLE
[Perf] Avoid ViewBuffers for writing bound TagHelper attribute values

### DIFF
--- a/src/Microsoft.AspNetCore.Razor/CodeGenerators/CSharpTagHelperCodeRenderer.cs
+++ b/src/Microsoft.AspNetCore.Razor/CodeGenerators/CSharpTagHelperCodeRenderer.cs
@@ -687,7 +687,7 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators
                 // Scopes are a runtime feature.
                 if (!_designTimeMode)
                 {
-                    _writer.WriteMethodInvocation(_tagHelperContext.StartTagHelperWritingScopeMethodName, "null");
+                    _writer.WriteMethodInvocation(_tagHelperContext.BeginWriteTagHelperAttributeMethodName);
                 }
 
                 var visitor = htmlEncodeValues ? _bodyVisitor : _literalBodyVisitor;
@@ -698,7 +698,7 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators
                 {
                     _writer
                         .WriteStartAssignment(StringValueBufferVariableName)
-                        .WriteMethodInvocation(_tagHelperContext.EndTagHelperWritingScopeMethodName);
+                        .WriteMethodInvocation(_tagHelperContext.EndWriteTagHelperAttributeMethodName);
                 }
             }
             finally
@@ -733,11 +733,7 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators
             }
             else
             {
-                writer.WriteInstanceMethodInvocation(
-                    StringValueBufferVariableName,
-                    _tagHelperContext.TagHelperContentGetContentMethodName,
-                    endLine: false,
-                    parameters: _tagHelperContext.HtmlEncoderPropertyName);
+                writer.Write(StringValueBufferVariableName);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Razor/CodeGenerators/GeneratedTagHelperContext.cs
+++ b/src/Microsoft.AspNetCore.Razor/CodeGenerators/GeneratedTagHelperContext.cs
@@ -29,6 +29,8 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators
             MarkAsHtmlEncodedMethodName = "Html.Raw";
             StartTagHelperWritingScopeMethodName = "StartTagHelperWritingScope";
             EndTagHelperWritingScopeMethodName = "EndTagHelperWritingScope";
+            BeginWriteTagHelperAttributeMethodName = "BeginWriteTagHelperAttribute";
+            EndWriteTagHelperAttributeMethodName = "EndWriteTagHelperAttribute";
             RunnerTypeName = "Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner";
             ScopeManagerTypeName = "Microsoft.AspNetCore.Razor.Runtime.TagHelperScopeManager";
             ExecutionContextTypeName = "Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext";
@@ -161,6 +163,16 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators
         /// The name of the method used to end a writing scope.
         /// </summary>
         public string EndTagHelperWritingScopeMethodName { get; set; }
+
+        /// <summary>
+        /// The name of the method used to begin an attribute writing scope.
+        /// </summary>
+        public string BeginWriteTagHelperAttributeMethodName { get; set; }
+
+        /// <summary>
+        /// The name of the method used to end an attribute writing scope.
+        /// </summary>
+        public string EndWriteTagHelperAttributeMethodName { get; set; }
 
         /// <summary>
         /// The name of the type used to run tag helpers.

--- a/src/Microsoft.AspNetCore.Razor/CodeGenerators/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
+++ b/src/Microsoft.AspNetCore.Razor/CodeGenerators/Visitors/CSharpTagHelperFieldDeclarationVisitor.cs
@@ -53,10 +53,12 @@ namespace Microsoft.AspNetCore.Razor.CodeGenerators.Visitors
                     // Need to disable the warning "X is assigned to but never used." for the value buffer since
                     // whether it's used depends on how a TagHelper is used.
                     Writer.WritePragma("warning disable 0414");
-                    WritePrivateField(
-                        _tagHelperContext.TagHelperContentTypeName,
-                        CSharpTagHelperCodeRenderer.StringValueBufferVariableName,
-                        value: null);
+                    Writer
+                        .Write("private ")
+                        .WriteVariableDeclaration(
+                            "string", 
+                            CSharpTagHelperCodeRenderer.StringValueBufferVariableName,
+                            value: null);
                     Writer.WritePragma("warning restore 0414");
 
                     WritePrivateField(

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/AttributeTargetingTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/AttributeTargetingTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.CustomAttributeCodeGenerator.cs
@@ -7,7 +7,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -56,7 +56,7 @@ namespace TestOutput
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-                StartTagHelperWritingScope(null);
+                BeginWriteTagHelperAttribute();
                 WriteLiteral("2000 + ");
 #line 6 "BasicTagHelpers.cshtml"
                                 Write(ViewBag.DefaultInterval);
@@ -64,8 +64,8 @@ namespace TestOutput
 #line default
 #line hidden
                 WriteLiteral(" + 1");
-                __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer.GetContent(HtmlEncoder)));
+                __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer));
                 __TestNamespace_InputTagHelper.Type = **From custom attribute code renderer**: "text";
                 __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.Prefixed.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.Prefixed.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/BasicTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -57,7 +57,7 @@ namespace TestOutput
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-                StartTagHelperWritingScope(null);
+                BeginWriteTagHelperAttribute();
                 WriteLiteral("2000 + ");
 #line 6 "BasicTagHelpers.cshtml"
                                 Write(ViewBag.DefaultInterval);
@@ -65,8 +65,8 @@ namespace TestOutput
 #line default
 #line hidden
                 WriteLiteral(" + 1");
-                __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer.GetContent(HtmlEncoder)));
+                __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer));
                 __TestNamespace_InputTagHelper.Type = "text";
                 __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/ComplexTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -127,14 +127,14 @@ namespace TestOutput
                     __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                     __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                     __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-                    StartTagHelperWritingScope(null);
+                    BeginWriteTagHelperAttribute();
 #line 16 "ComplexTagHelpers.cshtml"
                                  WriteLiteral(checkbox);
 
 #line default
 #line hidden
-                    __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                    __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer.GetContent(HtmlEncoder);
+                    __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+                    __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer;
                     __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
                     __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 16 "ComplexTagHelpers.cshtml"
@@ -171,14 +171,14 @@ namespace TestOutput
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-                StartTagHelperWritingScope(null);
+                BeginWriteTagHelperAttribute();
 #line 17 "ComplexTagHelpers.cshtml"
                   WriteLiteral(true ? "checkbox" : "anything");
 
 #line default
 #line hidden
-                __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer.GetContent(HtmlEncoder);
+                __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+                __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer;
                 __tagHelperExecutionContext.AddTagHelperAttribute("tYPe", __TestNamespace_InputTagHelper.Type);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
@@ -196,7 +196,7 @@ namespace TestOutput
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-                StartTagHelperWritingScope(null);
+                BeginWriteTagHelperAttribute();
 #line 18 "ComplexTagHelpers.cshtml"
                               if(true) {
 
@@ -217,8 +217,8 @@ namespace TestOutput
 #line default
 #line hidden
 
-                __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer.GetContent(HtmlEncoder);
+                __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+                __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer;
                 __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateAttributeTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateTargetTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DuplicateTargetTagHelper.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/DynamicAttributeTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -104,7 +104,7 @@ WriteTo(__razor_attribute_value_writer, string.Empty);
             );
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
-            StartTagHelperWritingScope(null);
+            BeginWriteTagHelperAttribute();
             WriteLiteral("prefix ");
 #line 7 "DynamicAttributeTagHelpers.cshtml"
          WriteLiteral(DateTime.Now);
@@ -112,8 +112,8 @@ WriteTo(__razor_attribute_value_writer, string.Empty);
 #line default
 #line hidden
             WriteLiteral(" suffix");
-            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-            __TestNamespace_InputTagHelper.Bound = __tagHelperStringValueBuffer.GetContent(HtmlEncoder);
+            __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+            __TestNamespace_InputTagHelper.Bound = __tagHelperStringValueBuffer;
             __tagHelperExecutionContext.AddTagHelperAttribute("bound", __TestNamespace_InputTagHelper.Bound);
             BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 3);
             AddHtmlAttributeValue("", 204, "prefix", 204, 6, true);
@@ -137,7 +137,7 @@ AddHtmlAttributeValue(" ", 210, DateTime.Now, 211, 14, false);
             );
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
-            StartTagHelperWritingScope(null);
+            BeginWriteTagHelperAttribute();
 #line 9 "DynamicAttributeTagHelpers.cshtml"
   WriteLiteral(long.MinValue);
 
@@ -178,8 +178,8 @@ AddHtmlAttributeValue(" ", 210, DateTime.Now, 211, 14, false);
 
 #line default
 #line hidden
-            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-            __TestNamespace_InputTagHelper.Bound = __tagHelperStringValueBuffer.GetContent(HtmlEncoder);
+            __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+            __TestNamespace_InputTagHelper.Bound = __tagHelperStringValueBuffer;
             __tagHelperExecutionContext.AddTagHelperAttribute("bound", __TestNamespace_InputTagHelper.Bound);
             BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unbound", 3);
 #line 10 "DynamicAttributeTagHelpers.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EmptyAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EmptyAttributeTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EnumTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EnumTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EscapedTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/EscapedTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -45,14 +45,14 @@ namespace TestOutput
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-            StartTagHelperWritingScope(null);
+            BeginWriteTagHelperAttribute();
 #line 6 "EscapedTagHelpers.cshtml"
                                       WriteLiteral(DateTime.Now);
 
 #line default
 #line hidden
-            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-            __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer.GetContent(HtmlEncoder);
+            __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+            __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer;
             __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
 #line 6 "EscapedTagHelpers.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/IncompleteTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/IncompleteTagHelper.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/MinimizedTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/MinimizedTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/NestedScriptTagTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -57,7 +57,7 @@ namespace TestOutput
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-                StartTagHelperWritingScope(null);
+                BeginWriteTagHelperAttribute();
                 WriteLiteral("2000 + ");
 #line 8 "NestedScriptTagTagHelpers.cshtml"
                                             Write(ViewBag.DefaultInterval);
@@ -65,8 +65,8 @@ namespace TestOutput
 #line default
 #line hidden
                 WriteLiteral(" + 1");
-                __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer.GetContent(HtmlEncoder)));
+                __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+                __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer));
                 __TestNamespace_InputTagHelper.Type = "text";
                 __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type);
                 __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.Reversed.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -177,7 +177,7 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty["salt"] = 37;
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["paprika"] = "another string";
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __TestNamespace_InputTagHelper2.StringDictionaryProperty["paprika"]);
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["paprika"] = __TestNamespace_InputTagHelper2.StringDictionaryProperty["paprika"];
-            StartTagHelperWritingScope(null);
+            BeginWriteTagHelperAttribute();
             WriteLiteral("literate ");
 #line 21 "PrefixedAttributeTagHelpers.cshtml"
                              WriteLiteral(literate);
@@ -185,8 +185,8 @@ __TestNamespace_InputTagHelper2.IntDictionaryProperty["salt"] = 37;
 #line default
 #line hidden
             WriteLiteral("?");
-            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-            __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"] = __tagHelperStringValueBuffer.GetContent(HtmlEncoder);
+            __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+            __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"] = __tagHelperStringValueBuffer;
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-cumin", __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"]);
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"] = __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"];
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/PrefixedAttributeTagHelpers.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -177,7 +177,7 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"] = 37;
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["paprika"] = "another string";
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-paprika", __TestNamespace_InputTagHelper1.StringDictionaryProperty["paprika"]);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["paprika"] = __TestNamespace_InputTagHelper1.StringDictionaryProperty["paprika"];
-            StartTagHelperWritingScope(null);
+            BeginWriteTagHelperAttribute();
             WriteLiteral("literate ");
 #line 21 "PrefixedAttributeTagHelpers.cshtml"
                              WriteLiteral(literate);
@@ -185,8 +185,8 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["salt"] = 37;
 #line default
 #line hidden
             WriteLiteral("?");
-            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-            __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"] = __tagHelperStringValueBuffer.GetContent(HtmlEncoder);
+            __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+            __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"] = __tagHelperStringValueBuffer;
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-cumin", __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"]);
             __TestNamespace_InputTagHelper2.StringDictionaryProperty["cumin"] = __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"];
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelper.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelperWithNewlineBeforeAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SingleTagHelperWithNewlineBeforeAttributes.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/SymbolBoundAttributes.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersInSection.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -77,15 +77,15 @@ namespace TestOutput
                 );
                 __TestNamespace_MyTagHelper = CreateTagHelper<global::TestNamespace.MyTagHelper>();
                 __tagHelperExecutionContext.Add(__TestNamespace_MyTagHelper);
-                StartTagHelperWritingScope(null);
+                BeginWriteTagHelperAttribute();
                 WriteLiteral("Current Time: ");
 #line 9 "TagHelpersInSection.cshtml"
                                       WriteLiteral(DateTime.Now);
 
 #line default
 #line hidden
-                __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-                __TestNamespace_MyTagHelper.BoundProperty = __tagHelperStringValueBuffer.GetContent(HtmlEncoder);
+                __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+                __TestNamespace_MyTagHelper.BoundProperty = __tagHelperStringValueBuffer;
                 __tagHelperExecutionContext.AddTagHelperAttribute("boundproperty", __TestNamespace_MyTagHelper.BoundProperty);
                 BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "unboundproperty", 3);
                 AddHtmlAttributeValue("", 186, "Current", 186, 7, true);

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersWithWeirdlySpacedAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TagHelpersWithWeirdlySpacedAttributes.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;
@@ -48,14 +48,14 @@ __TestNamespace_PTagHelper.Age = 1337;
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age);
-            StartTagHelperWritingScope(null);
+            BeginWriteTagHelperAttribute();
 #line 7 "TagHelpersWithWeirdlySpacedAttributes.cshtml"
              Write(true);
 
 #line default
 #line hidden
-            __tagHelperStringValueBuffer = EndTagHelperWritingScope();
-            __tagHelperExecutionContext.AddHtmlAttribute("data-content", Html.Raw(__tagHelperStringValueBuffer.GetContent(HtmlEncoder)));
+            __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+            __tagHelperExecutionContext.AddHtmlAttribute("data-content", Html.Raw(__tagHelperStringValueBuffer));
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/TestFiles/CodeGenerator/Output/TransitionsInTagHelperAttributes.cs
@@ -8,7 +8,7 @@ namespace TestOutput
     {
         #line hidden
         #pragma warning disable 0414
-        private global::Microsoft.AspNetCore.Razor.TagHelperContent __tagHelperStringValueBuffer = null;
+        private string __tagHelperStringValueBuffer = null;
         #pragma warning restore 0414
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperExecutionContext __tagHelperExecutionContext = null;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelperRunner __tagHelperRunner = null;


### PR DESCRIPTION
Fixes #717 
This fix has dependency on https://github.com/aspnet/Mvc/pull/4732 
The scenario is https://github.com/aspnet/Mvc/issues/4593 

Currently, writing TagHelper attribute uses the same code as the TagHelper content writing. This uses StartTagHelperWritingScope and EndTagHelperWritingScope which is expensive for writing attributes as these methods uses ViewBuffer, ViewBufferTextWriter. We an use simple StringWriter for writing attributes. Also, as attribute writing is not nested, we can use a shared writer within the RazorPage. The RazorPage has two new methods special cased for writing TagHelper attributes using the shared StringWriter. Razor uses these methods to determine the attribute values. 