### PR TITLE
Add model for differentiating design time and runtime parsing.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorDesignTimeCSharpLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorDesignTimeCSharpLoweringPhase.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    internal class DefaultRazorDesignTimeCSharpLoweringPhase : RazorEnginePhaseBase, IRazorCSharpLoweringPhase
+    {
+        protected override void ExecuteCore(RazorCodeDocument codeDocument)
+        {
+            var irDocument = codeDocument.GetIRDocument();
+            ThrowForMissingDependency(irDocument);
+
+            var syntaxTree = codeDocument.GetSyntaxTree();
+            ThrowForMissingDependency(syntaxTree);
+
+            // Render design time CSharp
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorEngineBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Evolution
@@ -16,6 +17,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         public ICollection<IRazorEngineFeature> Features { get; }
 
         public IList<IRazorEnginePhase> Phases { get; }
+
+        public bool DesignTime { get; set; }
 
         public RazorEngine Build()
         {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorRuntimeCSharpLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorRuntimeCSharpLoweringPhase.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Razor.Evolution.Legacy;
 
 namespace Microsoft.AspNetCore.Razor.Evolution
 {
-    internal class DefaultRazorCSharpLoweringPhase : RazorEnginePhaseBase, IRazorCSharpLoweringPhase
+    internal class DefaultRazorRuntimeCSharpLoweringPhase : RazorEnginePhaseBase, IRazorCSharpLoweringPhase
     {
         protected override void ExecuteCore(RazorCodeDocument codeDocument)
         {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/IRazorEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/IRazorEngineBuilder.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
         IList<IRazorEnginePhase> Phases { get; }
 
+        bool DesignTime { get; set; }
+
         RazorEngine Build();
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/DefaultRazorRuntimeCSharpLoweringPhaseTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/DefaultRazorRuntimeCSharpLoweringPhaseTest.cs
@@ -8,13 +8,13 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Evolution
 {
-    public class DefaultRazorCSharpLoweringPhaseTest
+    public class DefaultRazorRuntimeCSharpLoweringPhaseTest
     {
         [Fact]
         public void Execute_ThrowsForMissingDependency()
         {
             // Arrange
-            var phase = new DefaultRazorCSharpLoweringPhase();
+            var phase = new DefaultRazorRuntimeCSharpLoweringPhase();
 
             var engine = RazorEngine.CreateEmpty(b => b.Phases.Add(phase));
 
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             // Act & Assert
             ExceptionAssert.Throws<InvalidOperationException>(
                 () => phase.Execute(codeDocument),
-                $"The '{nameof(DefaultRazorCSharpLoweringPhase)}' phase requires a '{nameof(DocumentIRNode)}' " +
+                $"The '{nameof(DefaultRazorRuntimeCSharpLoweringPhase)}' phase requires a '{nameof(DocumentIRNode)}' " +
                 $"provided by the '{nameof(RazorCodeDocument)}'.");
         }
     }


### PR DESCRIPTION
- If needed, a phase/feature can always retrieve the syntax tree to lookup whether the parse tree was made in a "design time" fashion.
- Future DesignTime / Runtime specific bits will be added to their corresponding `AddRuntimeDefaults`/`AddDesignTimeDefaults` methods.