### PR TITLE
Optimize 'Span.Content' memory allocation

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/Span.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/Span.cs
@@ -42,14 +42,23 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             {
                 if (_content == null)
                 {
-                    var builder = new StringBuilder();
-                    for (var i = 0; i < Symbols.Count; i++)
+                    var symbolCount = Symbols.Count;
+                    if (symbolCount == 1)
                     {
-                        var symbol = Symbols[i];
-                        builder.Append(symbol.Content);
+                        // Perf: no StringBuilder allocation if not necessary
+                        _content = Symbols[0].Content;
                     }
+                    else
+                    {
+                        var builder = new StringBuilder();
+                        for (var i = 0; i < symbolCount; i++)
+                        {
+                            var symbol = Symbols[i];
+                            builder.Append(symbol.Content);
+                        }
 
-                    _content = builder.ToString();
+                        _content = builder.ToString();
+                    }
                 }
 
                 return _content;


### PR DESCRIPTION
See #873 
Tested with the [LagePageMvc](https://github.com/aspnet/Performance/blob/dev/testapp/LargePageMvc/Views/Home/Index.cshtml) page. It goes in the fast path in ~5100 cases (so I suppose it should save ~15300 allocations: `new StringBuilder()`, the initial StringBuilder chunk, and the `StringBuilder.ToString()`).