### PR TITLE
Optimize HTML symbol content string allocation

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/CSharpTokenizer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/CSharpTokenizer.cs
@@ -543,12 +543,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             {
                 CSharpKeyword keyword;
                 var type = CSharpSymbolType.Identifier;
-                if (_keywords.TryGetValue(Buffer.ToString(), out keyword))
+                var symbolContent = Buffer.ToString();
+                if (_keywords.TryGetValue(symbolContent, out keyword))
                 {
                     type = CSharpSymbolType.Keyword;
                 }
 
-                symbol = new CSharpSymbol(CurrentStart, Buffer.ToString(), type)
+                symbol = new CSharpSymbol(CurrentStart, symbolContent, type)
                 {
                     Keyword = type == CSharpSymbolType.Keyword ? (CSharpKeyword?)keyword : null,
                 };

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/HtmlTokenizer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/HtmlTokenizer.cs
@@ -70,6 +70,62 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             }
         }
 
+        // Optimize memory allocation by returning constants for the most frequent cases
+        protected override string GetSymbolContent(HtmlSymbolType type)
+        {
+            var symbolLength = Buffer.Length;
+
+            if (symbolLength == 1)
+            {
+                switch (type)
+                {
+                    case HtmlSymbolType.OpenAngle:
+                        return "<";
+                    case HtmlSymbolType.Bang:
+                        return "!";
+                    case HtmlSymbolType.ForwardSlash:
+                        return "/";
+                    case HtmlSymbolType.QuestionMark:
+                        return "?";
+                    case HtmlSymbolType.LeftBracket:
+                        return "[";
+                    case HtmlSymbolType.CloseAngle:
+                        return ">";
+                    case HtmlSymbolType.RightBracket:
+                        return "]";
+                    case HtmlSymbolType.Equals:
+                        return "=";
+                    case HtmlSymbolType.DoubleQuote:
+                        return "\"";
+                    case HtmlSymbolType.SingleQuote:
+                        return "'";
+                    case HtmlSymbolType.WhiteSpace:
+                        if (Buffer[0] == ' ')
+                        {
+                            return " ";
+                        }
+                        if (Buffer[0] == '\t')
+                        {
+                            return "\t";
+                        }
+                        break;
+                    case HtmlSymbolType.NewLine:
+                        if (Buffer[0] == '\n')
+                        {
+                            return "\n";
+                        }
+                        break;
+                }
+            }
+
+            if (symbolLength == 2 && type == HtmlSymbolType.NewLine)
+            {
+                return "\r\n";
+            }
+
+            return base.GetSymbolContent(type);
+        }
+
         // http://dev.w3.org/html5/spec/Overview.html#data-state
         private StateResult Data()
         {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/Tokenizer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/Tokenizer.cs
@@ -215,10 +215,15 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
                     errors[i] = CurrentErrors[i];
                 }
 
-                sym = CreateSymbol(start, Buffer.ToString(), type, errors);
+                sym = CreateSymbol(start, GetSymbolContent(type), type, errors);
             }
             StartSymbol();
             return sym;
+        }
+
+        protected virtual string GetSymbolContent(TSymbolType type)
+        {
+            return Buffer.ToString();
         }
 
         protected bool TakeUntil(Func<char, bool> predicate)


### PR DESCRIPTION
See #873.
The `Tokenizer` class may be frequently instancied for small pieces of text (if there is C#/HTML mix). So I don't want to allocate a new dictionary for few symbol redundancy. That's why I changed my design to a simplier solution.
I cannot give Visual Studio 2017RC Profiling result (issue declared) or dotMemory screenshot (too few contributions the free licence :-). But I have added manually counters to evaluate the same [LargePageMvc page](https://github.com/aspnet/Performance/blob/dev/testapp/LargePageMvc/Views/Home/Index.cshtml). It goes from ~215000 to ~73500 `Buffer.ToString()` calls. So the optimization saves ~142500 string allocations for this file.