### PR TITLE
DefaultRazorIRLoweringPhase is too agressive

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.codegen.cs
@@ -27,7 +27,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Basic Asynchronous Statement Nested:  <b>");
+            WriteLiteral("</p>\r\n    <p>Basic Asynchronous Statement Nested: ");
+            WriteLiteral(" <b>");
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                              Write(await Foo());
 
@@ -70,7 +71,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Advanced Asynchronous Statement Nested:  <b>");
+            WriteLiteral("</p>\r\n    <p>Advanced Asynchronous Statement Nested: ");
+            WriteLiteral(" <b>");
 #line 24 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                                 Write(await Foo(boolValue: false));
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
@@ -29,13 +29,18 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    <p class=\"Hello World\" ");
+            WriteLiteral("\r\n<");
+            WriteLiteral("div class=\"randomNonTagHelperAttribute\">\r\n    <");
+            WriteLiteral("p class=\"Hello World\" ");
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml"
                        Write(DateTime.Now);
 
 #line default
 #line hidden
-            WriteLiteral(">\r\n        <input type=\"text\" />\r\n        <em>Not a TagHelper: </em> ");
+            WriteLiteral(">\r\n        <");
+            WriteLiteral("input type=\"text\" />\r\n        <");
+            WriteLiteral("em>Not a TagHelper: </");
+            WriteLiteral("em> ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -66,7 +71,9 @@ __TestNamespace_InputTagHelper2.Checked = true;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n    </p>\r\n</div>");
+            WriteLiteral("\r\n    </");
+            WriteLiteral("p>\r\n</");
+            WriteLiteral("div>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.codegen.cs
@@ -26,7 +26,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("    Hello, World\r\n    <p>Hello, World</p>\r\n");
+            WriteLiteral("    ");
+            WriteLiteral("Hello, World\r\n    <p>Hello, World</p>\r\n");
             WriteLiteral("\r\n");
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
  while(i <= 10) {

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.codegen.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<p>This should  be shown</p>\r\n\r\n");
+            WriteLiteral("\r\n<p>This should ");
+            WriteLiteral(" be shown</p>\r\n\r\n");
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml"
                                        
     Exception foo = 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.codegen.cs
@@ -115,7 +115,8 @@ WriteTo(__razor_template_writer, item);
 
 #line default
 #line hidden
-    WriteLiteralTo(__razor_template_writer, "        <ul>\r\n            <li>Child Items... ?</li>\r\n        </ul>\r\n    </li>");
+    WriteLiteralTo(__razor_template_writer, "        <ul>\r\n            <li>Child Items... ?</li>\r\n");
+    WriteLiteralTo(__razor_template_writer, "        </ul>\r\n    </li>");
 }
 )));
 


### PR DESCRIPTION
This change fixes a bug where DefaultRazorIRLoweringPhase is too
aggressive in merging HTML spans. You can hit the bug by delimiting two
html spans with a metacode character like:
```
<foo>@{ <bar/> }</foo>
```
The lowering phase will combine these HTML nodes, which is invalid as they
don't have contiguous spans.

The change here is to merge spans only when they both have an invalid
location or are contiguous.