### PR TITLE
Add extensible directive abstractions

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
@@ -206,6 +206,30 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 Namespace.Children.Insert(i, @using);
             }
 
+            public override void VisitDirectiveToken(DirectiveTokenChunkGenerator chunkGenerator, Span span)
+            {
+                Builder.Add(new DirectiveTokenIRNode()
+                {
+                    Content = span.Content,
+                    Descriptor = chunkGenerator.Descriptor,
+                    SourceLocation = span.Start,
+                });
+            }
+
+            public override void VisitStartDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
+            {
+                Builder.Push(new DirectiveIRNode()
+                {
+                    Name = chunkGenerator.Descriptor.Name,
+                    Descriptor = chunkGenerator.Descriptor,
+                });
+            }
+
+            public override void VisitEndDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
+            {
+                Builder.Pop();
+            }
+
             private class ContainerRazorIRNode : RazorIRNode
             {
                 private SourceLocation? _location;

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptor.cs
@@ -1,0 +1,16 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    public class DirectiveDescriptor
+    {
+        public string Name { get; set; }
+
+        public DirectiveDescriptorKind Kind { get; set; }
+
+        public IReadOnlyList<DirectiveTokenDescriptor> Tokens { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorBuilder.cs
@@ -1,0 +1,96 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    public static class DirectiveDescriptorBuilder
+    {
+        public static IDirectiveDescriptorBuilder Create(string name)
+        {
+            return new DefaultDirectiveDescriptorBuilder(name, DirectiveDescriptorKind.SingleLine);
+        }
+
+        public static IDirectiveDescriptorBuilder CreateRazorBlock(string name)
+        {
+            return new DefaultDirectiveDescriptorBuilder(name, DirectiveDescriptorKind.RazorBlock);
+        }
+
+        public static IDirectiveDescriptorBuilder CreateCodeBlock(string name)
+        {
+            return new DefaultDirectiveDescriptorBuilder(name, DirectiveDescriptorKind.CodeBlock);
+        }
+
+        private class DefaultDirectiveDescriptorBuilder : IDirectiveDescriptorBuilder
+        {
+            private readonly List<DirectiveTokenDescriptor> _tokenDescriptors;
+            private readonly string _name;
+            private readonly DirectiveDescriptorKind _type;
+
+            public DefaultDirectiveDescriptorBuilder(string name, DirectiveDescriptorKind type)
+            {
+                _name = name;
+                _type = type;
+                _tokenDescriptors = new List<DirectiveTokenDescriptor>();
+            }
+
+            public IDirectiveDescriptorBuilder AddType()
+            {
+                var descriptor = new DirectiveTokenDescriptor()
+                {
+                    Kind = DirectiveTokenKind.Type
+                };
+                _tokenDescriptors.Add(descriptor);
+
+                return this;
+            }
+
+            public IDirectiveDescriptorBuilder AddMember()
+            {
+                var descriptor = new DirectiveTokenDescriptor()
+                {
+                    Kind = DirectiveTokenKind.Member
+                };
+                _tokenDescriptors.Add(descriptor);
+
+                return this;
+            }
+
+            public IDirectiveDescriptorBuilder AddString()
+            {
+                var descriptor = new DirectiveTokenDescriptor()
+                {
+                    Kind = DirectiveTokenKind.String
+                };
+                _tokenDescriptors.Add(descriptor);
+
+                return this;
+            }
+
+            public IDirectiveDescriptorBuilder AddLiteral(string literal)
+            {
+                var descriptor = new DirectiveTokenDescriptor()
+                {
+                    Kind = DirectiveTokenKind.Literal,
+                    Value = literal,
+                };
+                _tokenDescriptors.Add(descriptor);
+
+                return this;
+            }
+
+            public DirectiveDescriptor Build()
+            {
+                var descriptor = new DirectiveDescriptor
+                {
+                    Name = _name,
+                    Kind = _type,
+                    Tokens = _tokenDescriptors,
+                };
+
+                return descriptor;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorComparer.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    internal class DirectiveDescriptorComparer : IEqualityComparer<DirectiveDescriptor>
+    {
+        public static readonly DirectiveDescriptorComparer Default = new DirectiveDescriptorComparer();
+
+        protected DirectiveDescriptorComparer()
+        {
+        }
+
+        public bool Equals(DirectiveDescriptor descriptorX, DirectiveDescriptor descriptorY)
+        {
+            if (descriptorX == descriptorY)
+            {
+                return true;
+            }
+
+            return descriptorX != null &&
+                string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal) &&
+                descriptorX.Kind == descriptorY.Kind &&
+                Enumerable.SequenceEqual(
+                    descriptorX.Tokens,
+                    descriptorY.Tokens,
+                    DirectiveTokenDescriptorComparer.Default);
+        }
+
+        public int GetHashCode(DirectiveDescriptor descriptor)
+        {
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(descriptor.Name, StringComparer.Ordinal);
+            hashCodeCombiner.Add(descriptor.Kind);
+
+            return hashCodeCombiner.CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorKind.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorKind.cs
@@ -1,0 +1,12 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    public enum DirectiveDescriptorKind
+    {
+        SingleLine,
+        RazorBlock,
+        CodeBlock
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenDescriptor.cs
@@ -1,0 +1,12 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    public class DirectiveTokenDescriptor
+    {
+        public DirectiveTokenKind Kind { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenDescriptorComparer.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    internal class DirectiveTokenDescriptorComparer : IEqualityComparer<DirectiveTokenDescriptor>
+    {
+        public static readonly DirectiveTokenDescriptorComparer Default = new DirectiveTokenDescriptorComparer();
+
+        protected DirectiveTokenDescriptorComparer()
+        {
+        }
+
+        public bool Equals(DirectiveTokenDescriptor descriptorX, DirectiveTokenDescriptor descriptorY)
+        {
+            if (descriptorX == descriptorY)
+            {
+                return true;
+            }
+
+            return descriptorX != null &&
+                string.Equals(descriptorX.Value, descriptorY.Value, StringComparison.Ordinal) &&
+                descriptorX.Kind == descriptorY.Kind;
+        }
+
+        public int GetHashCode(DirectiveTokenDescriptor descriptor)
+        {
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(descriptor.Value, StringComparer.Ordinal);
+            hashCodeCombiner.Add(descriptor.Kind);
+
+            return hashCodeCombiner.CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenKind.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenKind.cs
@@ -1,0 +1,13 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    public enum DirectiveTokenKind
+    {
+        Type,
+        Member,
+        String,
+        Literal
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/IDirectiveDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/IDirectiveDescriptorBuilder.cs
@@ -1,0 +1,18 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    public interface IDirectiveDescriptorBuilder
+    {
+        IDirectiveDescriptorBuilder AddType();
+
+        IDirectiveDescriptorBuilder AddMember();
+
+        IDirectiveDescriptorBuilder AddString();
+
+        IDirectiveDescriptorBuilder AddLiteral(string literal);
+
+        DirectiveDescriptor Build();
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DirectiveIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DirectiveIRNode.cs
@@ -1,0 +1,34 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Evolution.Legacy;
+
+namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
+{
+    public class DirectiveIRNode : RazorIRNode
+    {
+        public override IList<RazorIRNode> Children { get; } = new List<RazorIRNode>();
+
+        public override RazorIRNode Parent { get; set; }
+
+        internal override SourceLocation SourceLocation { get; set; }
+
+        public string Name { get; set; }
+
+        public IEnumerable<DirectiveTokenIRNode> Tokens => Children.OfType<DirectiveTokenIRNode>();
+
+        public DirectiveDescriptor Descriptor { get; set; }
+
+        public override void Accept(RazorIRNodeVisitor visitor)
+        {
+            visitor.VisitDirective(this);
+        }
+
+        public override TResult Accept<TResult>(RazorIRNodeVisitor<TResult> visitor)
+        {
+            return visitor.VisitDirective(this);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DirectiveTokenIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DirectiveTokenIRNode.cs
@@ -1,0 +1,31 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Evolution.Legacy;
+
+namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
+{
+    public class DirectiveTokenIRNode : RazorIRNode
+    {
+        public override IList<RazorIRNode> Children { get; } = EmptyArray;
+
+        public override RazorIRNode Parent { get; set; }
+
+        internal override SourceLocation SourceLocation { get; set; }
+
+        public string Content { get; set; }
+
+        public DirectiveTokenDescriptor Descriptor { get; set; }
+
+        public override void Accept(RazorIRNodeVisitor visitor)
+        {
+            visitor.VisitDirectiveToken(this);
+        }
+
+        public override TResult Accept<TResult>(RazorIRNodeVisitor<TResult> visitor)
+        {
+            return visitor.VisitDirectiveToken(this);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNodeVisitor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNodeVisitor.cs
@@ -14,6 +14,16 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
         {
         }
 
+        public virtual void VisitDirectiveToken(DirectiveTokenIRNode node)
+        {
+            VisitDefault(node);
+        }
+
+        public virtual void VisitDirective(DirectiveIRNode node)
+        {
+            VisitDefault(node);
+        }
+
         public virtual void VisitTemplate(TemplateIRNode node)
         {
             VisitDefault(node);

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNodeVisitorOfT.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNodeVisitorOfT.cs
@@ -15,6 +15,16 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
             return default(TResult);
         }
 
+        public virtual TResult VisitDirectiveToken(DirectiveTokenIRNode node)
+        {
+            return VisitDefault(node);
+        }
+
+        public virtual TResult VisitDirective(DirectiveIRNode node)
+        {
+            return VisitDefault(node);
+        }
+
         public virtual TResult VisitTemplate(TemplateIRNode node)
         {
             return VisitDefault(node);

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/DirectiveChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/DirectiveChunkGenerator.cs
@@ -1,0 +1,45 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
+{
+    internal class DirectiveChunkGenerator : ParentChunkGenerator
+    {
+        private static readonly Type Type = typeof(DirectiveChunkGenerator);
+
+        public DirectiveChunkGenerator(DirectiveDescriptor descriptor)
+        {
+            Descriptor = descriptor;
+        }
+
+        public DirectiveDescriptor Descriptor { get; }
+
+        public override void AcceptStart(ParserVisitor visitor, Block block)
+        {
+            visitor.VisitStartDirectiveBlock(this, block);
+        }
+
+        public override void AcceptEnd(ParserVisitor visitor, Block block)
+        {
+            visitor.VisitEndDirectiveBlock(this, block);
+        }
+        public override bool Equals(object obj)
+        {
+            var other = obj as DirectiveChunkGenerator;
+            return base.Equals(other) &&
+                DirectiveDescriptorComparer.Default.Equals(Descriptor, other.Descriptor);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(base.GetHashCode());
+            combiner.Add(Type);
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/DirectiveTokenChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/DirectiveTokenChunkGenerator.cs
@@ -1,0 +1,41 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
+{
+    internal class DirectiveTokenChunkGenerator : SpanChunkGenerator
+    {
+        private static readonly Type Type = typeof(DirectiveTokenChunkGenerator);
+
+        public DirectiveTokenChunkGenerator(DirectiveTokenDescriptor tokenDescriptor)
+        {
+            Descriptor = tokenDescriptor;
+        }
+
+        public DirectiveTokenDescriptor Descriptor { get; set; }
+
+        public override void Accept(ParserVisitor visitor, Span span)
+        {
+            visitor.VisitDirectiveToken(this, span);
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as DirectiveTokenChunkGenerator;
+            return base.Equals(other) &&
+                DirectiveTokenDescriptorComparer.Default.Equals(Descriptor, other.Descriptor);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(base.GetHashCode());
+            combiner.Add(Type);
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/ParserVisitor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/ParserVisitor.cs
@@ -89,7 +89,19 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
         {
         }
 
+        public virtual void VisitDirectiveToken(DirectiveTokenChunkGenerator chunkGenerator, Span block)
+        {
+        }
+
         public virtual void VisitEndTemplateBlock(TemplateBlockChunkGenerator chunkGenerator, Block block)
+        {
+        }
+
+        public virtual void VisitStartDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
+        {
+        }
+
+        public virtual void VisitEndDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/LegacyResources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/LegacyResources.resx
@@ -179,6 +179,9 @@
   <data name="CSharpSymbol_Whitespace" xml:space="preserve">
     <value>&lt;&lt;white space&gt;&gt;</value>
   </data>
+  <data name="DirectiveExpectsIdentifier" xml:space="preserve">
+    <value>The '{0}' directive expects an identifier.</value>
+  </data>
   <data name="EndBlock_Called_Without_Matching_StartBlock" xml:space="preserve">
     <value>"EndBlock" was called without a matching call to "StartBlock".</value>
   </data>
@@ -380,5 +383,11 @@ Instead, wrap the contents of the block in "{{}}":
   </data>
   <data name="TokenizerView_CannotPutBack" xml:space="preserve">
     <value>In order to put a symbol back, it must have been the symbol which ended at the current position. The specified symbol ends at {0}, but the current position is {1}</value>
+  </data>
+  <data name="UnexpectedDirectiveLiteral" xml:space="preserve">
+    <value>Unexpected literal following the '{0}' directive. Expected '{1}'.</value>
+  </data>
+  <data name="UnexpectedEOFAfterDirective" xml:space="preserve">
+    <value>Unexpected end of file following the '{0}' directive. Expected '{1}'.</value>
   </data>
 </root>

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Properties/LegacyResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Properties/LegacyResources.Designer.cs
@@ -331,6 +331,22 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         }
 
         /// <summary>
+        /// The '{0}' directive expects an identifier.
+        /// </summary>
+        internal static string DirectiveExpectsIdentifier
+        {
+            get { return GetString("DirectiveExpectsIdentifier"); }
+        }
+
+        /// <summary>
+        /// The '{0}' directive expects an identifier.
+        /// </summary>
+        internal static string FormatDirectiveExpectsIdentifier(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DirectiveExpectsIdentifier"), p0);
+        }
+
+        /// <summary>
         /// "EndBlock" was called without a matching call to "StartBlock".
         /// </summary>
         internal static string EndBlock_Called_Without_Matching_StartBlock
@@ -1316,6 +1332,38 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         internal static string FormatTokenizerView_CannotPutBack(object p0, object p1)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("TokenizerView_CannotPutBack"), p0, p1);
+        }
+
+        /// <summary>
+        /// Unexpected literal following the '{0}' directive. Expected '{1}'.
+        /// </summary>
+        internal static string UnexpectedDirectiveLiteral
+        {
+            get { return GetString("UnexpectedDirectiveLiteral"); }
+        }
+
+        /// <summary>
+        /// Unexpected literal following the '{0}' directive. Expected '{1}'.
+        /// </summary>
+        internal static string FormatUnexpectedDirectiveLiteral(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnexpectedDirectiveLiteral"), p0, p1);
+        }
+
+        /// <summary>
+        /// Unexpected end of file following the '{0}' directive. Expected '{1}'.
+        /// </summary>
+        internal static string UnexpectedEOFAfterDirective
+        {
+            get { return GetString("UnexpectedEOFAfterDirective"); }
+        }
+
+        /// <summary>
+        /// Unexpected end of file following the '{0}' directive. Expected '{1}'.
+        /// </summary>
+        internal static string FormatUnexpectedEOFAfterDirective(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnexpectedEOFAfterDirective"), p0, p1);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/DirectiveDescriptorBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/DirectiveDescriptorBuilderTest.cs
@@ -1,0 +1,123 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    public class DirectiveDescriptorBuilderTest
+    {
+        [Fact]
+        public void Create_BuildsSingleLineDirectiveDescriptor()
+        {
+            // Act
+            var descriptor = DirectiveDescriptorBuilder.Create("custom").Build();
+
+            // Assert
+            Assert.Equal(DirectiveDescriptorKind.SingleLine, descriptor.Kind);
+        }
+
+        [Fact]
+        public void CreateRazorBlock_BuildsRazorBlockDirectiveDescriptor()
+        {
+            // Act
+            var descriptor = DirectiveDescriptorBuilder.CreateRazorBlock("custom").Build();
+
+            // Assert
+            Assert.Equal(DirectiveDescriptorKind.RazorBlock, descriptor.Kind);
+        }
+
+        [Fact]
+        public void CreateCodeBlock_BuildsCodeBlockDirectiveDescriptor()
+        {
+            // Act
+            var descriptor = DirectiveDescriptorBuilder.CreateCodeBlock("custom").Build();
+
+            // Assert
+            Assert.Equal(DirectiveDescriptorKind.CodeBlock, descriptor.Kind);
+        }
+
+        [Fact]
+        public void AddType_AddsToken()
+        {
+            // Arrange
+            var builder = DirectiveDescriptorBuilder.Create("custom");
+
+            // Act
+            var descriptor = builder.AddType().Build();
+
+            // Assert
+            var token = Assert.Single(descriptor.Tokens);
+            Assert.Equal(DirectiveTokenKind.Type, token.Kind);
+        }
+
+        [Fact]
+        public void AddMember_AddsToken()
+        {
+            // Arrange
+            var builder = DirectiveDescriptorBuilder.Create("custom");
+
+            // Act
+            var descriptor = builder.AddMember().Build();
+
+            // Assert
+            var token = Assert.Single(descriptor.Tokens);
+            Assert.Equal(DirectiveTokenKind.Member, token.Kind);
+        }
+
+        [Fact]
+        public void AddString_AddsToken()
+        {
+            // Arrange
+            var builder = DirectiveDescriptorBuilder.Create("custom");
+
+            // Act
+            var descriptor = builder.AddString().Build();
+
+            // Assert
+            var token = Assert.Single(descriptor.Tokens);
+            Assert.Equal(DirectiveTokenKind.String, token.Kind);
+        }
+
+        [Fact]
+        public void AddLiteral_AddsToken()
+        {
+            // Arrange
+            var builder = DirectiveDescriptorBuilder.Create("custom");
+
+            // Act
+            var descriptor = builder.AddLiteral(",").Build();
+
+            // Assert
+            var token = Assert.Single(descriptor.Tokens);
+            Assert.Equal(DirectiveTokenKind.Literal, token.Kind);
+            Assert.Equal(",", token.Value);
+        }
+
+        [Fact]
+        public void AddX_MaintainsMultipleTokens()
+        {
+            // Arrange
+            var builder = DirectiveDescriptorBuilder.Create("custom");
+
+            // Act
+            var descriptor = builder
+                .AddType()
+                .AddMember()
+                .AddString()
+                .AddLiteral(",")
+                .Build();
+
+            // Assert
+            Assert.Collection(descriptor.Tokens,
+                token => Assert.Equal(DirectiveTokenKind.Type, token.Kind),
+                token => Assert.Equal(DirectiveTokenKind.Member, token.Kind),
+                token => Assert.Equal(DirectiveTokenKind.String, token.Kind),
+                token =>
+                {
+                    Assert.Equal(DirectiveTokenKind.Literal, token.Kind);
+                    Assert.Equal(",", token.Value);
+                });
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Legacy/ParserTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Legacy/ParserTestBase.cs
@@ -60,11 +60,19 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
 
         internal virtual RazorSyntaxTree ParseCodeBlock(string document, bool designTime = false)
         {
+            return ParseCodeBlock(document, Enumerable.Empty<DirectiveDescriptor>(), designTime);
+        }
+
+        internal virtual RazorSyntaxTree ParseCodeBlock(
+            string document,
+            IEnumerable<DirectiveDescriptor> descriptors,
+            bool designTime)
+        {
             using (var reader = new SeekableTextReader(document))
             {
                 var context = new ParserContext(reader, designTime);
 
-                var parser = new CSharpCodeParser(context);
+                var parser = new CSharpCodeParser(descriptors, context);
                 parser.HtmlParser = new HtmlMarkupParser(context)
                 {
                     CodeParser = parser,


### PR DESCRIPTION
- Based generic directive implementation off of descriptors.
- Added parsing logic to consume descriptors and parse content that's expected.
- Added parsing errors to automagically detect unexpected directive pieces.
- Updated visitor implementations to understand the directive bits.
- Added a builder abstraction to easily create descriptors. Had to maintain the ability to manually construct a descriptor to enable convenient serialization/deserialization.

#853

Will add tests once design looks good. 

/cc @rynowak 