### PR TITLE
Reset writer scope for tag helpers inside template

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/RuntimeTagHelperWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/CodeGeneration/RuntimeTagHelperWriter.cs
@@ -149,9 +149,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.CodeGeneration
             // This can be removed once all the tag helper nodes are moved out of the renderers.
             var initialRenderingConventions = context.RenderingConventions;
             context.RenderingConventions = new CSharpRenderingConventions(context.Writer);
-            using (context.Writer.BuildAsyncLambda(endLine: false))
+
+            using (context.Push(new RuntimeBasicWriter()))
             {
-                context.RenderChildren(node);
+                using (context.Writer.BuildAsyncLambda(endLine: false))
+                {
+                    context.RenderChildren(node);
+                }
             }
             context.RenderingConventions = initialRenderingConventions;
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/CodeGeneration/RuntimeTagHelperWriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/CodeGeneration/RuntimeTagHelperWriterTest.cs
@@ -100,6 +100,7 @@ private global::MyTagHelper __MyTagHelper = null;
             var context = new CSharpRenderingContext()
             {
                 Writer = new Legacy.CSharpCodeWriter(),
+                BasicWriter = new RuntimeBasicWriter(),
                 IdGenerator = () => "test",
                 RenderChildren = n => { }
             };

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -773,6 +773,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
             // Arrange, Act & Assert
             RunRuntimeTagHelpersTest(TestTagHelperDescriptors.TagHelpersInSectionDescriptors);
         }
+
+        [Fact]
+        public void TagHelpersWithTemplate_Runtime()
+        {
+            // Arrange, Act & Assert
+            RunRuntimeTagHelpersTest(TestTagHelperDescriptors.SimpleTagHelperDescriptors);
+        }
         #endregion
 
         #region DesignTime
