### PR TITLE
Optimize memory et performance of HtmlContentIRNode.Content

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelExpressionPass.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelExpressionPass.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                         builder.Add(new RazorIRToken()
                         {
                             Kind = RazorIRToken.TokenKind.CSharp,
-                            Content = original.Content,
+                            Content = original.Content.ToString(),
                             Source = original.Source,
                         });
                     }
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                                 builder.Add(new RazorIRToken()
                                 {
                                     Kind = RazorIRToken.TokenKind.CSharp,
-                                    Content = html.Content,
+                                    Content = html.Content.ToString(),
                                     Source = html.Source,
                                 });
                             }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
@@ -234,7 +234,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
                     var htmlNode = node.Children.First() as HtmlContentIRNode;
                     if (htmlNode != null)
                     {
-                        Context.Writer.WriteStringLiteral(htmlNode.Content);
+                        Context.Writer.WriteStringLiteral(htmlNode.Content.ToString());
                     }
                 }
                 else
@@ -321,7 +321,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
                     Context.AddLineMappingFor(node);
                 }
 
-                Context.Writer.Write(((HtmlContentIRNode)node).Content);
+                Context.Writer.Write(((HtmlContentIRNode)node).Content.ToString());
             }
             else if (node is RazorIRToken token && token.IsCSharp)
             {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/RuntimeCSharpRenderer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/RuntimeCSharpRenderer.cs
@@ -44,12 +44,12 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
                 string textToRender;
                 if (node.Content.Length <= MaxStringLiteralLength)
                 {
-                    textToRender = node.Content;
+                    textToRender = node.Content.ToString();
                 }
                 else
                 {
                     var charactersToSubstring = Math.Min(MaxStringLiteralLength, node.Content.Length - charactersConsumed);
-                    textToRender = node.Content.Substring(charactersConsumed, charactersToSubstring);
+                    textToRender = node.Content.ToString(charactersConsumed, charactersToSubstring);
                 }
 
                 Context.Writer
@@ -667,7 +667,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
             }
             else if (node is HtmlContentIRNode)
             {
-                Context.Writer.Write(((HtmlContentIRNode)node).Content);
+                Context.Writer.Write(((HtmlContentIRNode)node).Content.ToString());
             }
             else if (node is RazorIRToken token && token.IsCSharp)
             {

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
@@ -440,7 +440,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             }
             private void Combine(HtmlContentIRNode node, Span span)
             {
-                node.Content.Append(span.Content);
+                node.Content.Append(span.Content); // Perf: using StringBuilder.Append() is far more performant than string '+' operator for large HTML sequences
                 if (node.Source != null)
                 {
                     Debug.Assert(node.Source.Value.FilePath != null);

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Microsoft.AspNetCore.Razor.Evolution.Intermediate;
 using Microsoft.AspNetCore.Razor.Evolution.Legacy;
 
@@ -433,13 +434,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
                 _builder.Add(new HtmlContentIRNode()
                 {
-                    Content = span.Content,
+                    Content = new StringBuilder(span.Content),
                     Source = BuildSourceSpanFromNode(span),
                 });
             }
             private void Combine(HtmlContentIRNode node, Span span)
             {
-                node.Content = node.Content + span.Content;
+                node.Content.Append(span.Content);
                 if (node.Source != null)
                 {
                     Debug.Assert(node.Source.Value.FilePath != null);

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlContentIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Intermediate/HtmlContentIRNode.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
 {
     public sealed class HtmlContentIRNode : RazorIRNode
     {
-        public string Content { get; set; }
+        public StringBuilder Content { get; set; }
 
         public override IList<RazorIRNode> Children { get; } = EmptyArray;
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/RazorPreallocatedTagHelperAttributeOptimizationPass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/RazorPreallocatedTagHelperAttributeOptimizationPass.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                     return;
                 }
 
-                var plainTextValue = (node.Children.First() as HtmlContentIRNode).Content;
+                var plainTextValue = (node.Children.First() as HtmlContentIRNode).Content.ToString();
                 DeclarePreallocatedTagHelperHtmlAttributeIRNode declaration = null;
 
                 for (var i = 0; i < _classDeclaration.Children.Count; i++)
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                     return;
                 }
 
-                var plainTextValue = (node.Children.First() as HtmlContentIRNode).Content;
+                var plainTextValue = (node.Children.First() as HtmlContentIRNode).Content.ToString();
 
                 DeclarePreallocatedTagHelperAttributeIRNode declaration = null;
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelExpressionPassTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelExpressionPassTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             var setProperty = tagHelper.Children.OfType<SetTagHelperPropertyIRNode>().Single();
 
             var child = Assert.IsType<HtmlContentIRNode>(Assert.Single(setProperty.Children));
-            Assert.Equal("17", child.Content);
+            Assert.Equal("17", child.Content.ToString());
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/DefaultInstrumentationPassTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/DefaultInstrumentationPassTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text;
 using Microsoft.AspNetCore.Razor.Evolution.Intermediate;
 using Xunit;
 using static Microsoft.AspNetCore.Razor.Evolution.Intermediate.RazorIRAssert;
@@ -16,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             var builder = RazorIRBuilder.Document();
             builder.Add(new HtmlContentIRNode()
             {
-                Content = "Hi",
+                Content = new StringBuilder("Hi"),
                 Source = CreateSource(1),
             });
 
@@ -42,7 +43,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             var builder = RazorIRBuilder.Document();
             builder.Add(new HtmlContentIRNode()
             {
-                Content = "Hi",
+                Content = new StringBuilder("Hi"),
             });
 
             var irDocument = (DocumentIRNode)builder.Build();

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/RazorIRNodeWriter.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
 
         public override void VisitHtml(HtmlContentIRNode node)
         {
-            WriteContentNode(node, node.Content);
+            WriteContentNode(node, node.Content.ToString());
         }
 
         public override void VisitHtmlAttribute(HtmlAttributeIRNode node)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/RazorIRAssert.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Intermediate/RazorIRAssert.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Intermediate
             try
             {
                 var html = Assert.IsType<HtmlContentIRNode>(node);
-                Assert.Equal(expected, html.Content);
+                Assert.Equal(expected, html.Content.ToString());
             }
             catch (XunitException e)
             {


### PR DESCRIPTION
It changes the `HtmlContentIRNode.Content` property type from `string` to `StringBuilder`.
A test with large pages like [this](https://github.com/aspnet/Performance/blob/dev/testapp/LargePageMvc/Views/Home/Index.cshtml) shows a big performance improvement, because it allows to concatenate content instead of creating new strings in `DefaultRazorIRLoweringPhase.MainSourceVisitor.Combine`.
On my computer, compilation of a page takes now ~1 second when it was taking ~22 seconds (!) before...