### PR TITLE
Add assembly name filtering to GetTagHelpers calls.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -9,14 +10,15 @@ namespace Microsoft.CodeAnalysis.Razor
 {
     internal abstract class TagHelperResolver : ILanguageService
     {
-        public abstract TagHelperResolutionResult GetTagHelpers(Compilation compilation);
+        public abstract TagHelperResolutionResult GetTagHelpers(Compilation compilation, IEnumerable<string> assemblyNameFilters);
 
         public virtual async Task<TagHelperResolutionResult> GetTagHelpersAsync(
             Project project,
+            IEnumerable<string> assemblyNameFilters,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-            return GetTagHelpers(compilation);
+            return GetTagHelpers(compilation, assemblyNameFilters);
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Remote.Razor/RazorLanguageService.cs
+++ b/src/Microsoft.CodeAnalysis.Remote.Razor/RazorLanguageService.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
         {
         }
 
-        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(Guid projectIdBytes, string projectDebugName, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(Guid projectIdBytes, string projectDebugName, IEnumerable<string> assemblyNameFilters, CancellationToken cancellationToken = default(CancellationToken))
         {
             var projectId = ProjectId.CreateFromSerialized(projectIdBytes, projectDebugName);
 
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             var project = solution.GetProject(projectId);
 
             var resolver = new DefaultTagHelperResolver(designTime: true);
-            var result = await resolver.GetTagHelpersAsync(project, cancellationToken).ConfigureAwait(false);
+            var result = await resolver.GetTagHelpersAsync(project, assemblyNameFilters, cancellationToken).ConfigureAwait(false);
 
             return result;
         }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperResolver.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperResolver.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Evolution;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 
@@ -18,7 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
         [Import]
         public VisualStudioWorkspace Workspace { get; set; }
 
-        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project)
+        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project, IEnumerable<string> assemblyNameFilters)
         {
             try
             {
@@ -27,13 +26,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 {
                     // The OOP host is turned off, so let's do this in process.
                     var resolver = new CodeAnalysis.Razor.DefaultTagHelperResolver(designTime: true);
-                    var result =  await resolver.GetTagHelpersAsync(project, CancellationToken.None).ConfigureAwait(false);
+                    var result =  await resolver.GetTagHelpersAsync(project, assemblyNameFilters, CancellationToken.None).ConfigureAwait(false);
                     return result;
                 }
 
                 using (var session = await client.CreateSessionAsync(project.Solution))
                 {
-                    var result = await session.InvokeAsync<TagHelperResolutionResult>("GetTagHelpersAsync", new object[] { project.Id.Id, "Foo", }).ConfigureAwait(false);
+                    var result = await session.InvokeAsync<TagHelperResolutionResult>("GetTagHelpersAsync", new object[] { project.Id.Id, "Foo", assemblyNameFilters, }).ConfigureAwait(false);
                     return result;
                 }
             }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/ITagHelperResolver.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/ITagHelperResolver.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
@@ -9,6 +10,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     public interface ITagHelperResolver
     {
-        Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project);
+        Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project, IEnumerable<string> assemblyNameFilters);
     }
 }


### PR DESCRIPTION
- Updated the Razor extension to properly discover all assembly names available to a project and use those as a TagHelper filter.

#1022