### PR TITLE
Fix absolute path handling.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/RazorProject.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/RazorProject.cs
@@ -59,8 +59,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         /// </remarks>
         public virtual IEnumerable<RazorProjectItem> FindHierarchicalItems(string basePath, string path, string fileName)
         {
-            EnsureValidPath(basePath);
-            EnsureValidPath(path);
+            basePath = NormalizeAndEnsureValidPath(basePath);
+            path = NormalizeAndEnsureValidPath(path);
             if (string.IsNullOrEmpty(fileName))
             {
                 throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(fileName));
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         /// Performs validation for paths passed to methods of <see cref="RazorProject"/>.
         /// </summary>
         /// <param name="path">The path to validate.</param>
-        protected virtual void EnsureValidPath(string path)
+        protected virtual string NormalizeAndEnsureValidPath(string path)
         {
             if (string.IsNullOrEmpty(path))
             {
@@ -120,6 +120,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             {
                 throw new ArgumentException(Resources.RazorProject_PathMustStartWithForwardSlash, nameof(path));
             }
+
+            return path;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/RazorProjectTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/RazorProjectTest.cs
@@ -11,30 +11,43 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 {
     public class RazorProjectTest
     {
+        [Fact]
+        public void NormalizeAndEnsureValidPath_DoesNotModifyPath()
+        {
+            // Arrange
+            var project = new TestRazorProject(new Dictionary<string, RazorProjectItem>());
+
+            // Act
+            var path = project.NormalizeAndEnsureValidPath("/Views/Home/Index.cshtml");
+
+            // Assert
+            Assert.Equal("/Views/Home/Index.cshtml", path);
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void EnsureValidPath_ThrowsIfPathIsNullOrEmpty(string path)
+        public void NormalizeAndEnsureValidPath_ThrowsIfPathIsNullOrEmpty(string path)
         {
             // Arrange
             var project = new TestRazorProject(new Dictionary<string, RazorProjectItem>());
 
             // Act and Assert
-            ExceptionAssert.ThrowsArgumentNullOrEmptyString(() => project.EnsureValidPath(path), "path");
+            ExceptionAssert.ThrowsArgumentNullOrEmptyString(() => project.NormalizeAndEnsureValidPath(path), "path");
         }
 
         [Theory]
         [InlineData("foo")]
         [InlineData("~/foo")]
         [InlineData("\\foo")]
-        public void EnsureValidPath_ThrowsIfPathDoesNotStartWithForwardSlash(string path)
+        public void NormalizeAndEnsureValidPath_ThrowsIfPathDoesNotStartWithForwardSlash(string path)
         {
             // Arrange
             var project = new TestRazorProject(new Dictionary<string, RazorProjectItem>());
 
             // Act and Assert
             ExceptionAssert.ThrowsArgument(
-                () => project.EnsureValidPath(path),
+                () => project.NormalizeAndEnsureValidPath(path),
                 "path",
                 "Path must begin with a forward slash '/'.");
         }
@@ -338,7 +351,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 return item;
             }
 
-            public new void EnsureValidPath(string path) => base.EnsureValidPath(path);
+            public new string NormalizeAndEnsureValidPath(string path) => base.NormalizeAndEnsureValidPath(path);
         }
     }
 }


### PR DESCRIPTION
- Normalize paths to be absolute and to also use forward slashes.
- Updated our `EnsureValidPath` method to be `NormalizeAndEnsureValidPath`.

#1106