### PR TITLE
Refactor ParserVisitor

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultDirectiveSyntaxTreePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultDirectiveSyntaxTreePass.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 tree.Root.Accept(this);
             }
 
-            public override void VisitStartDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
+            public override void VisitDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
             {
                 if (_nestedLevel > 0)
                 {
@@ -51,10 +51,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 }
 
                 _nestedLevel++;
-            }
 
-            public override void VisitEndDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
-            {
+                VisitDefault(block);
+
                 _nestedLevel--;
             }
         }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/AttributeBlockChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/AttributeBlockChunkGenerator.cs
@@ -36,14 +36,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             //context.ChunkTreeBuilder.EndParentChunk();
         }
 
-        public override void AcceptStart(ParserVisitor visitor, Block block)
+        public override void Accept(ParserVisitor visitor, Block block)
         {
-            visitor.VisitStartAttributeBlock(this, block);
-        }
-
-        public override void AcceptEnd(ParserVisitor visitor, Block block)
-        {
-            visitor.VisitEndAttributeBlock(this, block);
+            visitor.VisitAttributeBlock(this, block);
         }
 
         public override string ToString()

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/DirectiveChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/DirectiveChunkGenerator.cs
@@ -17,15 +17,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
 
         public DirectiveDescriptor Descriptor { get; }
 
-        public override void AcceptStart(ParserVisitor visitor, Block block)
+        public override void Accept(ParserVisitor visitor, Block block)
         {
-            visitor.VisitStartDirectiveBlock(this, block);
+            visitor.VisitDirectiveBlock(this, block);
         }
 
-        public override void AcceptEnd(ParserVisitor visitor, Block block)
-        {
-            visitor.VisitEndDirectiveBlock(this, block);
-        }
         public override bool Equals(object obj)
         {
             var other = obj as DirectiveChunkGenerator;

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/DynamicAttributeBlockChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/DynamicAttributeBlockChunkGenerator.cs
@@ -23,14 +23,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
 
         public SourceLocation ValueStart { get; }
 
-        public override void AcceptStart(ParserVisitor visitor, Block block)
+        public override void Accept(ParserVisitor visitor, Block block)
         {
-            visitor.VisitStartDynamicAttributeBlock(this, block);
-        }
-
-        public override void AcceptEnd(ParserVisitor visitor, Block block)
-        {
-            visitor.VisitEndDynamicAttributeBlock(this, block);
+            visitor.VisitDynamicAttributeBlock(this, block);
         }
 
         public override void GenerateStartParentChunk(Block target, ChunkGeneratorContext context)

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/ExpressionChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/ExpressionChunkGenerator.cs
@@ -29,14 +29,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             visitor.VisitExpressionSpan(this, span);
         }
 
