### PR TITLE
[Design] Add workspace monitoring for Roslyn APIs.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/WorkspaceMonitor.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/WorkspaceMonitor.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    public class WorkspaceMonitor
+    {
+        private readonly Workspace _workspace;
+
+        public WorkspaceMonitor(Workspace workspace)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            _workspace = workspace;
+
+            _workspace.WorkspaceChanged += OnWorkspaceChanged;
+        }
+
+        public event Action TagHelperFileChanged;
+
+        public event Action ReferencesChanged;
+
+        private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs args)
+        {
+            switch (args.Kind)
+            {
+                case WorkspaceChangeKind.DocumentAdded:
+                case WorkspaceChangeKind.DocumentChanged:
+                    var document = _workspace.CurrentSolution.GetDocument(args.DocumentId);
+                    var filePath = document?.FilePath;
+
+                    if (filePath != null &&
+                        filePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) &&
+                        filePath.IndexOf("TagHelper", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        TagHelperFileChanged?.Invoke();
+                    }
+                    break;
+
+                case WorkspaceChangeKind.ProjectChanged:
+                    var change = args.NewSolution.GetChanges(args.OldSolution);
+                    foreach (var projectChange in change.GetProjectChanges())
+                    {
+                        if (projectChange.GetAddedMetadataReferences().Any() ||
+                            projectChange.GetAddedProjectReferences().Any() ||
+                            projectChange.GetRemovedMetadataReferences().Any() ||
+                            projectChange.GetRemovedProjectReferences().Any())
+                        {
+                            ReferencesChanged?.Invoke();
+                        }
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/WorkspaceMonitorProvider.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/WorkspaceMonitorProvider.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    public class WorkspaceMonitorProvider
+    {
+        private readonly List<WorkspaceMonitorEntry> _workspaceMonitorEntries;
+
+        public WorkspaceMonitorProvider()
+        {
+            _workspaceMonitorEntries = new List<WorkspaceMonitorEntry>();
+        }
+
+        public WorkspaceMonitor GetWorkspaceMonitor(Workspace workspace)
+        {
+            var entry = GetEntry(workspace);
+
+            entry.MonitorRequestCount++;
+
+            return entry.Monitor;
+        }
+
+        public WorkspaceMonitor StopMonitoring(Workspace workspace)
+        {
+            var entry = GetEntry(workspace);
+
+            entry.MonitorRequestCount--;
+
+            if (entry.MonitorRequestCount == 0)
+            {
+                _workspaceMonitorEntries.Remove(entry);
+            }
+
+            return entry.Monitor;
+        }
+
+        private WorkspaceMonitorEntry GetEntry(Workspace workspace)
+        {
+            var entry = _workspaceMonitorEntries.FirstOrDefault(e => e.Workspace == workspace);
+            if (entry == null)
+            {
+                entry = new WorkspaceMonitorEntry(workspace);
+                _workspaceMonitorEntries.Add(entry);
+            }
+
+            return entry;
+        }
+
+        private class WorkspaceMonitorEntry
+        {
+            public WorkspaceMonitorEntry(Workspace workspace)
+            {
+                Workspace = workspace;
+                Monitor = new WorkspaceMonitor(workspace);
+            }
+
+            public int MonitorRequestCount { get; set; }
+
+            public Workspace Workspace { get; }
+
+            public WorkspaceMonitor Monitor { get; }
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/WorkspaceRegistrationMonitor.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/WorkspaceRegistrationMonitor.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    public class WorkspaceRegistrationMonitor
+    {
+        private readonly WorkspaceRegistration _registration;
+        private Workspace _workspace;
+
+        public WorkspaceRegistrationMonitor(WorkspaceRegistration registration)
+        {
+            _registration = registration;
+
+            _registration.WorkspaceChanged += OnWorkspaceRegistrationChanged;
+        }
+
+        public event Action<Workspace> ConnectedToWorkspace;
+
+        public event Action<Workspace> DisconnectedFromWorkspace;
+
+        private void OnWorkspaceRegistrationChanged(object sender, EventArgs e)
+        {
+            if (_workspace != null)
+            {
+                DisconnectedFromWorkspace?.Invoke(_workspace);
+            }
+
+            if (_registration.Workspace != null)
+            {
+                _workspace = _registration.Workspace;
+                ConnectedToWorkspace?.Invoke(_workspace);
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/WorkspaceRegistrationMonitorProvider.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/WorkspaceRegistrationMonitorProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    public class WorkspaceRegistrationMonitorProvider
+    {
+        public WorkspaceRegistrationMonitor GetRegistrationMonitor(SourceTextContainer documentsRoslynBuffer)
+        {
+            var workspaceRegistration = Workspace.GetWorkspaceRegistration(documentsRoslynBuffer);
+            var registrationMonitor = new WorkspaceRegistrationMonitor(workspaceRegistration);
+
+            return registrationMonitor;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/IRazorEditorWorkerProvider.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/IRazorEditorWorkerProvider.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public interface IRazorEditorWorkerProvider
+    {
+        RazorEditorWorker GetWorker(ITextBuffer documentBuffer);
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorEditorWorker.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorEditorWorker.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public class RazorEditorWorker
+    {
+        public event Action TagHelpersChanged;
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorEditorWorkerProvider.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorEditorWorkerProvider.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [Export(typeof(IRazorEditorWorkerProvider))]
+    public class RazorEditorWorkerProvider : IRazorEditorWorkerProvider
+    {
+        private readonly WorkspaceRegistrationMonitorProvider _workspaceProvider;
+        private readonly WorkspaceMonitorProvider _workspaceMonitorProvider;
+
+        public RazorEditorWorkerProvider()
+        {
+            _workspaceProvider = new WorkspaceRegistrationMonitorProvider();
+            _workspaceMonitorProvider = new WorkspaceMonitorProvider();
+        }
+
+        public RazorEditorWorker GetWorker(ITextBuffer documentBuffer)
+        {
+            var roslynBuffer = GetRoslynBuffer(documentBuffer);
+            var editorWorker = new RazorEditorWorker();
+
+            var registrationMonitor = _workspaceProvider.GetRegistrationMonitor(roslynBuffer);
+            registrationMonitor.ConnectedToWorkspace += workspace =>
+            {
+                var workspaceMonitor = _workspaceMonitorProvider.GetWorkspaceMonitor(workspace);
+
+                workspaceMonitor.TagHelperFileChanged += OnTagHelpersChanged;
+                workspaceMonitor.ReferencesChanged += OnTagHelpersChanged;
+            };
+            registrationMonitor.DisconnectedFromWorkspace += workspace =>
+            {
+                var workspaceMonitor = _workspaceMonitorProvider.StopMonitoring(workspace);
+
+                workspaceMonitor.TagHelperFileChanged -= OnTagHelpersChanged;
+                workspaceMonitor.ReferencesChanged -= OnTagHelpersChanged;
+            };
+
+            void OnTagHelpersChanged()
+            {
+                editorWorker.TagHelpersChanged?.Invoke();
+            }
+
+            return editorWorker;
+        }
+
+        private SourceTextContainer GetRoslynBuffer(ITextBuffer documentBuffer)
+        {
+            // Need to design a better approach of extracting the roslyn buffer from the document buffer.
+            var roslynBufferProvider = (Func<SourceTextContainer>)documentBuffer.Properties["RoslynBufferProvider"];
+            var roslynBuffer = roslynBufferProvider();
+
+            return roslynBuffer;
+        }
+    }
+}


### PR DESCRIPTION
- Added tracking of TagHelper files and project reference changes. Explored other tracking options and found that these were the minimum bar.
- This does not include build tracking.

#852