### PR TITLE
Transitioned SourceLocation => MappingLocation on IRNodes.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpAttributeValueIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpAttributeValueIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string Prefix { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpExpressionIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpExpressionIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public override void Accept(RazorIRNodeVisitor visitor)
         {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpStatementIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpStatementIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string Content { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpTokenIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/CSharpTokenIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string Content { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/ClassDeclarationIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/ClassDeclarationIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string AccessModifier { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DirectiveIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DirectiveIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string Name { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DirectiveTokenIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DirectiveTokenIRNode.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string Content { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DocumentIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/DocumentIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public override void Accept(RazorIRNodeVisitor visitor)
         {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlAttributeIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlAttributeIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string Name { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlAttributeValueIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlAttributeValueIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string Prefix { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlContentIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlContentIRNode.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public override void Accept(RazorIRNodeVisitor visitor)
         {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/NamespaceDeclarationIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/NamespaceDeclarationIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string Content { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNode.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public abstract RazorIRNode Parent { get; set; }
 
-        internal abstract SourceLocation SourceLocation { get; set; }
+        internal abstract MappingLocation SourceRange { get; set; }
 
         public abstract void Accept(RazorIRNodeVisitor visitor);
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorMethodDeclarationIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorMethodDeclarationIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string AccessModifier { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/TemplateIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/TemplateIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public override void Accept(RazorIRNodeVisitor visitor)
         {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/UsingStatementIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/UsingStatementIRNode.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
         public override RazorIRNode Parent { get; set; }
 
-        internal override SourceLocation SourceLocation { get; set; }
+        internal override MappingLocation SourceRange { get; set; }
 
         public string Content { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/MappingLocation.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/MappingLocation.cs
@@ -14,12 +14,17 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
         }
 
         public MappingLocation(SourceLocation location, int contentLength)
+            : this (location.AbsoluteIndex, location.LineIndex, location.CharacterIndex, contentLength, location.FilePath)
         {
+        }
+
+        public MappingLocation(int absoluteIndex, int lineIndex, int characterIndex, int contentLength, string filePath)
+        {
+            AbsoluteIndex = absoluteIndex;
+            LineIndex = lineIndex;
+            CharacterIndex = characterIndex;
             ContentLength = contentLength;
-            AbsoluteIndex = location.AbsoluteIndex;
-            LineIndex = location.LineIndex;
-            CharacterIndex = location.CharacterIndex;
-            FilePath = location.FilePath;
+            FilePath = filePath;
         }
 
         public int ContentLength { get; }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
             WriteIndent();
             WriteName(node);
             WriteSeparator();
-            WriteLocation(node);
+            WriteSourceRange(node);
         }
 
         protected void WriteContentNode(RazorIRNode node, params string[] content)
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
             WriteIndent();
             WriteName(node);
             WriteSeparator();
-            WriteLocation(node);
+            WriteSourceRange(node);
 
             for (var i = 0; i < content.Length; i++)
             {
@@ -140,9 +140,12 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
             }
         }
 
-        protected void WriteLocation(RazorIRNode node)
+        protected void WriteSourceRange(RazorIRNode node)
         {
-            _writer.Write(node.SourceLocation.ToString());
+            if (node.SourceRange != null)
+            {
+                _writer.Write(node.SourceRange.ToString());
+            }
         }
 
         protected void WriteContent(string content)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/DefaultRazorIRBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/DefaultRazorIRBuilderTest.cs
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
             public override RazorIRNode Parent { get; set; }
 
-            internal override SourceLocation SourceLocation { get; set; }
+            internal override MappingLocation SourceRange { get; set; }
 
             public override void Accept(RazorIRNodeVisitor visitor)
             {

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/RazorIRNodeWalkerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/RazorIRNodeWalkerTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 
             public override RazorIRNode Parent { get; set; }
 
-            internal override SourceLocation SourceLocation { get; set; }
+            internal override MappingLocation SourceRange { get; set; }
 
             public override void Accept(RazorIRNodeVisitor visitor)
             {

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/BasicIntegrationTest/CustomDirective.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/BasicIntegrationTest/CustomDirective.ir.txt
@@ -1,7 +1,7 @@
-Document - (0:0,0)
-    NamespaceDeclaration - (0:0,0) - 
-        ClassDeclaration - (0:0,0) -  -  -  - 
-            RazorMethodDeclaration - (0:0,0) -  -  -  - 
-                HtmlContent - (0:0,0) - 
-                Directive - (0:0,0) - test_directive
-                HtmlContent - (15:0,15) - 
+Document - 
+    NamespaceDeclaration -  - 
+        ClassDeclaration -  -  -  -  - 
+            RazorMethodDeclaration -  -  -  -  - 
+                HtmlContent - (0:0,0 [0] ) - 
+                Directive -  - test_directive
+                HtmlContent - (15:0,15 [0] ) - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/BasicIntegrationTest/Empty.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/BasicIntegrationTest/Empty.ir.txt
@@ -1,5 +1,5 @@
-Document - (0:0,0)
-    NamespaceDeclaration - (0:0,0) - 
-        ClassDeclaration - (0:0,0) -  -  -  - 
-            RazorMethodDeclaration - (0:0,0) -  -  -  - 
-                HtmlContent - (0:0,0) - 
+Document - 
+    NamespaceDeclaration -  - 
+        ClassDeclaration -  -  -  -  - 
+            RazorMethodDeclaration -  -  -  -  - 
+                HtmlContent - (0:0,0 [0] ) - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/BasicIntegrationTest/HelloWorld.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/BasicIntegrationTest/HelloWorld.ir.txt
@@ -1,5 +1,5 @@
-Document - (0:0,0)
-    NamespaceDeclaration - (0:0,0) - 
-        ClassDeclaration - (0:0,0) -  -  -  - 
-            RazorMethodDeclaration - (0:0,0) -  -  -  - 
-                HtmlContent - (0:0,0) - Hello, World!
+Document - 
+    NamespaceDeclaration -  - 
+        ClassDeclaration -  -  -  -  - 
+            RazorMethodDeclaration -  -  -  -  - 
+                HtmlContent - (0:0,0 [13] ) - Hello, World!

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.ir.txt
@@ -1,10 +1,10 @@
-Document - (0:0,0)
-    NamespaceDeclaration - (0:0,0) - 
-        ClassDeclaration - (0:0,0) -  -  -  - 
-            RazorMethodDeclaration - (0:0,0) -  -  -  - 
-                HtmlContent - (0:0,0) - <html>\r\n<body>\r\n    <span
-                HtmlAttribute - (25:2,9) -  val=" - "
-                    CSharpAttributeValue - (31:2,15) - 
-                        CSharpExpression - (31:2,15)
-                            CSharpToken - (32:2,16) - Hello
-                HtmlContent - (38:2,22) -  />\r\n</body>\r\n</html>"
+Document - 
+    NamespaceDeclaration -  - 
+        ClassDeclaration -  -  -  -  - 
+            RazorMethodDeclaration -  -  -  -  - 
+                HtmlContent - (0:0,0 [6] ) - <html>\r\n<body>\r\n    <span
+                HtmlAttribute - (25:2,9 [13] ) -  val=" - "
+                    CSharpAttributeValue - (31:2,15 [6] ) - 
+                        CSharpExpression - (32:2,16 [5] )
+                            CSharpToken - (32:2,16 [5] ) - Hello
+                HtmlContent - (38:2,22 [3] ) -  />\r\n</body>\r\n</html>"

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.ir.txt
@@ -1,8 +1,8 @@
-Document - (0:0,0)
-    NamespaceDeclaration - (0:0,0) - 
-        ClassDeclaration - (0:0,0) -  -  -  - 
-            RazorMethodDeclaration - (0:0,0) -  -  -  - 
-                HtmlContent - (0:0,0) - <html>\r\n<body>\r\n    <span data\-val="
-                CSharpExpression - (36:2,20)
-                    CSharpToken - (37:2,21) - Hello
-                HtmlContent - (42:2,26) - " />\r\n</body>\r\n</html>"
+Document - 
+    NamespaceDeclaration -  - 
+        ClassDeclaration -  -  -  -  - 
+            RazorMethodDeclaration -  -  -  -  - 
+                HtmlContent - (0:0,0 [6] ) - <html>\r\n<body>\r\n    <span data\-val="
+                CSharpExpression - (37:2,21 [5] )
+                    CSharpToken - (37:2,21 [5] ) - Hello
+                HtmlContent - (42:2,26 [1] ) - " />\r\n</body>\r\n</html>"


### PR DESCRIPTION
- Also modified the property name from `SourceLocation` => `DocumentLocation` to avoid ambiguity.
- Updated IR baselines
- Updated IR baseline infrastructure to conditionally render the document location.

#884 

/cc @rynowak 