### PR TITLE
Workaround tooling issue with runtime only TagHelpers.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Properties/Resources.Designer.cs
@@ -137,20 +137,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             => GetString("TagHelperAssemblyNameCannotBeEmptyOrNull");
 
         /// <summary>
-        /// The assembly '{0}' could not be resolved or contains no tag helpers.
-        /// </summary>
-        internal static string TagHelperAssemblyCouldNotBeResolved
-        {
-            get => GetString("TagHelperAssemblyCouldNotBeResolved");
-        }
-
-        /// <summary>
-        /// The assembly '{0}' could not be resolved or contains no tag helpers.
-        /// </summary>
-        internal static string FormatTagHelperAssemblyCouldNotBeResolved(object p0)
-            => string.Format(CultureInfo.CurrentCulture, GetString("TagHelperAssemblyCouldNotBeResolved"), p0);
-
-        /// <summary>
         /// Path must begin with a forward slash '/'.
         /// </summary>
         internal static string RazorProject_PathMustStartWithForwardSlash

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Resources.resx
@@ -144,9 +144,6 @@
   <data name="TagHelperAssemblyNameCannotBeEmptyOrNull" xml:space="preserve">
     <value>Tag helper directive assembly name cannot be null or empty.</value>
   </data>
-  <data name="TagHelperAssemblyCouldNotBeResolved" xml:space="preserve">
-    <value>The assembly '{0}' could not be resolved or contains no tag helpers.</value>
-  </data>
   <data name="RazorProject_PathMustStartWithForwardSlash" xml:space="preserve">
     <value>Path must begin with a forward slash '/'.</value>
   </data>

--- a/src/Microsoft.AspNetCore.Razor.Evolution/TagHelperBinderSyntaxTreePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/TagHelperBinderSyntaxTreePass.cs
@@ -138,12 +138,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
                         if (!AssemblyContainsTagHelpers(parsed.AssemblyName, tagHelpers))
                         {
-                            errorSink.OnError(
-                                parsed.AssemblyNameLocation,
-                                Resources.FormatTagHelperAssemblyCouldNotBeResolved(parsed.AssemblyName),
-                                parsed.AssemblyName.Length);
-
-                            // Skip this one, it's an error
+                            // No tag helpers in the assembly.
                             break;
                         }
 
@@ -170,12 +165,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
                         if (!AssemblyContainsTagHelpers(parsed.AssemblyName, tagHelpers))
                         {
-                            errorSink.OnError(
-                                parsed.AssemblyNameLocation,
-                                Resources.FormatTagHelperAssemblyCouldNotBeResolved(parsed.AssemblyName),
-                                parsed.AssemblyName.Length);
-
-                            // Skip this one, it's an error
+                            // No tag helpers in the assembly.
                             break;
                         }
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TagHelperBinderSyntaxTreePassTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TagHelperBinderSyntaxTreePassTest.cs
@@ -257,40 +257,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution
         }
 
         [Fact]
-        public void Execute_AddsErrorWhenNoTagHelpersAreFoundInAssembly()
-        {
-            // Arrange
-            var engine = RazorEngine.Create(builder =>
-            {
-                builder.Features.Add(new TestTagHelperFeature());
-            });
-
-            var pass = new TagHelperBinderSyntaxTreePass()
-            {
-                Engine = engine,
-            };
-
-            var sourceDocument = CreateTestSourceDocument();
-            var codeDocument = RazorCodeDocument.Create(sourceDocument);
-            var originalTree = RazorSyntaxTree.Parse(sourceDocument);
-
-            var expectedError = RazorDiagnostic.Create(
-                new RazorError(
-                    Resources.FormatTagHelperAssemblyCouldNotBeResolved("TestAssembly"),
-                    new SourceLocation(Environment.NewLine.Length + 17, 1, 1),
-                    length: 12));
-
-            // Act
-            var outputTree = pass.Execute(codeDocument, originalTree);
-
-            // Assert
-            Assert.Same(originalTree.Root, outputTree.Root);
-
-            var error = Assert.Single(outputTree.Diagnostics);
-            Assert.Equal(expectedError, error);
-        }
-
-        [Fact]
         public void Execute_RecreatesSyntaxTreeOnResolverErrors()
         {
             // Arrange


### PR DESCRIPTION
This is an FYI PR since it's a potential temporary workaround to unblock tooling.

- Prior to this if all instances of `TagHelper`s in an assembly had editor browsable never we'd log an error saying that no TagHelpers were found for that assembly. Until we can evaluate a better fix for this issue I've removed the logic that logs those errors and its corresponding tests/resources.

#1145