### PR TITLE
Handle single line directives properly

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/CSharpCodeParser.cs
@@ -1568,6 +1568,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             {
                 case DirectiveDescriptorKind.SingleLine:
                     Optional(CSharpSymbolType.Semicolon);
+                    AcceptWhile(IsSpacingToken(includeNewLines: false, includeComments: true));
 
                     if (At(CSharpSymbolType.NewLine))
                     {

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Legacy/CSharpDirectivesTest.cs
@@ -219,6 +219,27 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
         }
 
         [Fact]
+        public void DirectiveDescriptor_NoErrorsSemicolonAfterDirective()
+        {
+            // Arrange
+            var descriptor = DirectiveDescriptorBuilder.Create("custom").AddString().Build();
+
+            // Act & Assert
+            ParseCodeBlockTest(
+                "@custom hello ;  ",
+                new[] { descriptor },
+                new DirectiveBlock(
+                    new DirectiveChunkGenerator(descriptor),
+                    Factory.CodeTransition(),
+                    Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
+                    Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
+                    Factory.Span(SpanKind.Markup, "hello", markup: false)
+                        .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
+                        .Accepts(AcceptedCharacters.NonWhiteSpace),
+                    Factory.Span(SpanKind.Markup, " ;  ", markup: false).Accepts(AcceptedCharacters.WhiteSpace)));
+        }
+
+        [Fact]
         public void DirectiveDescriptor_ErrorsExtraContentAfterDirective()
         {
             // Arrange


### PR DESCRIPTION
Without this change it throws a parser error if there is whitespace after the semicolon.

@NTaylorMullen @pranavkm @rynowak 