### PR TITLE
Make `HtmlContentIRNode` content newlines platform agnostic.

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNetCore.Razor.Evolution.Intermediate;
@@ -155,9 +156,10 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
                 return;
             }
 
-            // We explicitly escape newlines in node content so that the IR can be compared line-by-line.
+            // We explicitly escape newlines in node content so that the IR can be compared line-by-line. The escaped
+            // newline cannot be platform specific so we need to drop the windows \r.
             // Also, escape our separator so we can search for ` - `to find delimiters.
-            _writer.Write(content.Replace("\r", "\\r").Replace("\n", "\\n").Replace("-", "\\-"));
+            _writer.Write(content.Replace("\r", string.Empty).Replace("\n", "\\n").Replace(" - ", "\\-"));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.ir.txt
@@ -2,9 +2,9 @@ Document -
     NamespaceDeclaration -  - 
         ClassDeclaration -  -  -  -  - 
             RazorMethodDeclaration -  -  -  -  - 
-                HtmlContent - (0:0,0 [6] ) - <html>\r\n<body>\r\n    <span
+                HtmlContent - (0:0,0 [6] ) - <html>\n<body>\n    <span
                 HtmlAttribute - (25:2,9 [13] ) -  val=" - "
                     CSharpAttributeValue - (31:2,15 [6] ) - 
                         CSharpExpression - (32:2,16 [5] )
                             CSharpToken - (32:2,16 [5] ) - Hello
-                HtmlContent - (38:2,22 [3] ) -  />\r\n</body>\r\n</html>"
+                HtmlContent - (38:2,22 [3] ) -  />\n</body>\n</html>"

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.ir.txt
@@ -2,7 +2,7 @@ Document -
     NamespaceDeclaration -  - 
         ClassDeclaration -  -  -  -  - 
             RazorMethodDeclaration -  -  -  -  - 
-                HtmlContent - (0:0,0 [6] ) - <html>\r\n<body>\r\n    <span data\-val="
+                HtmlContent - (0:0,0 [6] ) - <html>\n<body>\n    <span data-val="
                 CSharpExpression - (37:2,21 [5] )
                     CSharpToken - (37:2,21 [5] ) - Hello
-                HtmlContent - (42:2,26 [1] ) - " />\r\n</body>\r\n</html>"
+                HtmlContent - (42:2,26 [1] ) - " />\n</body>\n</html>"


### PR DESCRIPTION
- Prior to this the platform that the newlines were escaped on would be the platform the baselines would pass on.

#888

/cc @rynowak - Mostly just curious about your opinion of the `[NEWLINE]` identifier.