### PR TITLE
Change TagHelpers to work in partial parsing.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor/Parser/SyntaxTree/Block.cs
+++ b/src/Microsoft.AspNetCore.Razor/Parser/SyntaxTree/Block.cs
@@ -154,11 +154,13 @@ namespace Microsoft.AspNetCore.Razor.Parser.SyntaxTree
             }
         }
 
-        public Span LocateOwner(TextChange change)
+        public virtual Span LocateOwner(TextChange change) => LocateOwner(change, Children);
+
+        protected static Span LocateOwner(TextChange change, IEnumerable<SyntaxTreeNode> elements)
         {
             // Ask each child recursively
             Span owner = null;
-            foreach (SyntaxTreeNode element in Children)
+            foreach (var element in elements)
             {
                 var span = element as Span;
                 if (span == null)

--- a/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/Internal/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNetCore.Razor/Parser/TagHelpers/Internal/TagHelperBlockRewriter.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Chunks.Generators;
 using Microsoft.AspNetCore.Razor.Compilation.TagHelpers;
+using Microsoft.AspNetCore.Razor.Editor;
 using Microsoft.AspNetCore.Razor.Parser.Internal;
 using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -468,7 +469,8 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                 spanBuilder.ChunkGenerator = new MarkupChunkGenerator();
                             }
 
-                            spanBuilder.Kind = SpanKind.Code;
+                            ConfigureNonStringAttribute(spanBuilder);
+
                             span = spanBuilder.Build();
                         }
                     }
@@ -628,7 +630,7 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
             // SyntaxTreeNode reflects that.
             if (isBoundNonStringAttribute)
             {
-                builder.Kind = SpanKind.Code;
+                ConfigureNonStringAttribute(builder);
             }
 
             return builder.Build();
@@ -699,6 +701,18 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
         {
             return htmlSymbol.Type == HtmlSymbolType.DoubleQuote ||
                    htmlSymbol.Type == HtmlSymbolType.SingleQuote;
+        }
+
+        private static void ConfigureNonStringAttribute(SpanBuilder builder)
+        {
+            builder.Kind = SpanKind.Code;
+            builder.EditHandler = new ImplicitExpressionEditHandler(
+                    builder.EditHandler.Tokenizer,
+                    CSharpCodeParser.DefaultKeywords,
+                    acceptTrailingDot: true)
+            {
+                AcceptedCharacters = AcceptedCharacters.AnyExceptNewline
+            };
         }
 
         private class TryParseResult

--- a/test/Microsoft.AspNetCore.Razor.Test/Framework/TestSpanBuilder.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Framework/TestSpanBuilder.cs
@@ -139,7 +139,27 @@ namespace Microsoft.AspNetCore.Razor.Test.Framework
 
         public static SpanConstructor CodeMarkup(this SpanFactory self, params string[] content)
         {
-            return self.Span(SpanKind.Code, content, markup: true).With(new MarkupChunkGenerator());
+            return self
+                .Span(SpanKind.Code, content, markup: true)
+                .AsCodeMarkup();
+        }
+
+        public static SpanConstructor CSharpCodeMarkup(this SpanFactory self, string content)
+        {
+            return self.Code(content)
+                .AsImplicitExpression(CSharpCodeParser.DefaultKeywords, acceptTrailingDot: true)
+                .AsCodeMarkup();
+        }
+
+        public static SpanConstructor AsCodeMarkup(this SpanConstructor self)
+        {
+            return self
+                .With(new ImplicitExpressionEditHandler(
+                    SpanConstructor.TestTokenizer,
+                    CSharpCodeParser.DefaultKeywords,
+                    acceptTrailingDot: true))
+                .With(new MarkupChunkGenerator())
+                .Accepts(AcceptedCharacters.AnyExceptNewline);
         }
 
         public static SourceLocation GetLocationAndAdvance(this SourceLocationTracker self, string content)

