### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/IntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/IntegrationTestBase.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-#if NET451
+#if NET452
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Messaging;
 #else
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
 
         private static string FindTestProjectRoot()
         {
-#if NET451
+#if NET452
             var currentDirectory = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
 #else
             var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
@@ -50,14 +50,14 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
         private static readonly bool GenerateBaselines = false;
 #endif
 
-#if !NET451
+#if !NET452
         private static readonly AsyncLocal<string> _filename = new AsyncLocal<string>();
 #endif
 
         // Used by the test framework to set the 'base' name for test files.
         public static string Filename
         {
-#if NET451
+#if NET452
             get
             {
                 var handle = (ObjectHandle)CallContext.LogicalGetData("IntegrationTestBase_Filename");

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Microsoft.AspNetCore.Razor.Evolution.Test.csproj
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Microsoft.AspNetCore.Razor.Evolution.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Microsoft.AspNetCore.Razor.Runtime.Test.csproj
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Microsoft.AspNetCore.Razor.Runtime.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperDesignTimeDescriptorFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperDesignTimeDescriptorFactoryTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             ".TagHelpers.DocumentedTagHelper.RemarksProperty\" />";
 
         private static readonly string BaseDir =
-#if NET451
+#if NET452
             AppDomain.CurrentDomain.BaseDirectory;
 #else
             AppContext.BaseDirectory;

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/XmlDocumentationProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/XmlDocumentationProviderTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
     public class XmlDocumentationProviderTest
     {
         private static readonly string BaseDir =
-#if NET451
+#if NET452
             AppDomain.CurrentDomain.BaseDirectory;
 #else
             AppContext.BaseDirectory;

--- a/test/Microsoft.AspNetCore.Razor.Test/Microsoft.AspNetCore.Razor.Test.csproj
+++ b/test/Microsoft.AspNetCore.Razor.Test/Microsoft.AspNetCore.Razor.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
   </PropertyGroup>

--- a/test/Microsoft.CodeAnalysis.Razor.Test/Microsoft.CodeAnalysis.Razor.Test.csproj
+++ b/test/Microsoft.CodeAnalysis.Razor.Test/Microsoft.CodeAnalysis.Razor.Test.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows