### PR TITLE
Allow RazorSourceDocument to consume empty streams.

### DIFF
--- a/Razor.sln
+++ b/Razor.sln
@@ -14,6 +14,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F8C12DD6-659D-405A-AA27-FB22AD92A010}"
 	ProjectSection(SolutionItems) = preProject
+		build\common.props = build\common.props
 		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject

--- a/src/Microsoft.AspNetCore.Razor.Evolution/RazorSourceDocument.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/RazorSourceDocument.cs
@@ -50,31 +50,38 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
         private static RazorSourceDocument ReadFromInternal(Stream stream, string filename, Encoding encoding)
         {
-            var reader = new StreamReader(
-                stream,
-                encoding ?? Encoding.UTF8,
-                detectEncodingFromByteOrderMarks: true,
-                bufferSize: (int)stream.Length,
-                leaveOpen: true);
+            var streamLength = (int)stream.Length;
+            var content = string.Empty;
+            var contentEncoding = encoding ?? Encoding.UTF8;
 
-            using (reader)
+            if (streamLength > 0)
             {
-                var content = reader.ReadToEnd();
+                var reader = new StreamReader(
+                    stream,
+                    contentEncoding,
+                    detectEncodingFromByteOrderMarks: true,
+                    bufferSize: streamLength,
+                    leaveOpen: true);
 
-                if (encoding == null)
+                using (reader)
                 {
-                    encoding = reader.CurrentEncoding;
-                }
-                else if (encoding != reader.CurrentEncoding)
-                {
-                    throw new InvalidOperationException(
-                        Resources.FormatMismatchedContentEncoding(
-                            encoding.EncodingName,
-                            reader.CurrentEncoding.EncodingName));
-                }
+                    content = reader.ReadToEnd();
 
-                return new DefaultRazorSourceDocument(content, encoding, filename);
+                    if (encoding == null)
+                    {
+                        contentEncoding = reader.CurrentEncoding;
+                    }
+                    else if (encoding != reader.CurrentEncoding)
+                    {
+                        throw new InvalidOperationException(
+                            Resources.FormatMismatchedContentEncoding(
+                                encoding.EncodingName,
+                                reader.CurrentEncoding.EncodingName));
+                    }
+                }
             }
+
+            return new DefaultRazorSourceDocument(content, contentEncoding, filename);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/RazorSourceDocumentTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/RazorSourceDocumentTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
     public class RazorSourceDocumentTest
     {
         [Fact]
-        public void Create()
+        public void ReadFrom()
         {
             // Arrange
             var content = TestRazorSourceDocument.CreateStreamContent();
@@ -25,10 +25,24 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         }
 
         [Fact]
-        public void Create_WithEncoding()
+        public void ReadFrom_WithEncoding()
         {
             // Arrange
             var content = TestRazorSourceDocument.CreateStreamContent(encoding: Encoding.UTF32);
+
+            // Act
+            var document = RazorSourceDocument.ReadFrom(content, "file.cshtml", Encoding.UTF32);
+
+            // Assert
+            Assert.Equal("file.cshtml", document.Filename);
+            Assert.Same(Encoding.UTF32, Assert.IsType<DefaultRazorSourceDocument>(document).Encoding);
+        }
+
+        [Fact]
+        public void ReadFrom_EmptyStream_WithEncoding()
+        {
+            // Arrange
+            var content = TestRazorSourceDocument.CreateStreamContent(content: string.Empty, encoding: Encoding.UTF32);
 
             // Act
             var document = RazorSourceDocument.ReadFrom(content, "file.cshtml", Encoding.UTF32);
@@ -43,6 +57,21 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         {
             // Arrange
             var content = TestRazorSourceDocument.CreateStreamContent(encoding: Encoding.UTF32);
+
+            // Act
+            var document = RazorSourceDocument.ReadFrom(content, "file.cshtml");
+
+            // Assert
+            Assert.IsType<DefaultRazorSourceDocument>(document);
+            Assert.Equal("file.cshtml", document.Filename);
+            Assert.Equal(Encoding.UTF32, document.Encoding);
+        }
+
+        [Fact]
+        public void ReadFrom_EmptyStream_DetectsEncoding()
+        {
+            // Arrange
+            var content = TestRazorSourceDocument.CreateStreamContent(content: string.Empty, encoding: Encoding.UTF32);
 
             // Act
             var document = RazorSourceDocument.ReadFrom(content, "file.cshtml");


### PR DESCRIPTION
- Added tests to validate how encoding flows when used with empty streams in addition to their usability (not throwing).

#947