### PR TITLE
Add line mappings for using directives.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
@@ -67,6 +67,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
             {
                 using (Context.Writer.BuildLinePragma(node.Source.Value))
                 {
+                    Context.AddLineMappingFor(node);
                     Context.Writer.WriteUsing(node.Content);
                 }
             }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Inject.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Inject.mappings.txt
@@ -1,3 +1,8 @@
+Source Location: (1:0,1 [17] /TestFiles/Input/Inject.cshtml)
+|using MyNamespace|
+Generated Location: (574:32,0 [17] )
+|using MyNamespace|
+
 Source Location: (28:1,8 [5] /TestFiles/Input/Inject.cshtml)
 |MyApp|
 Generated Location: (869:41,0 [5] )

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPages.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPages.mappings.txt
@@ -1,3 +1,8 @@
+Source Location: (60:4,1 [41] /TestFiles/Input/RazorPages.cshtml)
+|using Microsoft.AspNetCore.Mvc.RazorPages|
+Generated Location: (565:32,0 [41] )
+|using Microsoft.AspNetCore.Mvc.RazorPages|
+
 Source Location: (16:2,7 [8] /TestFiles/Input/RazorPages.cshtml)
 |NewModel|
 Generated Location: (879:41,0 [8] )

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.mappings.txt
@@ -1,3 +1,28 @@
+Source Location: (1:0,1 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
+|using System.IO|
+Generated Location: (232:6,0 [15] )
+|using System.IO|
+
+Source Location: (19:1,1 [32] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
+|using Foo = System.Text.Encoding|
+Generated Location: (363:11,0 [32] )
+|using Foo = System.Text.Encoding|
+
+Source Location: (71:4,1 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
+|using static System|
+Generated Location: (511:16,0 [19] )
+|using static System|
+
+Source Location: (93:5,1 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
+|using static System.Console|
+Generated Location: (646:21,0 [27] )
+|using static System.Console|
+
+Source Location: (123:6,1 [41] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
+|using static global::System.Text.Encoding|
+Generated Location: (789:26,0 [41] )
+|using static global::System.Text.Encoding|
+
 Source Location: (197:8,29 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
 |typeof(Path).FullName|
 Generated Location: (1381:41,29 [21] )


### PR DESCRIPTION
- We were generating line pragmas for using directives but not line mappings. This resulted in 0 IntelliSense when written within the Razor editor.
- Regenerated test files to reflect new line mappings.

#1162