### PR TITLE
Allow null parent tag when calling `GetTagHelpersGivenParent`.

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsService.cs
@@ -138,11 +138,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 throw new ArgumentNullException(nameof(documentContext));
             }
 
-            if (parentTag == null)
-            {
-                throw new ArgumentNullException(nameof(parentTag));
-            }
-
             var matchingDescriptors = new List<TagHelperDescriptor>();
             var descriptors = documentContext?.TagHelpers;
             if (descriptors?.Count == 0)

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DefaultTagHelperFactsServiceTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DefaultTagHelperFactsServiceTest.cs
@@ -287,6 +287,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
         }
 
         [Fact]
+        public void GetTagHelpersGivenParent_AllowsRootParentTag()
+        {
+            // Arrange
+            var documentDescriptors = new[]
+            {
+                ITagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
+                    .TagMatchingRule(rule => rule.RequireTagName("div"))
+                    .Build()
+            };
+            var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
+            var service = new DefaultTagHelperFactsService();
+
+            // Act
+            var descriptors = service.GetTagHelpersGivenParent(documentContext, parentTag: null /* root */);
+
+            // Assert
+            Assert.Equal(documentDescriptors, descriptors, TagHelperDescriptorComparer.CaseSensitive);
+        }
+
+        [Fact]
         public void GetTagHelpersGivenParent_AllowsUnspecifiedParentTagHelpers()
         {
             // Arrange


### PR DESCRIPTION
- A `null` parent tag in all of our other API represents "any" parent tag, or in this case "root". Prior to this change we'd expect the caller to do their own verification of the parent and then assume all `TagHelperDescriptor`s are valid; this isn't sufficient because only our code base should have that knowledge.

#1188