### PR TITLE
Update TagHelperMatchingConventions to disallow opt-out prefix.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Evolution/TagHelperMatchingConventions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Evolution/TagHelperMatchingConventions.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.Razor.Evolution
     {
         public const string ElementCatchAllName = "*";
 
+        public const char ElementOptOutCharacter = '!';
+
         public static bool SatisfiesRule(
             string tagNameWithoutPrefix,
             string parentTagName,
@@ -64,6 +66,17 @@ namespace Microsoft.AspNetCore.Razor.Evolution
             if (rule == null)
             {
                 throw new ArgumentNullException(nameof(rule));
+            }
+
+            if (string.IsNullOrEmpty(tagNameWithoutPrefix))
+            {
+                return false;
+            }
+
+            if (tagNameWithoutPrefix[0] == ElementOptOutCharacter)
+            {
+                // TagHelpers can never satisfy tag names that are prefixed with the opt-out character.
+                return false;
             }
 
             if (rule.TagName != ElementCatchAllName &&

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsService.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Razor.Evolution.Legacy;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
@@ -48,8 +47,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
         }
 
         public override IEnumerable<BoundAttributeDescriptor> GetBoundTagHelperAttributes(
-            TagHelperDocumentContext documentContext, 
-            string attributeName, 
+            TagHelperDocumentContext documentContext,
+            string attributeName,
             TagHelperBinding binding)
         {
             if (documentContext == null)

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DefaultTagHelperFactsServiceTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DefaultTagHelperFactsServiceTest.cs
@@ -14,6 +14,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
         // into TagHelperDescriptorProvider.GetTagHelperBinding.
 
         [Fact]
+        public void GetTagHelperBinding_DoesNotAllowOptOutCharacterPrefix()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                ITagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
+                    .TagMatchingRule(rule => rule.RequireTagName("*"))
+                    .Build()
+            };
+            var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
+            var service = new DefaultTagHelperFactsService();
+
+            // Act
+            var binding = service.GetTagHelperBinding(documentContext, "!a", Enumerable.Empty<KeyValuePair<string, string>>(), parentTag: null);
+
+            // Assert
+            Assert.Null(binding);
+        }
+
+        [Fact]
         public void GetTagHelperBinding_WorksAsExpected()
         {
             // Arrange
@@ -131,6 +151,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
             // Assert
             Assert.Equal(expectedAttributeDescriptors, descriptors, BoundAttributeDescriptorComparer.CaseSensitive);
+        }
+
+        [Fact]
+        public void GetTagHelpersGivenTag_DoesNotAllowOptOutCharacterPrefix()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                ITagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
+                    .TagMatchingRule(rule => rule.RequireTagName("*"))
+                    .Build()
+            };
+            var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
+            var service = new DefaultTagHelperFactsService();
+
+            // Act
+            var descriptors = service.GetTagHelpersGivenTag(documentContext, "!strong", parentTag: null);
+
+            // Assert
+            Assert.Empty(descriptors);
         }
 
         [Fact]


### PR DESCRIPTION
- Prior to this change the `TagHelper` parsing would strip the opt-out character (`!`) from tag names that got passed to the TagHelper matching services. At design time this proved to be a problem because they have their own understanding of the HTML document and only pass us full tag names (names that include `!`). This changes the matching conventions to immediately return false if a tag name is seen to contain the `TagHelper` opt-out.
- Added two `DefaultTagHelperFactService` tests to verify that tag names with opt-out prefixes are denied `TagHelperDescriptor`s.

#1186