### PR TITLE
Add support for namespace tokens in extensible directives

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
@@ -159,6 +159,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
                 {
                     case DirectiveTokenKind.Type:
 
+                        // {node.Content} __typeHelper = null;
+
                         Context.AddLineMappingFor(node);
                         Context.Writer
                             .Write(node.Content)
@@ -166,8 +168,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
                             .WriteStartAssignment(TypeHelper)
                             .WriteLine("null;");
                         break;
+
                     case DirectiveTokenKind.Member:
+
+                        // global::System.Object __typeHelper = null;
+
                         Context.Writer
+                            .Write("global::")
                             .Write(typeof(object).FullName)
                             .Write(" ");
 
@@ -176,6 +183,27 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
                             .Write(node.Content)
                             .WriteLine(" = null;");
                         break;
+
+                    case DirectiveTokenKind.Namespace:
+
+                        // global::System.Object __typeHelper = nameof({node.Content});
+
+                        Context.Writer
+                            .Write("global::")
+                            .Write(typeof(object).FullName)
+                            .Write(" ")
+                            .Write(TypeHelper);
+
+                        Context.Writer.Write(" = ");
+
+                        Context.Writer.Write("nameof(");
+
+                        Context.AddLineMappingFor(node);
+                        Context.Writer
+                            .Write(node.Content)
+                            .WriteLine(");");
+                        break;
+
                     case DirectiveTokenKind.String:
                         Context.Writer
                             .Write(typeof(object).FullName)

--- a/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/DesignTimeCSharpRenderer.cs
@@ -205,7 +205,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
                         break;
 
                     case DirectiveTokenKind.String:
+
+                        // global::System.Object __typeHelper = "{node.Content}";
+
                         Context.Writer
+                            .Write("global::")
                             .Write(typeof(object).FullName)
                             .Write(" ")
                             .WriteStartAssignment(TypeHelper);

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveDescriptorBuilder.cs
@@ -61,6 +61,18 @@ namespace Microsoft.AspNetCore.Razor.Evolution
                 return this;
             }
 
+            public IDirectiveDescriptorBuilder AddNamespace()
+            {
+                var descriptor = new DirectiveTokenDescriptor()
+                {
+                    Kind = DirectiveTokenKind.Namespace,
+                    Optional = _optional,
+                };
+                _tokenDescriptors.Add(descriptor);
+
+                return this;
+            }
+
             public IDirectiveDescriptorBuilder AddString()
             {
                 var descriptor = new DirectiveTokenDescriptor()

--- a/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenKind.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/DirectiveTokenKind.cs
@@ -6,6 +6,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution
     public enum DirectiveTokenKind
     {
         Type,
+        Namespace,
         Member,
         String,
     }

--- a/src/Microsoft.AspNetCore.Razor.Evolution/IDirectiveDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/IDirectiveDescriptorBuilder.cs
@@ -9,6 +9,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution
 
         IDirectiveDescriptorBuilder AddMember();
 
+        IDirectiveDescriptorBuilder AddNamespace();
+
         IDirectiveDescriptorBuilder AddString();
 
         IDirectiveDescriptorBuilder BeginOptionals();

--- a/src/Microsoft.AspNetCore.Razor.Evolution/LegacyResources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/LegacyResources.resx
@@ -182,6 +182,9 @@
   <data name="DirectiveExpectsIdentifier" xml:space="preserve">
     <value>The '{0}' directive expects an identifier.</value>
   </data>
+  <data name="DirectiveExpectsNamespace" xml:space="preserve">
+    <value>The '{0}' directive expects a namespace name.</value>
+  </data>
   <data name="DirectiveExpectsQuotedStringLiteral" xml:space="preserve">
     <value>The '{0}' directive expects a string surrounded by double quotes.</value>
   </data>

--- a/src/Microsoft.AspNetCore.Razor.Evolution/Properties/LegacyResources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Properties/LegacyResources.Designer.cs
@@ -305,6 +305,20 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             => string.Format(CultureInfo.CurrentCulture, GetString("DirectiveExpectsIdentifier"), p0);
 
         /// <summary>
+        /// The '{0}' directive expects a namespace name.
+        /// </summary>
+        internal static string DirectiveExpectsNamespace
+        {
+            get => GetString("DirectiveExpectsNamespace");
+        }
+
+        /// <summary>
+        /// The '{0}' directive expects a namespace name.
+        /// </summary>
+        internal static string FormatDirectiveExpectsNamespace(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("DirectiveExpectsNamespace"), p0);
+
+        /// <summary>
         /// The '{0}' directive expects a string surrounded by double quotes.
         /// </summary>
         internal static string DirectiveExpectsQuotedStringLiteral

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -773,6 +773,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
             // Arrange, Act & Assert
             RunRuntimeTagHelpersTest(TestTagHelperDescriptors.TagHelpersInSectionDescriptors);
         }