-        public void AcceptStart(ParserVisitor visitor, Block block)
+        public void Accept(ParserVisitor visitor, Block block)
         {
-            visitor.VisitStartExpressionBlock(this, block);
-        }
-
-        public void AcceptEnd(ParserVisitor visitor, Block block)
-        {
-            visitor.VisitEndExpressionBlock(this, block);
+            visitor.VisitExpressionBlock(this, block);
         }
 
         public override string ToString()

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/IParentChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/IParentChunkGenerator.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
     {
         void GenerateStartParentChunk(Block target, ChunkGeneratorContext context);
         void GenerateEndParentChunk(Block target, ChunkGeneratorContext context);
-        void AcceptStart(ParserVisitor visitor, Block block);
-        void AcceptEnd(ParserVisitor visitor, Block block);
+
+        void Accept(ParserVisitor visitor, Block block);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/ParentChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/ParentChunkGenerator.cs
@@ -9,8 +9,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
 
         public static readonly IParentChunkGenerator Null = new NullParentChunkGenerator();
 
-        public abstract void AcceptStart(ParserVisitor visitor, Block block);
-        public abstract void AcceptEnd(ParserVisitor visitor, Block block);
+        public abstract void Accept(ParserVisitor visitor, Block block);
 
         public virtual void GenerateStartParentChunk(Block target, ChunkGeneratorContext context)
         {
@@ -46,12 +45,12 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
                 return "None";
             }
 
-            public void AcceptStart(ParserVisitor visitor, Block block)
+            public void Accept(ParserVisitor visitor, Block block)
             {
-            }
-
-            public void AcceptEnd(ParserVisitor visitor, Block block)
-            {
+                for (var i = 0; i < block.Children.Count; i++)
+                {
+                    block.Children[i].Accept(visitor);
+                }
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/ParserVisitor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/ParserVisitor.cs
@@ -5,31 +5,19 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
 {
     internal abstract class ParserVisitor
     {
-        public virtual void VisitBlock(Block block)
+        protected virtual void VisitDefault(Block block)
         {
-            VisitStartBlock(block);
-
             for (var i = 0; i < block.Children.Count; i++)
             {
                 block.Children[i].Accept(this);
             }
-
-            VisitEndBlock(block);
         }
 
-        public virtual void VisitStartBlock(Block block)
+        public virtual void VisitBlock(Block block)
         {
             if (block.ChunkGenerator != null)
             {
-                block.ChunkGenerator.AcceptStart(this, block);
-            }
-        }
-
-        public virtual void VisitEndBlock(Block block)
-        {
-            if (block.ChunkGenerator != null)
-            {
-                block.ChunkGenerator.AcceptEnd(this, block);
+                block.ChunkGenerator.Accept(this, block);
             }
         }
 
@@ -41,28 +29,19 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             }
         }
 
-        public virtual void VisitStartDynamicAttributeBlock(DynamicAttributeBlockChunkGenerator chunkGenerator, Block block)
+        public virtual void VisitDynamicAttributeBlock(DynamicAttributeBlockChunkGenerator chunkGenerator, Block block)
         {
+            VisitDefault(block);
         }
 
-        public virtual void VisitEndDynamicAttributeBlock(DynamicAttributeBlockChunkGenerator chunkGenerator, Block block)
+        public virtual void VisitExpressionBlock(ExpressionChunkGenerator chunkGenerator, Block block)
         {
+            VisitDefault(block);
         }
 
-        public virtual void VisitStartExpressionBlock(ExpressionChunkGenerator chunkGenerator, Block block)
+        public virtual void VisitAttributeBlock(AttributeBlockChunkGenerator chunkGenerator, Block block)
         {
-        }
-
-        public virtual void VisitEndExpressionBlock(ExpressionChunkGenerator chunkGenerator, Block block)
-        {
-        }
-
-        public virtual void VisitStartAttributeBlock(AttributeBlockChunkGenerator chunkGenerator, Block block)
-        {
-        }
-
-        public virtual void VisitEndAttributeBlock(AttributeBlockChunkGenerator chunkGenerator, Block block)
-        {
+            VisitDefault(block);
         }
 
         public virtual void VisitExpressionSpan(ExpressionChunkGenerator chunkGenerator, Span span)
@@ -89,36 +68,24 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
         {
         }
 
-        public virtual void VisitEndTemplateBlock(TemplateBlockChunkGenerator chunkGenerator, Block block)
+        public virtual void VisitDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
         {
+            VisitDefault(block);
         }
 
-        public virtual void VisitStartDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
+        public virtual void VisitTemplateBlock(TemplateBlockChunkGenerator chunkGenerator, Block block)
         {
+            VisitDefault(block);
         }
 
-        public virtual void VisitEndDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
+        public virtual void VisitCommentBlock(RazorCommentChunkGenerator chunkGenerator, Block block)
         {
+            VisitDefault(block);
         }
 
-        public virtual void VisitStartTemplateBlock(TemplateBlockChunkGenerator chunkGenerator, Block block)
+        public virtual void VisitTagHelperBlock(TagHelperChunkGenerator chunkGenerator, Block block)
         {
-        }
-
-        public virtual void VisitEndCommentBlock(RazorCommentChunkGenerator chunkGenerator, Block block)
-        {
-        }
-
-        public virtual void VisitStartCommentBlock(RazorCommentChunkGenerator chunkGenerator, Block block)
-        {
-        }
-
-        public virtual void VisitStartTagHelperBlock(TagHelperChunkGenerator chunkGenerator, Block block)
-        {
-        }
-
-        public virtual void VisitEndTagHelperBlock(TagHelperChunkGenerator chunkGenerator, Block block)
-        {
+            VisitDefault(block);
         }
 
         public virtual void VisitAddTagHelperSpan(AddTagHelperChunkGenerator chunkGenerator, Span span)

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/RazorCommentChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/RazorCommentChunkGenerator.cs
@@ -5,14 +5,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
 {
     internal class RazorCommentChunkGenerator : ParentChunkGenerator
     {
-        public override void AcceptStart(ParserVisitor visitor, Block block)
+        public override void Accept(ParserVisitor visitor, Block block)
         {
-            visitor.VisitStartCommentBlock(this, block);
-        }
-
-        public override void AcceptEnd(ParserVisitor visitor, Block block)
-        {
-            visitor.VisitEndCommentBlock(this, block);
+            visitor.VisitCommentBlock(this, block);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/TagHelperChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/TagHelperChunkGenerator.cs
@@ -84,14 +84,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             //context.ChunkTreeBuilder.EndParentChunk();
         }
 
-        public override void AcceptStart(ParserVisitor visitor, Block block)
+        public override void Accept(ParserVisitor visitor, Block block)
         {
-            visitor.VisitStartTagHelperBlock(this, block);
-        }
-
-        public override void AcceptEnd(ParserVisitor visitor, Block block)
-        {
-            visitor.VisitEndTagHelperBlock(this, block);
+            visitor.VisitTagHelperBlock(this, block);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/TemplateBlockChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/TemplateBlockChunkGenerator.cs
@@ -5,14 +5,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
 {
     internal class TemplateBlockChunkGenerator : ParentChunkGenerator
     {
-        public override void AcceptStart(ParserVisitor visitor, Block block)
+        public override void Accept(ParserVisitor visitor, Block block)
         {
-            visitor.VisitStartTemplateBlock(this, block);
-        }
-
-        public override void AcceptEnd(ParserVisitor visitor, Block block)
-        {
-            visitor.VisitEndTemplateBlock(this, block);
+            visitor.VisitTemplateBlock(this, block);
         }
 
         public override void GenerateStartParentChunk(Block target, ChunkGeneratorContext context)


### PR DESCRIPTION
We need the visitor to allow control over whether to recurse or not into
something. This change makes the old ParserVisitor class behave much more
like the newer IR Walkers.

We need this for the tokens refactor because IR lowering will not be just
a trivial visitor anymore in the future.