--- a/test/Microsoft.AspNetCore.Razor.Test/Parser/TagHelpers/Internal/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Parser/TagHelpers/Internal/TagHelperBlockRewriterTest.cs
@@ -1013,9 +1013,8 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                                 new ExpressionBlock(
                                                     factory.CodeTransition(),
                                                     factory
-                                                        .Code("DateTime.Now.Year")
-                                                        .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace)))))
+                                                        .CSharpCodeMarkup("DateTime.Now.Year")
+                                                        .With(new ExpressionChunkGenerator())))))
                                 }))
                     },
                     {
@@ -1031,14 +1030,10 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                             new MarkupBlock(
                                                 factory.CodeMarkup(" "),
                                                 new ExpressionBlock(
+                                                    factory.CSharpCodeMarkup("@"),
                                                     factory
-                                                        .CodeTransition()
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()),
-                                                    factory
-                                                        .Code("DateTime.Now.Year")
-                                                        .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace)))))
+                                                        .CSharpCodeMarkup("DateTime.Now.Year")
+                                                        .With(new ExpressionChunkGenerator())))))
                                 }))
                     },
                     {
@@ -1078,14 +1073,9 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                             new MarkupBlock(
                                                 factory.CodeMarkup(" "),
                                                 new ExpressionBlock(
-                                                    factory
-                                                        .CodeTransition()
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()),
-                                                    factory
-                                                        .Code("value")
-                                                        .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                                    factory.CSharpCodeMarkup("@"),
+                                                    factory.CSharpCodeMarkup("value")
+                                                        .With(new ExpressionChunkGenerator()))),
                                             factory.CodeMarkup(" +"),
                                             factory.CodeMarkup(" 2"))),
                                     new TagHelperAttributeNode(
@@ -1094,33 +1084,26 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                             factory.CodeMarkup("(bool)"),
                                             new MarkupBlock(
                                                 new ExpressionBlock(
+                                                    factory.CSharpCodeMarkup("@"),
                                                     factory
-                                                        .CodeTransition()
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()),
-                                                    factory
-                                                        .Code("Bag[\"val\"]")
-                                                        .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                                        .CSharpCodeMarkup("Bag[\"val\"]")
+                                                        .With(new ExpressionChunkGenerator()))),
                                             factory.CodeMarkup(" ?"),
                                             new MarkupBlock(
-                                                factory.CodeMarkup(" @").Accepts(AcceptedCharacters.None),
+                                                factory.CodeMarkup(" @")
+                                                    .As(SpanKind.Code),
                                                 factory.CodeMarkup("@")
-                                                    .With(SpanChunkGenerator.Null)
-                                                    .Accepts(AcceptedCharacters.None)),
+                                                    .As(SpanKind.Code)
+                                                    .With(SpanChunkGenerator.Null)),
                                             factory.CodeMarkup("DateTime"),
                                             factory.CodeMarkup(" :"),
                                             new MarkupBlock(
                                                 factory.CodeMarkup(" "),
                                                 new ExpressionBlock(
+                                                    factory.CSharpCodeMarkup("@"),
                                                     factory
-                                                        .CodeTransition()
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()),
-                                                    factory
-                                                        .Code("DateTime.Now")
-                                                        .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace)))),
+                                                        .CSharpCodeMarkup("DateTime.Now")
+                                                        .With(new ExpressionChunkGenerator())))),
                                         HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
