### PR TITLE
Revert: Don't generate CSharpStatementIRNode for whitespace

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
@@ -79,16 +79,27 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
         {
             if (node.Source != null)
             {
-                using (Context.Writer.BuildLinePragma(node.Source.Value))
+                IDisposable linePragmaScope = null;
+                if (!string.IsNullOrWhiteSpace(node.Content))
                 {
-                    var padding = BuildOffsetPadding(0, node.Source.Value, Context);
-                    Context.Writer.Write(padding);
+                    linePragmaScope = Context.Writer.BuildLinePragma(node.Source.Value);
+                }
 
-                    Context.AddLineMappingFor(node);
-                    Context.Writer.Write(node.Content);
+                var padding = BuildOffsetPadding(0, node.Source.Value, Context);
+                Context.Writer.Write(padding);
+                Context.AddLineMappingFor(node);
+                Context.Writer.Write(node.Content);
+
+                if (linePragmaScope != null)
+                {
+                    linePragmaScope.Dispose();
+                }
+                else
+                {
+                    Context.Writer.WriteLine();
                 }
             }
-            else
+            else if (!string.IsNullOrWhiteSpace(node.Content))
             {
                 Context.Writer.WriteLine(node.Content);
             }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/RuntimeCSharpRenderer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/RuntimeCSharpRenderer.cs
@@ -209,6 +209,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
 
         public override void VisitCSharpStatement(CSharpStatementIRNode node)
         {
+            if (string.IsNullOrWhiteSpace(node.Content))
+            {
+                return;
+            }
+
             if (node.Source != null)
             {
                 using (Context.Writer.BuildLinePragma(node.Source.Value))

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
@@ -388,22 +388,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
             public override void VisitStatementSpan(StatementChunkGenerator chunkGenerator, Span span)
             {
-                if (span.Symbols.Count == 1)
-                {
-                    if (span.Symbols[0] is CSharpSymbol symbol &&
-                        symbol.Type == CSharpSymbolType.Unknown &&
-                        symbol.Content.Length == 0)
-                    {
-                        // We don't want to create IR nodes for marker symbols.
-                        return;
-                    }
-                }
-
-                if (string.IsNullOrWhiteSpace(span.Content))
-                {
-                    return;
-                }
-
                 _builder.Add(new CSharpStatementIRNode()
                 {
                     Content = span.Content,

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.codegen.cs
@@ -28,11 +28,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
+                                                           
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                              __o = await Foo();
 
 #line default
 #line hidden
+                                                                               
 #line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                            __o = await;
 
@@ -63,11 +65,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
+                                                              
 #line 24 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                                 __o = await Foo(boolValue: false);
 
 #line default
 #line hidden
+                                                                                                  
 #line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                               __o = await ("wrrronggg");
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.ir.txt
@@ -20,10 +20,12 @@ Document -
                 HtmlContent - (259:10,50 [43] Await.cshtml) - </p>\n    <p>Basic Asynchronous Statement: 
                 CSharpStatement - (304:11,39 [14] Await.cshtml) -  await Foo(); 
                 HtmlContent - (319:11,54 [50] Await.cshtml) - </p>\n    <p>Basic Asynchronous Statement Nested: 
+                CSharpStatement - (371:12,46 [1] Await.cshtml) -  
                 HtmlContent - (372:12,47 [3] Await.cshtml) - <b>
                 CSharpExpression - (376:12,51 [11] Await.cshtml)
                     RazorIRToken - (376:12,51 [11] Await.cshtml) - CSharp - await Foo()
                 HtmlContent - (387:12,62 [4] Await.cshtml) - </b>
+                CSharpStatement - (391:12,66 [1] Await.cshtml) -  
                 HtmlContent - (393:12,68 [54] Await.cshtml) - </p>\n    <p>Basic Incomplete Asynchronous Statement: 
                 CSharpExpression - (448:13,49 [5] Await.cshtml)
                     RazorIRToken - (448:13,49 [5] Await.cshtml) - CSharp - await
@@ -41,10 +43,12 @@ Document -
                 HtmlContent - (827:21,82 [55] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Statement Extended: 
                 CSharpStatement - (884:22,51 [21] Await.cshtml) -  await Foo.Bar(1, 2) 
                 HtmlContent - (906:22,73 [53] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Statement Nested: 
+                CSharpStatement - (961:23,49 [1] Await.cshtml) -  
                 HtmlContent - (962:23,50 [3] Await.cshtml) - <b>
                 CSharpExpression - (966:23,54 [27] Await.cshtml)
                     RazorIRToken - (966:23,54 [27] Await.cshtml) - CSharp - await Foo(boolValue: false)
                 HtmlContent - (993:23,81 [4] Await.cshtml) - </b>
+                CSharpStatement - (997:23,85 [1] Await.cshtml) -  
                 HtmlContent - (999:23,87 [57] Await.cshtml) - </p>\n    <p>Advanced Incomplete Asynchronous Statement: 
                 CSharpExpression - (1057:24,52 [19] Await.cshtml)
                     RazorIRToken - (1057:24,52 [19] Await.cshtml) - CSharp - await ("wrrronggg")

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.mappings.txt
@@ -13,49 +13,69 @@ Source Location: (304:11,39 [14] TestFiles/IntegrationTests/CodeGenerationIntegr
 Generated Location: (1007:26,39 [14] )
 | await Foo(); |
 
+Source Location: (371:12,46 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
+| |
+Generated Location: (1112:30,58 [1] )
+| |
+
 Source Location: (376:12,51 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo()|
-Generated Location: (1187:31,51 [11] )
+Generated Location: (1248:32,51 [11] )
 |await Foo()|
+
+Source Location: (391:12,66 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
+| |
+Generated Location: (1371:36,78 [1] )
+| |
 
 Source Location: (448:13,49 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await|
-Generated Location: (1363:36,49 [5] )
+Generated Location: (1505:38,49 [5] )
 |await|
 
 Source Location: (578:18,42 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo(1, 2)|
-Generated Location: (1526:41,42 [15] )
+Generated Location: (1668:43,42 [15] )
 |await Foo(1, 2)|
 
 Source Location: (650:19,51 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo.Bar(1, 2)|
-Generated Location: (1708:46,51 [19] )
+Generated Location: (1850:48,51 [19] )
 |await Foo.Bar(1, 2)|
 
 Source Location: (716:20,41 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo("bob", true)|
-Generated Location: (1884:51,41 [22] )
+Generated Location: (2026:53,41 [22] )
 |await Foo("bob", true)|
 
 Source Location: (787:21,42 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | await Foo(something, hello: "world"); |
-Generated Location: (2064:56,42 [39] )
+Generated Location: (2206:58,42 [39] )
 | await Foo(something, hello: "world"); |
 
 Source Location: (884:22,51 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | await Foo.Bar(1, 2) |
-Generated Location: (2269:61,51 [21] )
+Generated Location: (2411:63,51 [21] )
 | await Foo.Bar(1, 2) |
+
+Source Location: (961:23,49 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
+| |
+Generated Location: (2526:67,61 [1] )
+| |
 
 Source Location: (966:23,54 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo(boolValue: false)|
-Generated Location: (2459:66,54 [27] )
+Generated Location: (2665:69,54 [27] )
 |await Foo(boolValue: false)|
+
+Source Location: (997:23,85 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
+| |
+Generated Location: (2823:73,97 [1] )
+| |
 
 Source Location: (1057:24,52 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await ("wrrronggg")|
-Generated Location: (2654:71,52 [19] )
+Generated Location: (2960:75,52 [19] )
 |await ("wrrronggg")|
 
 Source Location: (12:0,12 [76] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
@@ -65,7 +85,7 @@ Source Location: (12:0,12 [76] TestFiles/IntegrationTests/CodeGenerationIntegrat
         return "Bar";
     }
 |
-Generated Location: (2849:78,12 [76] )
+Generated Location: (3155:82,12 [76] )
 |
     public async Task<string> Foo()
     {

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.ir.txt
@@ -18,6 +18,7 @@ Document -
                 CSharpExpression - (376:12,51 [11] Await.cshtml)
                     RazorIRToken - (376:12,51 [11] Await.cshtml) - CSharp - await Foo()
                 HtmlContent - (387:12,62 [5] Await.cshtml) - </b> 
+                CSharpStatement - (392:12,67 [0] Await.cshtml) - 
                 HtmlContent - (393:12,68 [54] Await.cshtml) - </p>\n    <p>Basic Incomplete Asynchronous Statement: 
                 CSharpExpression - (448:13,49 [5] Await.cshtml)
                     RazorIRToken - (448:13,49 [5] Await.cshtml) - CSharp - await
@@ -39,6 +40,7 @@ Document -
                 CSharpExpression - (966:23,54 [27] Await.cshtml)
                     RazorIRToken - (966:23,54 [27] Await.cshtml) - CSharp - await Foo(boolValue: false)
                 HtmlContent - (993:23,81 [5] Await.cshtml) - </b> 
+                CSharpStatement - (998:23,86 [0] Await.cshtml) - 
                 HtmlContent - (999:23,87 [57] Await.cshtml) - </p>\n    <p>Advanced Incomplete Asynchronous Statement: 
                 CSharpExpression - (1057:24,52 [19] Await.cshtml)
                     RazorIRToken - (1057:24,52 [19] Await.cshtml) - CSharp - await ("wrrronggg")

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.codegen.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+              
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.ir.txt
@@ -11,3 +11,4 @@ Document -
                 CSharpStatement -  - #pragma warning restore 219
             CSharpStatement -  - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [0] CodeBlockAtEOF.cshtml) - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (2:0,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF.cshtml)
+||
+Generated Location: (578:15,14 [0] )
+||
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_Runtime.ir.txt
@@ -5,3 +5,4 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlockAtEOF_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [0] CodeBlockAtEOF.cshtml) - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.codegen.cs
@@ -30,6 +30,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
+                                                             
+
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.ir.txt
@@ -17,3 +17,4 @@ Document -
                 HtmlContent - (63:2,23 [4] CodeBlockWithTextElement.cshtml) - bar 
                 CSharpExpression - (69:2,29 [3] CodeBlockWithTextElement.cshtml)
                     RazorIRToken - (69:2,29 [3] CodeBlockWithTextElement.cshtml) - CSharp - a+b
+                CSharpStatement - (80:2,40 [2] CodeBlockWithTextElement.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.mappings.txt
@@ -17,3 +17,10 @@ Source Location: (69:2,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrati
 Generated Location: (1050:28,38 [3] )
 |a+b|
 
+Source Location: (80:2,40 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml)
+|
+|
+Generated Location: (1148:32,61 [2] )
+|
+|
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_Runtime.ir.txt
@@ -11,3 +11,4 @@ Document -
                 HtmlContent - (63:2,23 [4] CodeBlockWithTextElement.cshtml) - bar 
                 CSharpExpression - (69:2,29 [3] CodeBlockWithTextElement.cshtml)
                     RazorIRToken - (69:2,29 [3] CodeBlockWithTextElement.cshtml) - CSharp - a+b
+                CSharpStatement - (80:2,40 [2] CodeBlockWithTextElement.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
@@ -65,6 +65,8 @@ System.Object __typeHelper = "*, TestAssembly";
 #line default
 #line hidden
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+                                                                                      
+                
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
@@ -74,6 +76,8 @@ System.Object __typeHelper = "*, TestAssembly";
 #line hidden
             __TestNamespace_InputTagHelper.Type = string.Empty;
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+                                                                              
+                
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
@@ -57,6 +57,7 @@ Document -
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
+                        CSharpStatement - (474:15,74 [18] ComplexTagHelpers.cshtml) - \n                
                         TagHelper - (492:16,16 [50] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -68,6 +69,7 @@ Document -
                                 CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
                             ExecuteTagHelpers - 
+                        CSharpStatement - (542:16,66 [18] ComplexTagHelpers.cshtml) - \n                
                         TagHelper - (560:17,16 [81] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
@@ -48,172 +48,186 @@ Source Location: (463:15,63 [4] TestFiles/IntegrationTests/CodeGenerationIntegra
 Generated Location: (2755:62,63 [4] )
 |true|
 
+Source Location: (474:15,74 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|
+                |
+Generated Location: (2974:67,86 [18] )
+|
+                |
+
 Source Location: (507:16,31 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true ? "checkbox" : "anything"|
-Generated Location: (3221:70,31 [30] )
+Generated Location: (3327:72,31 [30] )
 |true ? "checkbox" : "anything"|
+
+Source Location: (542:16,66 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|
+                |
+Generated Location: (3623:78,78 [18] )
+|
+                |
 
 Source Location: (574:17,30 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if(true) { |
-Generated Location: (3771:79,30 [11] )
+Generated Location: (3975:83,30 [11] )
 |if(true) { |
 
 Source Location: (606:17,62 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | } else { |
-Generated Location: (3971:84,62 [10] )
+Generated Location: (4175:88,62 [10] )
 | } else { |
 
 Source Location: (637:17,93 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | }|
-Generated Location: (4201:89,93 [2] )
+Generated Location: (4405:93,93 [2] )
 | }|
 
 Source Location: (641:17,97 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
             }|
-Generated Location: (4581:96,97 [15] )
+Generated Location: (4785:100,97 [15] )
 |
             }|
 
 Source Location: (163:7,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (4849:103,32 [12] )
+Generated Location: (5053:107,32 [12] )
 |DateTime.Now|
 
 Source Location: (783:21,14 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | var @object = false;|
-Generated Location: (5003:108,14 [21] )
+Generated Location: (5207:112,14 [21] )
 | var @object = false;|
 
 Source Location: (836:22,29 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (5401:115,42 [1] )
+Generated Location: (5605:119,42 [1] )
 |(|
 
 Source Location: (837:22,30 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@object|
-Generated Location: (5402:115,43 [7] )
+Generated Location: (5606:119,43 [7] )
 |@object|
 
 Source Location: (844:22,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (5409:115,50 [1] )
+Generated Location: (5613:119,50 [1] )
 |)|
 
 Source Location: (711:20,39 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (5671:121,38 [23] )
+Generated Location: (5875:125,38 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (734:20,62 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | - 1970|
-Generated Location: (5694:121,61 [7] )
+Generated Location: (5898:125,61 [7] )
 | - 1970|
 
 Source Location: (976:25,61 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (6097:128,60 [1] )
+Generated Location: (6301:132,60 [1] )
 |(|
 
 Source Location: (977:25,62 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (6098:128,61 [30] )
+Generated Location: (6302:132,61 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1007:25,92 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (6128:128,91 [1] )
+Generated Location: (6332:132,91 [1] )
 |)|
 
 Source Location: (879:24,16 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |-1970 + |
-Generated Location: (6385:134,33 [8] )
+Generated Location: (6589:138,33 [8] )
 |-1970 + |
 
 Source Location: (887:24,24 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (6393:134,41 [1] )
+Generated Location: (6597:138,41 [1] )
 |@|
 
 Source Location: (888:24,25 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (6394:134,42 [23] )
+Generated Location: (6598:138,42 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (1106:28,28 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (6795:141,42 [30] )
+Generated Location: (6999:145,42 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1044:27,16 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year - 1970|
-Generated Location: (7081:147,33 [30] )
+Generated Location: (7285:151,33 [30] )
 |DateTimeOffset.Now.Year - 1970|
 
 Source Location: (1234:31,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (7489:154,42 [3] )
+Generated Location: (7693:158,42 [3] )
 |   |
 
 Source Location: (1237:31,31 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@(|
-Generated Location: (7492:154,45 [2] )
+Generated Location: (7696:158,45 [2] )
 |@(|
 
 Source Location: (1239:31,33 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |  DateTimeOffset.Now.Year  |
-Generated Location: (7494:154,47 [27] )
+Generated Location: (7698:158,47 [27] )
 |  DateTimeOffset.Now.Year  |
 
 Source Location: (1266:31,60 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (7521:154,74 [1] )
+Generated Location: (7725:158,74 [1] )
 |)|
 
 Source Location: (1267:31,61 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | > 2014   |
-Generated Location: (7522:154,75 [10] )
+Generated Location: (7726:158,75 [10] )
 | > 2014   |
 
 Source Location: (1171:30,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (7788:160,33 [1] )
+Generated Location: (7992:164,33 [1] )
 |(|
 
 Source Location: (1172:30,18 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"My age is this long.".Length|
-Generated Location: (7789:160,34 [29] )
+Generated Location: (7993:164,34 [29] )
 |"My age is this long.".Length|
 
 Source Location: (1201:30,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (7818:160,63 [1] )
+Generated Location: (8022:164,63 [1] )
 |)|
 
 Source Location: (1306:33,9 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |someMethod(|
-Generated Location: (7956:165,9 [11] )
+Generated Location: (8160:169,9 [11] )
 |someMethod(|
 
 Source Location: (1361:33,64 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checked|
-Generated Location: (8409:169,63 [7] )
+Generated Location: (8613:173,63 [7] )
 |checked|
 
 Source Location: (1326:33,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |123|
-Generated Location: (8664:175,33 [3] )
+Generated Location: (8868:179,33 [3] )
 |123|
 
 Source Location: (1375:33,78 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (8705:180,1 [1] )
+Generated Location: (8909:184,1 [1] )
 |)|
 
 Source Location: (1388:34,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
 }|
-Generated Location: (8844:185,10 [3] )
+Generated Location: (9048:189,10 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.ir.txt
@@ -20,6 +20,7 @@ Document -
                 TagHelper - (139:7,8 [529] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                         HtmlContent - (177:7,46 [34] ComplexTagHelpers.cshtml) - \n            <h1>Set Time:</h1>\n
+                        CSharpStatement - (211:9,0 [12] ComplexTagHelpers.cshtml) -             
                         CSharpStatement - (224:9,13 [27] ComplexTagHelpers.cshtml) - if (false)\n            {\n
                         HtmlContent - (251:11,0 [16] ComplexTagHelpers.cshtml) -                 
                         TagHelper - (267:11,16 [83] ComplexTagHelpers.cshtml)
@@ -102,6 +103,7 @@ Document -
                 TagHelper - (680:20,8 [181] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                         HtmlContent - (767:20,95 [2] ComplexTagHelpers.cshtml) - \n
+                        CSharpStatement - (769:21,0 [12] ComplexTagHelpers.cshtml) -             
                         CSharpStatement - (783:21,14 [21] ComplexTagHelpers.cshtml) -  var @object = false;
                         HtmlContent - (807:22,0 [12] ComplexTagHelpers.cshtml) -             
                         TagHelper - (819:22,12 [28] ComplexTagHelpers.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.codegen.cs
@@ -21,31 +21,43 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
+                                
+    
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
          __o = cls;
 
 #line default
 #line hidden
+                                  
+    
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
              __o = cls;
 
 #line default
 #line hidden
+                                      
+    
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
          __o = cls;
 
 #line default
 #line hidden
+                                      
+    
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
                                __o = ch;
 
 #line default
 #line hidden
+                                                       
+    
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
                                    __o = ch;
 
 #line default
 #line hidden
+                                                           
+    
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
                if(cls != null) { 
 
@@ -61,16 +73,26 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
+                                                       
+    
+                                  
+    
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
             __o = Url.Content("~/Scripts/jquery-1.6.2.min.js");
 
 #line default
 #line hidden
+                                                                                                            
+    
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
             __o = Url.Content("~/Scripts/modernizr-2.0.6-development-only.js");
 
 #line default
 #line hidden
+                                                                                                                            
+    
+                                                                                                                               
+
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.ir.txt
@@ -13,12 +13,14 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [48] ConditionalAttributes.cshtml) - \n    var ch = true;\n    var cls = "bar";\n    
                 HtmlContent - (50:3,4 [16] ConditionalAttributes.cshtml) - <a href="Foo" />
+                CSharpStatement - (66:3,20 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (72:4,4 [2] ConditionalAttributes.cshtml) - <p
                 HtmlAttribute - (74:4,6 [13] ConditionalAttributes.cshtml) -  class=" - "
                     CSharpAttributeValue - (82:4,14 [4] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (83:4,15 [3] ConditionalAttributes.cshtml)
                             RazorIRToken - (83:4,15 [3] ConditionalAttributes.cshtml) - CSharp - cls
                 HtmlContent - (87:4,19 [3] ConditionalAttributes.cshtml) -  />
+                CSharpStatement - (90:4,22 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (96:5,4 [2] ConditionalAttributes.cshtml) - <p
                 HtmlAttribute - (98:5,6 [17] ConditionalAttributes.cshtml) -  class=" - "
                     HtmlAttributeValue - (106:5,14 [3] ConditionalAttributes.cshtml) -  - foo
@@ -26,6 +28,7 @@ Document -
                         CSharpExpression - (111:5,19 [3] ConditionalAttributes.cshtml)
                             RazorIRToken - (111:5,19 [3] ConditionalAttributes.cshtml) - CSharp - cls
                 HtmlContent - (115:5,23 [3] ConditionalAttributes.cshtml) -  />
+                CSharpStatement - (118:5,26 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (124:6,4 [2] ConditionalAttributes.cshtml) - <p
                 HtmlAttribute - (126:6,6 [17] ConditionalAttributes.cshtml) -  class=" - "
                     CSharpAttributeValue - (134:6,14 [4] ConditionalAttributes.cshtml) - 
@@ -33,12 +36,14 @@ Document -
                             RazorIRToken - (135:6,15 [3] ConditionalAttributes.cshtml) - CSharp - cls
                     HtmlAttributeValue - (138:6,18 [4] ConditionalAttributes.cshtml) -   - foo
                 HtmlContent - (143:6,23 [3] ConditionalAttributes.cshtml) -  />
+                CSharpStatement - (146:6,26 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (152:7,4 [22] ConditionalAttributes.cshtml) - <input type="checkbox"
                 HtmlAttribute - (174:7,26 [14] ConditionalAttributes.cshtml) -  checked=" - "
                     CSharpAttributeValue - (184:7,36 [3] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (185:7,37 [2] ConditionalAttributes.cshtml)
                             RazorIRToken - (185:7,37 [2] ConditionalAttributes.cshtml) - CSharp - ch
                 HtmlContent - (188:7,40 [3] ConditionalAttributes.cshtml) -  />
+                CSharpStatement - (191:7,43 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (197:8,4 [22] ConditionalAttributes.cshtml) - <input type="checkbox"
                 HtmlAttribute - (219:8,26 [18] ConditionalAttributes.cshtml) -  checked=" - "
                     HtmlAttributeValue - (229:8,36 [3] ConditionalAttributes.cshtml) -  - foo
@@ -46,6 +51,7 @@ Document -
                         CSharpExpression - (234:8,41 [2] ConditionalAttributes.cshtml)
                             RazorIRToken - (234:8,41 [2] ConditionalAttributes.cshtml) - CSharp - ch
                 HtmlContent - (237:8,44 [3] ConditionalAttributes.cshtml) -  />
+                CSharpStatement - (240:8,47 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (246:9,4 [2] ConditionalAttributes.cshtml) - <p
                 HtmlAttribute - (248:9,6 [34] ConditionalAttributes.cshtml) -  class=" - "
                     CSharpAttributeValue - (256:9,14 [25] ConditionalAttributes.cshtml) - 
@@ -54,17 +60,22 @@ Document -
                             RazorIRToken - (276:9,34 [3] ConditionalAttributes.cshtml) - CSharp - cls
                         CSharpStatement - (279:9,37 [2] ConditionalAttributes.cshtml) -  }
                 HtmlContent - (282:9,40 [3] ConditionalAttributes.cshtml) -  />
+                CSharpStatement - (285:9,43 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (291:10,4 [18] ConditionalAttributes.cshtml) - <a href="~/Foo" />
+                CSharpStatement - (309:10,22 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (315:11,4 [7] ConditionalAttributes.cshtml) - <script
                 HtmlAttribute - (322:11,11 [52] ConditionalAttributes.cshtml) -  src=" - "
                     CSharpAttributeValue - (328:11,17 [45] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (329:11,18 [44] ConditionalAttributes.cshtml)
                             RazorIRToken - (329:11,18 [44] ConditionalAttributes.cshtml) - CSharp - Url.Content("~/Scripts/jquery-1.6.2.min.js")
                 HtmlContent - (374:11,63 [33] ConditionalAttributes.cshtml) -  type="text/javascript"></script>
+                CSharpStatement - (407:11,96 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (413:12,4 [7] ConditionalAttributes.cshtml) - <script
                 HtmlAttribute - (420:12,11 [68] ConditionalAttributes.cshtml) -  src=" - "
                     CSharpAttributeValue - (426:12,17 [61] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (427:12,18 [60] ConditionalAttributes.cshtml)
                             RazorIRToken - (427:12,18 [60] ConditionalAttributes.cshtml) - CSharp - Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")
                 HtmlContent - (488:12,79 [33] ConditionalAttributes.cshtml) -  type="text/javascript"></script>
+                CSharpStatement - (521:12,112 [6] ConditionalAttributes.cshtml) - \n    
                 HtmlContent - (527:13,4 [111] ConditionalAttributes.cshtml) - <script src="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.16/jquery-ui.min.js" type="text/javascript"></script>
+                CSharpStatement - (638:13,115 [2] ConditionalAttributes.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.mappings.txt
@@ -9,53 +9,130 @@ Generated Location: (670:16,2 [48] )
     var cls = "bar";
     |
 
+Source Location: (66:3,20 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (783:23,32 [6] )
+|
+    |
+
 Source Location: (83:4,15 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (863:24,15 [3] )
+Generated Location: (903:26,15 [3] )
 |cls|
+
+Source Location: (90:4,22 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (974:30,34 [6] )
+|
+    |
 
 Source Location: (111:5,19 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (1016:29,19 [3] )
+Generated Location: (1098:33,19 [3] )
 |cls|
+
+Source Location: (118:5,26 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (1173:37,38 [6] )
+|
+    |
 
 Source Location: (135:6,15 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (1165:34,15 [3] )
+Generated Location: (1293:40,15 [3] )
 |cls|
+
+Source Location: (146:6,26 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (1368:44,38 [6] )
+|
+    |
 
 Source Location: (185:7,37 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |ch|
-Generated Location: (1336:39,37 [2] )
+Generated Location: (1510:47,37 [2] )
 |ch|
+
+Source Location: (191:7,43 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (1601:51,55 [6] )
+|
+    |
 
 Source Location: (234:8,41 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |ch|
-Generated Location: (1510:44,41 [2] )
+Generated Location: (1747:54,41 [2] )
 |ch|
+
+Source Location: (240:8,47 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (1842:58,59 [6] )
+|
+    |
 
 Source Location: (257:9,15 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |if(cls != null) { |
-Generated Location: (1659:49,15 [18] )
+Generated Location: (1963:61,15 [18] )
 |if(cls != null) { |
 
 Source Location: (276:9,34 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (1842:54,34 [3] )
+Generated Location: (2146:66,34 [3] )
 |cls|
 
 Source Location: (279:9,37 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 | }|
-Generated Location: (2014:59,37 [2] )
+Generated Location: (2318:71,37 [2] )
 | }|
+
+Source Location: (285:9,43 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (2408:75,55 [6] )
+|
+    |
+
+Source Location: (309:10,22 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (2450:77,34 [6] )
+|
+    |
 
 Source Location: (329:11,18 [44] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |Url.Content("~/Scripts/jquery-1.6.2.min.js")|
-Generated Location: (2165:64,18 [44] )
+Generated Location: (2574:80,18 [44] )
 |Url.Content("~/Scripts/jquery-1.6.2.min.js")|
+
+Source Location: (407:11,96 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (2760:84,108 [6] )
+|
+    |
 
 Source Location: (427:12,18 [60] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")|
-Generated Location: (2359:69,18 [60] )
+Generated Location: (2884:87,18 [60] )
 |Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")|
+
+Source Location: (521:12,112 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+    |
+Generated Location: (3102:91,124 [6] )
+|
+    |
+
+Source Location: (638:13,115 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
+|
+|
+Generated Location: (3237:93,127 [2] )
+|
+|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_Runtime.ir.txt
@@ -52,3 +52,4 @@ Document -
                         CSharpExpression - (427:12,18 [60] ConditionalAttributes.cshtml)
                             RazorIRToken - (427:12,18 [60] ConditionalAttributes.cshtml) - CSharp - Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")
                 HtmlContent - (488:12,79 [152] ConditionalAttributes.cshtml) -  type="text/javascript"></script>\n    <script src="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.16/jquery-ui.min.js" type="text/javascript"></script>\n
+                CSharpStatement - (640:14,0 [0] ConditionalAttributes.cshtml) - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.codegen.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+              
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.ir.txt
@@ -12,3 +12,4 @@ Document -
             CSharpStatement -  - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] EmptyCodeBlock.cshtml) - This is markup\n\n
+                CSharpStatement - (20:2,2 [0] EmptyCodeBlock.cshtml) - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (20:2,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock.cshtml)
+||
+Generated Location: (578:15,14 [0] )
+||
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_Runtime.ir.txt
@@ -6,3 +6,4 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyCodeBlock_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] EmptyCodeBlock.cshtml) - This is markup\n\n
+                CSharpStatement - (20:2,2 [0] EmptyCodeBlock.cshtml) - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.codegen.cs
@@ -13,6 +13,10 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+              
+    
+                 
+
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.ir.txt
@@ -11,4 +11,6 @@ Document -
                 CSharpStatement -  - #pragma warning restore 219
             CSharpStatement -  - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [6] EmptyImplicitExpressionInCode.cshtml) - \n    
                 CSharpExpression - 
+                CSharpStatement - (9:1,5 [2] EmptyImplicitExpressionInCode.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.mappings.txt
@@ -1,0 +1,14 @@
+Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
+|
+    |
+Generated Location: (593:15,14 [6] )
+|
+    |
+
+Source Location: (9:1,5 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
+|
+|
+Generated Location: (618:17,17 [2] )
+|
+|
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_Runtime.ir.txt
@@ -5,4 +5,6 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyImplicitExpressionInCode_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [6] EmptyImplicitExpressionInCode.cshtml) - \n    
                 CSharpExpression - 
+                CSharpStatement - (9:1,5 [2] EmptyImplicitExpressionInCode.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.ir.txt
@@ -6,4 +6,5 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_FunctionsBlockMinimal_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [4] FunctionsBlockMinimal.cshtml) - \n\n
+            CSharpStatement - (4:2,0 [1] FunctionsBlockMinimal.cshtml) - 	
             CSharpStatement - (16:2,12 [55] FunctionsBlockMinimal.cshtml) - \nstring foo(string input) {\n	return input + "!";\n}\n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.codegen.cs
@@ -20,6 +20,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 #line hidden
         }
         #pragma warning restore 1998
+                    
+
+
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock.cshtml"
             
     Random _rand = new Random();

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.ir.txt
@@ -15,4 +15,5 @@ Document -
                 HtmlContent - (138:9,1 [28] FunctionsBlock.cshtml) - \n\nHere's a random number: 
                 CSharpExpression - (167:11,25 [11] FunctionsBlock.cshtml)
                     RazorIRToken - (167:11,25 [11] FunctionsBlock.cshtml) - CSharp - RandomInt()
+            CSharpStatement - (12:0,12 [4] FunctionsBlock.cshtml) - \n\n
             CSharpStatement - (33:4,12 [104] FunctionsBlock.cshtml) - \n    Random _rand = new Random();\n    private int RandomInt() {\n        return _rand.Next();\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.mappings.txt
@@ -3,6 +3,15 @@ Source Location: (167:11,25 [11] TestFiles/IntegrationTests/CodeGenerationIntegr
 Generated Location: (680:16,25 [11] )
 |RandomInt()|
 
+Source Location: (12:0,12 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock.cshtml)
+|
+
+|
+Generated Location: (794:22,20 [4] )
+|
+
+|
+
 Source Location: (33:4,12 [104] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock.cshtml)
 |
     Random _rand = new Random();
@@ -10,7 +19,7 @@ Source Location: (33:4,12 [104] TestFiles/IntegrationTests/CodeGenerationIntegra
         return _rand.Next();
     }
 |
-Generated Location: (876:23,12 [104] )
+Generated Location: (902:26,12 [104] )
 |
     Random _rand = new Random();
     private int RandomInt() {

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_Runtime.ir.txt
@@ -9,4 +9,5 @@ Document -
                 HtmlContent - (140:10,0 [26] FunctionsBlock.cshtml) - \nHere's a random number: 
                 CSharpExpression - (167:11,25 [11] FunctionsBlock.cshtml)
                     RazorIRToken - (167:11,25 [11] FunctionsBlock.cshtml) - CSharp - RandomInt()
+            CSharpStatement - (12:0,12 [4] FunctionsBlock.cshtml) - \n\n
             CSharpStatement - (33:4,12 [104] FunctionsBlock.cshtml) - \n    Random _rand = new Random();\n    private int RandomInt() {\n        return _rand.Next();\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.codegen.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+              
+    
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode.cshtml"
      @Da
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.ir.txt
@@ -11,4 +11,5 @@ Document -
                 CSharpStatement -  - #pragma warning restore 219
             CSharpStatement -  - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [6] HiddenSpansInCode.cshtml) - \n    
                 CSharpStatement - (9:1,5 [5] HiddenSpansInCode.cshtml) - @Da\n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.mappings.txt
@@ -1,7 +1,14 @@
+Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode.cshtml)
+|
+    |
+Generated Location: (581:15,14 [6] )
+|
+    |
+
 Source Location: (9:1,5 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode.cshtml)
 |@Da
 |
-Generated Location: (665:16,5 [5] )
+Generated Location: (687:18,5 [5] )
 |@Da
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_Runtime.ir.txt
@@ -5,4 +5,5 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HiddenSpansInCode_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [6] HiddenSpansInCode.cshtml) - \n    
                 CSharpStatement - (9:1,5 [5] HiddenSpansInCode.cshtml) - @Da\n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.codegen.cs
@@ -29,6 +29,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
+                
+                                   
+
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
  while(i <= 10) {
     

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.ir.txt
@@ -16,7 +16,9 @@ Document -
                     HtmlContent - (35:2,15 [10] Instrumented.cshtml) - <p>Bar</p>
                 CSharpStatement - (45:2,25 [7] Instrumented.cshtml) - ;\n    
                 HtmlContent - (54:3,6 [14] Instrumented.cshtml) - Hello, World\n
+                CSharpStatement - (68:4,0 [4] Instrumented.cshtml) -     
                 HtmlContent - (72:4,4 [19] Instrumented.cshtml) - <p>Hello, World</p>
+                CSharpStatement - (91:4,23 [2] Instrumented.cshtml) - \n
                 HtmlContent - (96:6,0 [2] Instrumented.cshtml) - \n
                 CSharpStatement - (99:7,1 [22] Instrumented.cshtml) - while(i <= 10) {\n    
                 HtmlContent - (121:8,4 [19] Instrumented.cshtml) - <p>Hello from C#, #

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.mappings.txt
@@ -14,23 +14,35 @@ Generated Location: (965:26,25 [7] )
 |;
     |
 
+Source Location: (68:4,0 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
+|    |
+Generated Location: (1005:31,0 [4] )
+|    |
+
+Source Location: (91:4,23 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
+|
+|
+Generated Location: (1058:32,35 [2] )
+|
+|
+
 Source Location: (99:7,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |while(i <= 10) {
     |
-Generated Location: (1094:32,1 [22] )
+Generated Location: (1151:35,1 [22] )
 |while(i <= 10) {
     |
 
 Source Location: (142:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |i|
-Generated Location: (1262:38,25 [1] )
+Generated Location: (1319:41,25 [1] )
 |i|
 
 Source Location: (148:8,31 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
     i += 1;
 }|
-Generated Location: (1416:43,31 [16] )
+Generated Location: (1473:46,31 [16] )
 |
     i += 1;
 }|
@@ -38,14 +50,14 @@ Generated Location: (1416:43,31 [16] )
 Source Location: (169:12,1 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |if(i == 11) {
     |
-Generated Location: (1555:50,1 [19] )
+Generated Location: (1612:53,1 [19] )
 |if(i == 11) {
     |
 
 Source Location: (213:13,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (1725:56,29 [3] )
+Generated Location: (1782:59,29 [3] )
 |
 }|
 
@@ -53,7 +65,7 @@ Source Location: (221:16,1 [35] TestFiles/IntegrationTests/CodeGenerationIntegra
 |switch(i) {
     case 11:
         |
-Generated Location: (1851:62,1 [35] )
+Generated Location: (1908:65,1 [35] )
 |switch(i) {
     case 11:
         |
@@ -63,7 +75,7 @@ Source Location: (292:18,44 [40] TestFiles/IntegrationTests/CodeGenerationIntegr
         break;
     default:
         |
-Generated Location: (2052:69,44 [40] )
+Generated Location: (2109:72,44 [40] )
 |
         break;
     default:
@@ -73,7 +85,7 @@ Source Location: (361:21,37 [19] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
         break;
 }|
-Generated Location: (2251:77,37 [19] )
+Generated Location: (2308:80,37 [19] )
 |
         break;
 }|
@@ -81,26 +93,26 @@ Generated Location: (2251:77,37 [19] )
 Source Location: (385:25,1 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |for(int j = 1; j <= 10; j += 2) {
     |
-Generated Location: (2393:84,1 [39] )
+Generated Location: (2450:87,1 [39] )
 |for(int j = 1; j <= 10; j += 2) {
     |
 
 Source Location: (451:26,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |j|
-Generated Location: (2585:90,31 [1] )
+Generated Location: (2642:93,31 [1] )
 |j|
 
 Source Location: (457:26,37 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (2746:95,37 [3] )
+Generated Location: (2803:98,37 [3] )
 |
 }|
 
 Source Location: (465:29,1 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |try {
     |
-Generated Location: (2872:101,1 [11] )
+Generated Location: (2929:104,1 [11] )
 |try {
     |
 
@@ -108,34 +120,34 @@ Source Location: (511:30,39 [31] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
 } catch(Exception ex) {
     |
-Generated Location: (3044:107,39 [31] )
+Generated Location: (3101:110,39 [31] )
 |
 } catch(Exception ex) {
     |
 
 Source Location: (573:32,35 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |ex.Message|
-Generated Location: (3232:114,35 [10] )
+Generated Location: (3289:117,35 [10] )
 |ex.Message|
 
 Source Location: (588:32,50 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (3415:119,50 [3] )
+Generated Location: (3472:122,50 [3] )
 |
 }|
 
 Source Location: (596:35,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |lock(new object()) {
     |
-Generated Location: (3541:125,1 [26] )
+Generated Location: (3598:128,1 [26] )
 |lock(new object()) {
     |
 
 Source Location: (669:36,51 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (3740:131,51 [3] )
+Generated Location: (3797:134,51 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.ir.txt
@@ -11,6 +11,7 @@ Document -
                 CSharpStatement - (45:2,25 [3] Instrumented.cshtml) - ;\n
                 HtmlContent - (48:3,0 [4] Instrumented.cshtml) -     
                 HtmlContent - (54:3,6 [39] Instrumented.cshtml) - Hello, World\n    <p>Hello, World</p>\n
+                CSharpStatement - (93:5,0 [0] Instrumented.cshtml) - 
                 HtmlContent - (96:6,0 [2] Instrumented.cshtml) - \n
                 CSharpStatement - (99:7,1 [18] Instrumented.cshtml) - while(i <= 10) {\n
                 HtmlContent - (117:8,0 [23] Instrumented.cshtml) -     <p>Hello from C#, #

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.codegen.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+              
+    
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml"
      foreach (var result in (dynamic)Url)
     {
@@ -31,6 +33,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
+                 
+
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.ir.txt
@@ -11,9 +11,11 @@ Document -
                 CSharpStatement -  - #pragma warning restore 219
             CSharpStatement -  - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [6] NestedCSharp.cshtml) - \n    
                 CSharpStatement - (9:1,5 [53] NestedCSharp.cshtml) - foreach (var result in (dynamic)Url)\n    {\n        
                 HtmlContent - (62:3,8 [19] NestedCSharp.cshtml) - <div>\n            
                 CSharpExpression - (82:4,13 [16] NestedCSharp.cshtml)
                     RazorIRToken - (82:4,13 [16] NestedCSharp.cshtml) - CSharp - result.SomeValue
                 HtmlContent - (98:4,29 [17] NestedCSharp.cshtml) - .\n        </div>
                 CSharpStatement - (115:5,14 [7] NestedCSharp.cshtml) - \n    }
+                CSharpStatement - (122:6,5 [2] NestedCSharp.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.mappings.txt
@@ -1,21 +1,35 @@
+Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
+|
+    |
+Generated Location: (576:15,14 [6] )
+|
+    |
+
 Source Location: (9:1,5 [53] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |foreach (var result in (dynamic)Url)
     {
         |
-Generated Location: (655:16,5 [53] )
+Generated Location: (677:18,5 [53] )
 |foreach (var result in (dynamic)Url)
     {
         |
 
 Source Location: (82:4,13 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |result.SomeValue|
-Generated Location: (842:23,13 [16] )
+Generated Location: (864:25,13 [16] )
 |result.SomeValue|
 
 Source Location: (115:5,14 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |
     }|
-Generated Location: (994:28,14 [7] )
+Generated Location: (1016:30,14 [7] )
 |
     }|
+
+Source Location: (122:6,5 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
+|
+|
+Generated Location: (1073:35,17 [2] )
+|
+|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_Runtime.ir.txt
@@ -5,9 +5,11 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedCSharp_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [6] NestedCSharp.cshtml) - \n    
                 CSharpStatement - (9:1,5 [45] NestedCSharp.cshtml) - foreach (var result in (dynamic)Url)\n    {\n
                 HtmlContent - (54:3,0 [27] NestedCSharp.cshtml) -         <div>\n            
                 CSharpExpression - (82:4,13 [16] NestedCSharp.cshtml)
                     RazorIRToken - (82:4,13 [16] NestedCSharp.cshtml) - CSharp - result.SomeValue
                 HtmlContent - (98:4,29 [19] NestedCSharp.cshtml) - .\n        </div>\n
                 CSharpStatement - (117:6,0 [5] NestedCSharp.cshtml) -     }
+                CSharpStatement - (122:6,5 [2] NestedCSharp.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.ir.txt
@@ -13,6 +13,7 @@ Document -
                 TagHelper - (139:4,8 [433] NestedScriptTagTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                         HtmlContent - (180:4,49 [2] NestedScriptTagTagHelpers.cshtml) - \n
+                        CSharpStatement - (182:5,0 [12] NestedScriptTagTagHelpers.cshtml) -             
                         CSharpStatement - (195:5,13 [30] NestedScriptTagTagHelpers.cshtml) - for(var i = 0; i < 5; i++) {\n
                         HtmlContent - (225:6,0 [84] NestedScriptTagTagHelpers.cshtml) -                 <script id="nestedScriptTag" type="text/html">\n                    
                         TagHelper - (309:7,20 [86] NestedScriptTagTagHelpers.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.codegen.cs
@@ -113,6 +113,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
+                                              
 #line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
        __o = i;
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.ir.txt
@@ -45,6 +45,7 @@ Document -
                     RazorIRToken - (500:29,35 [10] NoLinePragmas.cshtml) - CSharp - ex.Message
                 HtmlContent - (511:29,46 [4] NoLinePragmas.cshtml) - </p>
                 CSharpStatement - (515:29,50 [7] NoLinePragmas.cshtml) - \n}\n\n
+                CSharpStatement - (556:32,34 [0] NoLinePragmas.cshtml) - 
                 HtmlContent - (556:32,34 [14] NoLinePragmas.cshtml) - \n<p>i is now 
                 CSharpExpression - (571:33,13 [1] NoLinePragmas.cshtml)
                     RazorIRToken - (571:33,13 [1] NoLinePragmas.cshtml) - CSharp - i

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.mappings.txt
@@ -122,22 +122,27 @@ Generated Location: (3128:109,50 [7] )
 
 |
 
+Source Location: (556:32,34 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
+||
+Generated Location: (3212:115,46 [0] )
+||
+
 Source Location: (571:33,13 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |i|
-Generated Location: (3269:116,13 [1] )
+Generated Location: (3317:117,13 [1] )
 |i|
 
 Source Location: (581:35,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |lock(new object()) {
     |
-Generated Location: (3395:121,1 [26] )
+Generated Location: (3443:122,1 [26] )
 |lock(new object()) {
     |
 
 Source Location: (654:36,51 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |
 }|
-Generated Location: (3595:127,51 [3] )
+Generated Location: (3643:128,51 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_Runtime.ir.txt
@@ -39,6 +39,7 @@ Document -
                     RazorIRToken - (500:29,35 [10] NoLinePragmas.cshtml) - CSharp - ex.Message
                 HtmlContent - (511:29,46 [6] NoLinePragmas.cshtml) - </p>\n
                 CSharpStatement - (517:30,0 [5] NoLinePragmas.cshtml) - }\n\n
+                CSharpStatement - (556:32,34 [2] NoLinePragmas.cshtml) - \n
                 HtmlContent - (558:33,0 [12] NoLinePragmas.cshtml) - <p>i is now 
                 CSharpExpression - (571:33,13 [1] NoLinePragmas.cshtml)
                     RazorIRToken - (571:33,13 [1] NoLinePragmas.cshtml) - CSharp - i

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.codegen.cs
@@ -13,26 +13,36 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+              
+    
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml"
 __o = ViewBag?.Data;
 
 #line default
 #line hidden
+                              
+    
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml"
 __o = ViewBag.IntIndexer?[0];
 
 #line default
 #line hidden
+                                       
+    
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml"
 __o = ViewBag.StrIndexer?["key"];
 
 #line default
 #line hidden
+                                           
+    
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml"
 __o = ViewBag?.Method(Value?[23]?.More)?["key"];
 
 #line default
 #line hidden
+                                                          
+
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml"
 __o = ViewBag?.Data;
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.ir.txt
@@ -11,14 +11,19 @@ Document -
                 CSharpStatement -  - #pragma warning restore 219
             CSharpStatement -  - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [6] NullConditionalExpressions.cshtml) - \n    
                 CSharpExpression - (9:1,5 [13] NullConditionalExpressions.cshtml)
                     RazorIRToken - (9:1,5 [13] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Data
+                CSharpStatement - (22:1,18 [6] NullConditionalExpressions.cshtml) - \n    
                 CSharpExpression - (29:2,5 [22] NullConditionalExpressions.cshtml)
                     RazorIRToken - (29:2,5 [22] NullConditionalExpressions.cshtml) - CSharp - ViewBag.IntIndexer?[0]
+                CSharpStatement - (51:2,27 [6] NullConditionalExpressions.cshtml) - \n    
                 CSharpExpression - (58:3,5 [26] NullConditionalExpressions.cshtml)
                     RazorIRToken - (58:3,5 [26] NullConditionalExpressions.cshtml) - CSharp - ViewBag.StrIndexer?["key"]
+                CSharpStatement - (84:3,31 [6] NullConditionalExpressions.cshtml) - \n    
                 CSharpExpression - (91:4,5 [41] NullConditionalExpressions.cshtml)
                     RazorIRToken - (91:4,5 [41] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Method(Value?[23]?.More)?["key"]
+                CSharpStatement - (132:4,46 [2] NullConditionalExpressions.cshtml) - \n
                 HtmlContent - (137:6,0 [2] NullConditionalExpressions.cshtml) - \n
                 CSharpExpression - (140:7,1 [13] NullConditionalExpressions.cshtml)
                     RazorIRToken - (140:7,1 [13] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Data

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.mappings.txt
@@ -1,40 +1,75 @@
+Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
+|
+    |
+Generated Location: (590:15,14 [6] )
+|
+    |
+
 Source Location: (9:1,5 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Data|
-Generated Location: (684:16,6 [13] )
+Generated Location: (706:18,6 [13] )
 |ViewBag?.Data|
+
+Source Location: (22:1,18 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
+|
+    |
+Generated Location: (783:22,30 [6] )
+|
+    |
 
 Source Location: (29:2,5 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.IntIndexer?[0]|
-Generated Location: (839:21,6 [22] )
+Generated Location: (899:25,6 [22] )
 |ViewBag.IntIndexer?[0]|
+
+Source Location: (51:2,27 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
+|
+    |
+Generated Location: (994:29,39 [6] )
+|
+    |
 
 Source Location: (58:3,5 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.StrIndexer?["key"]|
-Generated Location: (1003:26,6 [26] )
+Generated Location: (1110:32,6 [26] )
 |ViewBag.StrIndexer?["key"]|
+
+Source Location: (84:3,31 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
+|
+    |
+Generated Location: (1213:36,43 [6] )
+|
+    |
 
 Source Location: (91:4,5 [41] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
-Generated Location: (1171:31,6 [41] )
+Generated Location: (1329:39,6 [41] )
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
+
+Source Location: (132:4,46 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
+|
+|
+Generated Location: (1462:43,58 [2] )
+|
+|
 
 Source Location: (140:7,1 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Data|
-Generated Location: (1354:36,6 [13] )
+Generated Location: (1574:46,6 [13] )
 |ViewBag?.Data|
 
 Source Location: (156:8,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.IntIndexer?[0]|
-Generated Location: (1509:41,6 [22] )
+Generated Location: (1729:51,6 [22] )
 |ViewBag.IntIndexer?[0]|
 
 Source Location: (181:9,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.StrIndexer?["key"]|
-Generated Location: (1674:46,6 [26] )
+Generated Location: (1894:56,6 [26] )
 |ViewBag.StrIndexer?["key"]|
 
 Source Location: (210:10,1 [41] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
-Generated Location: (1843:51,6 [41] )
+Generated Location: (2063:61,6 [41] )
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_Runtime.ir.txt
@@ -5,14 +5,19 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NullConditionalExpressions_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [6] NullConditionalExpressions.cshtml) - \n    
                 CSharpExpression - (9:1,5 [13] NullConditionalExpressions.cshtml)
                     RazorIRToken - (9:1,5 [13] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Data
+                CSharpStatement - (22:1,18 [6] NullConditionalExpressions.cshtml) - \n    
                 CSharpExpression - (29:2,5 [22] NullConditionalExpressions.cshtml)
                     RazorIRToken - (29:2,5 [22] NullConditionalExpressions.cshtml) - CSharp - ViewBag.IntIndexer?[0]
+                CSharpStatement - (51:2,27 [6] NullConditionalExpressions.cshtml) - \n    
                 CSharpExpression - (58:3,5 [26] NullConditionalExpressions.cshtml)
                     RazorIRToken - (58:3,5 [26] NullConditionalExpressions.cshtml) - CSharp - ViewBag.StrIndexer?["key"]
+                CSharpStatement - (84:3,31 [6] NullConditionalExpressions.cshtml) - \n    
                 CSharpExpression - (91:4,5 [41] NullConditionalExpressions.cshtml)
                     RazorIRToken - (91:4,5 [41] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Method(Value?[23]?.More)?["key"]
+                CSharpStatement - (132:4,46 [2] NullConditionalExpressions.cshtml) - \n
                 HtmlContent - (137:6,0 [2] NullConditionalExpressions.cshtml) - \n
                 CSharpExpression - (140:7,1 [13] NullConditionalExpressions.cshtml)
                     RazorIRToken - (140:7,1 [13] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Data

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.codegen.cs
@@ -18,6 +18,9 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
 
 #line default
 #line hidden
+                   
+
+                   
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.ir.txt
@@ -14,4 +14,6 @@ Document -
                 HtmlContent - (0:0,0 [16] OpenedIf.cshtml) - <html>\n<body>\n
                 CSharpStatement - (17:2,1 [14] OpenedIf.cshtml) - if (true) { \n
                 HtmlContent - (31:3,0 [7] OpenedIf.cshtml) - </body>
+                CSharpStatement - (38:3,7 [2] OpenedIf.cshtml) - \n
                 HtmlContent - (40:4,0 [7] OpenedIf.cshtml) - </html>
+                CSharpStatement - (47:4,7 [0] OpenedIf.cshtml) - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.mappings.txt
@@ -5,3 +5,15 @@ Generated Location: (643:16,1 [14] )
 |if (true) { 
 |
 
+Source Location: (38:3,7 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf.cshtml)
+|
+|
+Generated Location: (707:20,19 [2] )
+|
+|
+
+Source Location: (47:4,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf.cshtml)
+||
+Generated Location: (730:22,19 [0] )
+||
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_Runtime.ir.txt
@@ -8,3 +8,4 @@ Document -
                 HtmlContent - (0:0,0 [16] OpenedIf.cshtml) - <html>\n<body>\n
                 CSharpStatement - (17:2,1 [14] OpenedIf.cshtml) - if (true) { \n
                 HtmlContent - (31:3,0 [16] OpenedIf.cshtml) - </body>\n</html>
+                CSharpStatement - (47:4,7 [0] OpenedIf.cshtml) - 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.codegen.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+              
+    
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml"
                                        
     Exception foo = 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.ir.txt
@@ -13,6 +13,7 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (36:0,36 [17] RazorComments.cshtml) - \n<p>This should 
                 HtmlContent - (62:1,24 [17] RazorComments.cshtml) -  be shown</p>\n\n
+                CSharpStatement - (81:3,2 [6] RazorComments.cshtml) - \n    
                 CSharpStatement - (122:4,39 [22] RazorComments.cshtml) - \n    Exception foo = 
                 CSharpStatement - (173:5,49 [58] RazorComments.cshtml) -  null;\n    if(foo != null) {\n        throw foo;\n    }\n
                 HtmlContent - (234:10,0 [2] RazorComments.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.mappings.txt
@@ -1,7 +1,14 @@
+Source Location: (81:3,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
+|
+    |
+Generated Location: (577:15,14 [6] )
+|
+    |
+
 Source Location: (122:4,39 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |
     Exception foo = |
-Generated Location: (691:16,39 [22] )
+Generated Location: (713:18,39 [22] )
 |
     Exception foo = |
 
@@ -11,7 +18,7 @@ Source Location: (173:5,49 [58] TestFiles/IntegrationTests/CodeGenerationIntegra
         throw foo;
     }
 |
-Generated Location: (884:22,49 [58] )
+Generated Location: (906:24,49 [58] )
 | null;
     if(foo != null) {
         throw foo;
@@ -20,21 +27,21 @@ Generated Location: (884:22,49 [58] )
 
 Source Location: (238:11,2 [24] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 | var bar = "@* bar *@"; |
-Generated Location: (1065:30,2 [24] )
+Generated Location: (1087:32,2 [24] )
 | var bar = "@* bar *@"; |
 
 Source Location: (310:12,45 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |bar|
-Generated Location: (1257:35,45 [3] )
+Generated Location: (1279:37,45 [3] )
 |bar|
 
 Source Location: (323:14,2 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |a|
-Generated Location: (1390:40,6 [1] )
+Generated Location: (1412:42,6 [1] )
 |a|
 
 Source Location: (328:14,7 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |b|
-Generated Location: (1391:40,7 [1] )
+Generated Location: (1413:42,7 [1] )
 |b|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.ir.txt
@@ -7,6 +7,7 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (36:0,36 [17] RazorComments.cshtml) - \n<p>This should 
                 HtmlContent - (62:1,24 [17] RazorComments.cshtml) -  be shown</p>\n\n
+                CSharpStatement - (81:3,2 [6] RazorComments.cshtml) - \n    
                 CSharpStatement - (122:4,39 [22] RazorComments.cshtml) - \n    Exception foo = 
                 CSharpStatement - (173:5,49 [58] RazorComments.cshtml) -  null;\n    if(foo != null) {\n        throw foo;\n    }\n
                 HtmlContent - (234:10,0 [2] RazorComments.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.ir.txt
@@ -23,6 +23,7 @@ Document -
                 HtmlContent - (224:13,0 [2] Sections.cshtml) - \n
                 CSharpStatement -  - DefineSection("NestedDelegates", async () => {
                 HtmlContent - (252:14,26 [2] Sections.cshtml) - \n
+                CSharpStatement - (254:15,0 [4] Sections.cshtml) -     
                 CSharpStatement - (260:15,6 [27] Sections.cshtml) -  Func<dynamic, object> f = 
                 Template - (288:15,34 [17] Sections.cshtml)
                     HtmlContent - (288:15,34 [6] Sections.cshtml) - <span>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.codegen.cs
@@ -38,6 +38,8 @@ __o = foo("");
 
 #line default
 #line hidden
+                        
+
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 __o = Repeat(10, item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.ir.txt
@@ -21,6 +21,7 @@ Document -
                 CSharpStatement - (349:11,63 [7] Templates.cshtml) - ;\n    
                 CSharpExpression - (357:12,5 [7] Templates.cshtml)
                     RazorIRToken - (357:12,5 [7] Templates.cshtml) - CSharp - foo("")
+                CSharpStatement - (364:12,12 [2] Templates.cshtml) - \n
                 HtmlContent - (369:14,0 [8] Templates.cshtml) - \n<ul>\n
                 CSharpExpression - (379:16,2 [31] Templates.cshtml)
                     RazorIRToken - (379:16,2 [11] Templates.cshtml) - CSharp - Repeat(10, 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.mappings.txt
@@ -22,90 +22,97 @@ Source Location: (357:12,5 [7] TestFiles/IntegrationTests/CodeGenerationIntegrat
 Generated Location: (1305:36,6 [7] )
 |foo("")|
 
+Source Location: (364:12,12 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
+|
+|
+Generated Location: (1370:40,24 [2] )
+|
+|
+
 Source Location: (379:16,2 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10, |
-Generated Location: (1438:41,6 [11] )
+Generated Location: (1466:43,6 [11] )
 |Repeat(10, |
 
 Source Location: (402:16,25 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (1653:43,25 [4] )
+Generated Location: (1681:45,25 [4] )
 |item|
 
 Source Location: (411:16,34 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (1695:48,1 [1] )
+Generated Location: (1723:50,1 [1] )
 |)|
 
 Source Location: (430:20,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (1822:53,6 [16] )
+Generated Location: (1850:55,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (463:21,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2038:56,21 [4] )
+Generated Location: (2066:58,21 [4] )
 |item|
 
 Source Location: (484:22,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2080:61,1 [1] )
+Generated Location: (2108:63,1 [1] )
 |)|
 
 Source Location: (501:26,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (2207:66,6 [16] )
+Generated Location: (2235:68,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (535:27,22 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2424:69,22 [4] )
+Generated Location: (2452:71,22 [4] )
 |item|
 
 Source Location: (557:28,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2466:74,1 [1] )
+Generated Location: (2494:76,1 [1] )
 |)|
 
 Source Location: (574:32,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (2593:79,6 [16] )
+Generated Location: (2621:81,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (609:33,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2811:82,23 [4] )
+Generated Location: (2839:84,23 [4] )
 |item|
 
 Source Location: (631:34,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2853:87,1 [1] )
+Generated Location: (2881:89,1 [1] )
 |)|
 
 Source Location: (655:39,5 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10, |
-Generated Location: (2980:92,6 [11] )
+Generated Location: (3008:94,6 [11] )
 |Repeat(10, |
 
 Source Location: (688:40,15 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (3185:94,15 [4] )
+Generated Location: (3213:96,15 [4] )
 |item|
 
 Source Location: (704:41,10 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |var parent = item;|
-Generated Location: (3319:99,10 [18] )
+Generated Location: (3347:101,10 [18] )
 |var parent = item;|
 
 Source Location: (863:46,9 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (3374:104,1 [1] )
+Generated Location: (3402:106,1 [1] )
 |)|
 
 Source Location: (12:0,12 [265] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
@@ -118,7 +125,7 @@ Source Location: (12:0,12 [265] TestFiles/IntegrationTests/CodeGenerationIntegra
         });
     }
 |
-Generated Location: (3555:111,12 [265] )
+Generated Location: (3583:113,12 [265] )
 |
     public HelperResult Repeat(int times, Func<int, object> template) {
         return new HelperResult((writer) => {

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.ir.txt
@@ -15,6 +15,7 @@ Document -
                 CSharpStatement - (349:11,63 [7] Templates.cshtml) - ;\n    
                 CSharpExpression - (357:12,5 [7] Templates.cshtml)
                     RazorIRToken - (357:12,5 [7] Templates.cshtml) - CSharp - foo("")
+                CSharpStatement - (364:12,12 [2] Templates.cshtml) - \n
                 HtmlContent - (369:14,0 [8] Templates.cshtml) - \n<ul>\n
                 CSharpExpression - (379:16,2 [31] Templates.cshtml)
                     RazorIRToken - (379:16,2 [11] Templates.cshtml) - CSharp - Repeat(10, 
@@ -52,13 +53,14 @@ Document -
                         HtmlContent - (613:33,27 [18] Templates.cshtml) -  of markup<br />\n
                     RazorIRToken - (631:34,0 [1] Templates.cshtml) - CSharp - )
                 HtmlContent - (632:34,1 [22] Templates.cshtml) - \n</p>\n\n\n<ul>\n    
-                CSharpExpression - (655:39,5 [133] Templates.cshtml)
+                CSharpExpression - (655:39,5 [141] Templates.cshtml)
                     RazorIRToken - (655:39,5 [11] Templates.cshtml) - CSharp - Repeat(10, 
-                    Template - (667:39,17 [121] Templates.cshtml)
+                    Template - (667:39,17 [129] Templates.cshtml)
                         HtmlContent - (667:39,17 [20] Templates.cshtml) - <li>\n        Item #
                         CSharpExpression - (688:40,15 [4] Templates.cshtml)
                             RazorIRToken - (688:40,15 [4] Templates.cshtml) - CSharp - item
                         HtmlContent - (692:40,19 [2] Templates.cshtml) - \n
+                        CSharpStatement - (694:41,0 [8] Templates.cshtml) -         
                         CSharpStatement - (704:41,10 [18] Templates.cshtml) - var parent = item;
                         HtmlContent - (725:42,0 [53] Templates.cshtml) -         <ul>\n            <li>Child Items... ?</li>\n
                         HtmlContent - (839:45,0 [24] Templates.cshtml) -         </ul>\n    </li>

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.codegen.cs
@@ -13,11 +13,15 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+              
+
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml"
 __o = DateTime.;
 
 #line default
 #line hidden
+                      
+
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.ir.txt
@@ -11,5 +11,7 @@ Document -
                 CSharpStatement -  - #pragma warning restore 219
             CSharpStatement -  - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [2] UnfinishedExpressionInCode.cshtml) - \n
                 CSharpExpression - (5:1,1 [9] UnfinishedExpressionInCode.cshtml)
                     RazorIRToken - (5:1,1 [9] UnfinishedExpressionInCode.cshtml) - CSharp - DateTime.
+                CSharpStatement - (14:1,10 [2] UnfinishedExpressionInCode.cshtml) - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.mappings.txt
@@ -1,5 +1,19 @@
+Source Location: (2:0,2 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml)
+|
+|
+Generated Location: (590:15,14 [2] )
+|
+|
+
 Source Location: (5:1,1 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml)
 |DateTime.|
-Generated Location: (684:16,6 [9] )
+Generated Location: (702:18,6 [9] )
 |DateTime.|
+
+Source Location: (14:1,10 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml)
+|
+|
+Generated Location: (767:22,22 [2] )
+|
+|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_Runtime.ir.txt
@@ -5,5 +5,7 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_UnfinishedExpressionInCode_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                CSharpStatement - (2:0,2 [2] UnfinishedExpressionInCode.cshtml) - \n
                 CSharpExpression - (5:1,1 [9] UnfinishedExpressionInCode.cshtml)
                     RazorIRToken - (5:1,1 [9] UnfinishedExpressionInCode.cshtml) - CSharp - DateTime.
+                CSharpStatement - (14:1,10 [2] UnfinishedExpressionInCode.cshtml) - \n


### PR DESCRIPTION
Reverting https://github.com/aspnet/Razor/pull/1127

This is not a full revert. This is still not generating line pragmas for whitespace nodes.

@NTaylorMullen @rynowak 