### PR TITLE
Add a service for initializing tooling

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultRazorTemplateEngineFactoryService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultRazorTemplateEngineFactoryService.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+using Microsoft.AspNetCore.Razor.Evolution;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [Export(typeof(RazorTemplateEngineFactoryService))]
+    internal class DefaultRazorTemplateEngineFactoryService : RazorTemplateEngineFactoryService
+    {
+        public override RazorTemplateEngine Create(string projectPath, Action<IRazorEngineBuilder> configure)
+        {
+            if (projectPath == null)
+            {
+                throw new ArgumentNullException(nameof(projectPath));
+            }
+
+            var engine = RazorEngine.CreateDesignTime(b =>
+            {
+                configure?.Invoke(b);
+
+                // For now we're hardcoded to use MVC's extensibility.
+                RazorExtensions.Register(b);
+            });
+
+            var templateEngine = new MvcRazorTemplateEngine(engine, new FileSystemRazorProject(projectPath));
+            templateEngine.Options.ImportsFileName = "_ViewImports.cshtml";
+            return templateEngine;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.Evolution\Microsoft.AspNetCore.Razor.Evolution.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Razor.Extensions\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorTemplateEngineFactoryService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorTemplateEngineFactoryService.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Evolution;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public abstract class RazorTemplateEngineFactoryService
+    {
+        public abstract RazorTemplateEngine Create(string projectPath, Action<IRazorEngineBuilder> configure);
+    }
+}


### PR DESCRIPTION
This is a new API for tooling to call to get a RazorTemplateEngine that's
initialized correctly. For now this is hardcoded to use MVC's conventions.

This is also a very temporary design to get us past the next wave of
changes.

We'll eventually want to change this to an ILanguageService, but this will
require some new plumbing in the editor, so let's defer that for another
day.