### PR TITLE
Remove literal directive tokens.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorDesignTimeCSharpLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorDesignTimeCSharpLoweringPhase.cs
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 const string TypeHelper = "__typeHelper";
 
                 var tokenKind = node.Descriptor.Kind;
-                if (node.Source == null || node.Descriptor.Kind == DirectiveTokenKind.Literal)
+                if (node.Source == null)
                 {
                     return;
                 }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorBuilder.cs
@@ -68,18 +68,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 return this;
             }
 
-            public IDirectiveDescriptorBuilder AddLiteral(string literal)
-            {
-                var descriptor = new DirectiveTokenDescriptor()
-                {
-                    Kind = DirectiveTokenKind.Literal,
-                    Value = literal,
-                };
-                _tokenDescriptors.Add(descriptor);
-
-                return this;
-            }
-
             public DirectiveDescriptor Build()
             {
                 var descriptor = new DirectiveDescriptor

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenDescriptor.cs
@@ -6,7 +6,5 @@ namespace Microsoft.AspNetCore.Razor.Evolution
     public class DirectiveTokenDescriptor
     {
         public DirectiveTokenKind Kind { get; set; }
-
-        public string Value { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenDescriptorComparer.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             }
 
             return descriptorX != null &&
-                string.Equals(descriptorX.Value, descriptorY.Value, StringComparison.Ordinal) &&
                 descriptorX.Kind == descriptorY.Kind;
         }
 
@@ -34,11 +33,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var hashCodeCombiner = HashCodeCombiner.Start();
-            hashCodeCombiner.Add(descriptor.Value, StringComparer.Ordinal);
-            hashCodeCombiner.Add(descriptor.Kind);
-
-            return hashCodeCombiner.CombinedHash;
+            return descriptor.Kind.GetHashCode();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenKind.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenKind.cs
@@ -8,6 +8,5 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         Type,
         Member,
         String,
-        Literal
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/IDirectiveDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/IDirectiveDescriptorBuilder.cs
@@ -11,8 +11,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
         IDirectiveDescriptorBuilder AddString();
 
-        IDirectiveDescriptorBuilder AddLiteral(string literal);
-
         DirectiveDescriptor Build();
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/CSharpCodeParser.cs
@@ -1551,20 +1551,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
                     case DirectiveTokenKind.String:
                         AcceptAndMoveNext();
                         break;
-                    case DirectiveTokenKind.Literal:
-                        if (string.Equals(CurrentSymbol.Content, tokenDescriptor.Value, StringComparison.Ordinal))
-                        {
-                            AcceptAndMoveNext();
-                        }
-                        else
-                        {
-                            Context.ErrorSink.OnError(
-                                CurrentStart,
-                                LegacyResources.FormatUnexpectedDirectiveLiteral(descriptor.Name, tokenDescriptor.Value),
-                                CurrentSymbol.Content.Length);
-                            return;
-                        }
-                        break;
                 }
 
                 Span.ChunkGenerator = new DirectiveTokenChunkGenerator(tokenDescriptor);

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/DirectiveDescriptorBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/DirectiveDescriptorBuilderTest.cs
@@ -80,21 +80,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         }
 
         [Fact]
-        public void AddLiteral_AddsToken()
-        {
-            // Arrange
-            var builder = DirectiveDescriptorBuilder.Create("custom");
-
-            // Act
-            var descriptor = builder.AddLiteral(",").Build();
-
-            // Assert
-            var token = Assert.Single(descriptor.Tokens);
-            Assert.Equal(DirectiveTokenKind.Literal, token.Kind);
-            Assert.Equal(",", token.Value);
-        }
-
-        [Fact]
         public void AddX_MaintainsMultipleTokens()
         {
             // Arrange
@@ -105,19 +90,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 .AddType()
                 .AddMember()
                 .AddString()
-                .AddLiteral(",")
                 .Build();
 
             // Assert
             Assert.Collection(descriptor.Tokens,
                 token => Assert.Equal(DirectiveTokenKind.Type, token.Kind),
                 token => Assert.Equal(DirectiveTokenKind.Member, token.Kind),
-                token => Assert.Equal(DirectiveTokenKind.String, token.Kind),
-                token =>
-                {
-                    Assert.Equal(DirectiveTokenKind.Literal, token.Kind);
-                    Assert.Equal(",", token.Value);
-                });
+                token => Assert.Equal(DirectiveTokenKind.String, token.Kind));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Legacy/CSharpDirectivesTest.cs
@@ -71,26 +71,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
         }
 
         [Fact]
-        public void DirectiveDescriptor_UnderstandsLiteralTokens()
-        {
-            // Arrange
-            var descriptor = DirectiveDescriptorBuilder.Create("custom").AddLiteral("!").Build();
-
-            // Act & Assert
-            ParseCodeBlockTest(
-                "@custom !",
-                new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
-                    Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "!", markup: false)
-                        .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
-                        .Accepts(AcceptedCharacters.NonWhiteSpace)));
-        }
-
-        [Fact]
         public void DirectiveDescriptor_UnderstandsMultipleTokens()
         {
             // Arrange
@@ -98,12 +78,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
                 .AddType()
                 .AddMember()
                 .AddString()
-                .AddLiteral("!")
                 .Build();
 
             // Act & Assert
             ParseCodeBlockTest(
-                "@custom System.Text.Encoding.ASCIIEncoding Some_Member AString !",
+                "@custom System.Text.Encoding.ASCIIEncoding Some_Member AString",
                 new[] { descriptor },
                 new DirectiveBlock(
                     new DirectiveChunkGenerator(descriptor),
@@ -123,11 +102,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
                     Factory.Span(SpanKind.Markup, "AString", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[2]))
-                        .Accepts(AcceptedCharacters.NonWhiteSpace),
-
-                    Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "!", markup: false)
-                        .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[3]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace)));
         }
 
@@ -241,28 +215,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Code, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace)),
-                expectedErorr);
-        }
-
-        [Fact]
-        public void DirectiveDescriptor_ErrorsForUnmatchedLiteralTokens()
-        {
-            // Arrange
-            var descriptor = DirectiveDescriptorBuilder.Create("custom").AddLiteral("!").Build();
-            var expectedErorr = new RazorError(
-                LegacyResources.FormatUnexpectedDirectiveLiteral("custom", "!"),
-                new SourceLocation(8, 0, 8),
-                length: 2);
-
-            // Act & Assert
-            ParseCodeBlockTest(
-                "@custom hi",
-                new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
-                    Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace)),
                 expectedErorr);
         }
 


### PR DESCRIPTION
- Literal directive tokens acted as a way for a user to provide markup bits to be required when parsing a directive.
- Removed source implementations.
- Removed tests validating the feature.

#969