### PR TITLE
Introducing RazorIRToken

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNodeVisitor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNodeVisitor.cs
@@ -19,6 +19,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
             VisitDefault(node);
         }
 
+        public virtual void VisitToken(RazorIRToken node)
+        {
+            VisitDefault(node);
+        }
+
         public virtual void VisitDirectiveToken(DirectiveTokenIRNode node)
         {
             VisitDefault(node);

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNodeVisitorOfT.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRNodeVisitorOfT.cs
@@ -20,6 +20,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
             return VisitDefault(node);
         }
 
+        public virtual TResult VisitToken(RazorIRToken node)
+        {
+            return VisitDefault(node);
+        }
+
         public virtual TResult VisitDirectiveToken(DirectiveTokenIRNode node)
         {
             return VisitDefault(node);

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRToken.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/RazorIRToken.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
+{
+    public sealed class RazorIRToken : RazorIRNode
+    {
+        public override IList<RazorIRNode> Children => RazorIRNode.EmptyArray;
+
+        public string Content { get; set; }
+
+        public bool IsCSharp => Kind == TokenKind.CSharp;
+
+        public bool IsHtml => Kind == TokenKind.Html;
+
+        public TokenKind Kind { get; set; } = TokenKind.Unknown;
+
+        public override RazorIRNode Parent { get; set; }
+
+        public override SourceSpan? Source { get; set; }
+
+        public override void Accept(RazorIRNodeVisitor visitor)
+        {
+            if (visitor == null)
+            {
+                throw new ArgumentNullException(nameof(visitor));
+            }
+
+            visitor.VisitToken(this);
+        }
+
+        public override TResult Accept<TResult>(RazorIRNodeVisitor<TResult> visitor)
+        {
+            if (visitor == null)
+            {
+                throw new ArgumentNullException(nameof(visitor));
+            }
+
+            return visitor.VisitToken(this);
+        }
+
+        public enum TokenKind
+        {
+            Unknown,
+            CSharp,
+            Html,
+        }
+    }
+}
+
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
@@ -47,6 +47,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
             WriteContentNode(node, node.Content);
         }
 
+        public override void VisitToken(RazorIRToken node)
+        {
+            WriteContentNode(node, node.Kind.ToString(), node.Content);
+        }
+
         public override void VisitDirective(DirectiveIRNode node)
         {
             WriteContentNode(node, node.Name);


### PR DESCRIPTION
This IR node will be part of the new token model for IR. It will be used
by all nodes that contain user content. Going forward, tokens will be the
thing that contains text and produces line mappings.

This commit just introduces the class.