### PR TITLE
Make the parser options configurable

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorDirectiveFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorDirectiveFeature.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Evolution
 {
-    internal class DefaultRazorDirectiveFeature : IRazorDirectiveFeature, IRazorConfigureParserFeature
+    internal class DefaultRazorDirectiveFeature : IRazorDirectiveFeature, IRazorParserOptionsFeature
     {
         public ICollection<DirectiveDescriptor> Directives { get; } = new List<DirectiveDescriptor>();
 
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
         public int Order => 100;
 
-        void IRazorConfigureParserFeature.Configure(RazorParserOptions options)
+        void IRazorParserOptionsFeature.Configure(RazorParserOptions options)
         {
             options.Directives.Clear();
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorParsingPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorParsingPhase.cs
@@ -7,11 +7,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 {
     internal class DefaultRazorParsingPhase : RazorEnginePhaseBase, IRazorParsingPhase
     {
-        private IRazorConfigureParserFeature[] _parserOptionsCallbacks;
+        private IRazorParserOptionsFeature[] _parserOptionsCallbacks;
 
         protected override void OnIntialized()
         {
-            _parserOptionsCallbacks = Engine.Features.OfType<IRazorConfigureParserFeature>().ToArray();
+            _parserOptionsCallbacks = Engine.Features.OfType<IRazorParserOptionsFeature>().ToArray();
         }
 
         protected override void ExecuteCore(RazorCodeDocument codeDocument)

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DesignTimeParserOptionsFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DesignTimeParserOptionsFeature.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Evolution
+{
+    internal class DesignTimeParserOptionsFeature : IRazorParserOptionsFeature
+    {
+        public RazorEngine Engine { get; set; }
+
+        public int Order { get; set; }
+
+        public void Configure(RazorParserOptions options)
+        {
+            options.DesignTimeMode = true;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Evolution/IRazorParserOptionsFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/IRazorParserOptionsFeature.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore.Razor.Evolution
 {
-    internal interface IRazorConfigureParserFeature : IRazorEngineFeature
+    public interface IRazorParserOptionsFeature : IRazorEngineFeature
     {
         int Order { get; }
 

--- a/src/Microsoft.AspNetCore.Razor.Evolution/RazorEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/RazorEngine.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
         internal static void AddDesignTimeDefaults(IRazorEngineBuilder builder)
         {
-            builder.Features.Add(new ConfigureDesignTimeOptions());
+            builder.Features.Add(new DesignTimeParserOptionsFeature());
             builder.Features.Add(new RazorDesignTimeIRPass());
         }
 
@@ -116,17 +116,5 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         public abstract IReadOnlyList<IRazorEnginePhase> Phases { get; }
 
         public abstract void Process(RazorCodeDocument document);
-
-        internal class ConfigureDesignTimeOptions : IRazorConfigureParserFeature
-        {
-            public RazorEngine Engine { get; set; }
-
-            public int Order { get; set; }
-
-            public void Configure(RazorParserOptions options)
-            {
-                options.DesignTimeMode = true;
-            }
-        }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/DefaultRazorParsingPhaseTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/DefaultRazorParsingPhaseTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             var engine = RazorEngine.CreateEmpty((b) =>
             {
                 b.Phases.Add(phase);
-                b.Features.Add(new MyConfigureParserOptions());
+                b.Features.Add(new MyParserOptionsFeature());
             });
 
             var codeDocument = TestRazorCodeDocument.CreateEmpty();
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             var engine = RazorEngine.CreateEmpty((b) =>
             {
                 b.Phases.Add(phase);
-                b.Features.Add(new MyConfigureParserOptions());
+                b.Features.Add(new MyParserOptionsFeature());
             });
 
             var imports = new[]
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 t => { Assert.Same(t.Source, imports[1]); Assert.Equal("test_directive", Assert.Single(t.Options.Directives).Name); });
         }
 
-        private class MyConfigureParserOptions : IRazorConfigureParserFeature
+        private class MyParserOptionsFeature : IRazorParserOptionsFeature
         {
             public RazorEngine Engine { get; set; }
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/RazorEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/RazorEngineTest.cs
@@ -185,7 +185,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 feature => Assert.IsType<DefaultDirectiveIRPass>(feature),
                 feature => Assert.IsType<DirectiveRemovalIROptimizationPass>(feature),
                 feature => Assert.IsType<DefaultDocumentClassifierPassFeature>(feature),
-                feature => Assert.IsType<RazorEngine.ConfigureDesignTimeOptions>(feature),
+                feature => Assert.IsType<DesignTimeParserOptionsFeature>(feature),
                 feature => Assert.IsType<RazorDesignTimeIRPass>(feature));
         }
 


### PR DESCRIPTION
The RazorParserOptions were only configurable via an internal interface
and an extension method on the builder. This isn't suitable for VS because
we need to be able to update the configuration while the editor is open,
without creating a new engine.