### PR TITLE
Use the TagHelperBinder to dedupe taghelpers

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/TagHelperDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/TagHelperDescriptorComparer.cs
@@ -20,6 +20,12 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
         public static readonly TagHelperDescriptorComparer Default = new TagHelperDescriptorComparer();
 
         /// <summary>
+        /// An instance of <see cref="TagHelperDescriptorComparer"/> that only compares 
+        /// <see cref="TagHelperDescriptor.TypeName"/>.
+        /// </summary>
+        public static readonly TagHelperDescriptorComparer TypeName = new TypeNameTagHelperDescriptorComparer();
+
+        /// <summary>
         /// Initializes a new <see cref="TagHelperDescriptorComparer"/> instance.
         /// </summary>
         protected TagHelperDescriptorComparer()
@@ -100,6 +106,35 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             }
 
             return hashCodeCombiner.CombinedHash;
+        }
+
+        private class TypeNameTagHelperDescriptorComparer : TagHelperDescriptorComparer
+        {
+            public override bool Equals(TagHelperDescriptor descriptorX, TagHelperDescriptor descriptorY)
+            {
+                if (object.ReferenceEquals(descriptorX, descriptorY))
+                {
+                    return true;
+                }
+                else if (descriptorX == null ^ descriptorY == null)
+                {
+                    return false;
+                }
+                else
+                {
+                    return string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal);
+                }
+            }
+
+            public override int GetHashCode(TagHelperDescriptor descriptor)
+            {
+                if (descriptor == null)
+                {
+                    throw new ArgumentNullException(nameof(descriptor));
+                }
+
+                return descriptor.TypeName == null ? 0 : StringComparer.Ordinal.GetHashCode(descriptor.TypeName);
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/TagHelperDescriptorProvider.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/TagHelperDescriptorProvider.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
                 }
             }
 
-            return applicableDescriptors;
+            return applicableDescriptors.Distinct(TagHelperDescriptorComparer.TypeName);
         }
 
         private bool HasRequiredParentTag(

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.codegen.cs
@@ -16,20 +16,14 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
-            __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
-            __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __TestNamespace_InputTagHelper.Type = "checkbox";
-            __TestNamespace_InputTagHelper.Type = __TestNamespace_InputTagHelper.Type;
-            __TestNamespace_CatchAllTagHelper.Type = __TestNamespace_InputTagHelper.Type;
             __TestNamespace_CatchAllTagHelper.Type = __TestNamespace_InputTagHelper.Type;
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper.cshtml"
 __TestNamespace_InputTagHelper.Checked = true;
 
 #line default
 #line hidden
-            __TestNamespace_InputTagHelper.Checked = __TestNamespace_InputTagHelper.Checked;
-            __TestNamespace_CatchAllTagHelper.Checked = __TestNamespace_InputTagHelper.Checked;
             __TestNamespace_CatchAllTagHelper.Checked = __TestNamespace_InputTagHelper.Checked;
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (67:2,32 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper.cshtml)
 |true|
-Generated Location: (1664:26,41 [4] )
+Generated Location: (1273:22,41 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.codegen.cs
@@ -36,17 +36,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
             );
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
-            __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
-            __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
-            __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
-            __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_CatchAllTagHelper);
             __TestNamespace_InputTagHelper.Type = (string)__tagHelperAttribute_0.Value;
-            __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
-            __TestNamespace_InputTagHelper.Type = (string)__tagHelperAttribute_0.Value;
-            __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
-            __TestNamespace_CatchAllTagHelper.Type = (string)__tagHelperAttribute_0.Value;
             __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
             __TestNamespace_CatchAllTagHelper.Type = (string)__tagHelperAttribute_0.Value;
             __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
@@ -56,8 +48,6 @@ __TestNamespace_InputTagHelper.Checked = true;
 #line default
 #line hidden
             __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
-            __TestNamespace_InputTagHelper.Checked = __TestNamespace_InputTagHelper.Checked;
-            __TestNamespace_CatchAllTagHelper.Checked = __TestNamespace_InputTagHelper.Checked;
             __TestNamespace_CatchAllTagHelper.Checked = __TestNamespace_InputTagHelper.Checked;
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)


### PR DESCRIPTION
This change does deduplication of taghelpers during the binding/rewriting
phase. This is needed when a taghelper has multiple sets of html
attributes that are required (behaves like an OR). This is used lots in
MVC.

The old codebase used to do this in the codegen phase, but it seems
beneficial to do as early as possible.