### PR TITLE
Fixing support for XML docs in OOP

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperResolver.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperResolver.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Evolution;
 using Microsoft.AspNetCore.Razor.Evolution.Legacy;
-using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Razor
 {

--- a/src/Microsoft.CodeAnalysis.Razor/XmlMemberDocumentation.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/XmlMemberDocumentation.cs
@@ -23,9 +23,8 @@ namespace Microsoft.CodeAnalysis.Razor
             }
 
             // the structure of the XML is defined by: https://msdn.microsoft.com/en-us/library/fsbx0t7x.aspx
-            // we expect the root node of the content we are passed to always be 'member'.
+            // we expect the root node of the content we are passed to always be 'member' or 'doc'.
             _element = XElement.Parse(content);
-            Debug.Assert(_element.Name == "member");
         }
 
         /// <summary>


### PR DESCRIPTION
The issue here is that the OOP host doesn't yet have support for
documentation, it will just return null. Fixing this code to look for the
documentation after we get the descriptors back into VS.

I tested this and confirmed that it works with TagHelpers in dlls + xml
file documentation as well as TagHelpers compiled in the project itself.