### PR TITLE
Add baselines for codegen tests

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -1509,6 +1509,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
             engine.Process(document);
 
             // Assert
+            AssertIRMatchesBaseline(document.GetIRDocument());
             AssertCSharpDocumentMatchesBaseline(document.GetCSharpDocument());
         }
 
@@ -1527,6 +1528,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
             engine.Process(document);
 
             // Assert
+            AssertIRMatchesBaseline(document.GetIRDocument());
             AssertDesignTimeDocumentMatchBaseline(document);
         }
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/PageDocumentIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/PageDocumentIntegrationTest.cs
@@ -1,9 +1,0 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
-{
-    public class PageDocumentIntegrationTest
-    {
-    }
-}

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,58 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_AttributeTargetingTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [15] AttributeTargetingTagHelpers.cshtml) - *, TestAssembly
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.CatchAllTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (29:0,29 [4] AttributeTargetingTagHelpers.cshtml) - \n\n
+                TagHelper - (33:2,0 [228] AttributeTargetingTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (48:2,15 [9] AttributeTargetingTagHelpers.cshtml) - \n    <p>
+                        TagHelper - (57:3,7 [36] AttributeTargetingTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - strong - TagMode.StartTagAndEndTag
+                                HtmlContent - (79:3,29 [5] AttributeTargetingTagHelpers.cshtml) - Hello
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddTagHelperHtmlAttribute -  - catchAll - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (75:3,25 [2] AttributeTargetingTagHelpers.cshtml) - hi
+                            ExecuteTagHelpers - 
+                        HtmlContent - (93:3,43 [62] AttributeTargetingTagHelpers.cshtml) - <strong>World</strong></p>\n    <input checked="true" />\n    
+                        TagHelper - (155:5,4 [40] AttributeTargetingTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - checkbox
+                            SetTagHelperProperty - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - checkbox
+                            SetTagHelperProperty - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml) - \n    
+                        TagHelper - (201:6,4 [54] AttributeTargetingTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            SetTagHelperProperty - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - checkbox
+                            SetTagHelperProperty - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - checkbox
+                            SetTagHelperProperty - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - true
+                            AddTagHelperHtmlAttribute -  - catchAll - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (249:6,52 [2] AttributeTargetingTagHelpers.cshtml) - hi
+                            ExecuteTagHelpers - 
+                        HtmlContent - (255:6,58 [2] AttributeTargetingTagHelpers.cshtml) - \n
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (43:2,10 [3] AttributeTargetingTagHelpers.cshtml) - btn
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.ir.txt
@@ -1,0 +1,47 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_AttributeTargetingTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - catchAll - hi - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_1 - type - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - class - btn - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.CatchAllTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:1,0 [2] AttributeTargetingTagHelpers.cshtml) - \n
+                TagHelper - (33:2,0 [228] AttributeTargetingTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (48:2,15 [9] AttributeTargetingTagHelpers.cshtml) - \n    <p>
+                        TagHelper - (57:3,7 [36] AttributeTargetingTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - strong - TagMode.StartTagAndEndTag
+                                HtmlContent - (79:3,29 [5] AttributeTargetingTagHelpers.cshtml) - Hello
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                            ExecuteTagHelpers - 
+                        HtmlContent - (93:3,43 [62] AttributeTargetingTagHelpers.cshtml) - <strong>World</strong></p>\n    <input checked="true" />\n    
+                        TagHelper - (155:5,4 [40] AttributeTargetingTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                            SetTagHelperProperty - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml) - \n    
+                        TagHelper - (201:6,4 [54] AttributeTargetingTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                            SetTagHelperProperty - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - true
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                            ExecuteTagHelpers - 
+                        HtmlContent - (255:6,58 [2] AttributeTargetingTagHelpers.cshtml) - \n
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,60 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] BasicTagHelpers.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [73] BasicTagHelpers.cshtml) - \n\n<div data-animation="fade" class="randomNonTagHelperAttribute">\n    
+                TagHelper - (104:3,4 [216] BasicTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (145:3,45 [10] BasicTagHelpers.cshtml) - \n        
+                        TagHelper - (155:4,8 [25] BasicTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                            CreateTagHelper -  - TestNamespace.PTagHelper
+                            AddTagHelperHtmlAttribute -  - data - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (164:4,17 [10] BasicTagHelpers.cshtml) - -delay1000
+                            ExecuteTagHelpers - 
+                        HtmlContent - (180:4,33 [10] BasicTagHelpers.cshtml) - \n        
+                        TagHelper - (190:5,8 [71] BasicTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            AddTagHelperHtmlAttribute -  - data-interval - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (212:5,30 [7] BasicTagHelpers.cshtml) - 2000 + 
+                                CSharpExpression - (220:5,38 [23] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (220:5,38 [23] BasicTagHelpers.cshtml) - CSharp - ViewBag.DefaultInterval
+                                HtmlContent - (243:5,61 [4] BasicTagHelpers.cshtml) -  + 1
+                            SetTagHelperProperty - (255:5,73 [4] BasicTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (255:5,73 [4] BasicTagHelpers.cshtml) - text
+                            SetTagHelperProperty - (255:5,73 [4] BasicTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (255:5,73 [4] BasicTagHelpers.cshtml) - text
+                            ExecuteTagHelpers - 
+                        HtmlContent - (261:5,79 [10] BasicTagHelpers.cshtml) - \n        
+                        TagHelper - (271:6,8 [39] BasicTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (284:6,21 [8] BasicTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (284:6,21 [8] BasicTagHelpers.cshtml) - checkbox
+                            SetTagHelperProperty - (284:6,21 [8] BasicTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (284:6,21 [8] BasicTagHelpers.cshtml) - checkbox
+                            SetTagHelperProperty - (303:6,40 [4] BasicTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (303:6,40 [4] BasicTagHelpers.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (310:6,47 [6] BasicTagHelpers.cshtml) - \n    
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (114:3,14 [11] BasicTagHelpers.cshtml) - Hello World
+                    AddTagHelperHtmlAttribute -  - data-delay - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (139:3,39 [4] BasicTagHelpers.cshtml) - 1000
+                    ExecuteTagHelpers - 
+                HtmlContent - (320:7,8 [8] BasicTagHelpers.cshtml) - \n</div>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.ir.txt
@@ -1,0 +1,38 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_Prefixed_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (17:0,17 [5] BasicTagHelpers_Prefixed.cshtml) - "THS"
+                DirectiveToken - (38:1,14 [17] BasicTagHelpers_Prefixed.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (22:0,22 [2] BasicTagHelpers_Prefixed.cshtml) - \n
+                HtmlContent - (55:1,31 [54] BasicTagHelpers_Prefixed.cshtml) - \n\n<THSdiv class="randomNonTagHelperAttribute">\n    
+                TagHelper - (109:4,4 [136] BasicTagHelpers_Prefixed.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (135:4,30 [56] BasicTagHelpers_Prefixed.cshtml) - \n        <p></p>\n        <input type="text">\n        
+                        TagHelper - (191:7,8 [41] BasicTagHelpers_Prefixed.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - checkbox
+                            SetTagHelperProperty - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - checkbox
+                            SetTagHelperProperty - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml) - \n    
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (122:4,17 [11] BasicTagHelpers_Prefixed.cshtml) - Hello World
+                    ExecuteTagHelpers - 
+                HtmlContent - (245:8,11 [11] BasicTagHelpers_Prefixed.cshtml) - \n</THSdiv>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.ir.txt
@@ -1,0 +1,28 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_Prefixed_Runtime -  - 
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_0 - type - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (57:2,0 [52] BasicTagHelpers_Prefixed.cshtml) - \n<THSdiv class="randomNonTagHelperAttribute">\n    
+                TagHelper - (109:4,4 [136] BasicTagHelpers_Prefixed.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (135:4,30 [56] BasicTagHelpers_Prefixed.cshtml) - \n        <p></p>\n        <input type="text">\n        
+                        TagHelper - (191:7,8 [41] BasicTagHelpers_Prefixed.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetTagHelperProperty - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml) - \n    
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                    ExecuteTagHelpers - 
+                HtmlContent - (245:8,11 [11] BasicTagHelpers_Prefixed.cshtml) - \n</THSdiv>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.ir.txt
@@ -1,0 +1,42 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_RemoveTagHelper_Runtime -  - 
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_0 - type - text - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_1 - type - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (72:2,0 [49] BasicTagHelpers_RemoveTagHelper.cshtml) - \n<div class="randomNonTagHelperAttribute">\n    
+                TagHelper - (121:4,4 [130] BasicTagHelpers_RemoveTagHelper.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (144:4,27 [10] BasicTagHelpers_RemoveTagHelper.cshtml) - \n        
+                        TagHelper - (154:5,8 [7] BasicTagHelpers_RemoveTagHelper.cshtml)
+                            InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                            CreateTagHelper -  - TestNamespace.PTagHelper
+                            ExecuteTagHelpers - 
+                        HtmlContent - (161:5,15 [10] BasicTagHelpers_RemoveTagHelper.cshtml) - \n        
+                        TagHelper - (171:6,8 [21] BasicTagHelpers_RemoveTagHelper.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            ExecuteTagHelpers - 
+                        HtmlContent - (192:6,29 [10] BasicTagHelpers_RemoveTagHelper.cshtml) - \n        
+                        TagHelper - (202:7,8 [39] BasicTagHelpers_RemoveTagHelper.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                            SetTagHelperProperty - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (241:7,47 [6] BasicTagHelpers_RemoveTagHelper.cshtml) - \n    
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                    ExecuteTagHelpers - 
+                HtmlContent - (251:8,8 [8] BasicTagHelpers_RemoveTagHelper.cshtml) - \n</div>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.ir.txt
@@ -1,0 +1,51 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - data - -delay1000 - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_1 - type - text - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_2 - type - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4 - data-delay - 1000 - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [71] BasicTagHelpers.cshtml) - \n<div data-animation="fade" class="randomNonTagHelperAttribute">\n    
+                TagHelper - (104:3,4 [216] BasicTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (145:3,45 [10] BasicTagHelpers.cshtml) - \n        
+                        TagHelper - (155:4,8 [25] BasicTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                            CreateTagHelper -  - TestNamespace.PTagHelper
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                            ExecuteTagHelpers - 
+                        HtmlContent - (180:4,33 [10] BasicTagHelpers.cshtml) - \n        
+                        TagHelper - (190:5,8 [71] BasicTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            AddTagHelperHtmlAttribute -  - data-interval - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (212:5,30 [7] BasicTagHelpers.cshtml) - 2000 + 
+                                CSharpExpression - (220:5,38 [23] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (220:5,38 [23] BasicTagHelpers.cshtml) - CSharp - ViewBag.DefaultInterval
+                                HtmlContent - (243:5,61 [4] BasicTagHelpers.cshtml) -  + 1
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                            ExecuteTagHelpers - 
+                        HtmlContent - (261:5,79 [10] BasicTagHelpers.cshtml) - \n        
+                        TagHelper - (271:6,8 [39] BasicTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_2 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_2 - type - Type
+                            SetTagHelperProperty - (303:6,40 [4] BasicTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (303:6,40 [4] BasicTagHelpers.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (310:6,47 [6] BasicTagHelpers.cshtml) - \n    
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4
+                    ExecuteTagHelpers - 
+                HtmlContent - (320:7,8 [8] BasicTagHelpers.cshtml) - \n</div>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,215 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ComplexTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] ComplexTagHelpers.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] ComplexTagHelpers.cshtml) - \n\n
+                CSharpStatement - (36:2,1 [52] ComplexTagHelpers.cshtml) - if (true)\n{\n    var checkbox = "checkbox";\n\n    
+                HtmlContent - (88:6,4 [51] ComplexTagHelpers.cshtml) - <div class="randomNonTagHelperAttribute">\n        
+                TagHelper - (139:7,8 [531] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (177:7,46 [46] ComplexTagHelpers.cshtml) - \n            <h1>Set Time:</h1>\n            
+                        CSharpStatement - (224:9,13 [43] ComplexTagHelpers.cshtml) - if (false)\n            {\n                
+                        TagHelper - (267:11,16 [83] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                                HtmlContent - (270:11,19 [10] ComplexTagHelpers.cshtml) - New Time: 
+                                TagHelper - (280:11,29 [66] ComplexTagHelpers.cshtml)
+                                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                                    SetTagHelperProperty - (293:11,42 [4] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        HtmlContent - (293:11,42 [4] ComplexTagHelpers.cshtml) - text
+                                    SetTagHelperProperty - (293:11,42 [4] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        HtmlContent - (293:11,42 [4] ComplexTagHelpers.cshtml) - text
+                                    AddTagHelperHtmlAttribute -  - value - HtmlAttributeValueStyle.DoubleQuotes
+                                        HtmlContent - (306:11,55 [0] ComplexTagHelpers.cshtml) - 
+                                    AddTagHelperHtmlAttribute -  - placeholder - HtmlAttributeValueStyle.DoubleQuotes
+                                        HtmlContent - (321:11,70 [22] ComplexTagHelpers.cshtml) - Enter in a new time...
+                                    ExecuteTagHelpers - 
+                            CreateTagHelper -  - TestNamespace.PTagHelper
+                            ExecuteTagHelpers - 
+                        CSharpStatement - (350:11,99 [66] ComplexTagHelpers.cshtml) - \n            }\n            else\n            {\n                
+                        TagHelper - (416:15,16 [58] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                                HtmlContent - (419:15,19 [14] ComplexTagHelpers.cshtml) - Current Time: 
+                                TagHelper - (433:15,33 [37] ComplexTagHelpers.cshtml)
+                                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                                    SetTagHelperProperty - (445:15,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
+                                    SetTagHelperProperty - (445:15,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
+                                    SetTagHelperProperty - (463:15,63 [4] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                        HtmlContent - (463:15,63 [4] ComplexTagHelpers.cshtml) - true
+                                    ExecuteTagHelpers - 
+                            CreateTagHelper -  - TestNamespace.PTagHelper
+                            ExecuteTagHelpers - 
+                        CSharpStatement - (474:15,74 [18] ComplexTagHelpers.cshtml) - \n                
+                        TagHelper - (492:16,16 [50] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (505:16,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
+                            SetTagHelperProperty - (505:16,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
+                            ExecuteTagHelpers - 
+                        CSharpStatement - (542:16,66 [18] ComplexTagHelpers.cshtml) - \n                
+                        TagHelper - (560:17,16 [81] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (573:17,29 [66] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpStatement - (574:17,30 [11] ComplexTagHelpers.cshtml) - if(true) { 
+                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml) - checkbox
+                                CSharpStatement - (606:17,62 [10] ComplexTagHelpers.cshtml) -  } else { 
+                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml) - anything
+                                CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml) -  }
+                            SetTagHelperProperty - (573:17,29 [66] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpStatement - (574:17,30 [11] ComplexTagHelpers.cshtml) - if(true) { 
+                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml) - checkbox
+                                CSharpStatement - (606:17,62 [10] ComplexTagHelpers.cshtml) -  } else { 
+                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml) - anything
+                                CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml) -  }
+                            ExecuteTagHelpers - 
+                        CSharpStatement - (641:17,97 [15] ComplexTagHelpers.cshtml) - \n            }
+                        HtmlContent - (656:18,13 [10] ComplexTagHelpers.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - time - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (148:7,17 [7] ComplexTagHelpers.cshtml) -  - Current
+                        HtmlAttributeValue - (155:7,24 [6] ComplexTagHelpers.cshtml) -   - Time:
+                        CSharpAttributeValue - (161:7,30 [14] ComplexTagHelpers.cshtml) -  
+                            CSharpExpression - (163:7,32 [12] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (163:7,32 [12] ComplexTagHelpers.cshtml) - CSharp - DateTime.Now
+                    ExecuteTagHelpers - 
+                HtmlContent - (670:19,12 [10] ComplexTagHelpers.cshtml) - \n        
+                TagHelper - (680:20,8 [181] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (767:20,95 [14] ComplexTagHelpers.cshtml) - \n            
+                        CSharpStatement - (783:21,14 [21] ComplexTagHelpers.cshtml) -  var @object = false;
+                        HtmlContent - (807:22,0 [12] ComplexTagHelpers.cshtml) -             
+                        TagHelper - (819:22,12 [28] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (835:22,28 [10] ComplexTagHelpers.cshtml) - ChecKED - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - (836:22,29 [9] ComplexTagHelpers.cshtml)
+                                    HtmlContent - (836:22,29 [1] ComplexTagHelpers.cshtml) - (
+                                    RazorIRToken - (837:22,30 [7] ComplexTagHelpers.cshtml) - CSharp - @object
+                                    HtmlContent - (844:22,37 [1] ComplexTagHelpers.cshtml) - )
+                            ExecuteTagHelpers - 
+                        HtmlContent - (847:22,40 [10] ComplexTagHelpers.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (692:20,20 [11] ComplexTagHelpers.cshtml) - first value
+                    SetTagHelperProperty - (710:20,38 [31] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (711:20,39 [23] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (711:20,39 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
+                        HtmlContent - (734:20,62 [7] ComplexTagHelpers.cshtml) - \-1970
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (752:20,80 [12] ComplexTagHelpers.cshtml) - second value
+                    ExecuteTagHelpers - 
+                HtmlContent - (861:23,12 [10] ComplexTagHelpers.cshtml) - \n        
+                TagHelper - (871:24,8 [155] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (913:24,50 [14] ComplexTagHelpers.cshtml) - \n            
+                        TagHelper - (927:25,12 [85] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (943:25,28 [5] ComplexTagHelpers.cshtml) - hello
+                            AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (959:25,44 [5] ComplexTagHelpers.cshtml) - world
+                            SetTagHelperProperty - (975:25,60 [33] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - (976:25,61 [32] ComplexTagHelpers.cshtml)
+                                    HtmlContent - (976:25,61 [1] ComplexTagHelpers.cshtml) - (
+                                    RazorIRToken - (977:25,62 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
+                                    HtmlContent - (1007:25,92 [1] ComplexTagHelpers.cshtml) - )
+                            ExecuteTagHelpers - 
+                        HtmlContent - (1012:25,97 [10] ComplexTagHelpers.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (879:24,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (879:24,16 [8] ComplexTagHelpers.cshtml) - -1970 + 
+                        CSharpExpression - (887:24,24 [24] ComplexTagHelpers.cshtml)
+                            HtmlContent - (887:24,24 [1] ComplexTagHelpers.cshtml) - @
+                            RazorIRToken - (888:24,25 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
+                    ExecuteTagHelpers - 
+                HtmlContent - (1026:26,12 [10] ComplexTagHelpers.cshtml) - \n        
+                TagHelper - (1036:27,8 [116] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (1076:27,48 [14] ComplexTagHelpers.cshtml) - \n            
+                        TagHelper - (1090:28,12 [48] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (1106:28,28 [30] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (1106:28,28 [30] ComplexTagHelpers.cshtml) - DateTimeOffset.Now.Year > 2014
+                            ExecuteTagHelpers - 
+                        HtmlContent - (1138:28,60 [10] ComplexTagHelpers.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (1044:27,16 [30] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (1044:27,16 [30] ComplexTagHelpers.cshtml) - DateTimeOffset.Now.Year\-1970
+                    ExecuteTagHelpers - 
+                HtmlContent - (1152:29,12 [10] ComplexTagHelpers.cshtml) - \n        
+                TagHelper - (1162:30,8 [133] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (1204:30,50 [14] ComplexTagHelpers.cshtml) - \n            
+                        TagHelper - (1218:31,12 [63] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (1234:31,28 [43] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (1234:31,28 [3] ComplexTagHelpers.cshtml) -    
+                                CSharpExpression - (1237:31,31 [30] ComplexTagHelpers.cshtml)
+                                    HtmlContent - (1237:31,31 [2] ComplexTagHelpers.cshtml) - @(
+                                    RazorIRToken - (1239:31,33 [27] ComplexTagHelpers.cshtml) - CSharp -   DateTimeOffset.Now.Year  
+                                    HtmlContent - (1266:31,60 [1] ComplexTagHelpers.cshtml) - )
+                                HtmlContent - (1267:31,61 [10] ComplexTagHelpers.cshtml) -  > 2014   
+                            ExecuteTagHelpers - 
+                        HtmlContent - (1281:31,75 [10] ComplexTagHelpers.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (1170:30,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (1171:30,17 [31] ComplexTagHelpers.cshtml)
+                            HtmlContent - (1171:30,17 [1] ComplexTagHelpers.cshtml) - (
+                            RazorIRToken - (1172:30,18 [29] ComplexTagHelpers.cshtml) - CSharp - "My age is this long.".Length
+                            HtmlContent - (1201:30,47 [1] ComplexTagHelpers.cshtml) - )
+                    ExecuteTagHelpers - 
+                HtmlContent - (1295:32,12 [10] ComplexTagHelpers.cshtml) - \n        
+                CSharpExpression - (1306:33,9 [69] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1306:33,9 [11] ComplexTagHelpers.cshtml) - CSharp - someMethod(
+                    Template - (1318:33,21 [57] ComplexTagHelpers.cshtml)
+                        TagHelper - (1318:33,21 [57] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                                TagHelper - (1345:33,48 [26] ComplexTagHelpers.cshtml)
+                                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                                    SetTagHelperProperty - (1360:33,63 [8] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (1361:33,64 [7] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (1361:33,64 [7] ComplexTagHelpers.cshtml) - CSharp - checked
+                                    ExecuteTagHelpers - 
+                            CreateTagHelper -  - TestNamespace.PTagHelper
+                            SetTagHelperProperty - (1326:33,29 [3] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (1326:33,29 [3] ComplexTagHelpers.cshtml) - 123
+                            AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (1338:33,41 [5] ComplexTagHelpers.cshtml) - hello
+                            ExecuteTagHelpers - 
+                    RazorIRToken - (1375:33,78 [1] ComplexTagHelpers.cshtml) - CSharp - )
+                HtmlContent - (1376:33,79 [12] ComplexTagHelpers.cshtml) - \n    </div>
+                CSharpStatement - (1388:34,10 [3] ComplexTagHelpers.cshtml) - \n}

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.ir.txt
@@ -1,0 +1,213 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ComplexTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_0 - type - text - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - value -  - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - placeholder - Enter in a new time... - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3 - unbound - first value - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4 - unbound - second value - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5 - unbound - hello - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_6 - unbound - world - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7 - class - hello - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] ComplexTagHelpers.cshtml) - \n
+                CSharpStatement - (36:2,1 [48] ComplexTagHelpers.cshtml) - if (true)\n{\n    var checkbox = "checkbox";\n\n
+                HtmlContent - (84:6,0 [55] ComplexTagHelpers.cshtml) -     <div class="randomNonTagHelperAttribute">\n        
+                TagHelper - (139:7,8 [529] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (177:7,46 [34] ComplexTagHelpers.cshtml) - \n            <h1>Set Time:</h1>\n
+                        CSharpStatement - (211:9,0 [12] ComplexTagHelpers.cshtml) -             
+                        CSharpStatement - (224:9,13 [27] ComplexTagHelpers.cshtml) - if (false)\n            {\n
+                        HtmlContent - (251:11,0 [16] ComplexTagHelpers.cshtml) -                 
+                        TagHelper - (267:11,16 [83] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                                HtmlContent - (270:11,19 [10] ComplexTagHelpers.cshtml) - New Time: 
+                                TagHelper - (280:11,29 [66] ComplexTagHelpers.cshtml)
+                                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                                    ExecuteTagHelpers - 
+                            CreateTagHelper -  - TestNamespace.PTagHelper
+                            ExecuteTagHelpers - 
+                        HtmlContent - (350:11,99 [2] ComplexTagHelpers.cshtml) - \n
+                        CSharpStatement - (352:12,0 [48] ComplexTagHelpers.cshtml) -             }\n            else\n            {\n
+                        HtmlContent - (400:15,0 [16] ComplexTagHelpers.cshtml) -                 
+                        TagHelper - (416:15,16 [58] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                                HtmlContent - (419:15,19 [14] ComplexTagHelpers.cshtml) - Current Time: 
+                                TagHelper - (433:15,33 [37] ComplexTagHelpers.cshtml)
+                                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                                    SetTagHelperProperty - (445:15,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
+                                    SetTagHelperProperty - (445:15,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
+                                    SetTagHelperProperty - (463:15,63 [4] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                        HtmlContent - (463:15,63 [4] ComplexTagHelpers.cshtml) - true
+                                    ExecuteTagHelpers - 
+                            CreateTagHelper -  - TestNamespace.PTagHelper
+                            ExecuteTagHelpers - 
+                        HtmlContent - (474:15,74 [18] ComplexTagHelpers.cshtml) - \n                
+                        TagHelper - (492:16,16 [50] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (505:16,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
+                            SetTagHelperProperty - (505:16,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
+                            ExecuteTagHelpers - 
+                        HtmlContent - (542:16,66 [18] ComplexTagHelpers.cshtml) - \n                
+                        TagHelper - (560:17,16 [79] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (573:17,29 [64] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpStatement - (574:17,30 [10] ComplexTagHelpers.cshtml) - if(true) {
+                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml) - checkbox
+                                CSharpStatement - (606:17,62 [9] ComplexTagHelpers.cshtml) -  } else {
+                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml) - anything
+                                CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml) -  }
+                            SetTagHelperProperty - (573:17,29 [64] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpStatement - (574:17,30 [10] ComplexTagHelpers.cshtml) - if(true) {
+                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml) - checkbox
+                                CSharpStatement - (606:17,62 [9] ComplexTagHelpers.cshtml) -  } else {
+                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml) - anything
+                                CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml) -  }
+                            ExecuteTagHelpers - 
+                        HtmlContent - (641:17,97 [2] ComplexTagHelpers.cshtml) - \n
+                        CSharpStatement - (643:18,0 [15] ComplexTagHelpers.cshtml) -             }\n
+                        HtmlContent - (658:19,0 [8] ComplexTagHelpers.cshtml) -         
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - time - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (148:7,17 [7] ComplexTagHelpers.cshtml) -  - Current
+                        HtmlAttributeValue - (155:7,24 [6] ComplexTagHelpers.cshtml) -   - Time:
+                        CSharpAttributeValue - (161:7,30 [14] ComplexTagHelpers.cshtml) -  
+                            CSharpExpression - (163:7,32 [12] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (163:7,32 [12] ComplexTagHelpers.cshtml) - CSharp - DateTime.Now
+                    ExecuteTagHelpers - 
+                HtmlContent - (670:19,12 [10] ComplexTagHelpers.cshtml) - \n        
+                TagHelper - (680:20,8 [181] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (767:20,95 [2] ComplexTagHelpers.cshtml) - \n
+                        CSharpStatement - (769:21,0 [12] ComplexTagHelpers.cshtml) -             
+                        CSharpStatement - (783:21,14 [21] ComplexTagHelpers.cshtml) -  var @object = false;
+                        HtmlContent - (807:22,0 [12] ComplexTagHelpers.cshtml) -             
+                        TagHelper - (819:22,12 [28] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (835:22,28 [10] ComplexTagHelpers.cshtml) - ChecKED - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - (836:22,29 [9] ComplexTagHelpers.cshtml)
+                                    HtmlContent - (836:22,29 [1] ComplexTagHelpers.cshtml) - (
+                                    RazorIRToken - (837:22,30 [7] ComplexTagHelpers.cshtml) - CSharp - @object
+                                    HtmlContent - (844:22,37 [1] ComplexTagHelpers.cshtml) - )
+                            ExecuteTagHelpers - 
+                        HtmlContent - (847:22,40 [10] ComplexTagHelpers.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
+                    SetTagHelperProperty - (710:20,38 [31] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (711:20,39 [23] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (711:20,39 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
+                        HtmlContent - (734:20,62 [7] ComplexTagHelpers.cshtml) - \-1970
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4
+                    ExecuteTagHelpers - 
+                HtmlContent - (861:23,12 [10] ComplexTagHelpers.cshtml) - \n        
+                TagHelper - (871:24,8 [155] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (913:24,50 [14] ComplexTagHelpers.cshtml) - \n            
+                        TagHelper - (927:25,12 [85] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_6
+                            SetTagHelperProperty - (975:25,60 [33] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - (976:25,61 [32] ComplexTagHelpers.cshtml)
+                                    HtmlContent - (976:25,61 [1] ComplexTagHelpers.cshtml) - (
+                                    RazorIRToken - (977:25,62 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
+                                    HtmlContent - (1007:25,92 [1] ComplexTagHelpers.cshtml) - )
+                            ExecuteTagHelpers - 
+                        HtmlContent - (1012:25,97 [10] ComplexTagHelpers.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (879:24,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (879:24,16 [8] ComplexTagHelpers.cshtml) - -1970 + 
+                        CSharpExpression - (887:24,24 [24] ComplexTagHelpers.cshtml)
+                            HtmlContent - (887:24,24 [1] ComplexTagHelpers.cshtml) - @
+                            RazorIRToken - (888:24,25 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
+                    ExecuteTagHelpers - 
+                HtmlContent - (1026:26,12 [10] ComplexTagHelpers.cshtml) - \n        
+                TagHelper - (1036:27,8 [116] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (1076:27,48 [14] ComplexTagHelpers.cshtml) - \n            
+                        TagHelper - (1090:28,12 [48] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (1106:28,28 [30] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (1106:28,28 [30] ComplexTagHelpers.cshtml) - DateTimeOffset.Now.Year > 2014
+                            ExecuteTagHelpers - 
+                        HtmlContent - (1138:28,60 [10] ComplexTagHelpers.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (1044:27,16 [30] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (1044:27,16 [30] ComplexTagHelpers.cshtml) - DateTimeOffset.Now.Year\-1970
+                    ExecuteTagHelpers - 
+                HtmlContent - (1152:29,12 [10] ComplexTagHelpers.cshtml) - \n        
+                TagHelper - (1162:30,8 [133] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (1204:30,50 [14] ComplexTagHelpers.cshtml) - \n            
+                        TagHelper - (1218:31,12 [63] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (1234:31,28 [43] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (1234:31,28 [3] ComplexTagHelpers.cshtml) -    
+                                CSharpExpression - (1237:31,31 [30] ComplexTagHelpers.cshtml)
+                                    HtmlContent - (1237:31,31 [2] ComplexTagHelpers.cshtml) - @(
+                                    RazorIRToken - (1239:31,33 [27] ComplexTagHelpers.cshtml) - CSharp -   DateTimeOffset.Now.Year  
+                                    HtmlContent - (1266:31,60 [1] ComplexTagHelpers.cshtml) - )
+                                HtmlContent - (1267:31,61 [10] ComplexTagHelpers.cshtml) -  > 2014   
+                            ExecuteTagHelpers - 
+                        HtmlContent - (1281:31,75 [10] ComplexTagHelpers.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (1170:30,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (1171:30,17 [31] ComplexTagHelpers.cshtml)
+                            HtmlContent - (1171:30,17 [1] ComplexTagHelpers.cshtml) - (
+                            RazorIRToken - (1172:30,18 [29] ComplexTagHelpers.cshtml) - CSharp - "My age is this long.".Length
+                            HtmlContent - (1201:30,47 [1] ComplexTagHelpers.cshtml) - )
+                    ExecuteTagHelpers - 
+                HtmlContent - (1295:32,12 [10] ComplexTagHelpers.cshtml) - \n        
+                CSharpExpression - (1306:33,9 [69] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1306:33,9 [11] ComplexTagHelpers.cshtml) - CSharp - someMethod(
+                    Template - (1318:33,21 [57] ComplexTagHelpers.cshtml)
+                        TagHelper - (1318:33,21 [57] ComplexTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                                TagHelper - (1345:33,48 [26] ComplexTagHelpers.cshtml)
+                                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                                    SetTagHelperProperty - (1360:33,63 [8] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (1361:33,64 [7] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (1361:33,64 [7] ComplexTagHelpers.cshtml) - CSharp - checked
+                                    ExecuteTagHelpers - 
+                            CreateTagHelper -  - TestNamespace.PTagHelper
+                            SetTagHelperProperty - (1326:33,29 [3] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (1326:33,29 [3] ComplexTagHelpers.cshtml) - 123
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7
+                            ExecuteTagHelpers - 
+                    RazorIRToken - (1375:33,78 [1] ComplexTagHelpers.cshtml) - CSharp - )
+                HtmlContent - (1376:33,79 [14] ComplexTagHelpers.cshtml) - \n    </div>\n
+                CSharpStatement - (1390:35,0 [1] ComplexTagHelpers.cshtml) - }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.ir.txt
@@ -1,0 +1,108 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CssSelectorTagHelperAttributes_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - href - ~/ - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - href - ~/hello - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - href - ~/?hello=world - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3 - href - ~/?hello=world@false - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_4 - type - text - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5 - value - 3 TagHelpers - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_6 - type - texty - HtmlAttributeValueStyle.SingleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_7 - type - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_8 - value - 2 TagHelper - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.ATagHelper - TestNamespace.CatchAllTagHelper - TestNamespace.ATagHelperMultipleSelectors - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2 - TestNamespace.CatchAllTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                TagHelper - (35:2,0 [30] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
+                        HtmlContent - (48:2,13 [13] CssSelectorTagHelperAttributes.cshtml) - 2 TagHelpers.
+                    CreateTagHelper -  - TestNamespace.ATagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    ExecuteTagHelpers - 
+                HtmlContent - (65:2,30 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                TagHelper - (67:3,0 [32] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
+                        HtmlContent - (83:3,16 [12] CssSelectorTagHelperAttributes.cshtml) - 1 TagHelper.
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                    ExecuteTagHelpers - 
+                HtmlContent - (99:3,32 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                TagHelper - (101:4,0 [41] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
+                        HtmlContent - (126:4,25 [12] CssSelectorTagHelperAttributes.cshtml) - 2 TagHelpers
+                    CreateTagHelper -  - TestNamespace.ATagHelperMultipleSelectors
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                    ExecuteTagHelpers - 
+                HtmlContent - (142:4,41 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                TagHelper - (144:5,0 [47] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
+                        HtmlContent - (175:5,31 [12] CssSelectorTagHelperAttributes.cshtml) - 2 TagHelpers
+                    CreateTagHelper -  - TestNamespace.ATagHelperMultipleSelectors
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - href - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (153:5,9 [2] CssSelectorTagHelperAttributes.cshtml) -  - ~/
+                        CSharpAttributeValue - (155:5,11 [6] CssSelectorTagHelperAttributes.cshtml) - 
+                            CSharpExpression - (156:5,12 [5] CssSelectorTagHelperAttributes.cshtml)
+                                RazorIRToken - (156:5,12 [5] CssSelectorTagHelperAttributes.cshtml) - CSharp - false
+                        HtmlAttributeValue - (161:5,17 [12] CssSelectorTagHelperAttributes.cshtml) -  - ?hello=world
+                    ExecuteTagHelpers - 
+                HtmlContent - (191:5,47 [35] CssSelectorTagHelperAttributes.cshtml) - \n<a href=' ~/'>0 TagHelpers.</a>\n
+                TagHelper - (226:7,0 [32] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
+                        HtmlContent - (243:7,17 [11] CssSelectorTagHelperAttributes.cshtml) - 1 TagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - href - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (234:7,8 [2] CssSelectorTagHelperAttributes.cshtml) -  - ~/
+                        CSharpAttributeValue - (236:7,10 [6] CssSelectorTagHelperAttributes.cshtml) - 
+                            CSharpExpression - (237:7,11 [5] CssSelectorTagHelperAttributes.cshtml)
+                                RazorIRToken - (237:7,11 [5] CssSelectorTagHelperAttributes.cshtml) - CSharp - false
+                    ExecuteTagHelpers - 
+                HtmlContent - (258:7,32 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                TagHelper - (260:8,0 [46] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
+                        HtmlContent - (291:8,31 [11] CssSelectorTagHelperAttributes.cshtml) - 1 TagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
+                    ExecuteTagHelpers - 
+                HtmlContent - (306:8,46 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                TagHelper - (308:9,0 [47] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
+                        HtmlContent - (340:9,32 [11] CssSelectorTagHelperAttributes.cshtml) - 1 TagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - href - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlAttributeValue - (317:9,9 [14] CssSelectorTagHelperAttributes.cshtml) -  - ~/?hello=world
+                        CSharpAttributeValue - (331:9,23 [7] CssSelectorTagHelperAttributes.cshtml) -  
+                            CSharpExpression - (333:9,25 [5] CssSelectorTagHelperAttributes.cshtml)
+                                RazorIRToken - (333:9,25 [5] CssSelectorTagHelperAttributes.cshtml) - CSharp - false
+                    ExecuteTagHelpers - 
+                HtmlContent - (355:9,47 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                TagHelper - (357:10,0 [42] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper2
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
+                    ExecuteTagHelpers - 
+                HtmlContent - (399:10,42 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                TagHelper - (401:11,0 [43] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper2
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - type - Type
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
+                    ExecuteTagHelpers - 
+                HtmlContent - (444:11,43 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                TagHelper - (446:12,0 [45] CssSelectorTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper2
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_7 - type - Type
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_8
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,75 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DuplicateAttributeTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] DuplicateAttributeTagHelpers.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] DuplicateAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (35:2,0 [259] DuplicateAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (65:2,30 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        TagHelper - (71:3,4 [39] DuplicateAttributeTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                            SetTagHelperProperty - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                            AddTagHelperHtmlAttribute -  - TYPE - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (98:3,31 [8] DuplicateAttributeTagHelpers.cshtml) - checkbox
+                            ExecuteTagHelpers - 
+                        HtmlContent - (110:3,43 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        TagHelper - (116:4,4 [70] DuplicateAttributeTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                            SetTagHelperProperty - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                            SetTagHelperProperty - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                            AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (158:4,46 [8] DuplicateAttributeTagHelpers.cshtml) - checkbox
+                            AddTagHelperHtmlAttribute -  - checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (177:4,65 [5] DuplicateAttributeTagHelpers.cshtml) - false
+                            ExecuteTagHelpers - 
+                        HtmlContent - (186:4,74 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        TagHelper - (192:5,4 [96] DuplicateAttributeTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                HtmlContent - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                            SetTagHelperProperty - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                HtmlContent - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                            SetTagHelperProperty - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                            AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (233:5,45 [8] DuplicateAttributeTagHelpers.cshtml) - checkbox
+                            AddTagHelperHtmlAttribute -  - checked - HtmlAttributeValueStyle.SingleQuotes
+                                HtmlContent - (251:5,63 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                            AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (263:5,75 [8] DuplicateAttributeTagHelpers.cshtml) - checkbox
+                            AddTagHelperHtmlAttribute -  - checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (281:5,93 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml) - \n
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - 3
+                    AddTagHelperHtmlAttribute -  - AGE - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (51:2,16 [2] DuplicateAttributeTagHelpers.cshtml) - 40
+                    AddTagHelperHtmlAttribute -  - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (60:2,25 [3] DuplicateAttributeTagHelpers.cshtml) - 500
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.ir.txt
@@ -1,0 +1,62 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DuplicateAttributeTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_0 - type - button - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - TYPE - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - type - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3 - checked - false - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_4 - type - button - HtmlAttributeValueStyle.SingleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5 - checked - true - HtmlAttributeValueStyle.SingleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_6 - checked - true - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7 - AGE - 40 - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_8 - Age - 500 - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] DuplicateAttributeTagHelpers.cshtml) - \n
+                TagHelper - (35:2,0 [259] DuplicateAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (65:2,30 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        TagHelper - (71:3,4 [39] DuplicateAttributeTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                            ExecuteTagHelpers - 
+                        HtmlContent - (110:3,43 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        TagHelper - (116:4,4 [70] DuplicateAttributeTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetTagHelperProperty - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
+                            ExecuteTagHelpers - 
+                        HtmlContent - (186:4,74 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        TagHelper - (192:5,4 [96] DuplicateAttributeTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
+                            SetTagHelperProperty - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_6
+                            ExecuteTagHelpers - 
+                        HtmlContent - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml) - \n
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - 3
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_8
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.ir.txt
@@ -1,0 +1,29 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DuplicateTargetTagHelper_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] DuplicateTargetTagHelper.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.CatchAllTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] DuplicateTargetTagHelper.cshtml) - \n\n
+                TagHelper - (35:2,0 [40] DuplicateTargetTagHelper.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetTagHelperProperty - (48:2,13 [8] DuplicateTargetTagHelper.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (48:2,13 [8] DuplicateTargetTagHelper.cshtml) - checkbox
+                    SetTagHelperProperty - (48:2,13 [8] DuplicateTargetTagHelper.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (48:2,13 [8] DuplicateTargetTagHelper.cshtml) - checkbox
+                    SetTagHelperProperty - (67:2,32 [4] DuplicateTargetTagHelper.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (67:2,32 [4] DuplicateTargetTagHelper.cshtml) - true
+                    SetTagHelperProperty - (67:2,32 [4] DuplicateTargetTagHelper.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (67:2,32 [4] DuplicateTargetTagHelper.cshtml) - true
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.ir.txt
@@ -1,0 +1,21 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DuplicateTargetTagHelper_Runtime -  - 
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_0 - type - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.CatchAllTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] DuplicateTargetTagHelper.cshtml) - \n
+                TagHelper - (35:2,0 [40] DuplicateTargetTagHelper.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                    SetTagHelperProperty - (67:2,32 [4] DuplicateTargetTagHelper.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (67:2,32 [4] DuplicateTargetTagHelper.cshtml) - true
+                    SetTagHelperProperty - (67:2,32 [4] DuplicateTargetTagHelper.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (67:2,32 [4] DuplicateTargetTagHelper.cshtml) - true
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,121 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DynamicAttributeTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] DynamicAttributeTagHelpers.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (35:2,0 [40] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (51:2,16 [6] DynamicAttributeTagHelpers.cshtml) -  - prefix
+                        CSharpAttributeValue - (57:2,22 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (59:2,24 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (59:2,24 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
+                    ExecuteTagHelpers - 
+                HtmlContent - (75:2,40 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (79:4,0 [71] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (95:4,16 [44] DynamicAttributeTagHelpers.cshtml) - 
+                            CSharpStatement - (96:4,17 [12] DynamicAttributeTagHelpers.cshtml) - if (true) { 
+                            CSharpExpression - (109:4,30 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (109:4,30 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - string.Empty
+                            CSharpStatement - (121:4,42 [10] DynamicAttributeTagHelpers.cshtml) -  } else { 
+                            CSharpExpression - (132:4,53 [5] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (132:4,53 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
+                            CSharpStatement - (137:4,58 [2] DynamicAttributeTagHelpers.cshtml) -  }
+                        HtmlAttributeValue - (139:4,60 [7] DynamicAttributeTagHelpers.cshtml) -   - suffix
+                    ExecuteTagHelpers - 
+                HtmlContent - (150:4,71 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (154:6,0 [83] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    SetTagHelperProperty - (168:6,14 [27] DynamicAttributeTagHelpers.cshtml) - bound - Bound - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (168:6,14 [7] DynamicAttributeTagHelpers.cshtml) - prefix 
+                        CSharpExpression - (176:6,22 [12] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (176:6,22 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
+                        HtmlContent - (188:6,34 [7] DynamicAttributeTagHelpers.cshtml) -  suffix
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (206:6,52 [6] DynamicAttributeTagHelpers.cshtml) -  - prefix
+                        CSharpAttributeValue - (212:6,58 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (214:6,60 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (214:6,60 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
+                        HtmlAttributeValue - (226:6,72 [7] DynamicAttributeTagHelpers.cshtml) -   - suffix
+                    ExecuteTagHelpers - 
+                HtmlContent - (237:6,83 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (241:8,0 [183] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    SetTagHelperProperty - (255:8,14 [73] DynamicAttributeTagHelpers.cshtml) - bound - Bound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (256:8,15 [13] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (256:8,15 [13] DynamicAttributeTagHelpers.cshtml) - CSharp - long.MinValue
+                        HtmlContent - (269:8,28 [1] DynamicAttributeTagHelpers.cshtml) -  
+                        CSharpStatement - (271:8,30 [12] DynamicAttributeTagHelpers.cshtml) - if (true) { 
+                        CSharpExpression - (284:8,43 [12] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (284:8,43 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - string.Empty
+                        CSharpStatement - (296:8,55 [10] DynamicAttributeTagHelpers.cshtml) -  } else { 
+                        CSharpExpression - (307:8,66 [5] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (307:8,66 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
+                        CSharpStatement - (312:8,71 [2] DynamicAttributeTagHelpers.cshtml) -  }
+                        HtmlContent - (314:8,73 [1] DynamicAttributeTagHelpers.cshtml) -  
+                        CSharpExpression - (316:8,75 [12] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (316:8,75 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (347:9,16 [14] DynamicAttributeTagHelpers.cshtml) - 
+                            CSharpExpression - (348:9,17 [13] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (348:9,17 [13] DynamicAttributeTagHelpers.cshtml) - CSharp - long.MinValue
+                        CSharpAttributeValue - (361:9,30 [45] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpStatement - (363:9,32 [12] DynamicAttributeTagHelpers.cshtml) - if (true) { 
+                            CSharpExpression - (376:9,45 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (376:9,45 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - string.Empty
+                            CSharpStatement - (388:9,57 [10] DynamicAttributeTagHelpers.cshtml) -  } else { 
+                            CSharpExpression - (399:9,68 [5] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (399:9,68 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
+                            CSharpStatement - (404:9,73 [2] DynamicAttributeTagHelpers.cshtml) -  }
+                        CSharpAttributeValue - (406:9,75 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (408:9,77 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (408:9,77 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (424:9,93 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (428:11,0 [80] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (444:11,16 [14] DynamicAttributeTagHelpers.cshtml) - 
+                            CSharpExpression - (445:11,17 [13] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (445:11,17 [13] DynamicAttributeTagHelpers.cshtml) - CSharp - long.MinValue
+                        CSharpAttributeValue - (458:11,30 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (460:11,32 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (460:11,32 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
+                        HtmlAttributeValue - (472:11,44 [7] DynamicAttributeTagHelpers.cshtml) -   - static
+                        HtmlAttributeValue - (479:11,51 [11] DynamicAttributeTagHelpers.cshtml) -      - content
+                        CSharpAttributeValue - (490:11,62 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (492:11,64 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (492:11,64 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (508:11,80 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (512:13,0 [64] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (528:13,16 [44] DynamicAttributeTagHelpers.cshtml) - 
+                            CSharpStatement - (529:13,17 [12] DynamicAttributeTagHelpers.cshtml) - if (true) { 
+                            CSharpExpression - (542:13,30 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (542:13,30 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - string.Empty
+                            CSharpStatement - (554:13,42 [10] DynamicAttributeTagHelpers.cshtml) -  } else { 
+                            CSharpExpression - (565:13,53 [5] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (565:13,53 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
+                            CSharpStatement - (570:13,58 [2] DynamicAttributeTagHelpers.cshtml) -  }
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.ir.txt
@@ -1,0 +1,114 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DynamicAttributeTagHelpers_Runtime -  - 
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] DynamicAttributeTagHelpers.cshtml) - \n
+                TagHelper - (35:2,0 [40] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (51:2,16 [6] DynamicAttributeTagHelpers.cshtml) -  - prefix
+                        CSharpAttributeValue - (57:2,22 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (59:2,24 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (59:2,24 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
+                    ExecuteTagHelpers - 
+                HtmlContent - (75:2,40 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (79:4,0 [71] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (95:4,16 [44] DynamicAttributeTagHelpers.cshtml) - 
+                            CSharpStatement - (96:4,17 [12] DynamicAttributeTagHelpers.cshtml) - if (true) { 
+                            CSharpExpression - (109:4,30 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (109:4,30 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - string.Empty
+                            CSharpStatement - (121:4,42 [10] DynamicAttributeTagHelpers.cshtml) -  } else { 
+                            CSharpExpression - (132:4,53 [5] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (132:4,53 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
+                            CSharpStatement - (137:4,58 [2] DynamicAttributeTagHelpers.cshtml) -  }
+                        HtmlAttributeValue - (139:4,60 [7] DynamicAttributeTagHelpers.cshtml) -   - suffix
+                    ExecuteTagHelpers - 
+                HtmlContent - (150:4,71 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (154:6,0 [83] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    SetTagHelperProperty - (168:6,14 [27] DynamicAttributeTagHelpers.cshtml) - bound - Bound - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (168:6,14 [7] DynamicAttributeTagHelpers.cshtml) - prefix 
+                        CSharpExpression - (176:6,22 [12] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (176:6,22 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
+                        HtmlContent - (188:6,34 [7] DynamicAttributeTagHelpers.cshtml) -  suffix
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (206:6,52 [6] DynamicAttributeTagHelpers.cshtml) -  - prefix
+                        CSharpAttributeValue - (212:6,58 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (214:6,60 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (214:6,60 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
+                        HtmlAttributeValue - (226:6,72 [7] DynamicAttributeTagHelpers.cshtml) -   - suffix
+                    ExecuteTagHelpers - 
+                HtmlContent - (237:6,83 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (241:8,0 [183] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    SetTagHelperProperty - (255:8,14 [73] DynamicAttributeTagHelpers.cshtml) - bound - Bound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (256:8,15 [13] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (256:8,15 [13] DynamicAttributeTagHelpers.cshtml) - CSharp - long.MinValue
+                        HtmlContent - (269:8,28 [1] DynamicAttributeTagHelpers.cshtml) -  
+                        CSharpStatement - (271:8,30 [12] DynamicAttributeTagHelpers.cshtml) - if (true) { 
+                        CSharpExpression - (284:8,43 [12] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (284:8,43 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - string.Empty
+                        CSharpStatement - (296:8,55 [10] DynamicAttributeTagHelpers.cshtml) -  } else { 
+                        CSharpExpression - (307:8,66 [5] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (307:8,66 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
+                        CSharpStatement - (312:8,71 [2] DynamicAttributeTagHelpers.cshtml) -  }
+                        HtmlContent - (314:8,73 [1] DynamicAttributeTagHelpers.cshtml) -  
+                        CSharpExpression - (316:8,75 [12] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (316:8,75 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (347:9,16 [14] DynamicAttributeTagHelpers.cshtml) - 
+                            CSharpExpression - (348:9,17 [13] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (348:9,17 [13] DynamicAttributeTagHelpers.cshtml) - CSharp - long.MinValue
+                        CSharpAttributeValue - (361:9,30 [45] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpStatement - (363:9,32 [12] DynamicAttributeTagHelpers.cshtml) - if (true) { 
+                            CSharpExpression - (376:9,45 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (376:9,45 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - string.Empty
+                            CSharpStatement - (388:9,57 [10] DynamicAttributeTagHelpers.cshtml) -  } else { 
+                            CSharpExpression - (399:9,68 [5] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (399:9,68 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
+                            CSharpStatement - (404:9,73 [2] DynamicAttributeTagHelpers.cshtml) -  }
+                        CSharpAttributeValue - (406:9,75 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (408:9,77 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (408:9,77 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (424:9,93 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (428:11,0 [80] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (444:11,16 [14] DynamicAttributeTagHelpers.cshtml) - 
+                            CSharpExpression - (445:11,17 [13] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (445:11,17 [13] DynamicAttributeTagHelpers.cshtml) - CSharp - long.MinValue
+                        CSharpAttributeValue - (458:11,30 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (460:11,32 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (460:11,32 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
+                        HtmlAttributeValue - (472:11,44 [7] DynamicAttributeTagHelpers.cshtml) -   - static
+                        HtmlAttributeValue - (479:11,51 [11] DynamicAttributeTagHelpers.cshtml) -      - content
+                        CSharpAttributeValue - (490:11,62 [14] DynamicAttributeTagHelpers.cshtml) -  
+                            CSharpExpression - (492:11,64 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (492:11,64 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (508:11,80 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                TagHelper - (512:13,0 [64] DynamicAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (528:13,16 [44] DynamicAttributeTagHelpers.cshtml) - 
+                            CSharpStatement - (529:13,17 [12] DynamicAttributeTagHelpers.cshtml) - if (true) { 
+                            CSharpExpression - (542:13,30 [12] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (542:13,30 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - string.Empty
+                            CSharpStatement - (554:13,42 [10] DynamicAttributeTagHelpers.cshtml) -  } else { 
+                            CSharpExpression - (565:13,53 [5] DynamicAttributeTagHelpers.cshtml)
+                                RazorIRToken - (565:13,53 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
+                            CSharpStatement - (570:13,58 [2] DynamicAttributeTagHelpers.cshtml) -  }
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,52 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyAttributeTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [15] EmptyAttributeTagHelpers.cshtml) - *, TestAssembly
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2 - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (29:0,29 [15] EmptyAttributeTagHelpers.cshtml) - \n\n<div>\n    
+                TagHelper - (44:3,4 [34] EmptyAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - 
+                    SetTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - 
+                    SetTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - 
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml) - 
+                    ExecuteTagHelpers - 
+                HtmlContent - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml) - \n    
+                TagHelper - (84:4,4 [64] EmptyAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (94:4,14 [10] EmptyAttributeTagHelpers.cshtml) - \n        
+                        TagHelper - (104:5,8 [34] EmptyAttributeTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - 
+                            SetTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - 
+                            SetTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - 
+                            AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml) - 
+                            ExecuteTagHelpers - 
+                        HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - \n    
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlContent - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - 
+                    ExecuteTagHelpers - 
+                HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml) - \n</div>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
@@ -1,0 +1,41 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyAttributeTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_0 - type -  - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - class -  - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2 - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:1,0 [13] EmptyAttributeTagHelpers.cshtml) - \n<div>\n    
+                TagHelper - (44:3,4 [34] EmptyAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                    SetTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - 
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                    ExecuteTagHelpers - 
+                HtmlContent - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml) - \n    
+                TagHelper - (84:4,4 [64] EmptyAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (94:4,14 [10] EmptyAttributeTagHelpers.cshtml) - \n        
+                        TagHelper - (104:5,8 [34] EmptyAttributeTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - 
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                            ExecuteTagHelpers - 
+                        HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - \n    
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlContent - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - 
+                    ExecuteTagHelpers - 
+                HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml) - \n</div>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,67 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EnumTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] EnumTagHelpers.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.CatchAllTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] EnumTagHelpers.cshtml) - \n\n
+                CSharpStatement - (37:2,2 [39] EnumTagHelpers.cshtml) - \n    var enumValue = MyEnum.MyValue;\n
+                HtmlContent - (79:5,0 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (81:6,0 [33] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetTagHelperProperty - (95:6,14 [15] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (96:6,15 [14] EnumTagHelpers.cshtml)
+                            RazorIRToken - (96:6,15 [14] EnumTagHelpers.cshtml) - CSharp - MyEnum.MyValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (114:6,33 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (116:7,0 [39] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (130:7,14 [21] EnumTagHelpers.cshtml) - 
+                            CSharpExpression - (131:7,15 [20] EnumTagHelpers.cshtml)
+                                RazorIRToken - (131:7,15 [20] EnumTagHelpers.cshtml) - CSharp - MyEnum.MySecondValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (155:7,39 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (157:8,0 [25] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetTagHelperProperty - (171:8,14 [7] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (171:8,14 [7] EnumTagHelpers.cshtml) - MyValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (182:8,25 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (184:9,0 [50] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetTagHelperProperty - (198:9,14 [13] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (198:9,14 [13] EnumTagHelpers.cshtml) - MySecondValue
+                    SetTagHelperProperty - (224:9,40 [7] EnumTagHelpers.cshtml) - catch-all - CatchAll - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (224:9,40 [7] EnumTagHelpers.cshtml) - MyValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (234:9,50 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (236:10,0 [51] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetTagHelperProperty - (250:10,14 [10] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (251:10,15 [9] EnumTagHelpers.cshtml)
+                            RazorIRToken - (251:10,15 [9] EnumTagHelpers.cshtml) - CSharp - enumValue
+                    SetTagHelperProperty - (273:10,37 [10] EnumTagHelpers.cshtml) - catch-all - CatchAll - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (274:10,38 [9] EnumTagHelpers.cshtml)
+                            RazorIRToken - (274:10,38 [9] EnumTagHelpers.cshtml) - CSharp - enumValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (287:10,51 [2] EnumTagHelpers.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.ir.txt
@@ -1,0 +1,60 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EnumTagHelpers_Runtime -  - 
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.CatchAllTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] EnumTagHelpers.cshtml) - \n
+                CSharpStatement - (37:2,2 [39] EnumTagHelpers.cshtml) - \n    var enumValue = MyEnum.MyValue;\n
+                HtmlContent - (79:5,0 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (81:6,0 [33] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetTagHelperProperty - (95:6,14 [15] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (96:6,15 [14] EnumTagHelpers.cshtml)
+                            RazorIRToken - (96:6,15 [14] EnumTagHelpers.cshtml) - CSharp - MyEnum.MyValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (114:6,33 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (116:7,0 [39] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (130:7,14 [21] EnumTagHelpers.cshtml) - 
+                            CSharpExpression - (131:7,15 [20] EnumTagHelpers.cshtml)
+                                RazorIRToken - (131:7,15 [20] EnumTagHelpers.cshtml) - CSharp - MyEnum.MySecondValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (155:7,39 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (157:8,0 [25] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetTagHelperProperty - (171:8,14 [7] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (171:8,14 [7] EnumTagHelpers.cshtml) - MyValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (182:8,25 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (184:9,0 [50] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetTagHelperProperty - (198:9,14 [13] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (198:9,14 [13] EnumTagHelpers.cshtml) - MySecondValue
+                    SetTagHelperProperty - (224:9,40 [7] EnumTagHelpers.cshtml) - catch-all - CatchAll - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (224:9,40 [7] EnumTagHelpers.cshtml) - MyValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (234:9,50 [2] EnumTagHelpers.cshtml) - \n
+                TagHelper - (236:10,0 [51] EnumTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    SetTagHelperProperty - (250:10,14 [10] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (251:10,15 [9] EnumTagHelpers.cshtml)
+                            RazorIRToken - (251:10,15 [9] EnumTagHelpers.cshtml) - CSharp - enumValue
+                    SetTagHelperProperty - (273:10,37 [10] EnumTagHelpers.cshtml) - catch-all - CatchAll - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (274:10,38 [9] EnumTagHelpers.cshtml)
+                            RazorIRToken - (274:10,38 [9] EnumTagHelpers.cshtml) - CSharp - enumValue
+                    ExecuteTagHelpers - 
+                HtmlContent - (287:10,51 [2] EnumTagHelpers.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,40 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EscapedTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [15] EscapedTagHelpers.cshtml) - *, TestAssembly
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (29:0,29 [5] EscapedTagHelpers.cshtml) - \n\n<
+                HtmlContent - (35:2,2 [47] EscapedTagHelpers.cshtml) - div class="randomNonTagHelperAttribute">\n    <
+                HtmlContent - (83:3,6 [22] EscapedTagHelpers.cshtml) - p class="Hello World" 
+                CSharpExpression - (106:3,29 [12] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (106:3,29 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
+                HtmlContent - (118:3,41 [12] EscapedTagHelpers.cshtml) - >\n        <
+                HtmlContent - (131:4,10 [31] EscapedTagHelpers.cshtml) - input type="text" />\n        <
+                HtmlContent - (163:5,10 [22] EscapedTagHelpers.cshtml) - em>Not a TagHelper: </
+                HtmlContent - (186:5,33 [4] EscapedTagHelpers.cshtml) - em> 
+                TagHelper - (190:5,37 [45] EscapedTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetTagHelperProperty - (203:5,50 [13] EscapedTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (204:5,51 [12] EscapedTagHelpers.cshtml)
+                            RazorIRToken - (204:5,51 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
+                    SetTagHelperProperty - (203:5,50 [13] EscapedTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (204:5,51 [12] EscapedTagHelpers.cshtml)
+                            RazorIRToken - (204:5,51 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
+                    SetTagHelperProperty - (227:5,74 [4] EscapedTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (227:5,74 [4] EscapedTagHelpers.cshtml) - true
+                    ExecuteTagHelpers - 
+                HtmlContent - (235:5,82 [8] EscapedTagHelpers.cshtml) - \n    </
+                HtmlContent - (244:6,7 [6] EscapedTagHelpers.cshtml) - p>\n</
+                HtmlContent - (251:7,3 [4] EscapedTagHelpers.cshtml) - div>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.ir.txt
@@ -1,0 +1,33 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EscapedTagHelpers_Runtime -  - 
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:1,0 [3] EscapedTagHelpers.cshtml) - \n<
+                HtmlContent - (35:2,2 [47] EscapedTagHelpers.cshtml) - div class="randomNonTagHelperAttribute">\n    <
+                HtmlContent - (83:3,6 [22] EscapedTagHelpers.cshtml) - p class="Hello World" 
+                CSharpExpression - (106:3,29 [12] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (106:3,29 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
+                HtmlContent - (118:3,41 [12] EscapedTagHelpers.cshtml) - >\n        <
+                HtmlContent - (131:4,10 [31] EscapedTagHelpers.cshtml) - input type="text" />\n        <
+                HtmlContent - (163:5,10 [22] EscapedTagHelpers.cshtml) - em>Not a TagHelper: </
+                HtmlContent - (186:5,33 [4] EscapedTagHelpers.cshtml) - em> 
+                TagHelper - (190:5,37 [45] EscapedTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetTagHelperProperty - (203:5,50 [13] EscapedTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (204:5,51 [12] EscapedTagHelpers.cshtml)
+                            RazorIRToken - (204:5,51 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
+                    SetTagHelperProperty - (203:5,50 [13] EscapedTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (204:5,51 [12] EscapedTagHelpers.cshtml)
+                            RazorIRToken - (204:5,51 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
+                    SetTagHelperProperty - (227:5,74 [4] EscapedTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (227:5,74 [4] EscapedTagHelpers.cshtml) - true
+                    ExecuteTagHelpers - 
+                HtmlContent - (235:5,82 [8] EscapedTagHelpers.cshtml) - \n    </
+                HtmlContent - (244:6,7 [6] EscapedTagHelpers.cshtml) - p>\n</
+                HtmlContent - (251:7,3 [4] EscapedTagHelpers.cshtml) - div>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.ir.txt
@@ -1,0 +1,22 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteTagHelper_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] IncompleteTagHelper.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] IncompleteTagHelper.cshtml) - \n\n
+                TagHelper - (35:2,0 [10] IncompleteTagHelper.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (45:2,10 [0] IncompleteTagHelper.cshtml) - 
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.ir.txt
@@ -1,0 +1,15 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteTagHelper_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - class -  - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] IncompleteTagHelper.cshtml) - \n
+                TagHelper - (35:2,0 [10] IncompleteTagHelper.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,71 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MinimizedTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] MinimizedTagHelpers.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.CatchAllTagHelper - TestNamespace.InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] MinimizedTagHelpers.cshtml) - \n\n
+                TagHelper - (35:2,0 [647] MinimizedTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (64:2,29 [34] MinimizedTagHelpers.cshtml) - \n    <input nottaghelper />\n    
+                        TagHelper - (98:4,4 [59] MinimizedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (112:4,18 [3] MinimizedTagHelpers.cshtml) - btn
+                            AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                            ExecuteTagHelpers - 
+                        HtmlContent - (157:5,39 [6] MinimizedTagHelpers.cshtml) - \n    
+                        TagHelper - (163:6,4 [119] MinimizedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (190:7,18 [3] MinimizedTagHelpers.cshtml) - btn
+                            AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                            AddTagHelperHtmlAttribute -  - input-unbound-required - HtmlAttributeValueStyle.Minimized
+                            SetTagHelperProperty - (273:7,101 [5] MinimizedTagHelpers.cshtml) - input-bound-required-string - BoundRequiredString - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (273:7,101 [5] MinimizedTagHelpers.cshtml) - hello
+                            ExecuteTagHelpers - 
+                        HtmlContent - (282:7,110 [6] MinimizedTagHelpers.cshtml) - \n    
+                        TagHelper - (288:8,4 [176] MinimizedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (315:9,18 [3] MinimizedTagHelpers.cshtml) - btn
+                            AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                            AddTagHelperHtmlAttribute -  - input-unbound-required - HtmlAttributeValueStyle.Minimized
+                            SetTagHelperProperty - (418:11,57 [5] MinimizedTagHelpers.cshtml) - catchall-bound-string - BoundRequiredString - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (418:11,57 [5] MinimizedTagHelpers.cshtml) - world
+                            SetTagHelperProperty - (454:11,93 [6] MinimizedTagHelpers.cshtml) - input-bound-required-string - BoundRequiredString - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (454:11,93 [6] MinimizedTagHelpers.cshtml) - hello2
+                            ExecuteTagHelpers - 
+                        HtmlContent - (464:11,103 [6] MinimizedTagHelpers.cshtml) - \n    
+                        TagHelper - (470:12,4 [206] MinimizedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (484:12,18 [3] MinimizedTagHelpers.cshtml) - btn
+                            AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (529:13,38 [5] MinimizedTagHelpers.cshtml) - hello
+                            AddTagHelperHtmlAttribute -  - input-unbound-required - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (578:14,40 [6] MinimizedTagHelpers.cshtml) - hello2
+                            AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                            SetTagHelperProperty - (667:16,40 [5] MinimizedTagHelpers.cshtml) - input-bound-required-string - BoundRequiredString - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (667:16,40 [5] MinimizedTagHelpers.cshtml) - world
+                            ExecuteTagHelpers - 
+                        HtmlContent - (676:16,49 [2] MinimizedTagHelpers.cshtml) - \n
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.ir.txt
@@ -1,0 +1,61 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MinimizedTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - class - btn - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_1 - input-bound-required-string - hello - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_2 - catchall-bound-string - world - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_3 - input-bound-required-string - hello2 - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4 - catchall-unbound-required - hello - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5 - input-unbound-required - hello2 - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_6 - input-bound-required-string - world - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.CatchAllTagHelper - TestNamespace.InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] MinimizedTagHelpers.cshtml) - \n
+                TagHelper - (35:2,0 [647] MinimizedTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (64:2,29 [34] MinimizedTagHelpers.cshtml) - \n    <input nottaghelper />\n    
+                        TagHelper - (98:4,4 [59] MinimizedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                            AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                            ExecuteTagHelpers - 
+                        HtmlContent - (157:5,39 [6] MinimizedTagHelpers.cshtml) - \n    
+                        TagHelper - (163:6,4 [119] MinimizedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                            AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                            AddTagHelperHtmlAttribute -  - input-unbound-required - HtmlAttributeValueStyle.Minimized
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - input-bound-required-string - BoundRequiredString
+                            ExecuteTagHelpers - 
+                        HtmlContent - (282:7,110 [6] MinimizedTagHelpers.cshtml) - \n    
+                        TagHelper - (288:8,4 [176] MinimizedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                            AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                            AddTagHelperHtmlAttribute -  - input-unbound-required - HtmlAttributeValueStyle.Minimized
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_2 - catchall-bound-string - BoundRequiredString
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_3 - input-bound-required-string - BoundRequiredString
+                            ExecuteTagHelpers - 
+                        HtmlContent - (464:11,103 [6] MinimizedTagHelpers.cshtml) - \n    
+                        TagHelper - (470:12,4 [206] MinimizedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
+                            AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - input-bound-required-string - BoundRequiredString
+                            ExecuteTagHelpers - 
+                        HtmlContent - (676:16,49 [2] MinimizedTagHelpers.cshtml) - \n
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,47 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedScriptTagTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] NestedScriptTagTagHelpers.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [108] NestedScriptTagTagHelpers.cshtml) - \n\n<script type="text/html">\n    <div data-animation="fade" class="randomNonTagHelperAttribute">\n        
+                TagHelper - (139:4,8 [433] NestedScriptTagTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (180:4,49 [14] NestedScriptTagTagHelpers.cshtml) - \n            
+                        CSharpStatement - (195:5,13 [46] NestedScriptTagTagHelpers.cshtml) - for(var i = 0; i < 5; i++) {\n                
+                        HtmlContent - (241:6,16 [68] NestedScriptTagTagHelpers.cshtml) - <script id="nestedScriptTag" type="text/html">\n                    
+                        TagHelper - (309:7,20 [86] NestedScriptTagTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            AddTagHelperHtmlAttribute -  - data-interval - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (331:7,42 [7] NestedScriptTagTagHelpers.cshtml) - 2000 + 
+                                CSharpExpression - (339:7,50 [23] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (339:7,50 [23] NestedScriptTagTagHelpers.cshtml) - CSharp - ViewBag.DefaultInterval
+                                HtmlContent - (362:7,73 [4] NestedScriptTagTagHelpers.cshtml) -  + 1
+                            SetTagHelperProperty - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - text
+                            SetTagHelperProperty - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - text
+                            SetTagHelperProperty - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (395:7,106 [27] NestedScriptTagTagHelpers.cshtml) - \n                </script>
+                        CSharpStatement - (422:8,25 [15] NestedScriptTagTagHelpers.cshtml) - \n            }
+                        HtmlContent - (437:9,13 [131] NestedScriptTagTagHelpers.cshtml) - \n            <script type="text/javascript">\n                var tag = '<input checked="true">';\n            </script>\n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (149:4,18 [11] NestedScriptTagTagHelpers.cshtml) - Hello World
+                    AddTagHelperHtmlAttribute -  - data-delay - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (174:4,43 [4] NestedScriptTagTagHelpers.cshtml) - 1000
+                    ExecuteTagHelpers - 
+                HtmlContent - (572:13,12 [23] NestedScriptTagTagHelpers.cshtml) - \n    </div>\n</script>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.ir.txt
@@ -1,0 +1,40 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedScriptTagTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_0 - type - text - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - data-delay - 1000 - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [106] NestedScriptTagTagHelpers.cshtml) - \n<script type="text/html">\n    <div data-animation="fade" class="randomNonTagHelperAttribute">\n        
+                TagHelper - (139:4,8 [433] NestedScriptTagTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (180:4,49 [2] NestedScriptTagTagHelpers.cshtml) - \n
+                        CSharpStatement - (182:5,0 [12] NestedScriptTagTagHelpers.cshtml) -             
+                        CSharpStatement - (195:5,13 [30] NestedScriptTagTagHelpers.cshtml) - for(var i = 0; i < 5; i++) {\n
+                        HtmlContent - (225:6,0 [84] NestedScriptTagTagHelpers.cshtml) -                 <script id="nestedScriptTag" type="text/html">\n                    
+                        TagHelper - (309:7,20 [86] NestedScriptTagTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
+                            CreateTagHelper -  - TestNamespace.InputTagHelper
+                            CreateTagHelper -  - TestNamespace.InputTagHelper2
+                            AddTagHelperHtmlAttribute -  - data-interval - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (331:7,42 [7] NestedScriptTagTagHelpers.cshtml) - 2000 + 
+                                CSharpExpression - (339:7,50 [23] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (339:7,50 [23] NestedScriptTagTagHelpers.cshtml) - CSharp - ViewBag.DefaultInterval
+                                HtmlContent - (362:7,73 [4] NestedScriptTagTagHelpers.cshtml) -  + 1
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
+                            SetTagHelperProperty - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - true
+                            ExecuteTagHelpers - 
+                        HtmlContent - (395:7,106 [29] NestedScriptTagTagHelpers.cshtml) - \n                </script>\n
+                        CSharpStatement - (424:9,0 [15] NestedScriptTagTagHelpers.cshtml) -             }\n
+                        HtmlContent - (439:10,0 [129] NestedScriptTagTagHelpers.cshtml) -             <script type="text/javascript">\n                var tag = '<input checked="true">';\n            </script>\n        
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                    ExecuteTagHelpers - 
+                HtmlContent - (572:13,12 [23] NestedScriptTagTagHelpers.cshtml) - \n    </div>\n</script>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,39 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [15] NestedTagHelpers.cshtml) - *, TestAssembly
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - SpanTagHelper - DivTagHelper - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (29:0,29 [2] NestedTagHelpers.cshtml) - \n
+                TagHelper - (31:1,0 [26] NestedTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - span - TagMode.StartTagAndEndTag
+                        HtmlContent - (46:1,15 [4] NestedTagHelpers.cshtml) - Hola
+                    CreateTagHelper -  - SpanTagHelper
+                    AddTagHelperHtmlAttribute -  - someattr - HtmlAttributeValueStyle.Minimized
+                    ExecuteTagHelpers - 
+                HtmlContent - (57:1,26 [2] NestedTagHelpers.cshtml) - \n
+                TagHelper - (59:2,0 [66] NestedTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                        HtmlContent - (78:2,19 [6] NestedTagHelpers.cshtml) - \n    
+                        TagHelper - (84:3,4 [33] NestedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - InputTagHelper
+                            SetTagHelperProperty - (97:3,17 [5] NestedTagHelpers.cshtml) - value - FooProp - HtmlAttributeValueStyle.DoubleQuotes
+                                HtmlContent - (97:3,17 [5] NestedTagHelpers.cshtml) - Hello
+                            AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.SingleQuotes
+                                HtmlContent - (109:3,29 [4] NestedTagHelpers.cshtml) - text
+                            ExecuteTagHelpers - 
+                        HtmlContent - (117:3,37 [2] NestedTagHelpers.cshtml) - \n
+                    CreateTagHelper -  - DivTagHelper
+                    AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (73:2,14 [3] NestedTagHelpers.cshtml) - foo
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.ir.txt
@@ -1,0 +1,31 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_0 - value - Hello - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - type - text - HtmlAttributeValueStyle.SingleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - unbound - foo - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - SpanTagHelper - DivTagHelper - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                TagHelper - (31:1,0 [26] NestedTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - span - TagMode.StartTagAndEndTag
+                        HtmlContent - (46:1,15 [4] NestedTagHelpers.cshtml) - Hola
+                    CreateTagHelper -  - SpanTagHelper
+                    AddTagHelperHtmlAttribute -  - someattr - HtmlAttributeValueStyle.Minimized
+                    ExecuteTagHelpers - 
+                HtmlContent - (57:1,26 [2] NestedTagHelpers.cshtml) - \n
+                TagHelper - (59:2,0 [66] NestedTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                        HtmlContent - (78:2,19 [6] NestedTagHelpers.cshtml) - \n    
+                        TagHelper - (84:3,4 [33] NestedTagHelpers.cshtml)
+                            InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                            CreateTagHelper -  - InputTagHelper
+                            SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - value - FooProp
+                            AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                            ExecuteTagHelpers - 
+                        HtmlContent - (117:3,37 [2] NestedTagHelpers.cshtml) - \n
+                    CreateTagHelper -  - DivTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,108 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_PrefixedAttributeTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] PrefixedAttributeTagHelpers.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper1 - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] PrefixedAttributeTagHelpers.cshtml) - \n\n
+                CSharpStatement - (37:2,2 [242] PrefixedAttributeTagHelpers.cshtml) - \n    var literate = "or illiterate";\n    var intDictionary = new Dictionary<string, int>\n    {\n        { "three", 3 },\n    };\n    var stringDictionary = new SortedDictionary<string, string>\n    {\n        { "name", "value" },\n    };\n
+                HtmlContent - (282:13,0 [49] PrefixedAttributeTagHelpers.cshtml) - \n<div class="randomNonTagHelperAttribute">\n    
+                TagHelper - (331:15,4 [92] PrefixedAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper1
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (344:15,17 [8] PrefixedAttributeTagHelpers.cshtml) - checkbox
+                    SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                    SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                    SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - stringDictionary
+                    SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - stringDictionary
+                    ExecuteTagHelpers - 
+                HtmlContent - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                TagHelper - (429:16,4 [103] PrefixedAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper1
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (442:16,17 [8] PrefixedAttributeTagHelpers.cshtml) - password
+                    SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                    SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                    SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                    SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                    ExecuteTagHelpers - 
+                HtmlContent - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                TagHelper - (538:17,4 [257] PrefixedAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper1
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (551:17,17 [5] PrefixedAttributeTagHelpers.cshtml) - radio
+                    SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                    SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                    SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - 98
+                    SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - 98
+                    AddTagHelperHtmlAttribute -  - int-prefix-salt - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (655:18,96 [1] PrefixedAttributeTagHelpers.cshtml) - 8
+                    SetTagHelperProperty - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - string-prefix-grabber - StringProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - string
+                    SetTagHelperProperty - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - string-prefix-grabber - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - string
+                    SetTagHelperProperty - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - string-prefix-paprika - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - another string
+                    SetTagHelperProperty - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - string-prefix-paprika - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - another string
+                    SetTagHelperProperty - (773:20,32 [19] PrefixedAttributeTagHelpers.cshtml) - string-prefix-cumin - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml) - literate 
+                        CSharpExpression - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml) - CSharp - literate
+                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - ?
+                    SetTagHelperProperty - (773:20,32 [19] PrefixedAttributeTagHelpers.cshtml) - string-prefix-cumin - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml) - literate 
+                        CSharpExpression - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml) - CSharp - literate
+                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - ?
+                    ExecuteTagHelpers - 
+                HtmlContent - (795:20,54 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                TagHelper - (801:21,4 [60] PrefixedAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper1
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - string-prefix-thyme - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - string
+                    SetTagHelperProperty - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - string-prefix-thyme - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - string
+                    ExecuteTagHelpers - 
+                HtmlContent - (861:21,64 [8] PrefixedAttributeTagHelpers.cshtml) - \n</div>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.ir.txt
@@ -1,0 +1,98 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_PrefixedAttributeTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - type - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - type - password - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - type - radio - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3 - int-prefix-salt - 8 - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_4 - string-prefix-grabber - string - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_5 - string-prefix-paprika - another string - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_6 - string-prefix-thyme - string - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.InputTagHelper1 - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] PrefixedAttributeTagHelpers.cshtml) - \n
+                CSharpStatement - (37:2,2 [242] PrefixedAttributeTagHelpers.cshtml) - \n    var literate = "or illiterate";\n    var intDictionary = new Dictionary<string, int>\n    {\n        { "three", 3 },\n    };\n    var stringDictionary = new SortedDictionary<string, string>\n    {\n        { "name", "value" },\n    };\n
+                HtmlContent - (282:13,0 [49] PrefixedAttributeTagHelpers.cshtml) - \n<div class="randomNonTagHelperAttribute">\n    
+                TagHelper - (331:15,4 [92] PrefixedAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper1
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                    SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                    SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - stringDictionary
+                    SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - stringDictionary
+                    ExecuteTagHelpers - 
+                HtmlContent - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                TagHelper - (429:16,4 [103] PrefixedAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper1
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                    SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                    SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                    SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                    SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                    ExecuteTagHelpers - 
+                HtmlContent - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                TagHelper - (538:17,4 [257] PrefixedAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper1
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                    SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                    SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                    SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - 98
+                    SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - 98
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - string-prefix-grabber - StringProperty
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - string-prefix-grabber - StringDictionaryProperty
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_5 - string-prefix-paprika - StringDictionaryProperty
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_5 - string-prefix-paprika - StringDictionaryProperty
+                    SetTagHelperProperty - (773:20,32 [19] PrefixedAttributeTagHelpers.cshtml) - string-prefix-cumin - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml) - literate 
+                        CSharpExpression - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml) - CSharp - literate
+                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - ?
+                    SetTagHelperProperty - (773:20,32 [19] PrefixedAttributeTagHelpers.cshtml) - string-prefix-cumin - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml) - literate 
+                        CSharpExpression - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml) - CSharp - literate
+                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - ?
+                    ExecuteTagHelpers - 
+                HtmlContent - (795:20,54 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                TagHelper - (801:21,4 [60] PrefixedAttributeTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper1
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - string-prefix-thyme - StringDictionaryProperty
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - string-prefix-thyme - StringDictionaryProperty
+                    ExecuteTagHelpers - 
+                HtmlContent - (861:21,64 [8] PrefixedAttributeTagHelpers.cshtml) - \n</div>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.ir.txt
@@ -1,0 +1,25 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SimpleTagHelpers_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [15] SimpleTagHelpers.cshtml) - *, TestAssembly
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (29:0,29 [27] SimpleTagHelpers.cshtml) - \n<p>Hola</p>\n<form>\n    
+                TagHelper - (56:3,4 [35] SimpleTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - InputTagHelper
+                    SetTagHelperProperty - (70:3,18 [5] SimpleTagHelpers.cshtml) - value - FooProp - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlContent - (70:3,18 [5] SimpleTagHelpers.cshtml) - Hello
+                    AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlContent - (83:3,31 [4] SimpleTagHelpers.cshtml) - text
+                    ExecuteTagHelpers - 
+                HtmlContent - (91:3,39 [9] SimpleTagHelpers.cshtml) - \n</form>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.ir.txt
@@ -1,0 +1,18 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SimpleTagHelpers_Runtime -  - 
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_0 - value - Hello - HtmlAttributeValueStyle.SingleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - type - text - HtmlAttributeValueStyle.SingleQuotes
+            DeclareTagHelperFields -  - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:1,0 [25] SimpleTagHelpers.cshtml) - <p>Hola</p>\n<form>\n    
+                TagHelper - (56:3,4 [35] SimpleTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - InputTagHelper
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - value - FooProp
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                    ExecuteTagHelpers - 
+                HtmlContent - (91:3,39 [9] SimpleTagHelpers.cshtml) - \n</form>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.ir.txt
@@ -1,0 +1,25 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelperWithNewlineBeforeAttributes_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - \n\n
+                TagHelper - (35:2,0 [53] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (73:3,34 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Body of Tag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (49:3,10 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Hello World
+                    SetTagHelperProperty - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - 1337
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.ir.txt
@@ -1,0 +1,18 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelperWithNewlineBeforeAttributes_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - \n
+                TagHelper - (35:2,0 [53] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (73:3,34 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Body of Tag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    SetTagHelperProperty - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - 1337
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.ir.txt
@@ -1,0 +1,25 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelper_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] SingleTagHelper.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] SingleTagHelper.cshtml) - \n\n
+                TagHelper - (35:2,0 [49] SingleTagHelper.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (69:2,34 [11] SingleTagHelper.cshtml) - Body of Tag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (45:2,10 [11] SingleTagHelper.cshtml) - Hello World
+                    SetTagHelperProperty - (63:2,28 [4] SingleTagHelper.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (63:2,28 [4] SingleTagHelper.cshtml) - 1337
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.ir.txt
@@ -1,0 +1,18 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelper_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] SingleTagHelper.cshtml) - \n
+                TagHelper - (35:2,0 [49] SingleTagHelper.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (69:2,34 [11] SingleTagHelper.cshtml) - Body of Tag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    SetTagHelperProperty - (63:2,28 [4] SingleTagHelper.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (63:2,28 [4] SingleTagHelper.cshtml) - 1337
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.ir.txt
@@ -1,0 +1,85 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SymbolBoundAttributes_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [15] SymbolBoundAttributes.cshtml) - *, TestAssembly
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.CatchAllTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (29:0,29 [255] SymbolBoundAttributes.cshtml) - \n\n<ul [item]="items"></ul>\n<ul [(item)]="items"></ul>\n<button (click)="doSomething()">Click Me</button>\n<button (^click)="doSomething()">Click Me</button>\n<template *something="value">\n</template>\n<div #local></div>\n<div #local="value"></div>\n\n
+                TagHelper - (284:11,0 [45] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - ul - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (302:11,18 [5] SymbolBoundAttributes.cshtml) - [item] - ListItems - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (302:11,18 [5] SymbolBoundAttributes.cshtml) - items
+                    AddTagHelperHtmlAttribute -  - [item] - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (317:11,33 [5] SymbolBoundAttributes.cshtml) - items
+                    ExecuteTagHelpers - 
+                HtmlContent - (329:11,45 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (331:12,0 [49] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - ul - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (351:12,20 [5] SymbolBoundAttributes.cshtml) - [(item)] - ArrayItems - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (351:12,20 [5] SymbolBoundAttributes.cshtml) - items
+                    AddTagHelperHtmlAttribute -  - [(item)] - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (368:12,37 [5] SymbolBoundAttributes.cshtml) - items
+                    ExecuteTagHelpers - 
+                HtmlContent - (380:12,49 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (382:13,0 [79] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - button - TagMode.StartTagAndEndTag
+                        HtmlContent - (444:13,62 [8] SymbolBoundAttributes.cshtml) - Click Me
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (405:13,23 [13] SymbolBoundAttributes.cshtml) - (click) - Event1 - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (405:13,23 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                    AddTagHelperHtmlAttribute -  - (click) - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (429:13,47 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                    ExecuteTagHelpers - 
+                HtmlContent - (461:13,79 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (463:14,0 [81] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - button - TagMode.StartTagAndEndTag
+                        HtmlContent - (527:14,64 [8] SymbolBoundAttributes.cshtml) - Click Me
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (487:14,24 [13] SymbolBoundAttributes.cshtml) - (^click) - Event2 - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (487:14,24 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                    AddTagHelperHtmlAttribute -  - (^click) - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (512:14,49 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                    ExecuteTagHelpers - 
+                HtmlContent - (544:14,81 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (546:15,0 [67] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - template - TagMode.StartTagAndEndTag
+                        HtmlContent - (600:15,54 [2] SymbolBoundAttributes.cshtml) - \n
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (574:15,28 [5] SymbolBoundAttributes.cshtml) - *something - StringProperty1 - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (574:15,28 [5] SymbolBoundAttributes.cshtml) - value
+                    AddTagHelperHtmlAttribute -  - *something - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (593:15,47 [5] SymbolBoundAttributes.cshtml) - value
+                    ExecuteTagHelpers - 
+                HtmlContent - (613:16,11 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (615:17,0 [33] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    AddTagHelperHtmlAttribute -  - #localminimized - HtmlAttributeValueStyle.Minimized
+                    ExecuteTagHelpers - 
+                HtmlContent - (648:17,33 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (650:18,0 [47] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (669:18,19 [5] SymbolBoundAttributes.cshtml) - #local - StringProperty2 - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (669:18,19 [5] SymbolBoundAttributes.cshtml) - value
+                    AddTagHelperHtmlAttribute -  - #local - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (684:18,34 [5] SymbolBoundAttributes.cshtml) - value
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.ir.txt
@@ -1,0 +1,78 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SymbolBoundAttributes_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - [item] - items - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - [(item)] - items - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - (click) - doSomething() - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3 - (^click) - doSomething() - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_4 - *something - value - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5 - *something - value - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_6 - #local - value - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7 - #local - value - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.CatchAllTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:1,0 [253] SymbolBoundAttributes.cshtml) - \n<ul [item]="items"></ul>\n<ul [(item)]="items"></ul>\n<button (click)="doSomething()">Click Me</button>\n<button (^click)="doSomething()">Click Me</button>\n<template *something="value">\n</template>\n<div #local></div>\n<div #local="value"></div>\n\n
+                TagHelper - (284:11,0 [45] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - ul - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (302:11,18 [5] SymbolBoundAttributes.cshtml) - [item] - ListItems - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (302:11,18 [5] SymbolBoundAttributes.cshtml) - items
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    ExecuteTagHelpers - 
+                HtmlContent - (329:11,45 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (331:12,0 [49] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - ul - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (351:12,20 [5] SymbolBoundAttributes.cshtml) - [(item)] - ArrayItems - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (351:12,20 [5] SymbolBoundAttributes.cshtml) - items
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                    ExecuteTagHelpers - 
+                HtmlContent - (380:12,49 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (382:13,0 [79] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - button - TagMode.StartTagAndEndTag
+                        HtmlContent - (444:13,62 [8] SymbolBoundAttributes.cshtml) - Click Me
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (405:13,23 [13] SymbolBoundAttributes.cshtml) - (click) - Event1 - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (405:13,23 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                    ExecuteTagHelpers - 
+                HtmlContent - (461:13,79 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (463:14,0 [81] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - button - TagMode.StartTagAndEndTag
+                        HtmlContent - (527:14,64 [8] SymbolBoundAttributes.cshtml) - Click Me
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetTagHelperProperty - (487:14,24 [13] SymbolBoundAttributes.cshtml) - (^click) - Event2 - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (487:14,24 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
+                    ExecuteTagHelpers - 
+                HtmlContent - (544:14,81 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (546:15,0 [67] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - template - TagMode.StartTagAndEndTag
+                        HtmlContent - (600:15,54 [2] SymbolBoundAttributes.cshtml) - \n
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - *something - StringProperty1
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
+                    ExecuteTagHelpers - 
+                HtmlContent - (613:16,11 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (615:17,0 [33] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    AddTagHelperHtmlAttribute -  - #localminimized - HtmlAttributeValueStyle.Minimized
+                    ExecuteTagHelpers - 
+                HtmlContent - (648:17,33 [2] SymbolBoundAttributes.cshtml) - \n
+                TagHelper - (650:18,0 [47] SymbolBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.CatchAllTagHelper
+                    AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - #local - StringProperty2
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.ir.txt
@@ -1,0 +1,38 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersInSection_Runtime -  - 
+            DeclareTagHelperFields -  - TestNamespace.MyTagHelper - TestNamespace.NestedTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] TagHelpersInSection.cshtml) - \n
+                CSharpStatement - (37:2,2 [31] TagHelpersInSection.cshtml) - \n    var code = "some code";\n
+                HtmlContent - (71:5,0 [2] TagHelpersInSection.cshtml) - \n
+                CSharpStatement -  - DefineSection("MySection", async () => {
+                HtmlContent - (93:6,20 [21] TagHelpersInSection.cshtml) - \n    <div>\n        
+                TagHelper - (114:8,8 [245] TagHelpersInSection.cshtml)
+                    InitializeTagHelperStructure -  - mytaghelper - TagMode.StartTagAndEndTag
+                        HtmlContent - (217:8,111 [52] TagHelpersInSection.cshtml) - \n            In None ContentBehavior.\n            
+                        TagHelper - (269:10,12 [66] TagHelpersInSection.cshtml)
+                            InitializeTagHelperStructure -  - nestedtaghelper - TagMode.StartTagAndEndTag
+                                HtmlContent - (286:10,29 [26] TagHelpersInSection.cshtml) - Some buffered values with 
+                                CSharpExpression - (313:10,56 [4] TagHelpersInSection.cshtml)
+                                    RazorIRToken - (313:10,56 [4] TagHelpersInSection.cshtml) - CSharp - code
+                            CreateTagHelper -  - TestNamespace.NestedTagHelper
+                            ExecuteTagHelpers - 
+                        HtmlContent - (335:10,78 [10] TagHelpersInSection.cshtml) - \n        
+                    CreateTagHelper -  - TestNamespace.MyTagHelper
+                    SetTagHelperProperty - (142:8,36 [27] TagHelpersInSection.cshtml) - boundproperty - BoundProperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (142:8,36 [14] TagHelpersInSection.cshtml) - Current Time: 
+                        CSharpExpression - (157:8,51 [12] TagHelpersInSection.cshtml)
+                            RazorIRToken - (157:8,51 [12] TagHelpersInSection.cshtml) - CSharp - DateTime.Now
+                    AddTagHelperHtmlAttribute -  - unboundproperty - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (188:8,82 [7] TagHelpersInSection.cshtml) -  - Current
+                        HtmlAttributeValue - (195:8,89 [6] TagHelpersInSection.cshtml) -   - Time:
+                        CSharpAttributeValue - (201:8,95 [14] TagHelpersInSection.cshtml) -  
+                            CSharpExpression - (203:8,97 [12] TagHelpersInSection.cshtml)
+                                RazorIRToken - (203:8,97 [12] TagHelpersInSection.cshtml) - CSharp - DateTime.Now
+                    ExecuteTagHelpers - 
+                HtmlContent - (359:11,22 [14] TagHelpersInSection.cshtml) - \n    </div>\n
+                CSharpStatement -  - });

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.ir.txt
@@ -1,0 +1,26 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithBoundAttributes_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [15] TagHelpersWithBoundAttributes.cshtml) - *, TestAssembly
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (29:0,29 [14] TagHelpersWithBoundAttributes.cshtml) - \n<form>\n    
+                TagHelper - (43:2,4 [34] TagHelpersWithBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - InputTagHelper
+                    SetTagHelperProperty - (56:2,17 [6] TagHelpersWithBoundAttributes.cshtml) - bound - BoundProp - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (57:2,18 [5] TagHelpersWithBoundAttributes.cshtml)
+                            RazorIRToken - (57:2,18 [5] TagHelpersWithBoundAttributes.cshtml) - CSharp - Hello
+                    AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlContent - (69:2,30 [4] TagHelpersWithBoundAttributes.cshtml) - text
+                    ExecuteTagHelpers - 
+                HtmlContent - (77:2,38 [9] TagHelpersWithBoundAttributes.cshtml) - \n</form>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.ir.txt
@@ -1,0 +1,19 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithBoundAttributes_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - type - text - HtmlAttributeValueStyle.SingleQuotes
+            DeclareTagHelperFields -  - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:1,0 [12] TagHelpersWithBoundAttributes.cshtml) - <form>\n    
+                TagHelper - (43:2,4 [34] TagHelpersWithBoundAttributes.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - InputTagHelper
+                    SetTagHelperProperty - (56:2,17 [6] TagHelpersWithBoundAttributes.cshtml) - bound - BoundProp - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (57:2,18 [5] TagHelpersWithBoundAttributes.cshtml)
+                            RazorIRToken - (57:2,18 [5] TagHelpersWithBoundAttributes.cshtml) - CSharp - Hello
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    ExecuteTagHelpers - 
+                HtmlContent - (77:2,38 [9] TagHelpersWithBoundAttributes.cshtml) - \n</form>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.ir.txt
@@ -1,0 +1,28 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithPrefix_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [15] TagHelpersWithPrefix.cshtml) - *, TestAssembly
+                DirectiveToken - (48:1,17 [5] TagHelpersWithPrefix.cshtml) - cool:
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (29:0,29 [2] TagHelpersWithPrefix.cshtml) - \n
+                HtmlContent - (53:1,22 [14] TagHelpersWithPrefix.cshtml) - \n<form>\n    
+                TagHelper - (67:3,4 [39] TagHelpersWithPrefix.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - InputTagHelper
+                    SetTagHelperProperty - (85:3,22 [6] TagHelpersWithPrefix.cshtml) - bound - BoundProp - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (86:3,23 [5] TagHelpersWithPrefix.cshtml)
+                            RazorIRToken - (86:3,23 [5] TagHelpersWithPrefix.cshtml) - CSharp - Hello
+                    AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlContent - (98:3,35 [4] TagHelpersWithPrefix.cshtml) - text
+                    ExecuteTagHelpers - 
+                HtmlContent - (106:3,43 [9] TagHelpersWithPrefix.cshtml) - \n</form>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.ir.txt
@@ -1,0 +1,19 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithPrefix_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - type - text - HtmlAttributeValueStyle.SingleQuotes
+            DeclareTagHelperFields -  - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (55:2,0 [12] TagHelpersWithPrefix.cshtml) - <form>\n    
+                TagHelper - (67:3,4 [39] TagHelpersWithPrefix.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - InputTagHelper
+                    SetTagHelperProperty - (85:3,22 [6] TagHelpersWithPrefix.cshtml) - bound - BoundProp - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (86:3,23 [5] TagHelpersWithPrefix.cshtml)
+                            RazorIRToken - (86:3,23 [5] TagHelpersWithPrefix.cshtml) - CSharp - Hello
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    ExecuteTagHelpers - 
+                HtmlContent - (106:3,43 [9] TagHelpersWithPrefix.cshtml) - \n</form>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.ir.txt
@@ -1,0 +1,61 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithWeirdlySpacedAttributes_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] TagHelpersWithWeirdlySpacedAttributes.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                TagHelper - (35:2,0 [85] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (105:6,25 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Body of Tag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (54:5,1 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Hello World
+                    SetTagHelperProperty - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - 1337
+                    AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - true
+                    ExecuteTagHelpers - 
+                HtmlContent - (120:6,40 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                TagHelper - (124:8,0 [47] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetTagHelperProperty - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlContent - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - text
+                    SetTagHelperProperty - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlContent - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - text
+                    AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (162:8,38 [5] TagHelpersWithWeirdlySpacedAttributes.cshtml) - hello
+                    ExecuteTagHelpers - 
+                HtmlContent - (171:8,47 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                TagHelper - (175:10,0 [46] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - 1234
+                    AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.SingleQuotes
+                        HtmlContent - (209:11,3 [6] TagHelpersWithWeirdlySpacedAttributes.cshtml) - hello2
+                    ExecuteTagHelpers - 
+                HtmlContent - (221:11,15 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                TagHelper - (225:13,0 [51] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetTagHelperProperty - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - password
+                    SetTagHelperProperty - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - password
+                    AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (270:14,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - blah
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.ir.txt
@@ -1,0 +1,52 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithWeirdlySpacedAttributes_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_1 - type - text - HtmlAttributeValueStyle.SingleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - data-content - hello - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3 - data-content - hello2 - HtmlAttributeValueStyle.SingleQuotes
+            DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_4 - type - password - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5 - data-content - blah - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n
+                TagHelper - (35:2,0 [85] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (105:6,25 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Body of Tag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    SetTagHelperProperty - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - 1337
+                    AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - true
+                    ExecuteTagHelpers - 
+                HtmlContent - (120:6,40 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                TagHelper - (124:8,0 [47] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                    ExecuteTagHelpers - 
+                HtmlContent - (171:8,47 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                TagHelper - (175:10,0 [46] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - 1234
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
+                    ExecuteTagHelpers - 
+                HtmlContent - (221:11,15 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                TagHelper - (225:13,0 [51] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                    CreateTagHelper -  - TestNamespace.InputTagHelper
+                    CreateTagHelper -  - TestNamespace.InputTagHelper2
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
+                    SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
+                    ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.ir.txt
@@ -1,0 +1,89 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TransitionsInTagHelperAttributes_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement -  - #pragma warning disable 219
+                CSharpStatement -  - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] TransitionsInTagHelperAttributes.cshtml) - "*, TestAssembly"
+                CSharpStatement -  - }
+                CSharpStatement -  - #pragma warning restore 219
+            CSharpStatement -  - private static System.Object __o = null;
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                CSharpStatement - (35:1,2 [59] TransitionsInTagHelperAttributes.cshtml) -  \n    var @class = "container-fluid";\n    var @int = 1;\n
+                HtmlContent - (97:5,0 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (99:6,0 [44] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (128:6,29 [11] TransitionsInTagHelperAttributes.cshtml) - Body of Tag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (109:6,10 [6] TransitionsInTagHelperAttributes.cshtml) - 
+                    SetTagHelperProperty - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - 1337
+                    ExecuteTagHelpers - 
+                HtmlContent - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (145:7,0 [34] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (155:7,10 [9] TransitionsInTagHelperAttributes.cshtml) - 
+                            CSharpExpression - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
+                    SetTagHelperProperty - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - 42
+                    ExecuteTagHelpers - 
+                HtmlContent - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (181:8,0 [36] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (191:8,10 [4] TransitionsInTagHelperAttributes.cshtml) - test
+                    SetTagHelperProperty - (202:8,21 [9] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (202:8,21 [5] TransitionsInTagHelperAttributes.cshtml) - 42 + 
+                        CSharpExpression - (207:8,26 [4] TransitionsInTagHelperAttributes.cshtml)
+                            HtmlContent - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - @
+                            RazorIRToken - (208:8,27 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
+                    ExecuteTagHelpers - 
+                HtmlContent - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (219:9,0 [31] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (229:9,10 [4] TransitionsInTagHelperAttributes.cshtml) - test
+                    SetTagHelperProperty - (240:9,21 [4] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (241:9,22 [3] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (241:9,22 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
+                    ExecuteTagHelpers - 
+                HtmlContent - (250:9,31 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (252:10,0 [34] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (262:10,10 [4] TransitionsInTagHelperAttributes.cshtml) - test
+                    SetTagHelperProperty - (273:10,21 [7] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (274:10,22 [6] TransitionsInTagHelperAttributes.cshtml)
+                            HtmlContent - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - (
+                            RazorIRToken - (275:10,23 [4] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int
+                            HtmlContent - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - )
+                    ExecuteTagHelpers - 
+                HtmlContent - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (288:11,0 [54] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (298:11,10 [7] TransitionsInTagHelperAttributes.cshtml) -  - custom-
+                        CSharpAttributeValue - (305:11,17 [9] TransitionsInTagHelperAttributes.cshtml) - 
+                            CSharpExpression - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
+                    SetTagHelperProperty - (321:11,33 [15] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (321:11,33 [4] TransitionsInTagHelperAttributes.cshtml) - 4 * 
+                        CSharpExpression - (325:11,37 [11] TransitionsInTagHelperAttributes.cshtml)
+                            HtmlContent - (325:11,37 [2] TransitionsInTagHelperAttributes.cshtml) - @(
+                            RazorIRToken - (327:11,39 [8] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int + 2
+                            HtmlContent - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - )
+                    ExecuteTagHelpers - 
+                HtmlContent - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.ir.txt
@@ -1,0 +1,79 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TransitionsInTagHelperAttributes_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - class - test - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - TestNamespace.PTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (35:1,2 [59] TransitionsInTagHelperAttributes.cshtml) -  \n    var @class = "container-fluid";\n    var @int = 1;\n
+                HtmlContent - (97:5,0 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (99:6,0 [44] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (128:6,29 [11] TransitionsInTagHelperAttributes.cshtml) - Body of Tag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (109:6,10 [6] TransitionsInTagHelperAttributes.cshtml) - 
+                    SetTagHelperProperty - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - 1337
+                    ExecuteTagHelpers - 
+                HtmlContent - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (145:7,0 [34] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpAttributeValue - (155:7,10 [9] TransitionsInTagHelperAttributes.cshtml) - 
+                            CSharpExpression - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
+                    SetTagHelperProperty - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - 42
+                    ExecuteTagHelpers - 
+                HtmlContent - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (181:8,0 [36] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    SetTagHelperProperty - (202:8,21 [9] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (202:8,21 [5] TransitionsInTagHelperAttributes.cshtml) - 42 + 
+                        CSharpExpression - (207:8,26 [4] TransitionsInTagHelperAttributes.cshtml)
+                            HtmlContent - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - @
+                            RazorIRToken - (208:8,27 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
+                    ExecuteTagHelpers - 
+                HtmlContent - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (219:9,0 [31] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    SetTagHelperProperty - (240:9,21 [4] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (241:9,22 [3] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (241:9,22 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
+                    ExecuteTagHelpers - 
+                HtmlContent - (250:9,31 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (252:10,0 [34] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                    SetTagHelperProperty - (273:10,21 [7] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (274:10,22 [6] TransitionsInTagHelperAttributes.cshtml)
+                            HtmlContent - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - (
+                            RazorIRToken - (275:10,23 [4] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int
+                            HtmlContent - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - )
+                    ExecuteTagHelpers - 
+                HtmlContent - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                TagHelper - (288:11,0 [54] TransitionsInTagHelperAttributes.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlAttributeValue - (298:11,10 [7] TransitionsInTagHelperAttributes.cshtml) -  - custom-
+                        CSharpAttributeValue - (305:11,17 [9] TransitionsInTagHelperAttributes.cshtml) - 
+                            CSharpExpression - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
+                    SetTagHelperProperty - (321:11,33 [15] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (321:11,33 [4] TransitionsInTagHelperAttributes.cshtml) - 4 * 
+                        CSharpExpression - (325:11,37 [11] TransitionsInTagHelperAttributes.cshtml)
+                            HtmlContent - (325:11,37 [2] TransitionsInTagHelperAttributes.cshtml) - @(
+                            RazorIRToken - (327:11,39 [8] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int + 2
+                            HtmlContent - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - )
+                    ExecuteTagHelpers - 
+                HtmlContent - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml) - \n


### PR DESCRIPTION
This will make is much easier to investigate failures that bubble up to
the codegen level. You'll be able to see if there was a change to the IR
rather than just the final code.