@@ -1196,27 +1179,19 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                         "age",
                                         new MarkupBlock(
                                             new MarkupBlock(
+                                                factory.CodeMarkup("@"),
                                                 factory.CodeMarkup("@")
-                                                    .Accepts(AcceptedCharacters.None)
-                                                    .With(new MarkupChunkGenerator()),
-                                                factory.CodeMarkup("@")
-                                                    .With(SpanChunkGenerator.Null)
-                                                    .Accepts(AcceptedCharacters.None)),
+                                                    .With(SpanChunkGenerator.Null)),
                                             new MarkupBlock(
-                                                factory.EmptyHtml().As(SpanKind.Code),
+                                                factory.EmptyHtml()
+                                                    .AsCodeMarkup()
+                                                    .As(SpanKind.Code),
                                                 new ExpressionBlock(
-                                                    factory.CodeTransition()
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()),
-                                                    factory.MetaCode("(")
-                                                        .Accepts(AcceptedCharacters.None)
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()),
-                                                    factory.Code("11+1").AsExpression(),
-                                                    factory.MetaCode(")")
-                                                        .Accepts(AcceptedCharacters.None)
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()))))),
+                                                    factory.CSharpCodeMarkup("@"),
+                                                    factory.CSharpCodeMarkup("("),
+                                                    factory.CSharpCodeMarkup("11+1")
+                                                        .With(new ExpressionChunkGenerator()),
+                                                    factory.CSharpCodeMarkup(")"))))),
                                     new TagHelperAttributeNode(
                                         "birthday",
                                         factory.CodeMarkup("DateTime.Now")),
@@ -2237,12 +2212,9 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                                 new MarkupBlock(
                                                 factory.CodeMarkup("    "),
                                                 new ExpressionBlock(
-                                                    factory.CodeTransition()
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()),
-                                                    factory.Code("true")
-                                                        .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                        .Accepts(AcceptedCharacters.NonWhiteSpace))),
+                                                    factory.CSharpCodeMarkup("@"),
+                                                    factory.CSharpCodeMarkup("true")
+                                                        .With(new ExpressionChunkGenerator()))),
                                                 factory.CodeMarkup("  ")),
                                             HtmlAttributeValueStyle.SingleQuotes)
                                     }
@@ -2264,18 +2236,11 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                                 new MarkupBlock(
                                                 factory.CodeMarkup("    "),
                                                 new ExpressionBlock(
-                                                    factory.CodeTransition()
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()),
-                                                    factory.MetaCode("(")
-                                                        .Accepts(AcceptedCharacters.None)
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()),
-                                                    factory.Code("true").AsExpression(),
-                                                    factory.MetaCode(")")
-                                                        .Accepts(AcceptedCharacters.None)
-                                                        .As(SpanKind.Code)
-                                                        .With(new MarkupChunkGenerator()))),
+                                                    factory.CSharpCodeMarkup("@"),
+                                                    factory.CSharpCodeMarkup("("),
+                                                    factory.CSharpCodeMarkup("true")
+                                                        .With(new ExpressionChunkGenerator()),
+                                                    factory.CSharpCodeMarkup(")"))),
                                                 factory.CodeMarkup("  ")),
                                             HtmlAttributeValueStyle.SingleQuotes)
                                     }

--- a/test/Microsoft.AspNetCore.Razor.Test/Parser/TagHelpers/Internal/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/Parser/TagHelpers/Internal/TagHelperParseTreeRewriterTest.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Chunks.Generators;
 using Microsoft.AspNetCore.Razor.Compilation.TagHelpers;
+using Microsoft.AspNetCore.Razor.Editor;
 using Microsoft.AspNetCore.Razor.Parser.Internal;
 using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -2452,8 +2453,8 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                                     new ExpressionBlock(
                                                         factory.CodeTransition(),
                                                         factory.Code("DateTime.Now")
-                                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                            .Accepts(AcceptedCharacters.NonWhiteSpace)))))
+                                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords, acceptTrailingDot: true)
+                                                            .Accepts(AcceptedCharacters.AnyExceptNewline)))))
                                     }
                                 })),
                         availableDescriptorsColon
@@ -2474,8 +2475,8 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                                     new ExpressionBlock(
                                                         factory.CodeTransition(),
                                                         factory.Code("DateTime.Now")
-                                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                            .Accepts(AcceptedCharacters.NonWhiteSpace)))))
+                                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords, acceptTrailingDot: true)
+                                                            .Accepts(AcceptedCharacters.AnyExceptNewline)))))
                                     }
                                 })),
                         availableDescriptorsText
