### PR TITLE
Obsolete `EditorHints`.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor/Editor/EditorHints.cs
+++ b/src/Microsoft.AspNetCore.Razor/Editor/EditorHints.cs
@@ -6,9 +6,10 @@ using System;
 namespace Microsoft.AspNetCore.Razor.Editor
 {
     /// <summary>
-    /// Used within <see cref="F:SpanEditHandler.EditorHints"/>.
+    /// This class is obsolete and will be removed in a future version.
     /// </summary>
     [Flags]
+    [Obsolete("This class is obsolete and will be removed in a future version.")]
     public enum EditorHints
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.Razor/Editor/SpanEditHandler.cs
+++ b/src/Microsoft.AspNetCore.Razor/Editor/SpanEditHandler.cs
@@ -29,8 +29,9 @@ namespace Microsoft.AspNetCore.Razor.Editor
         public AcceptedCharacters AcceptedCharacters { get; set; }
 
         /// <summary>
-        /// Provides a set of hints to editors which may be manipulating the document in which this span is located.
+        /// This property is obsolete and will be removed in a future version.
         /// </summary>
+        [Obsolete("This property is obsolete and will be removed in a future version.")]
         public EditorHints EditorHints { get; set; }
 
         public Func<string, IEnumerable<ISymbol>> Tokenizer { get; set; }
@@ -158,7 +159,10 @@ namespace Microsoft.AspNetCore.Razor.Editor
 
         public override string ToString()
         {
-            return GetType().Name + ";Accepts:" + AcceptedCharacters + ((EditorHints == EditorHints.None) ? string.Empty : (";Hints: " + EditorHints.ToString()));
+            return GetType().Name + ";Accepts:" + AcceptedCharacters +
+#pragma warning disable 618 // Ignore obsolete warning for EditorHints
+                ((EditorHints == EditorHints.None) ? string.Empty : (";Hints: " + EditorHints.ToString()));
+#pragma warning restore 618 // Ignore obsolete warning for EditorHints
         }
 
         public override bool Equals(object obj)
@@ -167,7 +171,9 @@ namespace Microsoft.AspNetCore.Razor.Editor
             return other != null &&
                 GetType() == other.GetType() &&
                 AcceptedCharacters == other.AcceptedCharacters &&
+#pragma warning disable 618 // Ignore obsolete warning for EditorHints
                 EditorHints == other.EditorHints;
+#pragma warning restore 618 // Ignore obsolete warning for EditorHints
         }
 
         public override int GetHashCode()

--- a/test/Microsoft.AspNetCore.Razor.Test/Editor/AutoCompleteEditHandlerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Editor/AutoCompleteEditHandlerTest.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Editor
 {
     public class AutoCompleteEditHandlerTest
     {
+#pragma warning disable 618 // Ignore obsolete warning for EditorHints
         public static TheoryData<AutoCompleteEditHandler, AutoCompleteEditHandler> MatchingTestDataSet
         {
             get
@@ -180,6 +181,7 @@ namespace Microsoft.AspNetCore.Razor.Editor
                 };
             }
         }
+#pragma warning restore 618 // Ignore obsolete warning for EditorHints
 
         [Theory]
         [MemberData(nameof(MatchingTestDataSet))]

--- a/test/Microsoft.AspNetCore.Razor.Test/Editor/ImplicitExpressionEditHandlerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Editor/ImplicitExpressionEditHandlerTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Razor.Editor
 {
     public class ImplicitExpressionEditHandlerTest
     {
+#pragma warning disable 618 // Ignore obsolete warning for EditorHints
         public static TheoryData<ImplicitExpressionEditHandler, ImplicitExpressionEditHandler> MatchingTestDataSet
         {
             get
@@ -253,6 +254,7 @@ namespace Microsoft.AspNetCore.Razor.Editor
                 };
             }
         }
+#pragma warning restore 618 // Ignore obsolete warning for EditorHints
 
         [Theory]
         [MemberData(nameof(MatchingTestDataSet))]

--- a/test/Microsoft.AspNetCore.Razor.Test/Editor/SpanEditHandlerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Editor/SpanEditHandlerTest.cs
@@ -11,6 +11,7 @@ namespace Microsoft.AspNetCore.Razor.Editor
 {
     public class SpanEditHandlerTest
     {
+#pragma warning disable 618 // Ignore obsolete warning for EditorHints
         public static TheoryData<SpanEditHandler, SpanEditHandler> MatchingTestDataSet
         {
             get
@@ -127,6 +128,7 @@ namespace Microsoft.AspNetCore.Razor.Editor
                 };
             }
         }
+#pragma warning restore 618 // Ignore obsolete warning for EditorHints
 
         [Theory]
         [MemberData(nameof(MatchingTestDataSet))]

--- a/test/Microsoft.AspNetCore.Razor.Test/Framework/TestSpanBuilder.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Framework/TestSpanBuilder.cs
@@ -269,10 +269,12 @@ namespace Microsoft.AspNetCore.Razor.Test.Framework
             });
         }
 
+#pragma warning disable 618 // Ignore obsolete warning for EditorHints
         public static SpanConstructor WithEditorHints(this SpanConstructor self, EditorHints hints)
         {
             return self.With(eh => eh.EditorHints = hints);
         }
+#pragma warning restore 618 // Ignore obsolete warning for EditorHints
     }
 
     public class UnclassifiedCodeSpanConstructor


### PR DESCRIPTION
- For tests added grouped pragma warning disables to not pollute the test files with too many duplicate warning disable/restores.

#780