### PR TITLE
Generate line mappings for empty expressions.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
@@ -19,10 +19,6 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
         public override void VisitCSharpExpression(CSharpExpressionIRNode node)
         {
             // We can't remove this yet, because it's still used recursively in a few places.
-            if (node.Children.Count == 0)
-            {
-                return;
-            }
 
             if (node.Source != null)
             {
@@ -35,19 +31,29 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
                         .Write(padding)
                         .WriteStartAssignment(RazorDesignTimeIRPass.DesignTimeVariable);
 
-                    for (var i = 0; i < node.Children.Count; i++)
+                    if (node.Children.Count > 0)
                     {
+                        for (var i = 0; i < node.Children.Count; i++)
+                        {
                         var token = node.Children[i] as RazorIRToken;
                         if (token != null && token.IsCSharp)
-                        {
-                            Context.AddLineMappingFor(token);
-                            Context.Writer.Write(token.Content);
+                            {
+                                Context.AddLineMappingFor(token);
+                                Context.Writer.Write(token.Content);
+                            }
+                            else
+                            {
+                                // There may be something else inside the expression like a Template or another extension node.
+                                Visit(node.Children[i]);
+                            }
                         }
-                        else
-                        {
-                            // There may be something else inside the expression like a Template or another extension node.
-                            Visit(node.Children[i]);
-                        }
+                    }
+                    else
+                    {
+                        // When typing "@" / "@(" we still need to provide IntelliSense. This is taken care of by creating a 0 length 
+                        // line mapping. It's also important that this 0 length line mapping exists in a line pragma so when a user 
+                        // starts typing additional characters following their "@" they get appropriately located errors.
+                        Context.AddLineMappingFor(node);
                     }
 
                     Context.Writer.WriteLine(";");

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DefaultRazorIRLoweringPhase.cs
@@ -344,6 +344,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
                 _builder.Pop();
 
+                var emptyExpression = true;
                 if (expressionNode.Children.Count > 0)
                 {
                     var sourceRangeStart = expressionNode
@@ -361,7 +362,18 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                             sourceRangeStart.Value.LineIndex,
                             sourceRangeStart.Value.CharacterIndex,
                             contentLength);
+                        emptyExpression = false;
                     }
+                }
+
+                if (emptyExpression)
+                {
+                    expressionNode.Source = new SourceSpan(
+                        block.Start.FilePath ?? FileName,
+                        block.Start.AbsoluteIndex,
+                        block.Start.LineIndex,
+                        block.Start.CharacterIndex,
+                        length: 0);
                 }
             }
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression.cshtml"
+__o = ;
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.ir.txt
@@ -17,4 +17,4 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] EmptyExplicitExpression.cshtml) - This is markup\n\n
-                CSharpExpression - 
+                CSharpExpression - (18:2,0 [0] EmptyExplicitExpression.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (18:2,0 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression.cshtml)
+||
+Generated Location: (678:16,6 [0] )
+||
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.codegen.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             WriteLiteral("This is markup\r\n\r\n");
-            Write();
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression.cshtml"
+Write();
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.ir.txt
@@ -6,4 +6,4 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyExplicitExpression_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] EmptyExplicitExpression.cshtml) - This is markup\n\n
-                CSharpExpression - 
+                CSharpExpression - (18:2,0 [0] EmptyExplicitExpression.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.codegen.cs
@@ -15,6 +15,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         {
               
     
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml"
+__o = ;
+
+#line default
+#line hidden
                  
 
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.ir.txt
@@ -18,6 +18,6 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [6] EmptyImplicitExpressionInCode.cshtml)
                     RazorIRToken - (2:0,2 [6] EmptyImplicitExpressionInCode.cshtml) - CSharp - \n    
-                CSharpExpression - 
+                CSharpExpression - (8:1,4 [0] EmptyImplicitExpressionInCode.cshtml)
                 CSharpStatement - (9:1,5 [2] EmptyImplicitExpressionInCode.cshtml)
                     RazorIRToken - (9:1,5 [2] EmptyImplicitExpressionInCode.cshtml) - CSharp - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.mappings.txt
@@ -5,10 +5,15 @@ Generated Location: (593:15,14 [6] )
 |
     |
 
+Source Location: (8:1,4 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
+||
+Generated Location: (712:18,6 [0] )
+||
+
 Source Location: (9:1,5 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
 |
 |
-Generated Location: (618:17,17 [2] )
+Generated Location: (763:22,17 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_Runtime.codegen.cs
@@ -9,7 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            Write();
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml"
+Write();
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_Runtime.ir.txt
@@ -7,6 +7,6 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [6] EmptyImplicitExpressionInCode.cshtml)
                     RazorIRToken - (2:0,2 [6] EmptyImplicitExpressionInCode.cshtml) - CSharp - \n    
-                CSharpExpression - 
+                CSharpExpression - (8:1,4 [0] EmptyImplicitExpressionInCode.cshtml)
                 CSharpStatement - (9:1,5 [2] EmptyImplicitExpressionInCode.cshtml)
                     RazorIRToken - (9:1,5 [2] EmptyImplicitExpressionInCode.cshtml) - CSharp - \n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression.cshtml"
+__o = ;
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.ir.txt
@@ -17,5 +17,5 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] EmptyImplicitExpression.cshtml) - This is markup\n\n
-                CSharpExpression - 
+                CSharpExpression - (18:2,0 [0] EmptyImplicitExpression.cshtml)
                 HtmlContent - (19:2,1 [1] EmptyImplicitExpression.cshtml) - !

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (18:2,0 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression.cshtml)
+||
+Generated Location: (678:16,6 [0] )
+||
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.codegen.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             WriteLiteral("This is markup\r\n\r\n");
-            Write();
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression.cshtml"
+Write();
+
+#line default
+#line hidden
             WriteLiteral("!");
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.ir.txt
@@ -6,5 +6,5 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyImplicitExpression_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] EmptyImplicitExpression.cshtml) - This is markup\n\n
-                CSharpExpression - 
+                CSharpExpression - (18:2,0 [0] EmptyImplicitExpression.cshtml)
                 HtmlContent - (19:2,1 [1] EmptyImplicitExpression.cshtml) - !

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF.cshtml"
+__o = ;
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.ir.txt
@@ -17,4 +17,4 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml) - This is markup\n\n
-                CSharpExpression - 
+                CSharpExpression - (18:2,0 [0] ExplicitExpressionAtEOF.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (18:2,0 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF.cshtml)
+||
+Generated Location: (678:16,6 [0] )
+||
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.codegen.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             WriteLiteral("This is markup\r\n\r\n");
-            Write();
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF.cshtml"
+Write();
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.ir.txt
@@ -6,4 +6,4 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpressionAtEOF_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml) - This is markup\n\n
-                CSharpExpression - 
+                CSharpExpression - (18:2,0 [0] ExplicitExpressionAtEOF.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.codegen.cs
@@ -13,6 +13,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF.cshtml"
+__o = ;
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.ir.txt
@@ -17,4 +17,4 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml) - This is markup\n\n
-                CSharpExpression - 
+                CSharpExpression - (18:2,0 [0] ImplicitExpressionAtEOF.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (18:2,0 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF.cshtml)
+||
+Generated Location: (678:16,6 [0] )
+||
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.codegen.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             WriteLiteral("This is markup\r\n\r\n");
-            Write();
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF.cshtml"
+Write();
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.ir.txt
@@ -6,4 +6,4 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ImplicitExpressionAtEOF_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml) - This is markup\n\n
-                CSharpExpression - 
+                CSharpExpression - (18:2,0 [0] ImplicitExpressionAtEOF.cshtml)


### PR DESCRIPTION
- At design time we weren't generating line mappings when a user would type `@` or `@(`. This results in no C# IntelliSense being provided to the user because the editor hasn't mapped any of Razor to the C# buffer.
- Updated the design time renderer and design time writer to account for empty expressions.
- Modified the `DefaultIRLoweringPhase` to set source locations on empty expression nodes.
- Re-generated test files to account for 0 length line mappings on empty expression nodes.

#1155