### PR TITLE
Correct an issue with codegen for taghelperprefix

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
@@ -390,9 +390,15 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                     Source = BuildSourceSpanFromNode(block)
                 });
 
+                var tagName = tagHelperBlock.TagName;
+                if (tagHelperBlock.Descriptors.First().Prefix != null)
+                {
+                    tagName = tagName.Substring(tagHelperBlock.Descriptors.First().Prefix.Length);
+                }
+
                 _builder.Push(new InitializeTagHelperStructureIRNode()
                 {
-                    TagName = tagHelperBlock.TagName,
+                    TagName = tagName,
                     TagMode = tagHelperBlock.TagMode
                 });
             }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/RazorCSharpDocument.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/RazorCSharpDocument.cs
@@ -12,6 +12,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
         internal IReadOnlyList<LineMapping> LineMappings { get; set; }
 
-        internal IReadOnlyList<RazorError> Diagnostics { get; set; }
+        public IReadOnlyList<RazorError> Diagnostics { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -561,6 +561,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
         }
 
         [Fact]
+        public void TagHelpersWithPrefix_Runtime()
+        {
+            // Arrange, Act & Assert
+            RunRuntimeTagHelpersTest(TestTagHelperDescriptors.SimpleTagHelperDescriptors);
+        }
+
+        [Fact]
         public void NestedTagHelpers_Runtime()
         {
 
@@ -1244,6 +1251,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
 
         [Fact]
         public void SimpleTagHelpers_DesignTime()
+        {
+            // Arrange, Act & Assert
+            RunDesignTimeTagHelpersTest(TestTagHelperDescriptors.SimpleTagHelperDescriptors);
+        }
+
+        [Fact]
+        public void TagHelpersWithPrefix_DesignTime()
         {
             // Arrange, Act & Assert
             RunDesignTimeTagHelpersTest(TestTagHelperDescriptors.SimpleTagHelperDescriptors);

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
@@ -33,9 +33,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             WriteLiteral("\r\n<THSdiv class=\"randomNonTagHelperAttribute\">\r\n    ");
-            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("THSp", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 WriteLiteral("\r\n        <p></p>\r\n        <input type=\"text\">\r\n        ");
-                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("THSinput", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
+                __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
                 }
                 );
                 __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml
@@ -1,0 +1,5 @@
+﻿@addTagHelper *, TestAssembly
+@tagHelperPrefix cool:
+<form>
+    <cool:input bound=@Hello type='text' />
+</form>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
@@ -1,0 +1,27 @@
+namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+{
+    #line hidden
+    using System;
+    using System.Threading.Tasks;
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithPrefix_DesignTime
+    {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        }
+        #pragma warning restore 219
+        private static System.Object __o = null;
+        private global::InputTagHelper __InputTagHelper = null;
+        #pragma warning disable 1998
+        public async System.Threading.Tasks.Task ExecuteAsync()
+        {
+            __InputTagHelper = CreateTagHelper<global::InputTagHelper>();
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml"
+                    __o = Hello;
+
+#line default
+#line hidden
+            __InputTagHelper.BoundProp = string.Empty;
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (86:3,23 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
+|Hello|
+Generated Location: (832:18,26 [5] )
+|Hello|
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
@@ -1,0 +1,59 @@
+#pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "984b7fd00fa0286dd56ceda786fa7cf893520df6"
+namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+{
+    #line hidden
+    using System;
+    using System.Threading.Tasks;
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithPrefix_Runtime
+    {
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
+        #line hidden
+        #pragma warning disable 0414
+        private string __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
+        {
+            get
+            {
+                if (__backed__tagHelperScopeManager == null)
+                {
+                    __backed__tagHelperScopeManager = new Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager(StartTagHelperWritingScope, EndTagHelperWritingScope);
+                }
+                return __backed__tagHelperScopeManager;
+            }
+        }
+        private global::InputTagHelper __InputTagHelper = null;
+        #pragma warning disable 1998
+        public async System.Threading.Tasks.Task ExecuteAsync()
+        {
+            WriteLiteral("<form>\r\n    ");
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
+            }
+            );
+            __InputTagHelper = CreateTagHelper<global::InputTagHelper>();
+            __tagHelperExecutionContext.Add(__InputTagHelper);
+            BeginWriteTagHelperAttribute();
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml"
+          WriteLiteral(Hello);
+
+#line default
+#line hidden
+            __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+            __InputTagHelper.BoundProp = __tagHelperStringValueBuffer;
+            __tagHelperExecutionContext.AddTagHelperAttribute("bound", __InputTagHelper.BoundProp, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+            __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                await __tagHelperExecutionContext.SetOutputContentAsync();
+            }
+            Write(__tagHelperExecutionContext.Output);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            WriteLiteral("\r\n</form>");
+        }
+        #pragma warning restore 1998
+    }
+}


### PR DESCRIPTION
The issue here is that when a taghelper prefix is in use it will be
including in the HTML output, when it should be chopped off.

See the diff in the codegen for examples.