@@ -1558,6 +1565,13 @@ namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests
         {
             // Arrange, Act & Assert
             RunDesignTimeTagHelpersTest(TestTagHelperDescriptors.EnumTagHelperDescriptors);
+        }
+
+        [Fact]
+        public void TagHelpersWithTemplate_DesignTime()
+        {
+            // Arrange, Act & Assert
+            RunDesignTimeTagHelpersTest(TestTagHelperDescriptors.SimpleTagHelperDescriptors);
         }
         #endregion
 

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml
@@ -1,0 +1,19 @@
+﻿@addTagHelper "*, TestAssembly"
+
+@functions {
+    public void RenderTemplate(string title, Func<string, HelperResult> template)
+    {
+        Output.WriteLine("<br /><p><em>Rendering Template:</em></p>");
+        var helperResult = template(title);
+        helperResult.WriteTo(Output, HtmlEncoder);
+    }
+}
+
+<div>
+    @{
+        RenderTemplate(
+            "Template: ",
+            @<div condition="true"><h3>@item</h3><input type="checkbox" checked="true" /></div>);
+    }
+</div>
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
@@ -1,0 +1,61 @@
+namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+{
+    #line hidden
+    using System;
+    using System.Threading.Tasks;
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithTemplate_DesignTime
+    {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        ((System.Action)(() => {
+System.Object __typeHelper = "*, TestAssembly";
+        }
+        ))();
+        }
+        #pragma warning restore 219
+        private static System.Object __o = null;
+        private global::DivTagHelper __DivTagHelper = null;
+        private global::InputTagHelper __InputTagHelper = null;
+        #pragma warning disable 1998
+        public async System.Threading.Tasks.Task ExecuteAsync()
+        {
+#line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
+      
+        RenderTemplate(
+            "Template: ",
+            
+
+#line default
+#line hidden
+            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+#line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
+                                  __o = item;
+
+#line default
+#line hidden
+                __InputTagHelper = CreateTagHelper<global::InputTagHelper>();
+                __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            }
+            )
+#line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
+                                                                                               );
+    
+
+#line default
+#line hidden
+            __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+        }
+        #pragma warning restore 1998
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
+            
+    public void RenderTemplate(string title, Func<string, HelperResult> template)
+    {
+        Output.WriteLine("<br /><p><em>Rendering Template:</em></p>");
+        var helperResult = template(title);
+        helperResult.WriteTo(Output, HtmlEncoder);
+    }
+
+#line default
+#line hidden
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.ir.txt
@@ -1,0 +1,53 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithTemplate_DesignTime -  - 
+            DirectiveTokenHelper - 
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - #pragma warning disable 219
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - private void __RazorDirectiveTokenHelpers__() {
+                DirectiveToken - (14:0,14 [17] TagHelpersWithTemplate.cshtml) - "*, TestAssembly"
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - }
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - #pragma warning restore 219
+            CSharpStatement - 
+                RazorIRToken -  - CSharp - private static System.Object __o = null;
+            DeclareTagHelperFields -  - DivTagHelper - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (31:0,31 [4] TagHelpersWithTemplate.cshtml) - \n\n
+                HtmlContent - (316:9,1 [4] TagHelpersWithTemplate.cshtml) - \n\n
+                TagHelper - (320:11,0 [179] TagHelpersWithTemplate.cshtml)
+                    InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                        HtmlContent - (325:11,5 [6] TagHelpersWithTemplate.cshtml) - \n    
+                        CSharpStatement - (333:12,6 [66] TagHelpersWithTemplate.cshtml)
+                            RazorIRToken - (333:12,6 [66] TagHelpersWithTemplate.cshtml) - CSharp - \n        RenderTemplate(\n            "Template: ",\n            
+                        Template - (400:15,13 [82] TagHelpersWithTemplate.cshtml)
+                            TagHelper - (400:15,13 [82] TagHelpersWithTemplate.cshtml)
+                                InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                                    HtmlContent - (422:15,35 [4] TagHelpersWithTemplate.cshtml) - <h3>
+                                    CSharpExpression - (427:15,40 [4] TagHelpersWithTemplate.cshtml)
+                                        RazorIRToken - (427:15,40 [4] TagHelpersWithTemplate.cshtml) - CSharp - item
+                                    HtmlContent - (431:15,44 [5] TagHelpersWithTemplate.cshtml) - </h3>
+                                    TagHelper - (436:15,49 [40] TagHelpersWithTemplate.cshtml)
+                                        InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                                        CreateTagHelper -  - InputTagHelper
+                                        AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
+                                            HtmlContent - (449:15,62 [8] TagHelpersWithTemplate.cshtml) - checkbox
+                                        AddTagHelperHtmlAttribute -  - checked - HtmlAttributeValueStyle.DoubleQuotes
+                                            HtmlContent - (468:15,81 [4] TagHelpersWithTemplate.cshtml) - true
+                                        ExecuteTagHelpers - 
+                                CreateTagHelper -  - DivTagHelper
+                                AddTagHelperHtmlAttribute -  - condition - HtmlAttributeValueStyle.DoubleQuotes
+                                    HtmlContent - (416:15,29 [4] TagHelpersWithTemplate.cshtml) - true
+                                ExecuteTagHelpers - 
+                        CSharpStatement - (482:15,95 [8] TagHelpersWithTemplate.cshtml)
+                            RazorIRToken - (482:15,95 [8] TagHelpersWithTemplate.cshtml) - CSharp - );\n    
+                    CreateTagHelper -  - DivTagHelper
+                    ExecuteTagHelpers - 
+                HtmlContent - (499:17,6 [4] TagHelpersWithTemplate.cshtml) - \n\n
+            CSharpStatement - (47:2,12 [268] TagHelpersWithTemplate.cshtml)
+                RazorIRToken - (47:2,12 [268] TagHelpersWithTemplate.cshtml) - CSharp - \n    public void RenderTemplate(string title, Func<string, HelperResult> template)\n    {\n        Output.WriteLine("<br /><p><em>Rendering Template:</em></p>");\n        var helperResult = template(title);\n        helperResult.WriteTo(Output, HtmlEncoder);\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
@@ -1,0 +1,47 @@
+Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
+|"*, TestAssembly"|
+Generated Location: (423:10,29 [17] )
+|"*, TestAssembly"|
+
+Source Location: (333:12,6 [66] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
+|
+        RenderTemplate(
+            "Template: ",
+            |
+Generated Location: (912:22,6 [66] )
+|
+        RenderTemplate(
+            "Template: ",
+            |
+
+Source Location: (427:15,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
+|item|
+Generated Location: (1255:31,40 [4] )
+|item|
+
+Source Location: (482:15,95 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
+|);
+    |
+Generated Location: (1671:40,95 [8] )
+|);
+    |
+
+Source Location: (47:2,12 [268] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
+|
+    public void RenderTemplate(string title, Func<string, HelperResult> template)
+    {
+        Output.WriteLine("<br /><p><em>Rendering Template:</em></p>");
+        var helperResult = template(title);
+        helperResult.WriteTo(Output, HtmlEncoder);
+    }
+|
+Generated Location: (1942:49,12 [268] )
+|
+    public void RenderTemplate(string title, Func<string, HelperResult> template)
+    {
+        Output.WriteLine("<br /><p><em>Rendering Template:</em></p>");
+        var helperResult = template(title);
+        helperResult.WriteTo(Output, HtmlEncoder);
+    }
+|
+

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
@@ -1,0 +1,116 @@
+#pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "f1ffadb1ad9c279ac40218b45a1688ac2f3ea857"
+namespace Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+{
+    #line hidden
+    using System;
+    using System.Threading.Tasks;
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithTemplate_Runtime
+    {
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("checked", new global::Microsoft.AspNetCore.Html.HtmlString("true"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("condition", new global::Microsoft.AspNetCore.Html.HtmlString("true"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+        #line hidden
+        #pragma warning disable 0414
+        private string __tagHelperStringValueBuffer = null;
+        #pragma warning restore 0414
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext = null;
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;
+        private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __tagHelperScopeManager
+        {
+            get
+            {
+                if (__backed__tagHelperScopeManager == null)
+                {
+                    __backed__tagHelperScopeManager = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager(StartTagHelperWritingScope, EndTagHelperWritingScope);
+                }
+                return __backed__tagHelperScopeManager;
+            }
+        }
+        private global::DivTagHelper __DivTagHelper = null;
+        private global::InputTagHelper __InputTagHelper = null;
+        #pragma warning disable 1998
+        public async System.Threading.Tasks.Task ExecuteAsync()
+        {
+            WriteLiteral("\r\n");
+            WriteLiteral("\r\n");
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+                WriteLiteral("\r\n");
+#line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
+      
+        RenderTemplate(
+            "Template: ",
+            
+
+#line default
+#line hidden
+                item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+                    __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+                        WriteLiteral("<h3>");
+#line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
+                                  Write(item);
+
+#line default
+#line hidden
+                        WriteLiteral("</h3>");
+                        __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
+                        }
+                        );
+                        __InputTagHelper = CreateTagHelper<global::InputTagHelper>();
+                        __tagHelperExecutionContext.Add(__InputTagHelper);
+                        __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_0);
+                        __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
+                        await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+                        if (!__tagHelperExecutionContext.Output.IsContentModified)
+                        {
+                            await __tagHelperExecutionContext.SetOutputContentAsync();
+                        }
+                        Write(__tagHelperExecutionContext.Output);
+                        __tagHelperExecutionContext = __tagHelperScopeManager.End();
+                    }
+                    );
+                    __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+                    __tagHelperExecutionContext.Add(__DivTagHelper);
+                    __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_2);
+                    await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+                    if (!__tagHelperExecutionContext.Output.IsContentModified)
+                    {
+                        await __tagHelperExecutionContext.SetOutputContentAsync();
+                    }
+                    WriteTo(__razor_template_writer, __tagHelperExecutionContext.Output);
+                    __tagHelperExecutionContext = __tagHelperScopeManager.End();
+                }
+                )
+#line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
+                                                                                               );
+    
+
+#line default
+#line hidden
+            }
+            );
+            __DivTagHelper = CreateTagHelper<global::DivTagHelper>();
+            __tagHelperExecutionContext.Add(__DivTagHelper);
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                await __tagHelperExecutionContext.SetOutputContentAsync();
+            }
+            Write(__tagHelperExecutionContext.Output);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            WriteLiteral("\r\n\r\n");
+        }
+        #pragma warning restore 1998
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
+            
+    public void RenderTemplate(string title, Func<string, HelperResult> template)
+    {
+        Output.WriteLine("<br /><p><em>Rendering Template:</em></p>");
+        var helperResult = template(title);
+        helperResult.WriteTo(Output, HtmlEncoder);
+    }
+
+#line default
+#line hidden
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Evolution.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.ir.txt
@@ -1,0 +1,43 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Evolution.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithTemplate_Runtime -  - 
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - type - checkbox - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - checked - true - HtmlAttributeValueStyle.DoubleQuotes
+            DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - condition - true - HtmlAttributeValueStyle.DoubleQuotes
+            DeclareTagHelperFields -  - DivTagHelper - InputTagHelper
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (33:1,0 [2] TagHelpersWithTemplate.cshtml) - \n
+                HtmlContent - (318:10,0 [2] TagHelpersWithTemplate.cshtml) - \n
+                TagHelper - (320:11,0 [179] TagHelpersWithTemplate.cshtml)
+                    InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                        HtmlContent - (325:11,5 [2] TagHelpersWithTemplate.cshtml) - \n
+                        CSharpStatement - (327:12,0 [4] TagHelpersWithTemplate.cshtml)
+                            RazorIRToken - (327:12,0 [4] TagHelpersWithTemplate.cshtml) - CSharp -     
+                        CSharpStatement - (333:12,6 [66] TagHelpersWithTemplate.cshtml)
+                            RazorIRToken - (333:12,6 [66] TagHelpersWithTemplate.cshtml) - CSharp - \n        RenderTemplate(\n            "Template: ",\n            
+                        Template - (400:15,13 [82] TagHelpersWithTemplate.cshtml)
+                            TagHelper - (400:15,13 [82] TagHelpersWithTemplate.cshtml)
+                                InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
+                                    HtmlContent - (422:15,35 [4] TagHelpersWithTemplate.cshtml) - <h3>
+                                    CSharpExpression - (427:15,40 [4] TagHelpersWithTemplate.cshtml)
+                                        RazorIRToken - (427:15,40 [4] TagHelpersWithTemplate.cshtml) - CSharp - item
+                                    HtmlContent - (431:15,44 [5] TagHelpersWithTemplate.cshtml) - </h3>
+                                    TagHelper - (436:15,49 [40] TagHelpersWithTemplate.cshtml)
+                                        InitializeTagHelperStructure -  - input - TagMode.SelfClosing
+                                        CreateTagHelper -  - InputTagHelper
+                                        AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
+                                        AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
+                                        ExecuteTagHelpers - 
+                                CreateTagHelper -  - DivTagHelper
+                                AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
+                                ExecuteTagHelpers - 
+                        CSharpStatement - (482:15,95 [8] TagHelpersWithTemplate.cshtml)
+                            RazorIRToken - (482:15,95 [8] TagHelpersWithTemplate.cshtml) - CSharp - );\n    
+                    CreateTagHelper -  - DivTagHelper
+                    ExecuteTagHelpers - 
+                HtmlContent - (499:17,6 [4] TagHelpersWithTemplate.cshtml) - \n\n
+            CSharpStatement - (47:2,12 [268] TagHelpersWithTemplate.cshtml)
+                RazorIRToken - (47:2,12 [268] TagHelpersWithTemplate.cshtml) - CSharp - \n    public void RenderTemplate(string title, Func<string, HelperResult> template)\n    {\n        Output.WriteLine("<br /><p><em>Rendering Template:</em></p>");\n        var helperResult = template(title);\n        helperResult.WriteTo(Output, HtmlEncoder);\n    }\n


### PR DESCRIPTION
After this change goes in, https://github.com/aspnet/Mvc/blob/dev/test/Microsoft.AspNetCore.Mvc.FunctionalTests/TagHelpersTest.cs#L37 can be re-enabled.

- Added a test for this scenario.

@NTaylorMullen @rynowak 