@@ -2493,24 +2494,19 @@ namespace Microsoft.AspNetCore.Razor.Parser.TagHelpers.Internal
                                             "bound",
                                             new MarkupBlock(
                                                 new MarkupBlock(
+                                                    factory.CodeMarkup("@"),
                                                     factory
                                                         .CodeMarkup("@")
-                                                        .With(new MarkupChunkGenerator())
-                                                        .Accepts(AcceptedCharacters.None),
-                                                    factory
-                                                        .CodeMarkup("@")
-                                                        .With(SpanChunkGenerator.Null)
-                                                        .Accepts(AcceptedCharacters.None)),
+                                                        .With(SpanChunkGenerator.Null)),
                                                 new MarkupBlock(
-                                                    factory.EmptyHtml().As(SpanKind.Code),
+                                                    factory
+                                                        .EmptyHtml()
+                                                        .As(SpanKind.Code)
+                                                        .AsCodeMarkup(),
                                                     new ExpressionBlock(
-                                                        factory
-                                                            .CodeTransition()
-                                                            .As(SpanKind.Code)
-                                                            .With(new MarkupChunkGenerator()),
-                                                        factory.Code("DateTime.Now")
-                                                            .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
-                                                            .Accepts(AcceptedCharacters.NonWhiteSpace)))))
+                                                        factory.CSharpCodeMarkup("@"),
+                                                        factory.CSharpCodeMarkup("DateTime.Now")
+                                                            .With(new ExpressionChunkGenerator())))))
                                     }
                                 })),
                         availableDescriptorsText

--- a/test/Microsoft.AspNetCore.Razor.Test/PartialParsingTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test/PartialParsingTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Web.WebPages.TestUtils;
 using Microsoft.AspNetCore.Razor.CodeGenerators;
+using Microsoft.AspNetCore.Razor.Compilation.TagHelpers;
 using Microsoft.AspNetCore.Razor.Parser.SyntaxTree;
 using Microsoft.AspNetCore.Razor.Test.Framework;
 using Microsoft.AspNetCore.Razor.Test.Utils;
@@ -58,7 +59,7 @@ namespace Microsoft.AspNetCore.Razor
             return new TestParserManager(parser);
         }
 
-        protected static RazorEngineHost CreateHost()
+        protected static RazorEngineHost CreateHost(ITagHelperDescriptorResolver descriptorResolver = null)
         {
             return new RazorEngineHost(new TLanguage())
             {
@@ -71,7 +72,8 @@ namespace Microsoft.AspNetCore.Razor
                     "Template",
                     "DefineSection",
                     new GeneratedTagHelperContext()),
-                DesignTimeMode = true
+                DesignTimeMode = true,
+                TagHelperDescriptorResolver = descriptorResolver
             };
         }
 


### PR DESCRIPTION
- Prior to this change any query for ownership within a TagHelper would never succeed. More specifically, when a user would try to write C# continuation statements like `@DateTime.` (note the `.`) they would not get IntelliSense for the `.` in string based TagHelper attributes because the `.` would immediately be handled as a markup period.
- TagHelpers structure can be influenced greatly by changes to the tags start/end body; therefore, only allowed modifications to TagHelper attribute values to avoid complexity and enable the more widespread scenario of a user typing C# code in an attribute value.
- Updated existing tests to reflect the new edit handlers that were added to TagHelper attributes.
- Added partial parsing tests to verify partial parses succeed/fail when expected.
- Verified this change works by replacing binaries in VS.
- Did not add doc comments since we've previously decided that Razor is a corner enough sub-system of ASP.NET that they don't add a whole lot of value. This is consistent with the classes changed.

#792

**Background**:
- `PartialParseResult.Accepted` = partial parse succeeded
- `PartialParseResult.Accepted | PartialParseResult.Provisional` = partial parse succeeded but when the user stops typing perform a full re-parse.
- `PartialParseResult.Rejected` = Can't accurately determine the state of the document, do a full re-parse to ensure correctness.

Before this change `Rejected` would always be returned which would force full re-parses on TagHelper attribute changes; in the case of `DateTime.` the period is always handled as a markup period on full re-parse. The fix here was to make that period be Accepted | Provisional so the `.` would be treated as C# until the next full re-parse occurred.