### PR TITLE
Add DisplayName to RequiredAttributeDescriptor.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/RequiredAttributeDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/RequiredAttributeDescriptorComparer.cs
@@ -63,6 +63,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
                 descriptorX.ValueComparison == descriptorY.ValueComparison &&
                 string.Equals(descriptorX.Name, descriptorY.Name, _stringComparison) &&
                 string.Equals(descriptorX.Value, descriptorY.Value, StringComparison.Ordinal) &&
+                string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal) &&
                 Enumerable.SequenceEqual(descriptorX.Diagnostics, descriptorY.Diagnostics);
         }
 
@@ -74,6 +75,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             hashCodeCombiner.Add(descriptor.ValueComparison);
             hashCodeCombiner.Add(descriptor.Name, _stringComparer);
             hashCodeCombiner.Add(descriptor.Value, StringComparer.Ordinal);
+            hashCodeCombiner.Add(descriptor.DisplayName, StringComparer.Ordinal);
 
             return hashCodeCombiner.CombinedHash;
         }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/RequiredAttributeDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/RequiredAttributeDescriptor.cs
@@ -18,6 +18,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
         public ValueComparisonMode ValueComparison { get; protected set; }
 
+        public string DisplayName { get; protected set; }
+
         public IReadOnlyList<RazorDiagnostic> Diagnostics { get; protected set; }
 
         public bool HasAnyErrors

--- a/src/Microsoft.AspNetCore.Razor.Evolution/RequiredAttributeDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/RequiredAttributeDescriptorBuilder.cs
@@ -72,11 +72,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 diagnostics.UnionWith(_diagnostics);
             }
 
+            var displayName = _nameComparison == RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch ? string.Concat(_name, "...") : _name;
             var rule = new DefaultTagHelperRequiredAttributeDescriptor(
                 _name,
                 _nameComparison,
                 _value,
                 _valueComparison,
+                displayName,
                 diagnostics);
 
             return rule;
@@ -128,12 +130,14 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 NameComparisonMode nameComparison,
                 string value,
                 ValueComparisonMode valueComparison,
+                string displayName,
                 IEnumerable<RazorDiagnostic> diagnostics)
             {
                 Name = name;
                 NameComparison = nameComparison;
                 Value = value;
                 ValueComparison = valueComparison;
+                DisplayName = displayName;
                 Diagnostics = new List<RazorDiagnostic>(diagnostics);
             }
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TagHelperRequiredAttributeDescriptorBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TagHelperRequiredAttributeDescriptorBuilderTest.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    public class TagHelperRequiredAttributeDescriptorBuilderTest
+    {
+        [Fact]
+        public void Build_DisplayNameIsName_NameComparisonFullMatch()
+        {
+            // Arrange
+            var descriptorBuilder = RequiredAttributeDescriptorBuilder.Create()
+                .Name("asp-action")
+                .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch);
+
+            // Act
+            var descriptor = descriptorBuilder.Build();
+
+            // Assert
+            Assert.Equal("asp-action", descriptor.DisplayName);
+        }
+
+        [Fact]
+        public void Build_DisplayNameIsNameWithDots_NameComparisonPrefixMatch()
+        {
+            // Arrange
+            var descriptorBuilder = RequiredAttributeDescriptorBuilder.Create()
+                .Name("asp-route-")
+                .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch);
+
+            // Act
+            var descriptor = descriptorBuilder.Build();
+
+            // Assert
+            Assert.Equal("asp-route-...", descriptor.DisplayName);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TagHelperRequiredAttributeDescriptorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TagHelperRequiredAttributeDescriptorTest.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Evolution
 {


### PR DESCRIPTION
- When `RequiredAttributeDescriptor`s are displayed in an editor their display name differs based on their name comparison mode. If their name comparison mode happens to be a prefix match then we need to append three dots to indicate that it's a required prefix for an attribute.
- Added a new descriptor builder test to validate `DisplayName` is created correctly.

#1119