### PR TITLE
Do not generate C# line pragmas without a file path.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/CSharpCodeWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/Legacy/CSharpCodeWriter.cs
@@ -509,6 +509,12 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
 
         public IDisposable BuildLinePragma(SourceSpan documentLocation)
         {
+            if (string.IsNullOrEmpty(documentLocation.FilePath))
+            {
+                // Can't build a valid line pragma without a file path.
+                return NullDisposable.Default;
+            }
+
             return new LinePragmaWriter(this, documentLocation);
         }
 
@@ -630,6 +636,19 @@ namespace Microsoft.AspNetCore.Razor.Evolution.Legacy
                     .WriteLineDefaultDirective()
                     .WriteLineHiddenDirective()
                     .SetIndent(_startIndent);
+            }
+        }
+
+        private class NullDisposable : IDisposable
+        {
+            public static readonly NullDisposable Default = new NullDisposable();
+
+            private NullDisposable()
+            {
+            }
+
+            public void Dispose()
+            {
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Basic.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Basic.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = global::System.Object;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_Basic_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Basic.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Basic.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (13:0,13 [4] /TestFiles/Input/Basic.cshtml)
 |logo|
-Generated Location: (1063:46,13 [4] )
+Generated Location: (829:22,13 [4] )
 |logo|
 
 Source Location: (43:2,5 [21] /TestFiles/Input/Basic.cshtml)
 |Html.Input("SomeKey")|
-Generated Location: (1148:51,6 [21] )
+Generated Location: (914:27,6 [21] )
 |Html.Input("SomeKey")|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Inject.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Inject.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = global::System.Object;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
 #line 1 "/TestFiles/Input/Inject.cshtml"
 using MyNamespace;
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Inject.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Inject.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (1:0,1 [17] /TestFiles/Input/Inject.cshtml)
 |using MyNamespace|
-Generated Location: (613:36,0 [17] )
+Generated Location: (379:12,0 [17] )
 |using MyNamespace|
 
 Source Location: (28:1,8 [5] /TestFiles/Input/Inject.cshtml)
 |MyApp|
-Generated Location: (908:45,0 [5] )
+Generated Location: (674:21,0 [5] )
 |MyApp|
 
 Source Location: (34:1,14 [14] /TestFiles/Input/Inject.cshtml)
 |MyPropertyName|
-Generated Location: (1010:49,14 [14] )
+Generated Location: (776:25,14 [14] )
 |MyPropertyName|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/InjectWithModel.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/InjectWithModel.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = MyModel;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_InjectWithModel_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<MyModel>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/InjectWithModel.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/InjectWithModel.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (7:0,7 [7] /TestFiles/Input/InjectWithModel.cshtml)
 |MyModel|
-Generated Location: (810:40,0 [7] )
+Generated Location: (576:16,0 [7] )
 |MyModel|
 
 Source Location: (24:1,8 [5] /TestFiles/Input/InjectWithModel.cshtml)
 |MyApp|
-Generated Location: (900:44,0 [5] )
+Generated Location: (666:20,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] /TestFiles/Input/InjectWithModel.cshtml)
 |MyPropertyName|
-Generated Location: (1002:48,14 [14] )
+Generated Location: (768:24,14 [14] )
 |MyPropertyName|
 
 Source Location: (54:2,8 [17] /TestFiles/Input/InjectWithModel.cshtml)
 |MyService<TModel>|
-Generated Location: (1086:52,0 [17] )
+Generated Location: (852:28,0 [17] )
 |MyService<TModel>|
 
 Source Location: (72:2,26 [4] /TestFiles/Input/InjectWithModel.cshtml)
 |Html|
-Generated Location: (1200:56,14 [4] )
+Generated Location: (966:32,14 [4] )
 |Html|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/InjectWithSemicolon.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/InjectWithSemicolon.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = MyModel;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_InjectWithSemicolon_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<MyModel>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/InjectWithSemicolon.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/InjectWithSemicolon.mappings.txt
@@ -1,45 +1,45 @@
 Source Location: (7:0,7 [7] /TestFiles/Input/InjectWithSemicolon.cshtml)
 |MyModel|
-Generated Location: (814:40,0 [7] )
+Generated Location: (580:16,0 [7] )
 |MyModel|
 
 Source Location: (24:1,8 [5] /TestFiles/Input/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (904:44,0 [5] )
+Generated Location: (670:20,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] /TestFiles/Input/InjectWithSemicolon.cshtml)
 |MyPropertyName|
-Generated Location: (1006:48,14 [14] )
+Generated Location: (772:24,14 [14] )
 |MyPropertyName|
 
 Source Location: (58:2,8 [17] /TestFiles/Input/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (1090:52,0 [17] )
+Generated Location: (856:28,0 [17] )
 |MyService<TModel>|
 
 Source Location: (76:2,26 [4] /TestFiles/Input/InjectWithSemicolon.cshtml)
 |Html|
-Generated Location: (1204:56,14 [4] )
+Generated Location: (970:32,14 [4] )
 |Html|
 
 Source Location: (93:3,8 [5] /TestFiles/Input/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1278:60,0 [5] )
+Generated Location: (1044:36,0 [5] )
 |MyApp|
 
 Source Location: (99:3,14 [15] /TestFiles/Input/InjectWithSemicolon.cshtml)
 |MyPropertyName2|
-Generated Location: (1380:64,14 [15] )
+Generated Location: (1146:40,14 [15] )
 |MyPropertyName2|
 
 Source Location: (129:4,8 [17] /TestFiles/Input/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (1465:68,0 [17] )
+Generated Location: (1231:44,0 [17] )
 |MyService<TModel>|
 
 Source Location: (147:4,26 [5] /TestFiles/Input/InjectWithSemicolon.cshtml)
 |Html2|
-Generated Location: (1579:72,14 [5] )
+Generated Location: (1345:48,14 [5] )
 |Html2|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Model.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Model.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = System.Collections.IEnumerable;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_Model_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<System.Collections.IEnumerable>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Model.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/Model.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (7:0,7 [30] /TestFiles/Input/Model.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (846:40,0 [30] )
+Generated Location: (612:16,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = DateTime;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_ModelExpressionTagHelper_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/ModelExpressionTagHelper.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (7:0,7 [8] /TestFiles/Input/ModelExpressionTagHelper.cshtml)
 |DateTime|
-Generated Location: (821:40,0 [8] )
+Generated Location: (587:16,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [108] /TestFiles/Input/ModelExpressionTagHelper.cshtml)
 |Microsoft.AspNetCore.Mvc.Razor.Extensions.InputTestTagHelper, Microsoft.AspNetCore.Mvc.Razor.Extensions.Test|
-Generated Location: (942:44,30 [108] )
+Generated Location: (708:20,30 [108] )
 |Microsoft.AspNetCore.Mvc.Razor.Extensions.InputTestTagHelper, Microsoft.AspNetCore.Mvc.Razor.Extensions.Test|
 
 Source Location: (162:4,17 [3] /TestFiles/Input/ModelExpressionTagHelper.cshtml)
 |Now|
-Generated Location: (1837:56,144 [3] )
+Generated Location: (1603:32,144 [3] )
 |Now|
 
 Source Location: (189:5,18 [5] /TestFiles/Input/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (2238:62,136 [5] )
+Generated Location: (2004:38,136 [5] )
 |Model|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/MultipleModels.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/MultipleModels.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = System.Collections.IEnumerable;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_MultipleModels_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<System.Collections.IEnumerable>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/MultipleModels.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/MultipleModels.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (7:0,7 [21] /TestFiles/Input/MultipleModels.cshtml)
 |ThisShouldBeGenerated|
-Generated Location: (855:40,0 [21] )
+Generated Location: (621:16,0 [21] )
 |ThisShouldBeGenerated|
 
 Source Location: (37:1,7 [30] /TestFiles/Input/MultipleModels.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (959:44,0 [30] )
+Generated Location: (725:20,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPages.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPages.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = NewModel;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
 #line 5 "/TestFiles/Input/RazorPages.cshtml"
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPages.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPages.mappings.txt
@@ -1,21 +1,21 @@
 Source Location: (60:4,1 [41] /TestFiles/Input/RazorPages.cshtml)
 |using Microsoft.AspNetCore.Mvc.RazorPages|
-Generated Location: (604:36,0 [41] )
+Generated Location: (370:12,0 [41] )
 |using Microsoft.AspNetCore.Mvc.RazorPages|
 
 Source Location: (16:2,7 [8] /TestFiles/Input/RazorPages.cshtml)
 |NewModel|
-Generated Location: (918:45,0 [8] )
+Generated Location: (684:21,0 [8] )
 |NewModel|
 
 Source Location: (40:3,14 [17] /TestFiles/Input/RazorPages.cshtml)
 |"*, TestAssembly"|
-Generated Location: (1038:49,29 [17] )
+Generated Location: (804:25,29 [17] )
 |"*, TestAssembly"|
 
 Source Location: (666:28,47 [4] /TestFiles/Input/RazorPages.cshtml)
 |Name|
-Generated Location: (1539:61,47 [4] )
+Generated Location: (1305:37,47 [4] )
 |Name|
 
 Source Location: (117:6,12 [360] /TestFiles/Input/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (117:6,12 [360] /TestFiles/Input/RazorPages.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1968:72,12 [360] )
+Generated Location: (1734:48,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPagesWithoutModel.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPagesWithoutModel.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = _TestFiles_Input_RazorPagesWithoutModel_cshtml;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
 #line 4 "/TestFiles/Input/RazorPagesWithoutModel.cshtml"
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPagesWithoutModel.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/RazorPagesWithoutModel.mappings.txt
@@ -1,16 +1,16 @@
 Source Location: (43:3,1 [41] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
 |using Microsoft.AspNetCore.Mvc.RazorPages|
-Generated Location: (654:36,0 [41] )
+Generated Location: (420:12,0 [41] )
 |using Microsoft.AspNetCore.Mvc.RazorPages|
 
 Source Location: (23:2,14 [17] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
 |"*, TestAssembly"|
-Generated Location: (1009:45,29 [17] )
+Generated Location: (775:21,29 [17] )
 |"*, TestAssembly"|
 
 Source Location: (571:24,47 [4] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
 |Name|
-Generated Location: (1522:57,47 [4] )
+Generated Location: (1288:33,47 [4] )
 |Name|
 
 Source Location: (100:5,12 [283] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
@@ -28,7 +28,7 @@ Source Location: (100:5,12 [283] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1963:68,12 [283] )
+Generated Location: (1729:44,12 [283] )
 |
     public IActionResult OnPost(Customer customer)
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/_ViewImports.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/_ViewImports.cs
@@ -2,37 +2,13 @@ namespace AspNetCore
 {
     #line hidden
     using TModel = global::System.Object;
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input__ViewImports_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/_ViewImports.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/DesignTime/_ViewImports.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (8:0,8 [19] /TestFiles/Input/_ViewImports.cshtml)
 |IHtmlHelper<TModel>|
-Generated Location: (821:40,0 [19] )
+Generated Location: (587:16,0 [19] )
 |IHtmlHelper<TModel>|
 
 Source Location: (28:0,28 [5] /TestFiles/Input/_ViewImports.cshtml)
 |Model|
-Generated Location: (937:44,14 [5] )
+Generated Location: (703:20,14 [5] )
 |Model|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/Basic.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/Basic.cs
@@ -2,37 +2,13 @@
 namespace AspNetCore
 {
     #line hidden
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_Basic_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/Inject.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/Inject.cs
@@ -2,37 +2,13 @@
 namespace AspNetCore
 {
     #line hidden
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
 #line 1 "/TestFiles/Input/Inject.cshtml"
 using MyNamespace;
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/InjectWithModel.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/InjectWithModel.cs
@@ -2,37 +2,13 @@
 namespace AspNetCore
 {
     #line hidden
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_InjectWithModel_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<MyModel>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/InjectWithSemicolon.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/InjectWithSemicolon.cs
@@ -2,37 +2,13 @@
 namespace AspNetCore
 {
     #line hidden
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_InjectWithSemicolon_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<MyModel>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/Model.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/Model.cs
@@ -2,37 +2,13 @@
 namespace AspNetCore
 {
     #line hidden
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_Model_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<System.Collections.IEnumerable>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/ModelExpressionTagHelper.cs
@@ -2,37 +2,13 @@
 namespace AspNetCore
 {
     #line hidden
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input_ModelExpressionTagHelper_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
         #line hidden

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/RazorPages.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/RazorPages.cs
@@ -2,37 +2,13 @@
 namespace AspNetCore
 {
     #line hidden
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
 #line 5 "/TestFiles/Input/RazorPages.cshtml"
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/RazorPagesWithoutModel.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/RazorPagesWithoutModel.cs
@@ -2,37 +2,13 @@
 namespace AspNetCore
 {
     #line hidden
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
 #line 4 "/TestFiles/Input/RazorPagesWithoutModel.cshtml"
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/_ViewImports.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/Output/Runtime/_ViewImports.cs
@@ -2,37 +2,13 @@
 namespace AspNetCore
 {
     #line hidden
-#line 1 ""
-using System;
-
-#line default
-#line hidden
+    using System;
     using System.Threading.Tasks;
-#line 2 ""
-using System.Linq;
-
-#line default
-#line hidden
-#line 3 ""
-using System.Collections.Generic;
-
-#line default
-#line hidden
-#line 4 ""
-using Microsoft.AspNetCore.Mvc;
-
-#line default
-#line hidden
-#line 5 ""
-using Microsoft.AspNetCore.Mvc.Rendering;
-
-#line default
-#line hidden
-#line 6 ""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-#line default
-#line hidden
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
     public class _TestFiles_Input__ViewImports_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 1998


### PR DESCRIPTION
- Prior to this change default imports would get line pragmas generated for them because thye'd have a source location but no file path (they were a dynamic document).
- Re-generated C# files to reflect new line pragma changes.

#1110