### PR TITLE
Nodes that have children should use .Children

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpAttributeValueIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpAttributeValueIRNode.cs
@@ -9,15 +9,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 {
     public class CSharpAttributeValueIRNode : RazorIRNode
     {
-        public override IList<RazorIRNode> Children { get; } = EmptyArray;
+        public override IList<RazorIRNode> Children { get; } = new List<RazorIRNode>();
 
         public override RazorIRNode Parent { get; set; }
 
         internal override SourceLocation SourceLocation { get; set; }
 
         public string Prefix { get; set; }
-
-        public RazorIRNode Content { get; set; }
 
         public override void Accept(RazorIRNodeVisitor visitor)
         {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpExpressionIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpExpressionIRNode.cs
@@ -9,13 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 {
     public class CSharpExpressionIRNode : RazorIRNode
     {
-        public override IList<RazorIRNode> Children { get; } = EmptyArray;
+        public override IList<RazorIRNode> Children { get; } = new List<RazorIRNode>();
 
         public override RazorIRNode Parent { get; set; }
 
         internal override SourceLocation SourceLocation { get; set; }
-
-        public RazorIRNode Content { get; set; }
 
         public override void Accept(RazorIRNodeVisitor visitor)
         {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlAttributeIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlAttributeIRNode.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 {
     public class HtmlAttributeIRNode : RazorIRNode
     {
-        public override IList<RazorIRNode> Children { get; } = EmptyArray;
+        public override IList<RazorIRNode> Children { get; } = new List<RazorIRNode>();
 
         public override RazorIRNode Parent { get; set; }
 
@@ -18,8 +18,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
         public string Name { get; set; }
 
         public string Prefix { get; set; }
-
-        public RazorIRNode Value { get; set; }
 
         public string Suffix { get; set; }
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/HtmlAttributeIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/HtmlAttributeIntegrationTest.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
+{
+    public class HtmlAttributeIntegrationTest : IntegrationTestBase
+    {
+        [Fact]
+        public void HtmlWithDataDashAttribute()
+        {
+            // Arrange
+            var engine = RazorEngine.Create();
+
+            var document = CreateCodeDocument();
+
+            // Act
+            engine.Process(document);
+
+            // Assert
+            AssertIRMatchesBaseline(document.GetIRDocument());
+        }
+
+        [Fact]
+        public void HtmlWithConditionalAttribute()
+        {
+            // Arrange
+            var engine = RazorEngine.Create();
+
+            var document = CreateCodeDocument();
+
+            // Act
+            engine.Process(document);
+
+            // Assert
+            AssertIRMatchesBaseline(document.GetIRDocument());
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
@@ -31,12 +31,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
 
         public override void VisitCSharpAttributeValue(CSharpAttributeValueIRNode node)
         {
-            WriteContentNode(node, node.Prefix, node.Content.ToString()); // This is broken.
-        }
-
-        public override void VisitCSharpExpression(CSharpExpressionIRNode node)
-        {
-            WriteContentNode(node, node.Content.ToString()); // This is broken
+            WriteContentNode(node, node.Prefix);
         }
 
         public override void VisitCSharpStatement(CSharpStatementIRNode node)
@@ -66,7 +61,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
 
         public override void VisitHtmlAttribute(HtmlAttributeIRNode node)
         {
-            WriteContentNode(node, node.Prefix, node.Value.ToString(), node.Suffix);
+            WriteContentNode(node, node.Prefix, node.Suffix);
         }
 
         public override void VisitHtmlAttributeValue(HtmlAttributeValueIRNode node)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/DefaultRazorIRLoweringPhaseIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/DefaultRazorIRLoweringPhaseIntegrationTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
         }
 
         [Fact]
-        public void Lower_WithUsing()
+        public void Lower_WithFunctions()
         {
             // Arrange
             var codeDocument = TestRazorCodeDocument.Create(@"@functions { public int Foo { get; set; }}");
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
         }
 
         [Fact]
-        public void Lower_WithFunctions()
+        public void Lower_WithUsing()
         {
             // Arrange
             var codeDocument = TestRazorCodeDocument.Create(@"@using System");

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/RazorIRAssert.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/RazorIRAssert.cs
@@ -101,11 +101,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
                 Assert.Equal(name, attribute.Name);
                 Assert.Equal(suffix, attribute.Suffix);
 
-                Children(attribute.Value, valueValidators);
+                Children(attribute, valueValidators);
             }
             catch (XunitException e)
             {
-                throw new IRAssertException(attribute, attribute.Value.Children, e.Message, e);
+                throw new IRAssertException(attribute, attribute.Children, e.Message, e);
             }
         }
 
@@ -117,11 +117,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
             {
                 Assert.Equal(prefix, attributeValue.Prefix);
 
-                Children(attributeValue.Content, n => CSharpExpression(expected, n));
+                Children(attributeValue, n => CSharpExpression(expected, n));
             }
             catch (XunitException e)
             {
-                throw new IRAssertException(attributeValue, attributeValue.Content.Children, e.Message, e);
+                throw new IRAssertException(attributeValue, attributeValue.Children, e.Message, e);
             }
         }
 
@@ -147,9 +147,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
                 var cSharp = Assert.IsType<CSharpExpressionIRNode>(node);
 
                 var content = new StringBuilder();
-                for (var i = 0; i < cSharp.Content.Children.Count; i++)
+                for (var i = 0; i < cSharp.Children.Count; i++)
                 {
-                    content.Append(((CSharpTokenIRNode)cSharp.Content.Children[i]).Content);
+                    content.Append(((CSharpTokenIRNode)cSharp.Children[i]).Content);
                 }
 
                 Assert.Equal(expected, content.ToString());

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.cshtml
@@ -1,0 +1,5 @@
+﻿<html>
+<body>
+    <span val="@Hello" />
+</body>
+</html>"

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.ir.txt
@@ -1,0 +1,10 @@
+Document - (0:0,0)
+    NamespaceDeclaration - (0:0,0) - 
+        ClassDeclaration - (0:0,0) -  -  -  - 
+            RazorMethodDeclaration - (0:0,0) -  -  -  - 
+                HtmlContent - (0:0,0) - <html>\r\n<body>\r\n    <span
+                HtmlAttribute - (25:2,9) -  val=" - "
+                    CSharpAttributeValue - (31:2,15) - 
+                        CSharpExpression - (31:2,15)
+                            CSharpToken - (32:2,16) - Hello
+                HtmlContent - (38:2,22) -  />\r\n</body>\r\n</html>"

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.cshtml
@@ -1,0 +1,5 @@
+﻿<html>
+<body>
+    <span data-val="@Hello" />
+</body>
+</html>"

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.ir.txt
@@ -1,0 +1,8 @@
+Document - (0:0,0)
+    NamespaceDeclaration - (0:0,0) - 
+        ClassDeclaration - (0:0,0) -  -  -  - 
+            RazorMethodDeclaration - (0:0,0) -  -  -  - 
+                HtmlContent - (0:0,0) - <html>\r\n<body>\r\n    <span data\-val="
+                CSharpExpression - (36:2,20)
+                    CSharpToken - (37:2,21) - Hello
+                HtmlContent - (42:2,26) - " />\r\n</body>\r\n</html>"


### PR DESCRIPTION
This removes special casing for nodes that contain children that were
hiding them in a .Content or .Value property.

/cc @NTaylorMullen 