+
         #endregion
 
         #region DesignTime

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/ExtensibleDirectiveTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/ExtensibleDirectiveTest.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Evolution.Intermediate;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
+{
+    // Extensible directives only have codegen for design time, so we're only testing that.
+    public class ExtensibleDirectiveTest : IntegrationTestBase
+    {
+        [Fact]
+        public void NamespaceToken()
+        {
+            // Arrange
+            var engine = RazorEngine.CreateDesignTime(builder =>
+            {
+                builder.Features.Add(new ApiSetsIRTestAdapter());
+
+                builder.AddDirective(DirectiveDescriptorBuilder.Create("custom").AddNamespace().Build());
+            });
+
+            var document = CreateCodeDocument();
+
+            // Act
+            engine.Process(document);
+
+            // Assert
+            AssertIRMatchesBaseline(document.GetIRDocument());
+            AssertDesignTimeDocumentMatchBaseline(document);
+        }
+
+        private class ApiSetsIRTestAdapter : RazorIRPassBase, IRazorIROptimizationPass
+        {
+            public override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIRNode irDocument)
+            {
+                var walker = new ApiSetsIRWalker();
+                walker.Visit(irDocument);
+            }
+
+            private class ApiSetsIRWalker : RazorIRNodeWalker
+            {
+                public override void VisitClass(ClassDeclarationIRNode node)
+                {
+                    node.Name = Filename.Replace('/', '_');
+                    node.AccessModifier = "public";
+
+                    VisitDefault(node);
+                }
+
+                public override void VisitNamespace(NamespaceDeclarationIRNode node)
+                {
+                    node.Content = typeof(CodeGenerationIntegrationTest).Namespace + ".TestFiles";
+
+                    VisitDefault(node);
+                }
+
+                public override void VisitRazorMethodDeclaration(RazorMethodDeclarationIRNode node)
+                {
+                    node.AccessModifier = "public";
+                    node.Modifiers = new[] { "async" };
+                    node.ReturnType = typeof(Task).FullName;
+                    node.Name = "ExecuteAsync";
+
+                    VisitDefault(node);
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/Legacy/CSharpDirectivesTest.cs
@@ -51,6 +51,66 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
         }
 
         [Fact]
+        public void Parser_ParsesNamespaceDirectiveToken_WithSingleSegment()
+        {
+            // Arrange
+            var descriptor = DirectiveDescriptorBuilder.Create("custom").AddNamespace().Build();
+
+            // Act & Assert
+            ParseCodeBlockTest(
+                "@custom BaseNamespace",
+                new[] { descriptor },
+                new DirectiveBlock(
+                    new DirectiveChunkGenerator(descriptor),
+                    Factory.CodeTransition(),
+                    Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
+                    Factory.Span(SpanKind.Code, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
+                    Factory.Span(SpanKind.Code, "BaseNamespace", markup: false)
+                        .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
+                        .Accepts(AcceptedCharacters.NonWhiteSpace)));
+        }
+
+        [Fact]
+        public void Parser_ParsesNamespaceDirectiveToken_WithMultipleSegments()
+        {
+            // Arrange
+            var descriptor = DirectiveDescriptorBuilder.Create("custom").AddNamespace().Build();
+
+            // Act & Assert
+            ParseCodeBlockTest(
+                "@custom BaseNamespace.Foo.Bar",
+                new[] { descriptor },
+                new DirectiveBlock(
+                    new DirectiveChunkGenerator(descriptor),
+                    Factory.CodeTransition(),
+                    Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
+                    Factory.Span(SpanKind.Code, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
+                    Factory.Span(SpanKind.Code, "BaseNamespace.Foo.Bar", markup: false)
+                        .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
+                        .Accepts(AcceptedCharacters.NonWhiteSpace)));
+        }
+
+        [Fact]
+        public void Parser_ParsesNamespace_WithMultipleSegments()
+        {
+            // Arrange
+            var descriptor = DirectiveDescriptorBuilder.Create("custom").AddNamespace().Build();
+
+            // Act & Assert
+            ParseCodeBlockTest(
+                "@custom BaseNamespace.Foo.Bar",
+                new[] { descriptor },
+                new DirectiveBlock(
+                    new DirectiveChunkGenerator(descriptor),
+                    Factory.CodeTransition(),
+                    Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
+                    Factory.Span(SpanKind.Code, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
+                    Factory.Span(SpanKind.Code, "BaseNamespace.Foo.Bar", markup: false)
+                        .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
+                        .Accepts(AcceptedCharacters.NonWhiteSpace)));
+        }
+
+        [Fact]
         public void DirectiveDescriptor_UnderstandsStringTokens()
         {
             // Arrange
@@ -347,7 +407,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
             // Arrange
             var descriptor = DirectiveDescriptorBuilder.Create("custom").AddString().Build();
             var expectedErorr = new RazorError(
-                LegacyResources.FormatUnexpectedDirectiveLiteral("custom", Environment.NewLine),
+                LegacyResources.FormatUnexpectedDirectiveLiteral("custom", "line break"),
                 new SourceLocation(16, 0, 16),
                 length: 7);
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective.cshtml)
 |"*, TestAssembly"|
-Generated Location: (422:10,29 [17] )
+Generated Location: (430:10,37 [17] )
 |"*, TestAssembly"|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (430:10,30 [15] )
+Generated Location: (438:10,38 [15] )
 |*, TestAssembly|
 
 Source Location: (187:5,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (1674:29,42 [4] )
+Generated Location: (1682:29,42 [4] )
 |true|
 
 Source Location: (233:6,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (2327:39,42 [4] )
+Generated Location: (2335:39,42 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (416:10,29 [17] )
+Generated Location: (424:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (220:5,38 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1379:26,38 [23] )
+Generated Location: (1387:26,38 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (303:6,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |true|
-Generated Location: (2077:37,42 [4] )
+Generated Location: (2085:37,42 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
@@ -8,11 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "THS";
+global::System.Object __typeHelper = "THS";
         }
         ))();
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (17:0,17 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |"THS"|
-Generated Location: (425:10,29 [5] )
+Generated Location: (433:10,37 [5] )
 |"THS"|
 
 Source Location: (38:1,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |"*, TestAssembly"|
-Generated Location: (522:14,29 [17] )
+Generated Location: (538:14,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (226:7,43 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |true|
-Generated Location: (1556:31,43 [4] )
+Generated Location: (1572:31,43 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (418:10,29 [17] )
+Generated Location: (426:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (36:2,1 [52] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
@@ -9,7 +9,7 @@ Source Location: (36:2,1 [52] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var checkbox = "checkbox";
 
     |
-Generated Location: (1043:23,1 [52] )
+Generated Location: (1051:23,1 [52] )
 |if (true)
 {
     var checkbox = "checkbox";
@@ -20,7 +20,7 @@ Source Location: (224:9,13 [43] TestFiles/IntegrationTests/CodeGenerationIntegra
 |if (false)
             {
                 |
-Generated Location: (1235:32,13 [43] )
+Generated Location: (1243:32,13 [43] )
 |if (false)
             {
                 |
@@ -31,7 +31,7 @@ Source Location: (350:11,99 [66] TestFiles/IntegrationTests/CodeGenerationIntegr
             else
             {
                 |
-Generated Location: (1955:44,99 [66] )
+Generated Location: (1963:44,99 [66] )
 |
             }
             else
@@ -40,194 +40,194 @@ Generated Location: (1955:44,99 [66] )
 
 Source Location: (446:15,46 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checkbox|
-Generated Location: (2402:55,46 [8] )
+Generated Location: (2410:55,46 [8] )
 |checkbox|
 
 Source Location: (463:15,63 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true|
-Generated Location: (2755:62,63 [4] )
+Generated Location: (2763:62,63 [4] )
 |true|
 
 Source Location: (474:15,74 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (2974:67,86 [18] )
+Generated Location: (2982:67,86 [18] )
 |
                 |
 
 Source Location: (507:16,31 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true ? "checkbox" : "anything"|
-Generated Location: (3327:72,31 [30] )
+Generated Location: (3335:72,31 [30] )
 |true ? "checkbox" : "anything"|
 
 Source Location: (542:16,66 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (3623:78,78 [18] )
+Generated Location: (3631:78,78 [18] )
 |
                 |
 
 Source Location: (574:17,30 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if(true) { |
-Generated Location: (3975:83,30 [11] )
+Generated Location: (3983:83,30 [11] )
 |if(true) { |
 
 Source Location: (606:17,62 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | } else { |
-Generated Location: (4175:88,62 [10] )
+Generated Location: (4183:88,62 [10] )
 | } else { |
 
 Source Location: (637:17,93 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | }|
-Generated Location: (4405:93,93 [2] )
+Generated Location: (4413:93,93 [2] )
 | }|
 
 Source Location: (641:17,97 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
             }|
-Generated Location: (4785:100,97 [15] )
+Generated Location: (4793:100,97 [15] )
 |
             }|
 
 Source Location: (163:7,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (5053:107,32 [12] )
+Generated Location: (5061:107,32 [12] )
 |DateTime.Now|
 
 Source Location: (783:21,14 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | var @object = false;|
-Generated Location: (5207:112,14 [21] )
+Generated Location: (5215:112,14 [21] )
 | var @object = false;|
 
 Source Location: (836:22,29 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (5605:119,42 [1] )
+Generated Location: (5613:119,42 [1] )
 |(|
 
 Source Location: (837:22,30 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@object|
-Generated Location: (5606:119,43 [7] )
+Generated Location: (5614:119,43 [7] )
 |@object|
 
 Source Location: (844:22,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (5613:119,50 [1] )
+Generated Location: (5621:119,50 [1] )
 |)|
 
 Source Location: (711:20,39 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (5875:125,38 [23] )
+Generated Location: (5883:125,38 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (734:20,62 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | - 1970|
-Generated Location: (5898:125,61 [7] )
+Generated Location: (5906:125,61 [7] )
 | - 1970|
 
 Source Location: (976:25,61 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (6301:132,60 [1] )
+Generated Location: (6309:132,60 [1] )
 |(|
 
 Source Location: (977:25,62 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (6302:132,61 [30] )
+Generated Location: (6310:132,61 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1007:25,92 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (6332:132,91 [1] )
+Generated Location: (6340:132,91 [1] )
 |)|
 
 Source Location: (879:24,16 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |-1970 + |
-Generated Location: (6589:138,33 [8] )
+Generated Location: (6597:138,33 [8] )
 |-1970 + |
 
 Source Location: (887:24,24 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (6597:138,41 [1] )
+Generated Location: (6605:138,41 [1] )
 |@|
 
 Source Location: (888:24,25 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (6598:138,42 [23] )
+Generated Location: (6606:138,42 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (1106:28,28 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (6999:145,42 [30] )
+Generated Location: (7007:145,42 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1044:27,16 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year - 1970|
-Generated Location: (7285:151,33 [30] )
+Generated Location: (7293:151,33 [30] )
 |DateTimeOffset.Now.Year - 1970|
 
 Source Location: (1234:31,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (7693:158,42 [3] )
+Generated Location: (7701:158,42 [3] )
 |   |
 
 Source Location: (1237:31,31 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@(|
-Generated Location: (7696:158,45 [2] )
+Generated Location: (7704:158,45 [2] )
 |@(|
 
 Source Location: (1239:31,33 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |  DateTimeOffset.Now.Year  |
-Generated Location: (7698:158,47 [27] )
+Generated Location: (7706:158,47 [27] )
 |  DateTimeOffset.Now.Year  |
 
 Source Location: (1266:31,60 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (7725:158,74 [1] )
+Generated Location: (7733:158,74 [1] )
 |)|
 
 Source Location: (1267:31,61 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | > 2014   |
-Generated Location: (7726:158,75 [10] )
+Generated Location: (7734:158,75 [10] )
 | > 2014   |
 
 Source Location: (1171:30,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (7992:164,33 [1] )
+Generated Location: (8000:164,33 [1] )
 |(|
 
 Source Location: (1172:30,18 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"My age is this long.".Length|
-Generated Location: (7993:164,34 [29] )
+Generated Location: (8001:164,34 [29] )
 |"My age is this long.".Length|
 
 Source Location: (1201:30,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (8022:164,63 [1] )
+Generated Location: (8030:164,63 [1] )
 |)|
 
 Source Location: (1306:33,9 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |someMethod(|
-Generated Location: (8160:169,9 [11] )
+Generated Location: (8168:169,9 [11] )
 |someMethod(|
 
 Source Location: (1361:33,64 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checked|
-Generated Location: (8613:173,63 [7] )
+Generated Location: (8621:173,63 [7] )
 |checked|
 
 Source Location: (1326:33,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |123|
-Generated Location: (8868:179,33 [3] )
+Generated Location: (8876:179,33 [3] )
 |123|
 
 Source Location: (1375:33,78 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (8909:184,1 [1] )
+Generated Location: (8917:184,1 [1] )
 |)|
 
 Source Location: (1388:34,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
 }|
-Generated Location: (9048:189,10 [3] )
+Generated Location: (9056:189,10 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object Footer = null;
+global::System.Object Footer = null;
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
@@ -1,49 +1,49 @@
 Source Location: (173:11,9 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Footer|
-Generated Location: (396:10,14 [6] )
+Generated Location: (404:10,22 [6] )
 |Footer|
 
 Source Location: (20:1,13 [36] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |for(int i = 1; i <= 10; i++) {
     |
-Generated Location: (749:20,13 [36] )
+Generated Location: (757:20,13 [36] )
 |for(int i = 1; i <= 10; i++) {
     |
 
 Source Location: (74:2,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |i|
-Generated Location: (926:26,22 [1] )
+Generated Location: (934:26,22 [1] )
 |i|
 
 Source Location: (79:2,27 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |
             }|
-Generated Location: (1074:31,27 [15] )
+Generated Location: (1082:31,27 [15] )
 |
             }|
 
 Source Location: (113:7,2 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(Bar.Baz)|
-Generated Location: (1214:37,6 [12] )
+Generated Location: (1222:37,6 [12] )
 |Foo(Bar.Baz)|
 
 Source Location: (129:8,1 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(|
-Generated Location: (1352:42,6 [4] )
+Generated Location: (1360:42,6 [4] )
 |Foo(|
 
 Source Location: (142:8,14 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |baz|
-Generated Location: (1549:44,14 [3] )
+Generated Location: (1557:44,14 [3] )
 |baz|
 
 Source Location: (153:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |)|
-Generated Location: (1590:49,1 [1] )
+Generated Location: (1598:49,1 [1] )
 |)|
 
 Source Location: (204:13,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |bar|
-Generated Location: (1791:55,6 [3] )
+Generated Location: (1799:55,6 [3] )
 |bar|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (429:10,29 [17] )
+Generated Location: (437:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (146:4,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (1822:31,42 [4] )
+Generated Location: (1830:31,42 [4] )
 |true|
 
 Source Location: (222:5,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (2364:40,42 [4] )
+Generated Location: (2372:40,42 [4] )
 |true|
 
 Source Location: (43:2,8 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |3|
-Generated Location: (2634:46,33 [1] )
+Generated Location: (2642:46,33 [1] )
 |3|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,155 +1,155 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (427:10,29 [17] )
+Generated Location: (435:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (59:2,24 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1007:22,24 [12] )
+Generated Location: (1015:22,24 [12] )
 |DateTime.Now|
 
 Source Location: (96:4,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (1275:28,17 [12] )
+Generated Location: (1283:28,17 [12] )
 |if (true) { |
 
 Source Location: (109:4,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (1452:33,30 [12] )
+Generated Location: (1460:33,30 [12] )
 |string.Empty|
 
 Source Location: (121:4,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (1642:38,42 [10] )
+Generated Location: (1650:38,42 [10] )
 | } else { |
 
 Source Location: (132:4,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (1840:43,53 [5] )
+Generated Location: (1848:43,53 [5] )
 |false|
 
 Source Location: (137:4,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (2039:48,58 [2] )
+Generated Location: (2047:48,58 [2] )
 | }|
 
 Source Location: (176:6,22 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (2301:54,22 [12] )
+Generated Location: (2309:54,22 [12] )
 |DateTime.Now|
 
 Source Location: (214:6,60 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (2575:60,60 [12] )
+Generated Location: (2583:60,60 [12] )
 |DateTime.Now|
 
 Source Location: (256:8,15 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (2841:66,15 [13] )
+Generated Location: (2849:66,15 [13] )
 |long.MinValue|
 
 Source Location: (271:8,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (3020:71,30 [12] )
+Generated Location: (3028:71,30 [12] )
 |if (true) { |
 
 Source Location: (284:8,43 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (3210:76,43 [12] )
+Generated Location: (3218:76,43 [12] )
 |string.Empty|
 
 Source Location: (296:8,55 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (3413:81,55 [10] )
+Generated Location: (3421:81,55 [10] )
 | } else { |
 
 Source Location: (307:8,66 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (3624:86,66 [5] )
+Generated Location: (3632:86,66 [5] )
 |false|
 
 Source Location: (312:8,71 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (3836:91,71 [2] )
+Generated Location: (3844:91,71 [2] )
 | }|
 
 Source Location: (316:8,75 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (4048:96,75 [12] )
+Generated Location: (4056:96,75 [12] )
 |int.MaxValue|
 
 Source Location: (348:9,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (4280:102,17 [13] )
+Generated Location: (4288:102,17 [13] )
 |long.MinValue|
 
 Source Location: (363:9,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (4462:107,32 [12] )
+Generated Location: (4470:107,32 [12] )
 |if (true) { |
 
 Source Location: (376:9,45 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (4655:112,45 [12] )
+Generated Location: (4663:112,45 [12] )
 |string.Empty|
 
 Source Location: (388:9,57 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (4861:117,57 [10] )
+Generated Location: (4869:117,57 [10] )
 | } else { |
 
 Source Location: (399:9,68 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (5075:122,68 [5] )
+Generated Location: (5083:122,68 [5] )
 |false|
 
 Source Location: (404:9,73 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (5290:127,73 [2] )
+Generated Location: (5298:127,73 [2] )
 | }|
 
 Source Location: (408:9,77 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (5505:132,77 [12] )
+Generated Location: (5513:132,77 [12] )
 |int.MaxValue|
 
 Source Location: (445:11,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (5774:138,17 [13] )
+Generated Location: (5782:138,17 [13] )
 |long.MinValue|
 
 Source Location: (460:11,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (5956:143,32 [12] )
+Generated Location: (5964:143,32 [12] )
 |DateTime.Now|
 
 Source Location: (492:11,64 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (6169:148,64 [12] )
+Generated Location: (6177:148,64 [12] )
 |int.MaxValue|
 
 Source Location: (529:13,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (6438:154,17 [12] )
+Generated Location: (6446:154,17 [12] )
 |if (true) { |
 
 Source Location: (542:13,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (6616:159,30 [12] )
+Generated Location: (6624:159,30 [12] )
 |string.Empty|
 
 Source Location: (554:13,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (6807:164,42 [10] )
+Generated Location: (6815:164,42 [10] )
 | } else { |
 
 Source Location: (565:13,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (7006:169,53 [5] )
+Generated Location: (7014:169,53 [5] )
 |false|
 
 Source Location: (570:13,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (7206:174,58 [2] )
+Generated Location: (7214:174,58 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (426:10,30 [15] )
+Generated Location: (434:10,38 [15] )
 |*, TestAssembly|
 
 Source Location: (66:3,26 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (1450:27,42 [0] )
+Generated Location: (1458:27,42 [0] )
 ||
 
 Source Location: (126:5,30 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (1978:36,42 [0] )
+Generated Location: (1986:36,42 [0] )
 ||
 
 Source Location: (92:4,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (2240:42,33 [0] )
+Generated Location: (2248:42,33 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
@@ -1,49 +1,49 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (415:10,29 [17] )
+Generated Location: (423:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (37:2,2 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |
     var enumValue = MyEnum.MyValue;
 |
-Generated Location: (957:22,2 [39] )
+Generated Location: (965:22,2 [39] )
 |
     var enumValue = MyEnum.MyValue;
 |
 
 Source Location: (96:6,15 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MyValue|
-Generated Location: (1368:30,39 [14] )
+Generated Location: (1376:30,39 [14] )
 |MyEnum.MyValue|
 
 Source Location: (131:7,15 [20] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MySecondValue|
-Generated Location: (1733:37,15 [20] )
+Generated Location: (1741:37,15 [20] )
 |MyEnum.MySecondValue|
 
 Source Location: (171:8,14 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (2222:44,133 [7] )
+Generated Location: (2230:44,133 [7] )
 |MyValue|
 
 Source Location: (198:9,14 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MySecondValue|
-Generated Location: (2699:51,133 [13] )
+Generated Location: (2707:51,133 [13] )
 |MySecondValue|
 
 Source Location: (224:9,40 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (2976:56,139 [7] )
+Generated Location: (2984:56,139 [7] )
 |MyValue|
 
 Source Location: (251:10,15 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (3359:63,39 [9] )
+Generated Location: (3367:63,39 [9] )
 |enumValue|
 
 Source Location: (274:10,38 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (3538:68,45 [9] )
+Generated Location: (3546:68,45 [9] )
 |enumValue|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (419:10,30 [15] )
+Generated Location: (427:10,38 [15] )
 |*, TestAssembly|
 
 Source Location: (106:3,29 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (986:22,29 [12] )
+Generated Location: (994:22,29 [12] )
 |DateTime.Now|
 
 Source Location: (204:5,51 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1384:29,51 [12] )
+Generated Location: (1392:29,51 [12] )
 |DateTime.Now|
 
 Source Location: (227:5,74 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |true|
-Generated Location: (1751:36,74 [4] )
+Generated Location: (1759:36,74 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (420:10,29 [17] )
+Generated Location: (428:10,37 [17] )
 |"*, TestAssembly"|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object Link = null;
+global::System.Object Link = null;
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (9:0,9 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |Link|
-Generated Location: (398:10,14 [4] )
+Generated Location: (406:10,22 [4] )
 |Link|
 
 Source Location: (44:1,14 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |if(link != null) { |
-Generated Location: (840:22,14 [19] )
+Generated Location: (848:22,14 [19] )
 |if(link != null) { |
 
 Source Location: (64:1,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |link|
-Generated Location: (1014:27,34 [4] )
+Generated Location: (1022:27,34 [4] )
 |link|
 
 Source Location: (68:1,38 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | } else { |
-Generated Location: (1178:32,38 [10] )
+Generated Location: (1186:32,38 [10] )
 | } else { |
 
 Source Location: (92:1,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | }|
-Generated Location: (1371:37,62 [2] )
+Generated Location: (1379:37,62 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (420:10,29 [17] )
+Generated Location: (428:10,37 [17] )
 |"*, TestAssembly"|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
@@ -1,29 +1,29 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (426:10,29 [17] )
+Generated Location: (434:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (195:5,13 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |for(var i = 0; i < 5; i++) {
                 |
-Generated Location: (1071:23,13 [46] )
+Generated Location: (1079:23,13 [46] )
 |for(var i = 0; i < 5; i++) {
                 |
 
 Source Location: (339:7,50 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1509:31,50 [23] )
+Generated Location: (1517:31,50 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (389:7,100 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |true|
-Generated Location: (1915:38,100 [4] )
+Generated Location: (1923:38,100 [4] )
 |true|
 
 Source Location: (422:8,25 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |
             }|
-Generated Location: (2079:43,25 [15] )
+Generated Location: (2087:43,25 [15] )
 |
             }|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (418:10,30 [15] )
+Generated Location: (426:10,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (428:10,29 [17] )
+Generated Location: (436:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (37:2,2 [242] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
@@ -15,7 +15,7 @@ Source Location: (37:2,2 [242] TestFiles/IntegrationTests/CodeGenerationIntegrat
         { "name", "value" },
     };
 |
-Generated Location: (981:22,2 [242] )
+Generated Location: (989:22,2 [242] )
 |
     var literate = "or illiterate";
     var intDictionary = new Dictionary<string, int>
@@ -30,51 +30,51 @@ Generated Location: (981:22,2 [242] )
 
 Source Location: (370:15,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (1624:38,56 [13] )
+Generated Location: (1632:38,56 [13] )
 |intDictionary|
 
 Source Location: (404:15,77 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |stringDictionary|
-Generated Location: (1976:44,77 [16] )
+Generated Location: (1984:44,77 [16] )
 |stringDictionary|
 
 Source Location: (468:16,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (2526:52,56 [13] )
+Generated Location: (2534:52,56 [13] )
 |intDictionary|
 
 Source Location: (502:16,77 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (2878:58,77 [2] )
+Generated Location: (2886:58,77 [2] )
 |37|
 
 Source Location: (526:16,101 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (3263:64,101 [2] )
+Generated Location: (3271:64,101 [2] )
 |42|
 
 Source Location: (590:18,31 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (3784:72,46 [2] )
+Generated Location: (3792:72,46 [2] )
 |42|
 
 Source Location: (611:18,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (4113:78,64 [2] )
+Generated Location: (4121:78,64 [2] )
 |37|
 
 Source Location: (634:18,75 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |98|
-Generated Location: (4468:84,75 [2] )
+Generated Location: (4476:84,75 [2] )
 |98|
 
 Source Location: (783:20,42 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |literate|
-Generated Location: (5250:94,42 [8] )
+Generated Location: (5258:94,42 [8] )
 |literate|
 
 Source Location: (826:21,29 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (5914:103,65 [2] )
+Generated Location: (5922:103,65 [2] )
 |37|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (17:0,17 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective.cshtml)
 |*, TestAssembly|
-Generated Location: (426:10,30 [15] )
+Generated Location: (434:10,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -8,15 +8,15 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object Section2 = null;
+global::System.Object Section2 = null;
         }
         ))();
         ((System.Action)(() => {
-System.Object Section1 = null;
+global::System.Object Section1 = null;
         }
         ))();
         ((System.Action)(() => {
-System.Object NestedDelegates = null;
+global::System.Object NestedDelegates = null;
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -1,44 +1,44 @@
 Source Location: (89:6,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section2|
-Generated Location: (394:10,14 [8] )
+Generated Location: (402:10,22 [8] )
 |Section2|
 
 Source Location: (172:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (486:14,14 [8] )
+Generated Location: (502:14,22 [8] )
 |Section1|
 
 Source Location: (235:14,9 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |NestedDelegates|
-Generated Location: (578:18,14 [15] )
+Generated Location: (602:18,22 [15] )
 |NestedDelegates|
 
 Source Location: (2:0,2 [44] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |
     Layout = "_SectionTestLayout.cshtml"
 |
-Generated Location: (927:28,2 [44] )
+Generated Location: (951:28,2 [44] )
 |
     Layout = "_SectionTestLayout.cshtml"
 |
 
 Source Location: (123:7,22 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |thing|
-Generated Location: (1183:35,22 [5] )
+Generated Location: (1207:35,22 [5] )
 |thing|
 
 Source Location: (260:15,6 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | Func<dynamic, object> f = |
-Generated Location: (1504:44,6 [27] )
+Generated Location: (1528:44,6 [27] )
 | Func<dynamic, object> f = |
 
 Source Location: (295:15,41 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |item|
-Generated Location: (1795:50,41 [4] )
+Generated Location: (1819:50,41 [4] )
 |item|
 
 Source Location: (306:15,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |; |
-Generated Location: (2000:57,52 [2] )
+Generated Location: (2024:57,52 [2] )
 |; |
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (418:10,30 [15] )
+Generated Location: (426:10,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (443:10,29 [17] )
+Generated Location: (451:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (67:3,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml)
 |1337|
-Generated Location: (1032:22,33 [4] )
+Generated Location: (1040:22,33 [4] )
 |1337|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (416:10,29 [17] )
+Generated Location: (424:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (63:2,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml)
 |1337|
-Generated Location: (978:22,33 [4] )
+Generated Location: (986:22,33 [4] )
 |1337|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (2022:85,9 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml)
 |WriteLiteralsToInHere|
-Generated Location: (400:10,14 [21] )
+Generated Location: (408:10,22 [21] )
 |WriteLiteralsToInHere|
 
 Source Location: (5701:205,9 [25] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml)
 |WriteLiteralsToInHereAlso|
-Generated Location: (505:14,14 [25] )
+Generated Location: (521:14,22 [25] )
 |WriteLiteralsToInHereAlso|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |*, TestAssembly|
-Generated Location: (423:10,30 [15] )
+Generated Location: (431:10,38 [15] )
 |*, TestAssembly|
 
 Source Location: (302:11,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1032:22,46 [5] )
+Generated Location: (1040:22,46 [5] )
 |items|
 
 Source Location: (351:12,20 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1325:28,47 [5] )
+Generated Location: (1333:28,47 [5] )
 |items|
 
 Source Location: (405:13,23 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (1614:34,43 [13] )
+Generated Location: (1622:34,43 [13] )
 |doSomething()|
 
 Source Location: (487:14,24 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (1911:40,43 [13] )
+Generated Location: (1919:40,43 [13] )
 |doSomething()|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml)
 |*, TestAssembly|
-Generated Location: (431:10,30 [15] )
+Generated Location: (439:10,38 [15] )
 |*, TestAssembly|
 
 Source Location: (57:2,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml)
 |Hello|
-Generated Location: (951:22,18 [5] )
+Generated Location: (959:22,18 [5] )
 |Hello|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
@@ -8,11 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         ((System.Action)(() => {
-System.Object __typeHelper = "cool:";
+global::System.Object __typeHelper = "cool:";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |*, TestAssembly|
-Generated Location: (422:10,30 [15] )
+Generated Location: (430:10,38 [15] )
 |*, TestAssembly|
 
 Source Location: (48:1,17 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |cool:|
-Generated Location: (531:14,30 [5] )
+Generated Location: (547:14,38 [5] )
 |cool:|
 
 Source Location: (86:3,23 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |Hello|
-Generated Location: (1037:26,23 [5] )
+Generated Location: (1053:26,23 [5] )
 |Hello|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (438:10,29 [17] )
+Generated Location: (446:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (74:5,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1337|
-Generated Location: (1210:24,33 [4] )
+Generated Location: (1218:24,33 [4] )
 |1337|
 
 Source Location: (99:6,19 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |true|
-Generated Location: (1380:29,19 [4] )
+Generated Location: (1388:29,19 [4] )
 |true|
 
 Source Location: (186:10,11 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1234|
-Generated Location: (2016:39,33 [4] )
+Generated Location: (2024:39,33 [4] )
 |1234|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Object __typeHelper = "*, TestAssembly";
+global::System.Object __typeHelper = "*, TestAssembly";
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (433:10,29 [17] )
+Generated Location: (441:10,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (35:1,2 [59] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
@@ -8,7 +8,7 @@ Source Location: (35:1,2 [59] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var @class = "container-fluid";
     var @int = 1;
 |
-Generated Location: (886:21,2 [59] )
+Generated Location: (894:21,2 [59] )
 | 
     var @class = "container-fluid";
     var @int = 1;
@@ -16,76 +16,76 @@ Generated Location: (886:21,2 [59] )
 
 Source Location: (122:6,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |1337|
-Generated Location: (1212:29,33 [4] )
+Generated Location: (1220:29,33 [4] )
 |1337|
 
 Source Location: (157:7,12 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (1465:35,12 [6] )
+Generated Location: (1473:35,12 [6] )
 |@class|
 
 Source Location: (171:7,26 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42|
-Generated Location: (1646:40,33 [2] )
+Generated Location: (1654:40,33 [2] )
 |42|
 
 Source Location: (202:8,21 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42 + |
-Generated Location: (1918:46,33 [5] )
+Generated Location: (1926:46,33 [5] )
 |42 + |
 
 Source Location: (207:8,26 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
-Generated Location: (1923:46,38 [1] )
+Generated Location: (1931:46,38 [1] )
 |@|
 
 Source Location: (208:8,27 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (1924:46,39 [3] )
+Generated Location: (1932:46,39 [3] )
 |int|
 
 Source Location: (241:9,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (2198:52,33 [3] )
+Generated Location: (2206:52,33 [3] )
 |int|
 
 Source Location: (274:10,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |(|
-Generated Location: (2472:58,33 [1] )
+Generated Location: (2480:58,33 [1] )
 |(|
 
 Source Location: (275:10,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int|
-Generated Location: (2473:58,34 [4] )
+Generated Location: (2481:58,34 [4] )
 |@int|
 
 Source Location: (279:10,27 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (2477:58,38 [1] )
+Generated Location: (2485:58,38 [1] )
 |)|
 
 Source Location: (307:11,19 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (2735:64,19 [6] )
+Generated Location: (2743:64,19 [6] )
 |@class|
 
 Source Location: (321:11,33 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |4 * |
-Generated Location: (2917:69,33 [4] )
+Generated Location: (2925:69,33 [4] )
 |4 * |
 
 Source Location: (325:11,37 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@(|
-Generated Location: (2921:69,37 [2] )
+Generated Location: (2929:69,37 [2] )
 |@(|
 
 Source Location: (327:11,39 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int + 2|
-Generated Location: (2923:69,39 [8] )
+Generated Location: (2931:69,39 [8] )
 |@int + 2|
 
 Source Location: (335:11,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (2931:69,47 [1] )
+Generated Location: (2939:69,47 [1] )
 |)|
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.codegen.cs
@@ -3,16 +3,12 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
-    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_StringLiterals_DesignTime
+    public class TestFiles_IntegrationTests_ExtensibleDirectiveTest_NamespaceToken
     {
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-global::System.Object WriteLiteralsToInHere = null;
-        }
-        ))();
-        ((System.Action)(() => {
-global::System.Object WriteLiteralsToInHereAlso = null;
+global::System.Object __typeHelper = nameof(Sytem.Globalization);
         }
         ))();
         }
@@ -21,10 +17,6 @@ global::System.Object WriteLiteralsToInHereAlso = null;
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            DefineSection("WriteLiteralsToInHere", async (__razor_section_writer) => {
-            });
-            DefineSection("WriteLiteralsToInHereAlso", async (__razor_section_writer) => {
-            });
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.cshtml
@@ -1,0 +1,1 @@
+﻿@custom Sytem.Globalization

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.ir.txt
@@ -1,0 +1,19 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_ExtensibleDirectiveTest_NamespaceToken -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - #pragma warning disable 219
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (8:0,8 [19] NamespaceToken.cshtml) - Sytem.Globalization
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - }
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - #pragma warning restore 219
+            CSharpStatement - 
+                RazorIRToken -  - CSharp - private static System.Object __o = null;
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (8:0,8 [19] TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.cshtml)
+|Sytem.Globalization|
+Generated Location: (413:10,44 [19] )
+|Sytem.Globalization|
+


### PR DESCRIPTION
This change adds support for accepting a namespace name in extensible
directives. This will be needed for the @namespace directive.

Implemented new parsing and codegen for namespaces using nameof().

Also fixed any issue where we were not global::-qualifying object where it
was used in the design time code for tokens.