### PR TITLE
Added property bag to tag helper descriptor.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor/Compilation/TagHelpers/TagHelperDescriptor.cs
@@ -17,9 +17,11 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
         private string _tagName;
         private string _typeName;
         private string _assemblyName;
+        private IDictionary<string, string> _propertyBag;
         private IEnumerable<TagHelperAttributeDescriptor> _attributes =
             Enumerable.Empty<TagHelperAttributeDescriptor>();
-        private IEnumerable<TagHelperRequiredAttributeDescriptor> _requiredAttributes = Enumerable.Empty<TagHelperRequiredAttributeDescriptor>();
+        private IEnumerable<TagHelperRequiredAttributeDescriptor> _requiredAttributes = 
+            Enumerable.Empty<TagHelperRequiredAttributeDescriptor>();
 
         /// <summary>
         /// Text used as a required prefix when matching HTML start and end tags in the Razor source to available
@@ -200,5 +202,21 @@ namespace Microsoft.AspNetCore.Razor.Compilation.TagHelpers
         /// tag helper.
         /// </summary>
         public TagHelperDesignTimeDescriptor DesignTimeDescriptor { get; set; }
+
+        /// <summary>
+        /// A dictionary containing additional information about the <see cref="TagHelperDescriptor"/>.
+        /// </summary>
+        public IDictionary<string, string> PropertyBag
+        {
+            get
+            {
+                if (_propertyBag == null)
+                {
+                    _propertyBag = new Dictionary<string, string>();
+                }
+
+                return _propertyBag;
+            }
+        }
     }
 }


### PR DESCRIPTION
Tag helper descriptor now has an empty `Dictionary<string, string> PropertyBag` to store properties. 

This might be used, for example, to mark a tag helper as a view component tag helper, if someone were to implement this feature. ¯\_(ツ)_/¯