### PR TITLE
Add a static 'register' method to MVC's extensions

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Evolution;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
+{
+    public static class RazorExtensions
+    {
+        public static void Register(IRazorEngineBuilder builder)
+        {
+            InjectDirective.Register(builder);
+            ModelDirective.Register(builder);
+            PageDirective.Register(builder);
+
+            builder.AddTargetExtension(new InjectDirectiveTargetExtension());
+
+            builder.Features.Add(new ModelExpressionPass());
+            builder.Features.Add(new PagesPropertyInjectionPass());
+            builder.Features.Add(new ViewComponentTagHelperPass());
+            builder.Features.Add(new RazorPageDocumentClassifierPass());
+            builder.Features.Add(new MvcViewDocumentClassifierPass());
+
+            if (!builder.DesignTime)
+            {
+                builder.Features.Add(new DefaultInstrumentationPass());
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/RazorEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/RazorEngineTest.cs
@@ -125,14 +125,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
             var engine = RazorEngine.Create(b =>
             {
-                InjectDirective.Register(b);
-                ModelDirective.Register(b);
-
-                b.AddTargetExtension(new InjectDirectiveTargetExtension());
-
-                b.Features.Add(new ModelExpressionPass());
-                b.Features.Add(new MvcViewDocumentClassifierPass());
-                b.Features.Add(new DefaultInstrumentationPass());
+                RazorExtensions.Register(b);
 
                 b.Features.Add(new DefaultTagHelperFeature());
                 b.Features.Add(GetMetadataReferenceFeature());
@@ -173,13 +166,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
             var engine = RazorEngine.CreateDesignTime(b =>
             {
-                InjectDirective.Register(b);
-                ModelDirective.Register(b);
-
-                b.AddTargetExtension(new InjectDirectiveTargetExtension());
-
-                b.Features.Add(new ModelExpressionPass());
-                b.Features.Add(new MvcViewDocumentClassifierPass());
+                RazorExtensions.Register(b);
 
                 b.Features.Add(new DefaultTagHelperFeature());
                 b.Features.Add(GetMetadataReferenceFeature());


### PR DESCRIPTION
This will be called by the IDE, and by MVC to register all of the
functionality in Microsoft.AspNet.Mvc.Razor.Extensions.