### PR TITLE
Perf: Removed Content property from HtmlContentIRNode

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RedirectedRuntimeBasicWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RedirectedRuntimeBasicWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
@@ -56,20 +57,31 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
         {
             const int MaxStringLiteralLength = 1024;
 
+            var builder = new StringBuilder();
+            for (var i = 0; i < node.Children.Count; i++)
+            {
+                if (node.Children[i] is RazorIRToken token && token.IsHtml)
+                {
+                    builder.Append(token.Content);
+                }
+            }
+
+            var content = builder.ToString();
+
             var charactersConsumed = 0;
 
             // Render the string in pieces to avoid Roslyn OOM exceptions at compile time: https://github.com/aspnet/External/issues/54
-            while (charactersConsumed < node.Content.Length)
+            while (charactersConsumed < content.Length)
             {
                 string textToRender;
-                if (node.Content.Length <= MaxStringLiteralLength)
+                if (content.Length <= MaxStringLiteralLength)
                 {
-                    textToRender = node.Content;
+                    textToRender = content;
                 }
                 else
                 {
-                    var charactersToSubstring = Math.Min(MaxStringLiteralLength, node.Content.Length - charactersConsumed);
-                    textToRender = node.Content.Substring(charactersConsumed, charactersToSubstring);
+                    var charactersToSubstring = Math.Min(MaxStringLiteralLength, content.Length - charactersConsumed);
+                    textToRender = content.Substring(charactersConsumed, charactersToSubstring);
                 }
 
                 context.Writer
@@ -79,8 +91,8 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
                     .WriteStringLiteral(textToRender)
                     .WriteEndMethodInvocation();
 
-                charactersConsumed += textToRender.Length;
+                    charactersConsumed += textToRender.Length;
+                }
             }
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeBasicWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeBasicWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
@@ -106,20 +107,31 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
         {
             const int MaxStringLiteralLength = 1024;
 
+            var builder = new StringBuilder();
+            for (var i = 0; i < node.Children.Count; i++)
+            {
+                if (node.Children[i] is RazorIRToken token && token.IsHtml)
+                {
+                    builder.Append(token.Content);
+                }
+            }
+
+            var content = builder.ToString();
+
             var charactersConsumed = 0;
 
             // Render the string in pieces to avoid Roslyn OOM exceptions at compile time: https://github.com/aspnet/External/issues/54
-            while (charactersConsumed < node.Content.Length)
+            while (charactersConsumed < content.Length)
             {
                 string textToRender;
-                if (node.Content.Length <= MaxStringLiteralLength)
+                if (content.Length <= MaxStringLiteralLength)
                 {
-                    textToRender = node.Content;
+                    textToRender = content;
                 }
                 else
                 {
-                    var charactersToSubstring = Math.Min(MaxStringLiteralLength, node.Content.Length - charactersConsumed);
-                    textToRender = node.Content.Substring(charactersConsumed, charactersToSubstring);
+                    var charactersToSubstring = Math.Min(MaxStringLiteralLength, content.Length - charactersConsumed);
+                    textToRender = content.Substring(charactersConsumed, charactersToSubstring);
                 }
 
                 context.Writer

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlContentIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlContentIRNode.cs
@@ -8,9 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 {
     public sealed class HtmlContentIRNode : RazorIRNode
     {
-        public string Content { get; set; }
-
-        public override IList<RazorIRNode> Children { get; } = EmptyArray;
+        public override IList<RazorIRNode> Children { get; } = new List<RazorIRNode>();
 
         public override RazorIRNode Parent { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorPreallocatedTagHelperAttributeOptimizationPass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorPreallocatedTagHelperAttributeOptimizationPass.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Text;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language
@@ -40,17 +41,17 @@ namespace Microsoft.AspNetCore.Razor.Language
                     return;
                 }
 
-                var plainTextValue = (node.Children.First() as HtmlContentIRNode).Content;
+                var htmlContentNode = node.Children.First() as HtmlContentIRNode;
+                var plainTextValue = GetContent(htmlContentNode);
+
                 DeclarePreallocatedTagHelperHtmlAttributeIRNode declaration = null;
 
                 for (var i = 0; i < _classDeclaration.Children.Count; i++)
                 {
                     var current = _classDeclaration.Children[i];
 
-                    if (current is DeclarePreallocatedTagHelperHtmlAttributeIRNode)
+                    if (current is DeclarePreallocatedTagHelperHtmlAttributeIRNode existingDeclaration)
                     {
-                        var existingDeclaration = (DeclarePreallocatedTagHelperHtmlAttributeIRNode)current;
-
                         if (string.Equals(existingDeclaration.Name, node.Name, StringComparison.Ordinal) &&
                             string.Equals(existingDeclaration.Value, plainTextValue, StringComparison.Ordinal) &&
                             existingDeclaration.ValueStyle == node.ValueStyle)
@@ -95,7 +96,8 @@ namespace Microsoft.AspNetCore.Razor.Language
                     return;
                 }
 
-                var plainTextValue = (node.Children.First() as HtmlContentIRNode).Content;
+                var htmlContentNode = node.Children.First() as HtmlContentIRNode;
+                var plainTextValue = GetContent(htmlContentNode);
 
                 DeclarePreallocatedTagHelperAttributeIRNode declaration = null;
 
@@ -103,10 +105,8 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     var current = _classDeclaration.Children[i];
 
-                    if (current is DeclarePreallocatedTagHelperAttributeIRNode)
+                    if (current is DeclarePreallocatedTagHelperAttributeIRNode existingDeclaration)
                     {
-                        var existingDeclaration = (DeclarePreallocatedTagHelperAttributeIRNode)current;
-
                         if (string.Equals(existingDeclaration.Name, node.AttributeName, StringComparison.Ordinal) &&
                             string.Equals(existingDeclaration.Value, plainTextValue, StringComparison.Ordinal) &&
                             existingDeclaration.ValueStyle == node.ValueStyle)
@@ -146,6 +146,20 @@ namespace Microsoft.AspNetCore.Razor.Language
 
                 var nodeIndex = node.Parent.Children.IndexOf(node);
                 node.Parent.Children[nodeIndex] = setPreallocatedProperty;
+            }
+
+            private string GetContent(HtmlContentIRNode node)
+            {
+                var builder = new StringBuilder();
+                for (var i = 0; i < node.Children.Count; i++)
+                {
+                    if (node.Children[i] is RazorIRToken token && token.IsHtml)
+                    {
+                        builder.Append(token.Content);
+                    }
+                }
+
+               return builder.ToString();
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelExpressionPassTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelExpressionPassTest.cs
@@ -49,8 +49,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             var tagHelper = FindTagHelperNode(irDocument);
             var setProperty = tagHelper.Children.OfType<SetTagHelperPropertyIRNode>().Single();
 
-            var child = Assert.IsType<HtmlContentIRNode>(Assert.Single(setProperty.Children));
-            Assert.Equal("17", child.Content);
+            var html = Assert.IsType<HtmlContentIRNode>(Assert.Single(setProperty.Children));
+            var token = Assert.IsType<RazorIRToken>(Assert.Single(html.Children));
+            Assert.Equal("17", token.Content);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RedirectedRuntimeBasicWriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RedirectedRuntimeBasicWriterTest.cs
@@ -192,10 +192,13 @@ Test(test_writer, i++);
                 Options = RazorParserOptions.CreateDefaultOptions(),
             };
 
-            var node = new HtmlContentIRNode()
+            var node = new HtmlContentIRNode();
+            node.Children.Add(new RazorIRToken()
             {
-                Content = "SomeContent"
-            };
+                Content = "SomeContent",
+                Kind = RazorIRToken.TokenKind.Html,
+                Parent = node
+            });
 
             // Act
             writer.WriteHtmlContent(context, node);
@@ -219,10 +222,13 @@ Test(test_writer, i++);
                 Options = RazorParserOptions.CreateDefaultOptions(),
             };
 
-            var node = new HtmlContentIRNode()
+            var node = new HtmlContentIRNode();
+            node.Children.Add(new RazorIRToken()
             {
-                Content = new string('*', 2000)
-            };
+                Content = new string('*', 2000),
+                Kind = RazorIRToken.TokenKind.Html,
+                Parent = node
+            });
 
             // Act
             writer.WriteHtmlContent(context, node);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RuntimeBasicWriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RuntimeBasicWriterTest.cs
@@ -326,10 +326,13 @@ if (true) { }
                 Options = RazorParserOptions.CreateDefaultOptions(),
             };
 
-            var node = new HtmlContentIRNode()
+            var node = new HtmlContentIRNode();
+            node.Children.Add(new RazorIRToken()
             {
-                Content = "SomeContent"
-            };
+                Content = "SomeContent",
+                Kind = RazorIRToken.TokenKind.Html,
+                Parent = node
+            });
 
             // Act
             writer.WriteHtmlContent(context, node);
@@ -353,10 +356,14 @@ if (true) { }
                 Options = RazorParserOptions.CreateDefaultOptions(),
             };
 
-            var node = new HtmlContentIRNode()
+
+            var node = new HtmlContentIRNode();
+            node.Children.Add(new RazorIRToken()
             {
-                Content = new string('*', 2000)
-            };
+                Content = new string('*', 2000),
+                Kind = RazorIRToken.TokenKind.Html,
+                Parent = node
+            });
 
             // Act
             writer.WriteHtmlContent(context, node);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultInstrumentationPassTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultInstrumentationPassTest.cs
@@ -14,11 +14,17 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var builder = RazorIRBuilder.Document();
-            builder.Add(new HtmlContentIRNode()
+            builder.Push(new HtmlContentIRNode()
             {
-                Content = "Hi",
                 Source = CreateSource(1),
             });
+            builder.Add(new RazorIRToken()
+            {
+                Content = "Hi",
+                Kind = RazorIRToken.TokenKind.Html,
+                Source = CreateSource(1)
+            });
+            builder.Pop();
 
             var irDocument = (DocumentIRNode)builder.Build();
 
@@ -40,10 +46,13 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var builder = RazorIRBuilder.Document();
-            builder.Add(new HtmlContentIRNode()
+            builder.Push(new HtmlContentIRNode());
+            builder.Add(new RazorIRToken()
             {
                 Content = "Hi",
+                Kind = RazorIRToken.TokenKind.Html,
             });
+            builder.Pop();
 
             var irDocument = (DocumentIRNode)builder.Build();
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/RazorIRNodeWriter.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/RazorIRNodeWriter.cs
@@ -51,11 +51,6 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             WriteContentNode(node, node.Content);
         }
 
-        public override void VisitHtml(HtmlContentIRNode node)
-        {
-            WriteContentNode(node, node.Content);
-        }
-
         public override void VisitHtmlAttribute(HtmlAttributeIRNode node)
         {
             WriteContentNode(node, node.Prefix, node.Suffix);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Intermediate/RazorIRAssert.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Intermediate/RazorIRAssert.cs
@@ -66,7 +66,15 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
             try
             {
                 var html = Assert.IsType<HtmlContentIRNode>(node);
-                Assert.Equal(expected, html.Content);
+                var content = new StringBuilder();
+                for (var i = 0; i < html.Children.Count; i++)
+                {
+                    var token = Assert.IsType<RazorIRToken>(html.Children[i]);
+                    Assert.Equal(RazorIRToken.TokenKind.Html, token.Kind);
+                    content.Append(token.Content);
+                }
+
+                Assert.Equal(expected, content.ToString());
             }
             catch (XunitException e)
             {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/BasicIntegrationTest/HelloWorld.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/BasicIntegrationTest/HelloWorld.ir.txt
@@ -5,4 +5,5 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - Template -  - 
             RazorMethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [13] HelloWorld.cshtml) - Hello, World!
+                HtmlContent - (0:0,0 [13] HelloWorld.cshtml)
+                    RazorIRToken - (0:0,0 [13] HelloWorld.cshtml) - Html - Hello, World!

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.ir.txt
@@ -17,4 +17,5 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [2] AddTagHelperDirective.cshtml) - \n
+                HtmlContent - (31:0,31 [2] AddTagHelperDirective.cshtml)
+                    RazorIRToken - (31:0,31 [2] AddTagHelperDirective.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.ir.txt
@@ -18,46 +18,70 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.CatchAllTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (29:0,29 [4] AttributeTargetingTagHelpers.cshtml) - \n\n
+                HtmlContent - (29:0,29 [4] AttributeTargetingTagHelpers.cshtml)
+                    RazorIRToken - (29:0,29 [4] AttributeTargetingTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (33:2,0 [228] AttributeTargetingTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (48:2,15 [9] AttributeTargetingTagHelpers.cshtml) - \n    <p>
+                        HtmlContent - (48:2,15 [9] AttributeTargetingTagHelpers.cshtml)
+                            RazorIRToken - (48:2,15 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
+                            RazorIRToken - (54:3,4 [3] AttributeTargetingTagHelpers.cshtml) - Html - <p>
                         TagHelper - (57:3,7 [36] AttributeTargetingTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - strong - TagMode.StartTagAndEndTag
-                                HtmlContent - (79:3,29 [5] AttributeTargetingTagHelpers.cshtml) - Hello
+                                HtmlContent - (79:3,29 [5] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (79:3,29 [5] AttributeTargetingTagHelpers.cshtml) - Html - Hello
                             CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                             AddTagHelperHtmlAttribute -  - catchAll - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (75:3,25 [2] AttributeTargetingTagHelpers.cshtml) - hi
+                                HtmlContent - (75:3,25 [2] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (75:3,25 [2] AttributeTargetingTagHelpers.cshtml) - Html - hi
                             ExecuteTagHelpers - 
-                        HtmlContent - (93:3,43 [62] AttributeTargetingTagHelpers.cshtml) - <strong>World</strong></p>\n    <input checked="true" />\n    
+                        HtmlContent - (93:3,43 [62] AttributeTargetingTagHelpers.cshtml)
+                            RazorIRToken - (93:3,43 [8] AttributeTargetingTagHelpers.cshtml) - Html - <strong>
+                            RazorIRToken - (101:3,51 [5] AttributeTargetingTagHelpers.cshtml) - Html - World
+                            RazorIRToken - (106:3,56 [9] AttributeTargetingTagHelpers.cshtml) - Html - </strong>
+                            RazorIRToken - (115:3,65 [4] AttributeTargetingTagHelpers.cshtml) - Html - </p>
+                            RazorIRToken - (119:3,69 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
+                            RazorIRToken - (125:4,4 [6] AttributeTargetingTagHelpers.cshtml) - Html - <input
+                            RazorIRToken - (131:4,10 [15] AttributeTargetingTagHelpers.cshtml) - Html -  checked="true"
+                            RazorIRToken - (146:4,25 [3] AttributeTargetingTagHelpers.cshtml) - Html -  />
+                            RazorIRToken - (149:4,28 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
                         TagHelper - (155:5,4 [40] AttributeTargetingTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - checkbox
+                                HtmlContent - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - Html - checkbox
                             SetTagHelperProperty - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - checkbox
+                                HtmlContent - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - Html - checkbox
                             SetTagHelperProperty - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - true
+                                HtmlContent - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml) - \n    
+                        HtmlContent - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml)
+                            RazorIRToken - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
                         TagHelper - (201:6,4 [54] AttributeTargetingTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                             SetTagHelperProperty - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - checkbox
+                                HtmlContent - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - Html - checkbox
                             SetTagHelperProperty - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - checkbox
+                                HtmlContent - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - Html - checkbox
                             SetTagHelperProperty - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - true
+                                HtmlContent - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - Html - true
                             AddTagHelperHtmlAttribute -  - catchAll - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (249:6,52 [2] AttributeTargetingTagHelpers.cshtml) - hi
+                                HtmlContent - (249:6,52 [2] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (249:6,52 [2] AttributeTargetingTagHelpers.cshtml) - Html - hi
                             ExecuteTagHelpers - 
-                        HtmlContent - (255:6,58 [2] AttributeTargetingTagHelpers.cshtml) - \n
+                        HtmlContent - (255:6,58 [2] AttributeTargetingTagHelpers.cshtml)
+                            RazorIRToken - (255:6,58 [2] AttributeTargetingTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (43:2,10 [3] AttributeTargetingTagHelpers.cshtml) - btn
+                        HtmlContent - (43:2,10 [3] AttributeTargetingTagHelpers.cshtml)
+                            RazorIRToken - (43:2,10 [3] AttributeTargetingTagHelpers.cshtml) - Html - btn
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.ir.txt
@@ -9,17 +9,30 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - class - btn - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.CatchAllTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:1,0 [2] AttributeTargetingTagHelpers.cshtml) - \n
+                HtmlContent - (31:1,0 [2] AttributeTargetingTagHelpers.cshtml)
+                    RazorIRToken - (31:1,0 [2] AttributeTargetingTagHelpers.cshtml) - Html - \n
                 TagHelper - (33:2,0 [228] AttributeTargetingTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (48:2,15 [9] AttributeTargetingTagHelpers.cshtml) - \n    <p>
+                        HtmlContent - (48:2,15 [9] AttributeTargetingTagHelpers.cshtml)
+                            RazorIRToken - (48:2,15 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
+                            RazorIRToken - (54:3,4 [3] AttributeTargetingTagHelpers.cshtml) - Html - <p>
                         TagHelper - (57:3,7 [36] AttributeTargetingTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - strong - TagMode.StartTagAndEndTag
-                                HtmlContent - (79:3,29 [5] AttributeTargetingTagHelpers.cshtml) - Hello
+                                HtmlContent - (79:3,29 [5] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (79:3,29 [5] AttributeTargetingTagHelpers.cshtml) - Html - Hello
                             CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                             ExecuteTagHelpers - 
-                        HtmlContent - (93:3,43 [62] AttributeTargetingTagHelpers.cshtml) - <strong>World</strong></p>\n    <input checked="true" />\n    
+                        HtmlContent - (93:3,43 [62] AttributeTargetingTagHelpers.cshtml)
+                            RazorIRToken - (93:3,43 [8] AttributeTargetingTagHelpers.cshtml) - Html - <strong>
+                            RazorIRToken - (101:3,51 [5] AttributeTargetingTagHelpers.cshtml) - Html - World
+                            RazorIRToken - (106:3,56 [9] AttributeTargetingTagHelpers.cshtml) - Html - </strong>
+                            RazorIRToken - (115:3,65 [4] AttributeTargetingTagHelpers.cshtml) - Html - </p>
+                            RazorIRToken - (119:3,69 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
+                            RazorIRToken - (125:4,4 [6] AttributeTargetingTagHelpers.cshtml) - Html - <input
+                            RazorIRToken - (131:4,10 [15] AttributeTargetingTagHelpers.cshtml) - Html -  checked="true"
+                            RazorIRToken - (146:4,25 [3] AttributeTargetingTagHelpers.cshtml) - Html -  />
+                            RazorIRToken - (149:4,28 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
                         TagHelper - (155:5,4 [40] AttributeTargetingTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -27,9 +40,11 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetTagHelperProperty - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - true
+                                HtmlContent - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml) - \n    
+                        HtmlContent - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml)
+                            RazorIRToken - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
                         TagHelper - (201:6,4 [54] AttributeTargetingTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -38,10 +53,12 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetTagHelperProperty - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - true
+                                HtmlContent - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml)
+                                    RazorIRToken - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - Html - true
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                             ExecuteTagHelpers - 
-                        HtmlContent - (255:6,58 [2] AttributeTargetingTagHelpers.cshtml) - \n
+                        HtmlContent - (255:6,58 [2] AttributeTargetingTagHelpers.cshtml)
+                            RazorIRToken - (255:6,58 [2] AttributeTargetingTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.ir.txt
@@ -16,54 +16,122 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (89:5,1 [102] Await.cshtml) - \n\n<section>\n    <h1>Basic Asynchronous Expression Test</h1>\n    <p>Basic Asynchronous Expression: 
+                HtmlContent - (89:5,1 [102] Await.cshtml)
+                    RazorIRToken - (89:5,1 [4] Await.cshtml) - Html - \n\n
+                    RazorIRToken - (93:7,0 [9] Await.cshtml) - Html - <section>
+                    RazorIRToken - (102:7,9 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (108:8,4 [4] Await.cshtml) - Html - <h1>
+                    RazorIRToken - (112:8,8 [34] Await.cshtml) - Html - Basic Asynchronous Expression Test
+                    RazorIRToken - (146:8,42 [5] Await.cshtml) - Html - </h1>
+                    RazorIRToken - (151:8,47 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (157:9,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (160:9,7 [31] Await.cshtml) - Html - Basic Asynchronous Expression: 
                 CSharpExpression - (192:9,39 [11] Await.cshtml)
                     RazorIRToken - (192:9,39 [11] Await.cshtml) - CSharp - await Foo()
-                HtmlContent - (203:9,50 [42] Await.cshtml) - </p>\n    <p>Basic Asynchronous Template: 
+                HtmlContent - (203:9,50 [42] Await.cshtml)
+                    RazorIRToken - (203:9,50 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (207:9,54 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (213:10,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (216:10,7 [29] Await.cshtml) - Html - Basic Asynchronous Template: 
                 CSharpExpression - (247:10,38 [11] Await.cshtml)
                     RazorIRToken - (247:10,38 [11] Await.cshtml) - CSharp - await Foo()
-                HtmlContent - (259:10,50 [43] Await.cshtml) - </p>\n    <p>Basic Asynchronous Statement: 
+                HtmlContent - (259:10,50 [43] Await.cshtml)
+                    RazorIRToken - (259:10,50 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (263:10,54 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (269:11,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (272:11,7 [30] Await.cshtml) - Html - Basic Asynchronous Statement: 
                 CSharpStatement - (304:11,39 [14] Await.cshtml)
                     RazorIRToken - (304:11,39 [14] Await.cshtml) - CSharp -  await Foo(); 
-                HtmlContent - (319:11,54 [50] Await.cshtml) - </p>\n    <p>Basic Asynchronous Statement Nested: 
+                HtmlContent - (319:11,54 [50] Await.cshtml)
+                    RazorIRToken - (319:11,54 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (323:11,58 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (329:12,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (332:12,7 [37] Await.cshtml) - Html - Basic Asynchronous Statement Nested: 
                 CSharpStatement - (371:12,46 [1] Await.cshtml)
                     RazorIRToken - (371:12,46 [1] Await.cshtml) - CSharp -  
-                HtmlContent - (372:12,47 [3] Await.cshtml) - <b>
+                HtmlContent - (372:12,47 [3] Await.cshtml)
+                    RazorIRToken - (372:12,47 [3] Await.cshtml) - Html - <b>
                 CSharpExpression - (376:12,51 [11] Await.cshtml)
                     RazorIRToken - (376:12,51 [11] Await.cshtml) - CSharp - await Foo()
-                HtmlContent - (387:12,62 [4] Await.cshtml) - </b>
+                HtmlContent - (387:12,62 [4] Await.cshtml)
+                    RazorIRToken - (387:12,62 [4] Await.cshtml) - Html - </b>
                 CSharpStatement - (391:12,66 [1] Await.cshtml)
                     RazorIRToken - (391:12,66 [1] Await.cshtml) - CSharp -  
-                HtmlContent - (393:12,68 [54] Await.cshtml) - </p>\n    <p>Basic Incomplete Asynchronous Statement: 
+                HtmlContent - (393:12,68 [54] Await.cshtml)
+                    RazorIRToken - (393:12,68 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (397:12,72 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (403:13,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (406:13,7 [41] Await.cshtml) - Html - Basic Incomplete Asynchronous Statement: 
                 CSharpExpression - (448:13,49 [5] Await.cshtml)
                     RazorIRToken - (448:13,49 [5] Await.cshtml) - CSharp - await
-                HtmlContent - (453:13,54 [124] Await.cshtml) - </p>\n</section>\n\n<section>\n    <h1>Advanced Asynchronous Expression Test</h1>\n    <p>Advanced Asynchronous Expression: 
+                HtmlContent - (453:13,54 [124] Await.cshtml)
+                    RazorIRToken - (453:13,54 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (457:13,58 [2] Await.cshtml) - Html - \n
+                    RazorIRToken - (459:14,0 [10] Await.cshtml) - Html - </section>
+                    RazorIRToken - (469:14,10 [4] Await.cshtml) - Html - \n\n
+                    RazorIRToken - (473:16,0 [9] Await.cshtml) - Html - <section>
+                    RazorIRToken - (482:16,9 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (488:17,4 [4] Await.cshtml) - Html - <h1>
+                    RazorIRToken - (492:17,8 [37] Await.cshtml) - Html - Advanced Asynchronous Expression Test
+                    RazorIRToken - (529:17,45 [5] Await.cshtml) - Html - </h1>
+                    RazorIRToken - (534:17,50 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (540:18,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (543:18,7 [34] Await.cshtml) - Html - Advanced Asynchronous Expression: 
                 CSharpExpression - (578:18,42 [15] Await.cshtml)
                     RazorIRToken - (578:18,42 [15] Await.cshtml) - CSharp - await Foo(1, 2)
-                HtmlContent - (593:18,57 [56] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Expression Extended: 
+                HtmlContent - (593:18,57 [56] Await.cshtml)
+                    RazorIRToken - (593:18,57 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (597:18,61 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (603:19,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (606:19,7 [43] Await.cshtml) - Html - Advanced Asynchronous Expression Extended: 
                 CSharpExpression - (650:19,51 [19] Await.cshtml)
                     RazorIRToken - (650:19,51 [19] Await.cshtml) - CSharp - await Foo.Bar(1, 2)
-                HtmlContent - (669:19,70 [45] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Template: 
+                HtmlContent - (669:19,70 [45] Await.cshtml)
+                    RazorIRToken - (669:19,70 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (673:19,74 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (679:20,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (682:20,7 [32] Await.cshtml) - Html - Advanced Asynchronous Template: 
                 CSharpExpression - (716:20,41 [22] Await.cshtml)
                     RazorIRToken - (716:20,41 [22] Await.cshtml) - CSharp - await Foo("bob", true)
-                HtmlContent - (739:20,64 [46] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Statement: 
+                HtmlContent - (739:20,64 [46] Await.cshtml)
+                    RazorIRToken - (739:20,64 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (743:20,68 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (749:21,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (752:21,7 [33] Await.cshtml) - Html - Advanced Asynchronous Statement: 
                 CSharpStatement - (787:21,42 [39] Await.cshtml)
                     RazorIRToken - (787:21,42 [39] Await.cshtml) - CSharp -  await Foo(something, hello: "world"); 
-                HtmlContent - (827:21,82 [55] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Statement Extended: 
+                HtmlContent - (827:21,82 [55] Await.cshtml)
+                    RazorIRToken - (827:21,82 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (831:21,86 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (837:22,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (840:22,7 [42] Await.cshtml) - Html - Advanced Asynchronous Statement Extended: 
                 CSharpStatement - (884:22,51 [21] Await.cshtml)
                     RazorIRToken - (884:22,51 [21] Await.cshtml) - CSharp -  await Foo.Bar(1, 2) 
-                HtmlContent - (906:22,73 [53] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Statement Nested: 
+                HtmlContent - (906:22,73 [53] Await.cshtml)
+                    RazorIRToken - (906:22,73 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (910:22,77 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (916:23,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (919:23,7 [40] Await.cshtml) - Html - Advanced Asynchronous Statement Nested: 
                 CSharpStatement - (961:23,49 [1] Await.cshtml)
                     RazorIRToken - (961:23,49 [1] Await.cshtml) - CSharp -  
-                HtmlContent - (962:23,50 [3] Await.cshtml) - <b>
+                HtmlContent - (962:23,50 [3] Await.cshtml)
+                    RazorIRToken - (962:23,50 [3] Await.cshtml) - Html - <b>
                 CSharpExpression - (966:23,54 [27] Await.cshtml)
                     RazorIRToken - (966:23,54 [27] Await.cshtml) - CSharp - await Foo(boolValue: false)
-                HtmlContent - (993:23,81 [4] Await.cshtml) - </b>
+                HtmlContent - (993:23,81 [4] Await.cshtml)
+                    RazorIRToken - (993:23,81 [4] Await.cshtml) - Html - </b>
                 CSharpStatement - (997:23,85 [1] Await.cshtml)
                     RazorIRToken - (997:23,85 [1] Await.cshtml) - CSharp -  
-                HtmlContent - (999:23,87 [57] Await.cshtml) - </p>\n    <p>Advanced Incomplete Asynchronous Statement: 
+                HtmlContent - (999:23,87 [57] Await.cshtml)
+                    RazorIRToken - (999:23,87 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (1003:23,91 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (1009:24,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (1012:24,7 [44] Await.cshtml) - Html - Advanced Incomplete Asynchronous Statement: 
                 CSharpExpression - (1057:24,52 [19] Await.cshtml)
                     RazorIRToken - (1057:24,52 [19] Await.cshtml) - CSharp - await ("wrrronggg")
-                HtmlContent - (1076:24,71 [16] Await.cshtml) - </p>\n</section>
+                HtmlContent - (1076:24,71 [16] Await.cshtml)
+                    RazorIRToken - (1076:24,71 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (1080:24,75 [2] Await.cshtml) - Html - \n
+                    RazorIRToken - (1082:25,0 [10] Await.cshtml) - Html - </section>
             CSharpStatement - (12:0,12 [76] Await.cshtml)
                 RazorIRToken - (12:0,12 [76] Await.cshtml) - CSharp - \n    public async Task<string> Foo()\n    {\n        return "Bar";\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.ir.txt
@@ -5,50 +5,122 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Await_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (91:6,0 [100] Await.cshtml) - \n<section>\n    <h1>Basic Asynchronous Expression Test</h1>\n    <p>Basic Asynchronous Expression: 
+                HtmlContent - (91:6,0 [100] Await.cshtml)
+                    RazorIRToken - (91:6,0 [2] Await.cshtml) - Html - \n
+                    RazorIRToken - (93:7,0 [9] Await.cshtml) - Html - <section>
+                    RazorIRToken - (102:7,9 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (108:8,4 [4] Await.cshtml) - Html - <h1>
+                    RazorIRToken - (112:8,8 [34] Await.cshtml) - Html - Basic Asynchronous Expression Test
+                    RazorIRToken - (146:8,42 [5] Await.cshtml) - Html - </h1>
+                    RazorIRToken - (151:8,47 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (157:9,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (160:9,7 [31] Await.cshtml) - Html - Basic Asynchronous Expression: 
                 CSharpExpression - (192:9,39 [11] Await.cshtml)
                     RazorIRToken - (192:9,39 [11] Await.cshtml) - CSharp - await Foo()
-                HtmlContent - (203:9,50 [42] Await.cshtml) - </p>\n    <p>Basic Asynchronous Template: 
+                HtmlContent - (203:9,50 [42] Await.cshtml)
+                    RazorIRToken - (203:9,50 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (207:9,54 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (213:10,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (216:10,7 [29] Await.cshtml) - Html - Basic Asynchronous Template: 
                 CSharpExpression - (247:10,38 [11] Await.cshtml)
                     RazorIRToken - (247:10,38 [11] Await.cshtml) - CSharp - await Foo()
-                HtmlContent - (259:10,50 [43] Await.cshtml) - </p>\n    <p>Basic Asynchronous Statement: 
+                HtmlContent - (259:10,50 [43] Await.cshtml)
+                    RazorIRToken - (259:10,50 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (263:10,54 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (269:11,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (272:11,7 [30] Await.cshtml) - Html - Basic Asynchronous Statement: 
                 CSharpStatement - (304:11,39 [14] Await.cshtml)
                     RazorIRToken - (304:11,39 [14] Await.cshtml) - CSharp -  await Foo(); 
-                HtmlContent - (319:11,54 [50] Await.cshtml) - </p>\n    <p>Basic Asynchronous Statement Nested: 
-                HtmlContent - (371:12,46 [4] Await.cshtml) -  <b>
+                HtmlContent - (319:11,54 [50] Await.cshtml)
+                    RazorIRToken - (319:11,54 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (323:11,58 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (329:12,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (332:12,7 [37] Await.cshtml) - Html - Basic Asynchronous Statement Nested: 
+                HtmlContent - (371:12,46 [4] Await.cshtml)
+                    RazorIRToken - (371:12,46 [1] Await.cshtml) - Html -  
+                    RazorIRToken - (372:12,47 [3] Await.cshtml) - Html - <b>
                 CSharpExpression - (376:12,51 [11] Await.cshtml)
                     RazorIRToken - (376:12,51 [11] Await.cshtml) - CSharp - await Foo()
-                HtmlContent - (387:12,62 [5] Await.cshtml) - </b> 
+                HtmlContent - (387:12,62 [5] Await.cshtml)
+                    RazorIRToken - (387:12,62 [4] Await.cshtml) - Html - </b>
+                    RazorIRToken - (391:12,66 [1] Await.cshtml) - Html -  
                 CSharpStatement - (392:12,67 [0] Await.cshtml)
                     RazorIRToken - (392:12,67 [0] Await.cshtml) - CSharp - 
-                HtmlContent - (393:12,68 [54] Await.cshtml) - </p>\n    <p>Basic Incomplete Asynchronous Statement: 
+                HtmlContent - (393:12,68 [54] Await.cshtml)
+                    RazorIRToken - (393:12,68 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (397:12,72 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (403:13,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (406:13,7 [41] Await.cshtml) - Html - Basic Incomplete Asynchronous Statement: 
                 CSharpExpression - (448:13,49 [5] Await.cshtml)
                     RazorIRToken - (448:13,49 [5] Await.cshtml) - CSharp - await
-                HtmlContent - (453:13,54 [124] Await.cshtml) - </p>\n</section>\n\n<section>\n    <h1>Advanced Asynchronous Expression Test</h1>\n    <p>Advanced Asynchronous Expression: 
+                HtmlContent - (453:13,54 [124] Await.cshtml)
+                    RazorIRToken - (453:13,54 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (457:13,58 [2] Await.cshtml) - Html - \n
+                    RazorIRToken - (459:14,0 [10] Await.cshtml) - Html - </section>
+                    RazorIRToken - (469:14,10 [4] Await.cshtml) - Html - \n\n
+                    RazorIRToken - (473:16,0 [9] Await.cshtml) - Html - <section>
+                    RazorIRToken - (482:16,9 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (488:17,4 [4] Await.cshtml) - Html - <h1>
+                    RazorIRToken - (492:17,8 [37] Await.cshtml) - Html - Advanced Asynchronous Expression Test
+                    RazorIRToken - (529:17,45 [5] Await.cshtml) - Html - </h1>
+                    RazorIRToken - (534:17,50 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (540:18,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (543:18,7 [34] Await.cshtml) - Html - Advanced Asynchronous Expression: 
                 CSharpExpression - (578:18,42 [15] Await.cshtml)
                     RazorIRToken - (578:18,42 [15] Await.cshtml) - CSharp - await Foo(1, 2)
-                HtmlContent - (593:18,57 [56] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Expression Extended: 
+                HtmlContent - (593:18,57 [56] Await.cshtml)
+                    RazorIRToken - (593:18,57 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (597:18,61 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (603:19,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (606:19,7 [43] Await.cshtml) - Html - Advanced Asynchronous Expression Extended: 
                 CSharpExpression - (650:19,51 [19] Await.cshtml)
                     RazorIRToken - (650:19,51 [19] Await.cshtml) - CSharp - await Foo.Bar(1, 2)
-                HtmlContent - (669:19,70 [45] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Template: 
+                HtmlContent - (669:19,70 [45] Await.cshtml)
+                    RazorIRToken - (669:19,70 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (673:19,74 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (679:20,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (682:20,7 [32] Await.cshtml) - Html - Advanced Asynchronous Template: 
                 CSharpExpression - (716:20,41 [22] Await.cshtml)
                     RazorIRToken - (716:20,41 [22] Await.cshtml) - CSharp - await Foo("bob", true)
-                HtmlContent - (739:20,64 [46] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Statement: 
+                HtmlContent - (739:20,64 [46] Await.cshtml)
+                    RazorIRToken - (739:20,64 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (743:20,68 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (749:21,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (752:21,7 [33] Await.cshtml) - Html - Advanced Asynchronous Statement: 
                 CSharpStatement - (787:21,42 [39] Await.cshtml)
                     RazorIRToken - (787:21,42 [39] Await.cshtml) - CSharp -  await Foo(something, hello: "world"); 
-                HtmlContent - (827:21,82 [55] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Statement Extended: 
+                HtmlContent - (827:21,82 [55] Await.cshtml)
+                    RazorIRToken - (827:21,82 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (831:21,86 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (837:22,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (840:22,7 [42] Await.cshtml) - Html - Advanced Asynchronous Statement Extended: 
                 CSharpStatement - (884:22,51 [21] Await.cshtml)
                     RazorIRToken - (884:22,51 [21] Await.cshtml) - CSharp -  await Foo.Bar(1, 2) 
-                HtmlContent - (906:22,73 [53] Await.cshtml) - </p>\n    <p>Advanced Asynchronous Statement Nested: 
-                HtmlContent - (961:23,49 [4] Await.cshtml) -  <b>
+                HtmlContent - (906:22,73 [53] Await.cshtml)
+                    RazorIRToken - (906:22,73 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (910:22,77 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (916:23,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (919:23,7 [40] Await.cshtml) - Html - Advanced Asynchronous Statement Nested: 
+                HtmlContent - (961:23,49 [4] Await.cshtml)
+                    RazorIRToken - (961:23,49 [1] Await.cshtml) - Html -  
+                    RazorIRToken - (962:23,50 [3] Await.cshtml) - Html - <b>
                 CSharpExpression - (966:23,54 [27] Await.cshtml)
                     RazorIRToken - (966:23,54 [27] Await.cshtml) - CSharp - await Foo(boolValue: false)
-                HtmlContent - (993:23,81 [5] Await.cshtml) - </b> 
+                HtmlContent - (993:23,81 [5] Await.cshtml)
+                    RazorIRToken - (993:23,81 [4] Await.cshtml) - Html - </b>
+                    RazorIRToken - (997:23,85 [1] Await.cshtml) - Html -  
                 CSharpStatement - (998:23,86 [0] Await.cshtml)
                     RazorIRToken - (998:23,86 [0] Await.cshtml) - CSharp - 
-                HtmlContent - (999:23,87 [57] Await.cshtml) - </p>\n    <p>Advanced Incomplete Asynchronous Statement: 
+                HtmlContent - (999:23,87 [57] Await.cshtml)
+                    RazorIRToken - (999:23,87 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (1003:23,91 [6] Await.cshtml) - Html - \n    
+                    RazorIRToken - (1009:24,4 [3] Await.cshtml) - Html - <p>
+                    RazorIRToken - (1012:24,7 [44] Await.cshtml) - Html - Advanced Incomplete Asynchronous Statement: 
                 CSharpExpression - (1057:24,52 [19] Await.cshtml)
                     RazorIRToken - (1057:24,52 [19] Await.cshtml) - CSharp - await ("wrrronggg")
-                HtmlContent - (1076:24,71 [16] Await.cshtml) - </p>\n</section>
+                HtmlContent - (1076:24,71 [16] Await.cshtml)
+                    RazorIRToken - (1076:24,71 [4] Await.cshtml) - Html - </p>
+                    RazorIRToken - (1080:24,75 [2] Await.cshtml) - Html - \n
+                    RazorIRToken - (1082:25,0 [10] Await.cshtml) - Html - </section>
             CSharpStatement - (12:0,12 [76] Await.cshtml)
                 RazorIRToken - (12:0,12 [76] Await.cshtml) - CSharp - \n    public async Task<string> Foo()\n    {\n        return "Bar";\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.ir.txt
@@ -20,4 +20,8 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] BasicImports.cshtml) - <p>Hi there!</p>\n
+                HtmlContent - (0:0,0 [18] BasicImports.cshtml)
+                    RazorIRToken - (0:0,0 [3] BasicImports.cshtml) - Html - <p>
+                    RazorIRToken - (3:0,3 [9] BasicImports.cshtml) - Html - Hi there!
+                    RazorIRToken - (12:0,12 [4] BasicImports.cshtml) - Html - </p>
+                    RazorIRToken - (16:0,16 [2] BasicImports.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.ir.txt
@@ -8,4 +8,8 @@ Document -
         UsingStatement - (23:1,1 [20] BasicImports_Imports1.cshtml) - System.Text
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicImports_Runtime - Hello - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] BasicImports.cshtml) - <p>Hi there!</p>\n
+                HtmlContent - (0:0,0 [18] BasicImports.cshtml)
+                    RazorIRToken - (0:0,0 [3] BasicImports.cshtml) - Html - <p>
+                    RazorIRToken - (3:0,3 [9] BasicImports.cshtml) - Html - Hi there!
+                    RazorIRToken - (12:0,12 [4] BasicImports.cshtml) - Html - </p>
+                    RazorIRToken - (16:0,16 [2] BasicImports.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.ir.txt
@@ -18,48 +18,72 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [73] BasicTagHelpers.cshtml) - \n\n<div data-animation="fade" class="randomNonTagHelperAttribute">\n    
+                HtmlContent - (31:0,31 [73] BasicTagHelpers.cshtml)
+                    RazorIRToken - (31:0,31 [4] BasicTagHelpers.cshtml) - Html - \n\n
+                    RazorIRToken - (35:2,0 [4] BasicTagHelpers.cshtml) - Html - <div
+                    RazorIRToken - (39:2,4 [17] BasicTagHelpers.cshtml) - Html -  data-animation="
+                    RazorIRToken - (56:2,21 [4] BasicTagHelpers.cshtml) - Html - fade
+                    RazorIRToken - (60:2,25 [1] BasicTagHelpers.cshtml) - Html - "
+                    RazorIRToken - (61:2,26 [36] BasicTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (97:2,62 [1] BasicTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (98:2,63 [6] BasicTagHelpers.cshtml) - Html - \n    
                 TagHelper - (104:3,4 [216] BasicTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (145:3,45 [10] BasicTagHelpers.cshtml) - \n        
+                        HtmlContent - (145:3,45 [10] BasicTagHelpers.cshtml)
+                            RazorIRToken - (145:3,45 [10] BasicTagHelpers.cshtml) - Html - \n        
                         TagHelper - (155:4,8 [25] BasicTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             AddTagHelperHtmlAttribute -  - data - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (164:4,17 [10] BasicTagHelpers.cshtml) - -delay1000
+                                HtmlContent - (164:4,17 [10] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (164:4,17 [10] BasicTagHelpers.cshtml) - Html - -delay1000
                             ExecuteTagHelpers - 
-                        HtmlContent - (180:4,33 [10] BasicTagHelpers.cshtml) - \n        
+                        HtmlContent - (180:4,33 [10] BasicTagHelpers.cshtml)
+                            RazorIRToken - (180:4,33 [10] BasicTagHelpers.cshtml) - Html - \n        
                         TagHelper - (190:5,8 [71] BasicTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             AddTagHelperHtmlAttribute -  - data-interval - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (212:5,30 [7] BasicTagHelpers.cshtml) - 2000 + 
+                                HtmlContent - (212:5,30 [7] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (212:5,30 [7] BasicTagHelpers.cshtml) - Html - 2000 + 
                                 CSharpExpression - (220:5,38 [23] BasicTagHelpers.cshtml)
                                     RazorIRToken - (220:5,38 [23] BasicTagHelpers.cshtml) - CSharp - ViewBag.DefaultInterval
-                                HtmlContent - (243:5,61 [4] BasicTagHelpers.cshtml) -  + 1
+                                HtmlContent - (243:5,61 [4] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (243:5,61 [4] BasicTagHelpers.cshtml) - Html -  + 1
                             SetTagHelperProperty - (255:5,73 [4] BasicTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (255:5,73 [4] BasicTagHelpers.cshtml) - text
+                                HtmlContent - (255:5,73 [4] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (255:5,73 [4] BasicTagHelpers.cshtml) - Html - text
                             SetTagHelperProperty - (255:5,73 [4] BasicTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (255:5,73 [4] BasicTagHelpers.cshtml) - text
+                                HtmlContent - (255:5,73 [4] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (255:5,73 [4] BasicTagHelpers.cshtml) - Html - text
                             ExecuteTagHelpers - 
-                        HtmlContent - (261:5,79 [10] BasicTagHelpers.cshtml) - \n        
+                        HtmlContent - (261:5,79 [10] BasicTagHelpers.cshtml)
+                            RazorIRToken - (261:5,79 [10] BasicTagHelpers.cshtml) - Html - \n        
                         TagHelper - (271:6,8 [39] BasicTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (284:6,21 [8] BasicTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (284:6,21 [8] BasicTagHelpers.cshtml) - checkbox
+                                HtmlContent - (284:6,21 [8] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (284:6,21 [8] BasicTagHelpers.cshtml) - Html - checkbox
                             SetTagHelperProperty - (284:6,21 [8] BasicTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (284:6,21 [8] BasicTagHelpers.cshtml) - checkbox
+                                HtmlContent - (284:6,21 [8] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (284:6,21 [8] BasicTagHelpers.cshtml) - Html - checkbox
                             SetTagHelperProperty - (303:6,40 [4] BasicTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (303:6,40 [4] BasicTagHelpers.cshtml) - true
+                                HtmlContent - (303:6,40 [4] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (303:6,40 [4] BasicTagHelpers.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (310:6,47 [6] BasicTagHelpers.cshtml) - \n    
+                        HtmlContent - (310:6,47 [6] BasicTagHelpers.cshtml)
+                            RazorIRToken - (310:6,47 [6] BasicTagHelpers.cshtml) - Html - \n    
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (114:3,14 [11] BasicTagHelpers.cshtml) - Hello World
+                        HtmlContent - (114:3,14 [11] BasicTagHelpers.cshtml)
+                            RazorIRToken - (114:3,14 [11] BasicTagHelpers.cshtml) - Html - Hello World
                     AddTagHelperHtmlAttribute -  - data-delay - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (139:3,39 [4] BasicTagHelpers.cshtml) - 1000
+                        HtmlContent - (139:3,39 [4] BasicTagHelpers.cshtml)
+                            RazorIRToken - (139:3,39 [4] BasicTagHelpers.cshtml) - Html - 1000
                     ExecuteTagHelpers - 
-                HtmlContent - (320:7,8 [8] BasicTagHelpers.cshtml) - \n</div>
+                HtmlContent - (320:7,8 [8] BasicTagHelpers.cshtml)
+                    RazorIRToken - (320:7,8 [2] BasicTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (322:8,0 [6] BasicTagHelpers.cshtml) - Html - </div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.ir.txt
@@ -19,25 +19,46 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (22:0,22 [2] BasicTagHelpers_Prefixed.cshtml) - \n
-                HtmlContent - (55:1,31 [54] BasicTagHelpers_Prefixed.cshtml) - \n\n<THSdiv class="randomNonTagHelperAttribute">\n    
+                HtmlContent - (22:0,22 [2] BasicTagHelpers_Prefixed.cshtml)
+                    RazorIRToken - (22:0,22 [2] BasicTagHelpers_Prefixed.cshtml) - Html - \n
+                HtmlContent - (55:1,31 [54] BasicTagHelpers_Prefixed.cshtml)
+                    RazorIRToken - (55:1,31 [4] BasicTagHelpers_Prefixed.cshtml) - Html - \n\n
+                    RazorIRToken - (59:3,0 [7] BasicTagHelpers_Prefixed.cshtml) - Html - <THSdiv
+                    RazorIRToken - (66:3,7 [36] BasicTagHelpers_Prefixed.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (102:3,43 [1] BasicTagHelpers_Prefixed.cshtml) - Html - >
+                    RazorIRToken - (103:3,44 [6] BasicTagHelpers_Prefixed.cshtml) - Html - \n    
                 TagHelper - (109:4,4 [136] BasicTagHelpers_Prefixed.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (135:4,30 [56] BasicTagHelpers_Prefixed.cshtml) - \n        <p></p>\n        <input type="text">\n        
+                        HtmlContent - (135:4,30 [56] BasicTagHelpers_Prefixed.cshtml)
+                            RazorIRToken - (135:4,30 [10] BasicTagHelpers_Prefixed.cshtml) - Html - \n        
+                            RazorIRToken - (145:5,8 [3] BasicTagHelpers_Prefixed.cshtml) - Html - <p>
+                            RazorIRToken - (148:5,11 [4] BasicTagHelpers_Prefixed.cshtml) - Html - </p>
+                            RazorIRToken - (152:5,15 [10] BasicTagHelpers_Prefixed.cshtml) - Html - \n        
+                            RazorIRToken - (162:6,8 [6] BasicTagHelpers_Prefixed.cshtml) - Html - <input
+                            RazorIRToken - (168:6,14 [12] BasicTagHelpers_Prefixed.cshtml) - Html -  type="text"
+                            RazorIRToken - (180:6,26 [1] BasicTagHelpers_Prefixed.cshtml) - Html - >
+                            RazorIRToken - (181:6,27 [10] BasicTagHelpers_Prefixed.cshtml) - Html - \n        
                         TagHelper - (191:7,8 [41] BasicTagHelpers_Prefixed.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - checkbox
+                                HtmlContent - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml)
+                                    RazorIRToken - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - Html - checkbox
                             SetTagHelperProperty - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - checkbox
+                                HtmlContent - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml)
+                                    RazorIRToken - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - Html - checkbox
                             SetTagHelperProperty - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - true
+                                HtmlContent - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml)
+                                    RazorIRToken - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml) - \n    
+                        HtmlContent - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml)
+                            RazorIRToken - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml) - Html - \n    
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (122:4,17 [11] BasicTagHelpers_Prefixed.cshtml) - Hello World
+                        HtmlContent - (122:4,17 [11] BasicTagHelpers_Prefixed.cshtml)
+                            RazorIRToken - (122:4,17 [11] BasicTagHelpers_Prefixed.cshtml) - Html - Hello World
                     ExecuteTagHelpers - 
-                HtmlContent - (245:8,11 [11] BasicTagHelpers_Prefixed.cshtml) - \n</THSdiv>
+                HtmlContent - (245:8,11 [11] BasicTagHelpers_Prefixed.cshtml)
+                    RazorIRToken - (245:8,11 [2] BasicTagHelpers_Prefixed.cshtml) - Html - \n
+                    RazorIRToken - (247:9,0 [9] BasicTagHelpers_Prefixed.cshtml) - Html - </THSdiv>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.ir.txt
@@ -8,10 +8,23 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (57:2,0 [52] BasicTagHelpers_Prefixed.cshtml) - \n<THSdiv class="randomNonTagHelperAttribute">\n    
+                HtmlContent - (57:2,0 [52] BasicTagHelpers_Prefixed.cshtml)
+                    RazorIRToken - (57:2,0 [2] BasicTagHelpers_Prefixed.cshtml) - Html - \n
+                    RazorIRToken - (59:3,0 [7] BasicTagHelpers_Prefixed.cshtml) - Html - <THSdiv
+                    RazorIRToken - (66:3,7 [36] BasicTagHelpers_Prefixed.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (102:3,43 [1] BasicTagHelpers_Prefixed.cshtml) - Html - >
+                    RazorIRToken - (103:3,44 [6] BasicTagHelpers_Prefixed.cshtml) - Html - \n    
                 TagHelper - (109:4,4 [136] BasicTagHelpers_Prefixed.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (135:4,30 [56] BasicTagHelpers_Prefixed.cshtml) - \n        <p></p>\n        <input type="text">\n        
+                        HtmlContent - (135:4,30 [56] BasicTagHelpers_Prefixed.cshtml)
+                            RazorIRToken - (135:4,30 [10] BasicTagHelpers_Prefixed.cshtml) - Html - \n        
+                            RazorIRToken - (145:5,8 [3] BasicTagHelpers_Prefixed.cshtml) - Html - <p>
+                            RazorIRToken - (148:5,11 [4] BasicTagHelpers_Prefixed.cshtml) - Html - </p>
+                            RazorIRToken - (152:5,15 [10] BasicTagHelpers_Prefixed.cshtml) - Html - \n        
+                            RazorIRToken - (162:6,8 [6] BasicTagHelpers_Prefixed.cshtml) - Html - <input
+                            RazorIRToken - (168:6,14 [12] BasicTagHelpers_Prefixed.cshtml) - Html -  type="text"
+                            RazorIRToken - (180:6,26 [1] BasicTagHelpers_Prefixed.cshtml) - Html - >
+                            RazorIRToken - (181:6,27 [10] BasicTagHelpers_Prefixed.cshtml) - Html - \n        
                         TagHelper - (191:7,8 [41] BasicTagHelpers_Prefixed.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -19,10 +32,14 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetTagHelperProperty - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - true
+                                HtmlContent - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml)
+                                    RazorIRToken - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml) - \n    
+                        HtmlContent - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml)
+                            RazorIRToken - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml) - Html - \n    
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     ExecuteTagHelpers - 
-                HtmlContent - (245:8,11 [11] BasicTagHelpers_Prefixed.cshtml) - \n</THSdiv>
+                HtmlContent - (245:8,11 [11] BasicTagHelpers_Prefixed.cshtml)
+                    RazorIRToken - (245:8,11 [2] BasicTagHelpers_Prefixed.cshtml) - Html - \n
+                    RazorIRToken - (247:9,0 [9] BasicTagHelpers_Prefixed.cshtml) - Html - </THSdiv>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.ir.txt
@@ -9,15 +9,22 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (72:2,0 [49] BasicTagHelpers_RemoveTagHelper.cshtml) - \n<div class="randomNonTagHelperAttribute">\n    
+                HtmlContent - (72:2,0 [49] BasicTagHelpers_RemoveTagHelper.cshtml)
+                    RazorIRToken - (72:2,0 [2] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - \n
+                    RazorIRToken - (74:3,0 [4] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - <div
+                    RazorIRToken - (78:3,4 [36] BasicTagHelpers_RemoveTagHelper.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (114:3,40 [1] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - >
+                    RazorIRToken - (115:3,41 [6] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - \n    
                 TagHelper - (121:4,4 [130] BasicTagHelpers_RemoveTagHelper.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (144:4,27 [10] BasicTagHelpers_RemoveTagHelper.cshtml) - \n        
+                        HtmlContent - (144:4,27 [10] BasicTagHelpers_RemoveTagHelper.cshtml)
+                            RazorIRToken - (144:4,27 [10] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - \n        
                         TagHelper - (154:5,8 [7] BasicTagHelpers_RemoveTagHelper.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
-                        HtmlContent - (161:5,15 [10] BasicTagHelpers_RemoveTagHelper.cshtml) - \n        
+                        HtmlContent - (161:5,15 [10] BasicTagHelpers_RemoveTagHelper.cshtml)
+                            RazorIRToken - (161:5,15 [10] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - \n        
                         TagHelper - (171:6,8 [21] BasicTagHelpers_RemoveTagHelper.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -25,7 +32,8 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             ExecuteTagHelpers - 
-                        HtmlContent - (192:6,29 [10] BasicTagHelpers_RemoveTagHelper.cshtml) - \n        
+                        HtmlContent - (192:6,29 [10] BasicTagHelpers_RemoveTagHelper.cshtml)
+                            RazorIRToken - (192:6,29 [10] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - \n        
                         TagHelper - (202:7,8 [39] BasicTagHelpers_RemoveTagHelper.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -33,10 +41,14 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetTagHelperProperty - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml) - true
+                                HtmlContent - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml)
+                                    RazorIRToken - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (241:7,47 [6] BasicTagHelpers_RemoveTagHelper.cshtml) - \n    
+                        HtmlContent - (241:7,47 [6] BasicTagHelpers_RemoveTagHelper.cshtml)
+                            RazorIRToken - (241:7,47 [6] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - \n    
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     ExecuteTagHelpers - 
-                HtmlContent - (251:8,8 [8] BasicTagHelpers_RemoveTagHelper.cshtml) - \n</div>
+                HtmlContent - (251:8,8 [8] BasicTagHelpers_RemoveTagHelper.cshtml)
+                    RazorIRToken - (251:8,8 [2] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - \n
+                    RazorIRToken - (253:9,0 [6] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - </div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.ir.txt
@@ -11,29 +11,42 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4 - data-delay - 1000 - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [71] BasicTagHelpers.cshtml) - \n<div data-animation="fade" class="randomNonTagHelperAttribute">\n    
+                HtmlContent - (33:1,0 [71] BasicTagHelpers.cshtml)
+                    RazorIRToken - (33:1,0 [2] BasicTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (35:2,0 [4] BasicTagHelpers.cshtml) - Html - <div
+                    RazorIRToken - (39:2,4 [17] BasicTagHelpers.cshtml) - Html -  data-animation="
+                    RazorIRToken - (56:2,21 [4] BasicTagHelpers.cshtml) - Html - fade
+                    RazorIRToken - (60:2,25 [1] BasicTagHelpers.cshtml) - Html - "
+                    RazorIRToken - (61:2,26 [36] BasicTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (97:2,62 [1] BasicTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (98:2,63 [6] BasicTagHelpers.cshtml) - Html - \n    
                 TagHelper - (104:3,4 [216] BasicTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (145:3,45 [10] BasicTagHelpers.cshtml) - \n        
+                        HtmlContent - (145:3,45 [10] BasicTagHelpers.cshtml)
+                            RazorIRToken - (145:3,45 [10] BasicTagHelpers.cshtml) - Html - \n        
                         TagHelper - (155:4,8 [25] BasicTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                             ExecuteTagHelpers - 
-                        HtmlContent - (180:4,33 [10] BasicTagHelpers.cshtml) - \n        
+                        HtmlContent - (180:4,33 [10] BasicTagHelpers.cshtml)
+                            RazorIRToken - (180:4,33 [10] BasicTagHelpers.cshtml) - Html - \n        
                         TagHelper - (190:5,8 [71] BasicTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             AddTagHelperHtmlAttribute -  - data-interval - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (212:5,30 [7] BasicTagHelpers.cshtml) - 2000 + 
+                                HtmlContent - (212:5,30 [7] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (212:5,30 [7] BasicTagHelpers.cshtml) - Html - 2000 + 
                                 CSharpExpression - (220:5,38 [23] BasicTagHelpers.cshtml)
                                     RazorIRToken - (220:5,38 [23] BasicTagHelpers.cshtml) - CSharp - ViewBag.DefaultInterval
-                                HtmlContent - (243:5,61 [4] BasicTagHelpers.cshtml) -  + 1
+                                HtmlContent - (243:5,61 [4] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (243:5,61 [4] BasicTagHelpers.cshtml) - Html -  + 1
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             ExecuteTagHelpers - 
-                        HtmlContent - (261:5,79 [10] BasicTagHelpers.cshtml) - \n        
+                        HtmlContent - (261:5,79 [10] BasicTagHelpers.cshtml)
+                            RazorIRToken - (261:5,79 [10] BasicTagHelpers.cshtml) - Html - \n        
                         TagHelper - (271:6,8 [39] BasicTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -41,11 +54,15 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_2 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_2 - type - Type
                             SetTagHelperProperty - (303:6,40 [4] BasicTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (303:6,40 [4] BasicTagHelpers.cshtml) - true
+                                HtmlContent - (303:6,40 [4] BasicTagHelpers.cshtml)
+                                    RazorIRToken - (303:6,40 [4] BasicTagHelpers.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (310:6,47 [6] BasicTagHelpers.cshtml) - \n    
+                        HtmlContent - (310:6,47 [6] BasicTagHelpers.cshtml)
+                            RazorIRToken - (310:6,47 [6] BasicTagHelpers.cshtml) - Html - \n    
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4
                     ExecuteTagHelpers - 
-                HtmlContent - (320:7,8 [8] BasicTagHelpers.cshtml) - \n</div>
+                HtmlContent - (320:7,8 [8] BasicTagHelpers.cshtml)
+                    RazorIRToken - (320:7,8 [2] BasicTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (322:8,0 [6] BasicTagHelpers.cshtml) - Html - </div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.ir.txt
@@ -18,57 +18,91 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [18] Blocks.cshtml)
                     RazorIRToken - (2:0,2 [18] Blocks.cshtml) - CSharp - \n    int i = 1;\n
-                HtmlContent - (23:3,0 [2] Blocks.cshtml) - \n
+                HtmlContent - (23:3,0 [2] Blocks.cshtml)
+                    RazorIRToken - (23:3,0 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (26:4,1 [22] Blocks.cshtml)
                     RazorIRToken - (26:4,1 [22] Blocks.cshtml) - CSharp - while(i <= 10) {\n    
-                HtmlContent - (48:5,4 [19] Blocks.cshtml) - <p>Hello from C#, #
+                HtmlContent - (48:5,4 [19] Blocks.cshtml)
+                    RazorIRToken - (48:5,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (51:5,7 [16] Blocks.cshtml) - Html - Hello from C#, #
                 CSharpExpression - (69:5,25 [1] Blocks.cshtml)
                     RazorIRToken - (69:5,25 [1] Blocks.cshtml) - CSharp - i
-                HtmlContent - (71:5,27 [4] Blocks.cshtml) - </p>
+                HtmlContent - (71:5,27 [4] Blocks.cshtml)
+                    RazorIRToken - (71:5,27 [4] Blocks.cshtml) - Html - </p>
                 CSharpStatement - (75:5,31 [16] Blocks.cshtml)
                     RazorIRToken - (75:5,31 [16] Blocks.cshtml) - CSharp - \n    i += 1;\n}
-                HtmlContent - (91:7,1 [4] Blocks.cshtml) - \n\n
+                HtmlContent - (91:7,1 [4] Blocks.cshtml)
+                    RazorIRToken - (91:7,1 [4] Blocks.cshtml) - Html - \n\n
                 CSharpStatement - (96:9,1 [19] Blocks.cshtml)
                     RazorIRToken - (96:9,1 [19] Blocks.cshtml) - CSharp - if(i == 11) {\n    
-                HtmlContent - (115:10,4 [25] Blocks.cshtml) - <p>We wrote 10 lines!</p>
+                HtmlContent - (115:10,4 [25] Blocks.cshtml)
+                    RazorIRToken - (115:10,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (118:10,7 [18] Blocks.cshtml) - Html - We wrote 10 lines!
+                    RazorIRToken - (136:10,25 [4] Blocks.cshtml) - Html - </p>
                 CSharpStatement - (140:10,29 [3] Blocks.cshtml)
                     RazorIRToken - (140:10,29 [3] Blocks.cshtml) - CSharp - \n}
-                HtmlContent - (143:11,1 [4] Blocks.cshtml) - \n\n
+                HtmlContent - (143:11,1 [4] Blocks.cshtml)
+                    RazorIRToken - (143:11,1 [4] Blocks.cshtml) - Html - \n\n
                 CSharpStatement - (148:13,1 [35] Blocks.cshtml)
                     RazorIRToken - (148:13,1 [35] Blocks.cshtml) - CSharp - switch(i) {\n    case 11:\n        
-                HtmlContent - (183:15,8 [36] Blocks.cshtml) - <p>No really, we wrote 10 lines!</p>
+                HtmlContent - (183:15,8 [36] Blocks.cshtml)
+                    RazorIRToken - (183:15,8 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (186:15,11 [29] Blocks.cshtml) - Html - No really, we wrote 10 lines!
+                    RazorIRToken - (215:15,40 [4] Blocks.cshtml) - Html - </p>
                 CSharpStatement - (219:15,44 [40] Blocks.cshtml)
                     RazorIRToken - (219:15,44 [40] Blocks.cshtml) - CSharp - \n        break;\n    default:\n        
-                HtmlContent - (259:18,8 [29] Blocks.cshtml) - <p>Actually, we didn't...</p>
+                HtmlContent - (259:18,8 [29] Blocks.cshtml)
+                    RazorIRToken - (259:18,8 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (262:18,11 [22] Blocks.cshtml) - Html - Actually, we didn't...
+                    RazorIRToken - (284:18,33 [4] Blocks.cshtml) - Html - </p>
                 CSharpStatement - (288:18,37 [19] Blocks.cshtml)
                     RazorIRToken - (288:18,37 [19] Blocks.cshtml) - CSharp - \n        break;\n}
-                HtmlContent - (307:20,1 [4] Blocks.cshtml) - \n\n
+                HtmlContent - (307:20,1 [4] Blocks.cshtml)
+                    RazorIRToken - (307:20,1 [4] Blocks.cshtml) - Html - \n\n
                 CSharpStatement - (312:22,1 [39] Blocks.cshtml)
                     RazorIRToken - (312:22,1 [39] Blocks.cshtml) - CSharp - for(int j = 1; j <= 10; j += 2) {\n    
-                HtmlContent - (351:23,4 [25] Blocks.cshtml) - <p>Hello again from C#, #
+                HtmlContent - (351:23,4 [25] Blocks.cshtml)
+                    RazorIRToken - (351:23,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (354:23,7 [22] Blocks.cshtml) - Html - Hello again from C#, #
                 CSharpExpression - (378:23,31 [1] Blocks.cshtml)
                     RazorIRToken - (378:23,31 [1] Blocks.cshtml) - CSharp - j
-                HtmlContent - (380:23,33 [4] Blocks.cshtml) - </p>
+                HtmlContent - (380:23,33 [4] Blocks.cshtml)
+                    RazorIRToken - (380:23,33 [4] Blocks.cshtml) - Html - </p>
                 CSharpStatement - (384:23,37 [3] Blocks.cshtml)
                     RazorIRToken - (384:23,37 [3] Blocks.cshtml) - CSharp - \n}
-                HtmlContent - (387:24,1 [4] Blocks.cshtml) - \n\n
+                HtmlContent - (387:24,1 [4] Blocks.cshtml)
+                    RazorIRToken - (387:24,1 [4] Blocks.cshtml) - Html - \n\n
                 CSharpStatement - (392:26,1 [11] Blocks.cshtml)
                     RazorIRToken - (392:26,1 [11] Blocks.cshtml) - CSharp - try {\n    
-                HtmlContent - (403:27,4 [35] Blocks.cshtml) - <p>That time, we wrote 5 lines!</p>
+                HtmlContent - (403:27,4 [35] Blocks.cshtml)
+                    RazorIRToken - (403:27,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (406:27,7 [28] Blocks.cshtml) - Html - That time, we wrote 5 lines!
+                    RazorIRToken - (434:27,35 [4] Blocks.cshtml) - Html - </p>
                 CSharpStatement - (438:27,39 [31] Blocks.cshtml)
                     RazorIRToken - (438:27,39 [31] Blocks.cshtml) - CSharp - \n} catch(Exception ex) {\n    
-                HtmlContent - (469:29,4 [29] Blocks.cshtml) - <p>Oh no! An error occurred: 
+                HtmlContent - (469:29,4 [29] Blocks.cshtml)
+                    RazorIRToken - (469:29,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (472:29,7 [26] Blocks.cshtml) - Html - Oh no! An error occurred: 
                 CSharpExpression - (500:29,35 [10] Blocks.cshtml)
                     RazorIRToken - (500:29,35 [10] Blocks.cshtml) - CSharp - ex.Message
-                HtmlContent - (511:29,46 [4] Blocks.cshtml) - </p>
+                HtmlContent - (511:29,46 [4] Blocks.cshtml)
+                    RazorIRToken - (511:29,46 [4] Blocks.cshtml) - Html - </p>
                 CSharpStatement - (515:29,50 [3] Blocks.cshtml)
                     RazorIRToken - (515:29,50 [3] Blocks.cshtml) - CSharp - \n}
-                HtmlContent - (518:30,1 [16] Blocks.cshtml) - \n\n<p>i is now 
+                HtmlContent - (518:30,1 [16] Blocks.cshtml)
+                    RazorIRToken - (518:30,1 [4] Blocks.cshtml) - Html - \n\n
+                    RazorIRToken - (522:32,0 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (525:32,3 [9] Blocks.cshtml) - Html - i is now 
                 CSharpExpression - (535:32,13 [1] Blocks.cshtml)
                     RazorIRToken - (535:32,13 [1] Blocks.cshtml) - CSharp - i
-                HtmlContent - (536:32,14 [8] Blocks.cshtml) - </p>\n\n
+                HtmlContent - (536:32,14 [8] Blocks.cshtml)
+                    RazorIRToken - (536:32,14 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (540:32,18 [4] Blocks.cshtml) - Html - \n\n
                 CSharpStatement - (545:34,1 [26] Blocks.cshtml)
                     RazorIRToken - (545:34,1 [26] Blocks.cshtml) - CSharp - lock(new object()) {\n    
-                HtmlContent - (571:35,4 [47] Blocks.cshtml) - <p>This block is locked, for your security!</p>
+                HtmlContent - (571:35,4 [47] Blocks.cshtml)
+                    RazorIRToken - (571:35,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (574:35,7 [40] Blocks.cshtml) - Html - This block is locked, for your security!
+                    RazorIRToken - (614:35,47 [4] Blocks.cshtml) - Html - </p>
                 CSharpStatement - (618:35,51 [3] Blocks.cshtml)
                     RazorIRToken - (618:35,51 [3] Blocks.cshtml) - CSharp - \n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_Runtime.ir.txt
@@ -7,57 +7,107 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [18] Blocks.cshtml)
                     RazorIRToken - (2:0,2 [18] Blocks.cshtml) - CSharp - \n    int i = 1;\n
-                HtmlContent - (23:3,0 [2] Blocks.cshtml) - \n
+                HtmlContent - (23:3,0 [2] Blocks.cshtml)
+                    RazorIRToken - (23:3,0 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (26:4,1 [18] Blocks.cshtml)
                     RazorIRToken - (26:4,1 [18] Blocks.cshtml) - CSharp - while(i <= 10) {\n
-                HtmlContent - (44:5,0 [23] Blocks.cshtml) -     <p>Hello from C#, #
+                HtmlContent - (44:5,0 [23] Blocks.cshtml)
+                    RazorIRToken - (44:5,0 [4] Blocks.cshtml) - Html -     
+                    RazorIRToken - (48:5,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (51:5,7 [16] Blocks.cshtml) - Html - Hello from C#, #
                 CSharpExpression - (69:5,25 [1] Blocks.cshtml)
                     RazorIRToken - (69:5,25 [1] Blocks.cshtml) - CSharp - i
-                HtmlContent - (71:5,27 [6] Blocks.cshtml) - </p>\n
+                HtmlContent - (71:5,27 [6] Blocks.cshtml)
+                    RazorIRToken - (71:5,27 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (75:5,31 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (77:6,0 [16] Blocks.cshtml)
                     RazorIRToken - (77:6,0 [16] Blocks.cshtml) - CSharp -     i += 1;\n}\n
-                HtmlContent - (93:8,0 [2] Blocks.cshtml) - \n
+                HtmlContent - (93:8,0 [2] Blocks.cshtml)
+                    RazorIRToken - (93:8,0 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (96:9,1 [15] Blocks.cshtml)
                     RazorIRToken - (96:9,1 [15] Blocks.cshtml) - CSharp - if(i == 11) {\n
-                HtmlContent - (111:10,0 [31] Blocks.cshtml) -     <p>We wrote 10 lines!</p>\n
+                HtmlContent - (111:10,0 [31] Blocks.cshtml)
+                    RazorIRToken - (111:10,0 [4] Blocks.cshtml) - Html -     
+                    RazorIRToken - (115:10,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (118:10,7 [18] Blocks.cshtml) - Html - We wrote 10 lines!
+                    RazorIRToken - (136:10,25 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (140:10,29 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (142:11,0 [3] Blocks.cshtml)
                     RazorIRToken - (142:11,0 [3] Blocks.cshtml) - CSharp - }\n
-                HtmlContent - (145:12,0 [2] Blocks.cshtml) - \n
+                HtmlContent - (145:12,0 [2] Blocks.cshtml)
+                    RazorIRToken - (145:12,0 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (148:13,1 [27] Blocks.cshtml)
                     RazorIRToken - (148:13,1 [27] Blocks.cshtml) - CSharp - switch(i) {\n    case 11:\n
-                HtmlContent - (175:15,0 [46] Blocks.cshtml) -         <p>No really, we wrote 10 lines!</p>\n
+                HtmlContent - (175:15,0 [46] Blocks.cshtml)
+                    RazorIRToken - (175:15,0 [8] Blocks.cshtml) - Html -         
+                    RazorIRToken - (183:15,8 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (186:15,11 [29] Blocks.cshtml) - Html - No really, we wrote 10 lines!
+                    RazorIRToken - (215:15,40 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (219:15,44 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (221:16,0 [30] Blocks.cshtml)
                     RazorIRToken - (221:16,0 [30] Blocks.cshtml) - CSharp -         break;\n    default:\n
-                HtmlContent - (251:18,0 [39] Blocks.cshtml) -         <p>Actually, we didn't...</p>\n
+                HtmlContent - (251:18,0 [39] Blocks.cshtml)
+                    RazorIRToken - (251:18,0 [8] Blocks.cshtml) - Html -         
+                    RazorIRToken - (259:18,8 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (262:18,11 [22] Blocks.cshtml) - Html - Actually, we didn't...
+                    RazorIRToken - (284:18,33 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (288:18,37 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (290:19,0 [19] Blocks.cshtml)
                     RazorIRToken - (290:19,0 [19] Blocks.cshtml) - CSharp -         break;\n}\n
-                HtmlContent - (309:21,0 [2] Blocks.cshtml) - \n
+                HtmlContent - (309:21,0 [2] Blocks.cshtml)
+                    RazorIRToken - (309:21,0 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (312:22,1 [35] Blocks.cshtml)
                     RazorIRToken - (312:22,1 [35] Blocks.cshtml) - CSharp - for(int j = 1; j <= 10; j += 2) {\n
-                HtmlContent - (347:23,0 [29] Blocks.cshtml) -     <p>Hello again from C#, #
+                HtmlContent - (347:23,0 [29] Blocks.cshtml)
+                    RazorIRToken - (347:23,0 [4] Blocks.cshtml) - Html -     
+                    RazorIRToken - (351:23,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (354:23,7 [22] Blocks.cshtml) - Html - Hello again from C#, #
                 CSharpExpression - (378:23,31 [1] Blocks.cshtml)
                     RazorIRToken - (378:23,31 [1] Blocks.cshtml) - CSharp - j
-                HtmlContent - (380:23,33 [6] Blocks.cshtml) - </p>\n
+                HtmlContent - (380:23,33 [6] Blocks.cshtml)
+                    RazorIRToken - (380:23,33 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (384:23,37 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (386:24,0 [3] Blocks.cshtml)
                     RazorIRToken - (386:24,0 [3] Blocks.cshtml) - CSharp - }\n
-                HtmlContent - (389:25,0 [2] Blocks.cshtml) - \n
+                HtmlContent - (389:25,0 [2] Blocks.cshtml)
+                    RazorIRToken - (389:25,0 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (392:26,1 [7] Blocks.cshtml)
                     RazorIRToken - (392:26,1 [7] Blocks.cshtml) - CSharp - try {\n
-                HtmlContent - (399:27,0 [41] Blocks.cshtml) -     <p>That time, we wrote 5 lines!</p>\n
+                HtmlContent - (399:27,0 [41] Blocks.cshtml)
+                    RazorIRToken - (399:27,0 [4] Blocks.cshtml) - Html -     
+                    RazorIRToken - (403:27,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (406:27,7 [28] Blocks.cshtml) - Html - That time, we wrote 5 lines!
+                    RazorIRToken - (434:27,35 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (438:27,39 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (440:28,0 [25] Blocks.cshtml)
                     RazorIRToken - (440:28,0 [25] Blocks.cshtml) - CSharp - } catch(Exception ex) {\n
-                HtmlContent - (465:29,0 [33] Blocks.cshtml) -     <p>Oh no! An error occurred: 
+                HtmlContent - (465:29,0 [33] Blocks.cshtml)
+                    RazorIRToken - (465:29,0 [4] Blocks.cshtml) - Html -     
+                    RazorIRToken - (469:29,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (472:29,7 [26] Blocks.cshtml) - Html - Oh no! An error occurred: 
                 CSharpExpression - (500:29,35 [10] Blocks.cshtml)
                     RazorIRToken - (500:29,35 [10] Blocks.cshtml) - CSharp - ex.Message
-                HtmlContent - (511:29,46 [6] Blocks.cshtml) - </p>\n
+                HtmlContent - (511:29,46 [6] Blocks.cshtml)
+                    RazorIRToken - (511:29,46 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (515:29,50 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (517:30,0 [3] Blocks.cshtml)
                     RazorIRToken - (517:30,0 [3] Blocks.cshtml) - CSharp - }\n
-                HtmlContent - (520:31,0 [14] Blocks.cshtml) - \n<p>i is now 
+                HtmlContent - (520:31,0 [14] Blocks.cshtml)
+                    RazorIRToken - (520:31,0 [2] Blocks.cshtml) - Html - \n
+                    RazorIRToken - (522:32,0 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (525:32,3 [9] Blocks.cshtml) - Html - i is now 
                 CSharpExpression - (535:32,13 [1] Blocks.cshtml)
                     RazorIRToken - (535:32,13 [1] Blocks.cshtml) - CSharp - i
-                HtmlContent - (536:32,14 [8] Blocks.cshtml) - </p>\n\n
+                HtmlContent - (536:32,14 [8] Blocks.cshtml)
+                    RazorIRToken - (536:32,14 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (540:32,18 [4] Blocks.cshtml) - Html - \n\n
                 CSharpStatement - (545:34,1 [22] Blocks.cshtml)
                     RazorIRToken - (545:34,1 [22] Blocks.cshtml) - CSharp - lock(new object()) {\n
-                HtmlContent - (567:35,0 [53] Blocks.cshtml) -     <p>This block is locked, for your security!</p>\n
+                HtmlContent - (567:35,0 [53] Blocks.cshtml)
+                    RazorIRToken - (567:35,0 [4] Blocks.cshtml) - Html -     
+                    RazorIRToken - (571:35,4 [3] Blocks.cshtml) - Html - <p>
+                    RazorIRToken - (574:35,7 [40] Blocks.cshtml) - Html - This block is locked, for your security!
+                    RazorIRToken - (614:35,47 [4] Blocks.cshtml) - Html - </p>
+                    RazorIRToken - (618:35,51 [2] Blocks.cshtml) - Html - \n
                 CSharpStatement - (620:36,0 [1] Blocks.cshtml)
                     RazorIRToken - (620:36,0 [1] Blocks.cshtml) - CSharp - }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.ir.txt
@@ -18,10 +18,12 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [17] CodeBlockWithTextElement.cshtml)
                     RazorIRToken - (2:0,2 [17] CodeBlockWithTextElement.cshtml) - CSharp - \n    var a = 1; 
-                HtmlContent - (25:1,21 [3] CodeBlockWithTextElement.cshtml) - foo
+                HtmlContent - (25:1,21 [3] CodeBlockWithTextElement.cshtml)
+                    RazorIRToken - (25:1,21 [3] CodeBlockWithTextElement.cshtml) - Html - foo
                 CSharpStatement - (35:1,31 [22] CodeBlockWithTextElement.cshtml)
                     RazorIRToken - (35:1,31 [22] CodeBlockWithTextElement.cshtml) - CSharp -  		\n    var b = 1;			
-                HtmlContent - (63:2,23 [4] CodeBlockWithTextElement.cshtml) - bar 
+                HtmlContent - (63:2,23 [4] CodeBlockWithTextElement.cshtml)
+                    RazorIRToken - (63:2,23 [4] CodeBlockWithTextElement.cshtml) - Html - bar 
                 CSharpExpression - (69:2,29 [3] CodeBlockWithTextElement.cshtml)
                     RazorIRToken - (69:2,29 [3] CodeBlockWithTextElement.cshtml) - CSharp - a+b
                 CSharpStatement - (80:2,40 [2] CodeBlockWithTextElement.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_Runtime.ir.txt
@@ -7,10 +7,12 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [16] CodeBlockWithTextElement.cshtml)
                     RazorIRToken - (2:0,2 [16] CodeBlockWithTextElement.cshtml) - CSharp - \n    var a = 1;
-                HtmlContent - (25:1,21 [3] CodeBlockWithTextElement.cshtml) - foo
+                HtmlContent - (25:1,21 [3] CodeBlockWithTextElement.cshtml)
+                    RazorIRToken - (25:1,21 [3] CodeBlockWithTextElement.cshtml) - Html - foo
                 CSharpStatement - (35:1,31 [19] CodeBlockWithTextElement.cshtml)
                     RazorIRToken - (35:1,31 [19] CodeBlockWithTextElement.cshtml) - CSharp -  		\n    var b = 1;
-                HtmlContent - (63:2,23 [4] CodeBlockWithTextElement.cshtml) - bar 
+                HtmlContent - (63:2,23 [4] CodeBlockWithTextElement.cshtml)
+                    RazorIRToken - (63:2,23 [4] CodeBlockWithTextElement.cshtml) - Html - bar 
                 CSharpExpression - (69:2,29 [3] CodeBlockWithTextElement.cshtml)
                     RazorIRToken - (69:2,29 [3] CodeBlockWithTextElement.cshtml) - CSharp - a+b
                 CSharpStatement - (80:2,40 [2] CodeBlockWithTextElement.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
@@ -18,30 +18,45 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] ComplexTagHelpers.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (31:0,31 [4] ComplexTagHelpers.cshtml) - Html - \n\n
                 CSharpStatement - (36:2,1 [52] ComplexTagHelpers.cshtml)
                     RazorIRToken - (36:2,1 [52] ComplexTagHelpers.cshtml) - CSharp - if (true)\n{\n    var checkbox = "checkbox";\n\n    
-                HtmlContent - (88:6,4 [51] ComplexTagHelpers.cshtml) - <div class="randomNonTagHelperAttribute">\n        
+                HtmlContent - (88:6,4 [51] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (88:6,4 [4] ComplexTagHelpers.cshtml) - Html - <div
+                    RazorIRToken - (92:6,8 [36] ComplexTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (128:6,44 [1] ComplexTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (129:6,45 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (139:7,8 [531] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (177:7,46 [46] ComplexTagHelpers.cshtml) - \n            <h1>Set Time:</h1>\n            
+                        HtmlContent - (177:7,46 [46] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (177:7,46 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                            RazorIRToken - (191:8,12 [4] ComplexTagHelpers.cshtml) - Html - <h1>
+                            RazorIRToken - (195:8,16 [9] ComplexTagHelpers.cshtml) - Html - Set Time:
+                            RazorIRToken - (204:8,25 [5] ComplexTagHelpers.cshtml) - Html - </h1>
+                            RazorIRToken - (209:8,30 [14] ComplexTagHelpers.cshtml) - Html - \n            
                         CSharpStatement - (224:9,13 [43] ComplexTagHelpers.cshtml)
                             RazorIRToken - (224:9,13 [43] ComplexTagHelpers.cshtml) - CSharp - if (false)\n            {\n                
                         TagHelper - (267:11,16 [83] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                HtmlContent - (270:11,19 [10] ComplexTagHelpers.cshtml) - New Time: 
+                                HtmlContent - (270:11,19 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (270:11,19 [10] ComplexTagHelpers.cshtml) - Html - New Time: 
                                 TagHelper - (280:11,29 [66] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
                                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                                     SetTagHelperProperty - (293:11,42 [4] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (293:11,42 [4] ComplexTagHelpers.cshtml) - text
+                                        HtmlContent - (293:11,42 [4] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (293:11,42 [4] ComplexTagHelpers.cshtml) - Html - text
                                     SetTagHelperProperty - (293:11,42 [4] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (293:11,42 [4] ComplexTagHelpers.cshtml) - text
+                                        HtmlContent - (293:11,42 [4] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (293:11,42 [4] ComplexTagHelpers.cshtml) - Html - text
                                     AddTagHelperHtmlAttribute -  - value - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (306:11,55 [0] ComplexTagHelpers.cshtml) - 
+                                        HtmlContent - (306:11,55 [0] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (306:11,55 [0] ComplexTagHelpers.cshtml) - Html - 
                                     AddTagHelperHtmlAttribute -  - placeholder - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (321:11,70 [22] ComplexTagHelpers.cshtml) - Enter in a new time...
+                                        HtmlContent - (321:11,70 [22] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (321:11,70 [22] ComplexTagHelpers.cshtml) - Html - Enter in a new time...
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
@@ -49,7 +64,8 @@ Document -
                             RazorIRToken - (350:11,99 [66] ComplexTagHelpers.cshtml) - CSharp - \n            }\n            else\n            {\n                
                         TagHelper - (416:15,16 [58] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                HtmlContent - (419:15,19 [14] ComplexTagHelpers.cshtml) - Current Time: 
+                                HtmlContent - (419:15,19 [14] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (419:15,19 [14] ComplexTagHelpers.cshtml) - Html - Current Time: 
                                 TagHelper - (433:15,33 [37] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -61,7 +77,8 @@ Document -
                                         CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
                                             RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
                                     SetTagHelperProperty - (463:15,63 [4] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (463:15,63 [4] ComplexTagHelpers.cshtml) - true
+                                        HtmlContent - (463:15,63 [4] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (463:15,63 [4] ComplexTagHelpers.cshtml) - Html - true
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
@@ -87,25 +104,30 @@ Document -
                             SetTagHelperProperty - (573:17,29 [66] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
                                 CSharpStatement - (574:17,30 [11] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (574:17,30 [11] ComplexTagHelpers.cshtml) - CSharp - if(true) { 
-                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml) - checkbox
+                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (591:17,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
                                 CSharpStatement - (606:17,62 [10] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (606:17,62 [10] ComplexTagHelpers.cshtml) - CSharp -  } else { 
-                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml) - anything
+                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (622:17,78 [8] ComplexTagHelpers.cshtml) - Html - anything
                                 CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (637:17,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
                             SetTagHelperProperty - (573:17,29 [66] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
                                 CSharpStatement - (574:17,30 [11] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (574:17,30 [11] ComplexTagHelpers.cshtml) - CSharp - if(true) { 
-                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml) - checkbox
+                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (591:17,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
                                 CSharpStatement - (606:17,62 [10] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (606:17,62 [10] ComplexTagHelpers.cshtml) - CSharp -  } else { 
-                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml) - anything
+                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (622:17,78 [8] ComplexTagHelpers.cshtml) - Html - anything
                                 CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (637:17,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
                             ExecuteTagHelpers - 
                         CSharpStatement - (641:17,97 [15] ComplexTagHelpers.cshtml)
                             RazorIRToken - (641:17,97 [15] ComplexTagHelpers.cshtml) - CSharp - \n            }
-                        HtmlContent - (656:18,13 [10] ComplexTagHelpers.cshtml) - \n        
+                        HtmlContent - (656:18,13 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (656:18,13 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - time - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlAttributeValue - (148:7,17 [7] ComplexTagHelpers.cshtml) -  - Current
@@ -114,101 +136,140 @@ Document -
                             CSharpExpression - (163:7,32 [12] ComplexTagHelpers.cshtml)
                                 RazorIRToken - (163:7,32 [12] ComplexTagHelpers.cshtml) - CSharp - DateTime.Now
                     ExecuteTagHelpers - 
-                HtmlContent - (670:19,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (670:19,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (670:19,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (680:20,8 [181] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (767:20,95 [14] ComplexTagHelpers.cshtml) - \n            
+                        HtmlContent - (767:20,95 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (767:20,95 [14] ComplexTagHelpers.cshtml) - Html - \n            
                         CSharpStatement - (783:21,14 [21] ComplexTagHelpers.cshtml)
                             RazorIRToken - (783:21,14 [21] ComplexTagHelpers.cshtml) - CSharp -  var @object = false;
-                        HtmlContent - (807:22,0 [12] ComplexTagHelpers.cshtml) -             
+                        HtmlContent - (807:22,0 [12] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (807:22,0 [12] ComplexTagHelpers.cshtml) - Html -             
                         TagHelper - (819:22,12 [28] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (835:22,28 [10] ComplexTagHelpers.cshtml) - ChecKED - Checked - HtmlAttributeValueStyle.DoubleQuotes
                                 CSharpExpression - (836:22,29 [9] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (836:22,29 [1] ComplexTagHelpers.cshtml) - (
+                                    HtmlContent - (836:22,29 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (836:22,29 [1] ComplexTagHelpers.cshtml) - Html - (
                                     RazorIRToken - (837:22,30 [7] ComplexTagHelpers.cshtml) - CSharp - @object
-                                    HtmlContent - (844:22,37 [1] ComplexTagHelpers.cshtml) - )
+                                    HtmlContent - (844:22,37 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (844:22,37 [1] ComplexTagHelpers.cshtml) - Html - )
                             ExecuteTagHelpers - 
-                        HtmlContent - (847:22,40 [10] ComplexTagHelpers.cshtml) - \n        
+                        HtmlContent - (847:22,40 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (847:22,40 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (692:20,20 [11] ComplexTagHelpers.cshtml) - first value
+                        HtmlContent - (692:20,20 [11] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (692:20,20 [11] ComplexTagHelpers.cshtml) - Html - first value
                     SetTagHelperProperty - (710:20,38 [31] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (711:20,39 [23] ComplexTagHelpers.cshtml)
                             RazorIRToken - (711:20,39 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
-                        HtmlContent - (734:20,62 [7] ComplexTagHelpers.cshtml) - \-1970
+                        HtmlContent - (734:20,62 [7] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (734:20,62 [2] ComplexTagHelpers.cshtml) - Html -  -
+                            RazorIRToken - (736:20,64 [5] ComplexTagHelpers.cshtml) - Html -  1970
                     AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (752:20,80 [12] ComplexTagHelpers.cshtml) - second value
+                        HtmlContent - (752:20,80 [12] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (752:20,80 [12] ComplexTagHelpers.cshtml) - Html - second value
                     ExecuteTagHelpers - 
-                HtmlContent - (861:23,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (861:23,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (861:23,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (871:24,8 [155] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (913:24,50 [14] ComplexTagHelpers.cshtml) - \n            
+                        HtmlContent - (913:24,50 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (913:24,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
                         TagHelper - (927:25,12 [85] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (943:25,28 [5] ComplexTagHelpers.cshtml) - hello
+                                HtmlContent - (943:25,28 [5] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (943:25,28 [5] ComplexTagHelpers.cshtml) - Html - hello
                             AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (959:25,44 [5] ComplexTagHelpers.cshtml) - world
+                                HtmlContent - (959:25,44 [5] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (959:25,44 [5] ComplexTagHelpers.cshtml) - Html - world
                             SetTagHelperProperty - (975:25,60 [33] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
                                 CSharpExpression - (976:25,61 [32] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (976:25,61 [1] ComplexTagHelpers.cshtml) - (
+                                    HtmlContent - (976:25,61 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (976:25,61 [1] ComplexTagHelpers.cshtml) - Html - (
                                     RazorIRToken - (977:25,62 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
-                                    HtmlContent - (1007:25,92 [1] ComplexTagHelpers.cshtml) - )
+                                    HtmlContent - (1007:25,92 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (1007:25,92 [1] ComplexTagHelpers.cshtml) - Html - )
                             ExecuteTagHelpers - 
-                        HtmlContent - (1012:25,97 [10] ComplexTagHelpers.cshtml) - \n        
+                        HtmlContent - (1012:25,97 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1012:25,97 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (879:24,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (879:24,16 [8] ComplexTagHelpers.cshtml) - -1970 + 
+                        HtmlContent - (879:24,16 [8] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (879:24,16 [5] ComplexTagHelpers.cshtml) - Html - -1970
+                            RazorIRToken - (884:24,21 [2] ComplexTagHelpers.cshtml) - Html -  +
+                            RazorIRToken - (886:24,23 [1] ComplexTagHelpers.cshtml) - Html -  
                         CSharpExpression - (887:24,24 [24] ComplexTagHelpers.cshtml)
-                            HtmlContent - (887:24,24 [1] ComplexTagHelpers.cshtml) - @
+                            HtmlContent - (887:24,24 [1] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (887:24,24 [1] ComplexTagHelpers.cshtml) - Html - @
                             RazorIRToken - (888:24,25 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
                     ExecuteTagHelpers - 
-                HtmlContent - (1026:26,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (1026:26,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1026:26,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (1036:27,8 [116] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (1076:27,48 [14] ComplexTagHelpers.cshtml) - \n            
+                        HtmlContent - (1076:27,48 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1076:27,48 [14] ComplexTagHelpers.cshtml) - Html - \n            
                         TagHelper - (1090:28,12 [48] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (1106:28,28 [30] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1106:28,28 [30] ComplexTagHelpers.cshtml) - DateTimeOffset.Now.Year > 2014
+                                HtmlContent - (1106:28,28 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1106:28,28 [30] ComplexTagHelpers.cshtml) - Html - DateTimeOffset.Now.Year > 2014
                             ExecuteTagHelpers - 
-                        HtmlContent - (1138:28,60 [10] ComplexTagHelpers.cshtml) - \n        
+                        HtmlContent - (1138:28,60 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1138:28,60 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (1044:27,16 [30] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (1044:27,16 [30] ComplexTagHelpers.cshtml) - DateTimeOffset.Now.Year\-1970
+                        HtmlContent - (1044:27,16 [30] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1044:27,16 [30] ComplexTagHelpers.cshtml) - Html - DateTimeOffset.Now.Year\-1970
                     ExecuteTagHelpers - 
-                HtmlContent - (1152:29,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (1152:29,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1152:29,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (1162:30,8 [133] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (1204:30,50 [14] ComplexTagHelpers.cshtml) - \n            
+                        HtmlContent - (1204:30,50 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1204:30,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
                         TagHelper - (1218:31,12 [63] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (1234:31,28 [43] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1234:31,28 [3] ComplexTagHelpers.cshtml) -    
+                                HtmlContent - (1234:31,28 [3] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1234:31,28 [3] ComplexTagHelpers.cshtml) - Html -    
                                 CSharpExpression - (1237:31,31 [30] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (1237:31,31 [2] ComplexTagHelpers.cshtml) - @(
+                                    HtmlContent - (1237:31,31 [2] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (1237:31,31 [1] ComplexTagHelpers.cshtml) - Html - @
+                                        RazorIRToken - (1238:31,32 [1] ComplexTagHelpers.cshtml) - Html - (
                                     RazorIRToken - (1239:31,33 [27] ComplexTagHelpers.cshtml) - CSharp -   DateTimeOffset.Now.Year  
-                                    HtmlContent - (1266:31,60 [1] ComplexTagHelpers.cshtml) - )
-                                HtmlContent - (1267:31,61 [10] ComplexTagHelpers.cshtml) -  > 2014   
+                                    HtmlContent - (1266:31,60 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (1266:31,60 [1] ComplexTagHelpers.cshtml) - Html - )
+                                HtmlContent - (1267:31,61 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1267:31,61 [2] ComplexTagHelpers.cshtml) - Html -  >
+                                    RazorIRToken - (1269:31,63 [5] ComplexTagHelpers.cshtml) - Html -  2014
+                                    RazorIRToken - (1274:31,68 [3] ComplexTagHelpers.cshtml) - Html -    
                             ExecuteTagHelpers - 
-                        HtmlContent - (1281:31,75 [10] ComplexTagHelpers.cshtml) - \n        
+                        HtmlContent - (1281:31,75 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1281:31,75 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (1170:30,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (1171:30,17 [31] ComplexTagHelpers.cshtml)
-                            HtmlContent - (1171:30,17 [1] ComplexTagHelpers.cshtml) - (
+                            HtmlContent - (1171:30,17 [1] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (1171:30,17 [1] ComplexTagHelpers.cshtml) - Html - (
                             RazorIRToken - (1172:30,18 [29] ComplexTagHelpers.cshtml) - CSharp - "My age is this long.".Length
-                            HtmlContent - (1201:30,47 [1] ComplexTagHelpers.cshtml) - )
+                            HtmlContent - (1201:30,47 [1] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (1201:30,47 [1] ComplexTagHelpers.cshtml) - Html - )
                     ExecuteTagHelpers - 
-                HtmlContent - (1295:32,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (1295:32,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1295:32,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 CSharpExpression - (1306:33,9 [69] ComplexTagHelpers.cshtml)
                     RazorIRToken - (1306:33,9 [11] ComplexTagHelpers.cshtml) - CSharp - someMethod(
                     Template - (1318:33,21 [57] ComplexTagHelpers.cshtml)
@@ -224,11 +285,15 @@ Document -
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             SetTagHelperProperty - (1326:33,29 [3] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1326:33,29 [3] ComplexTagHelpers.cshtml) - 123
+                                HtmlContent - (1326:33,29 [3] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1326:33,29 [3] ComplexTagHelpers.cshtml) - Html - 123
                             AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1338:33,41 [5] ComplexTagHelpers.cshtml) - hello
+                                HtmlContent - (1338:33,41 [5] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1338:33,41 [5] ComplexTagHelpers.cshtml) - Html - hello
                             ExecuteTagHelpers - 
                     RazorIRToken - (1375:33,78 [1] ComplexTagHelpers.cshtml) - CSharp - )
-                HtmlContent - (1376:33,79 [12] ComplexTagHelpers.cshtml) - \n    </div>
+                HtmlContent - (1376:33,79 [12] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1376:33,79 [6] ComplexTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (1382:34,4 [6] ComplexTagHelpers.cshtml) - Html - </div>
                 CSharpStatement - (1388:34,10 [3] ComplexTagHelpers.cshtml)
                     RazorIRToken - (1388:34,10 [3] ComplexTagHelpers.cshtml) - CSharp - \n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
@@ -119,10 +119,15 @@ Source Location: (711:20,39 [23] TestFiles/IntegrationTests/CodeGenerationIntegr
 Generated Location: (5882:125,38 [23] )
 |DateTimeOffset.Now.Year|
 
-Source Location: (734:20,62 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
-| - 1970|
-Generated Location: (5905:125,61 [7] )
-| - 1970|
+Source Location: (734:20,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+| -|
+Generated Location: (5905:125,61 [2] )
+| -|
+
+Source Location: (736:20,64 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+| 1970|
+Generated Location: (5907:125,63 [5] )
+| 1970|
 
 Source Location: (976:25,61 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
@@ -139,10 +144,20 @@ Source Location: (1007:25,92 [1] TestFiles/IntegrationTests/CodeGenerationIntegr
 Generated Location: (6339:132,91 [1] )
 |)|
 
-Source Location: (879:24,16 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
-|-1970 + |
-Generated Location: (6596:138,33 [8] )
-|-1970 + |
+Source Location: (879:24,16 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|-1970|
+Generated Location: (6596:138,33 [5] )
+|-1970|
+
+Source Location: (884:24,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+| +|
+Generated Location: (6601:138,38 [2] )
+| +|
+
+Source Location: (886:24,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+| |
+Generated Location: (6603:138,40 [1] )
+| |
 
 Source Location: (887:24,24 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
@@ -169,10 +184,15 @@ Source Location: (1234:31,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegr
 Generated Location: (7700:158,42 [3] )
 |   |
 
-Source Location: (1237:31,31 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
-|@(|
-Generated Location: (7703:158,45 [2] )
-|@(|
+Source Location: (1237:31,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|@|
+Generated Location: (7703:158,45 [1] )
+|@|
+
+Source Location: (1238:31,32 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|(|
+Generated Location: (7704:158,46 [1] )
+|(|
 
 Source Location: (1239:31,33 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |  DateTimeOffset.Now.Year  |
@@ -184,10 +204,20 @@ Source Location: (1266:31,60 [1] TestFiles/IntegrationTests/CodeGenerationIntegr
 Generated Location: (7732:158,74 [1] )
 |)|
 
-Source Location: (1267:31,61 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
-| > 2014   |
-Generated Location: (7733:158,75 [10] )
-| > 2014   |
+Source Location: (1267:31,61 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+| >|
+Generated Location: (7733:158,75 [2] )
+| >|
+
+Source Location: (1269:31,63 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+| 2014|
+Generated Location: (7735:158,77 [5] )
+| 2014|
+
+Source Location: (1274:31,68 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|   |
+Generated Location: (7740:158,82 [3] )
+|   |
 
 Source Location: (1171:30,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.ir.txt
@@ -14,21 +14,34 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7 - class - hello - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] ComplexTagHelpers.cshtml) - \n
+                HtmlContent - (33:1,0 [2] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (33:1,0 [2] ComplexTagHelpers.cshtml) - Html - \n
                 CSharpStatement - (36:2,1 [48] ComplexTagHelpers.cshtml)
                     RazorIRToken - (36:2,1 [48] ComplexTagHelpers.cshtml) - CSharp - if (true)\n{\n    var checkbox = "checkbox";\n\n
-                HtmlContent - (84:6,0 [55] ComplexTagHelpers.cshtml) -     <div class="randomNonTagHelperAttribute">\n        
+                HtmlContent - (84:6,0 [55] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (84:6,0 [4] ComplexTagHelpers.cshtml) - Html -     
+                    RazorIRToken - (88:6,4 [4] ComplexTagHelpers.cshtml) - Html - <div
+                    RazorIRToken - (92:6,8 [36] ComplexTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (128:6,44 [1] ComplexTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (129:6,45 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (139:7,8 [529] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (177:7,46 [34] ComplexTagHelpers.cshtml) - \n            <h1>Set Time:</h1>\n
+                        HtmlContent - (177:7,46 [34] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (177:7,46 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                            RazorIRToken - (191:8,12 [4] ComplexTagHelpers.cshtml) - Html - <h1>
+                            RazorIRToken - (195:8,16 [9] ComplexTagHelpers.cshtml) - Html - Set Time:
+                            RazorIRToken - (204:8,25 [5] ComplexTagHelpers.cshtml) - Html - </h1>
+                            RazorIRToken - (209:8,30 [2] ComplexTagHelpers.cshtml) - Html - \n
                         CSharpStatement - (211:9,0 [12] ComplexTagHelpers.cshtml)
                             RazorIRToken - (211:9,0 [12] ComplexTagHelpers.cshtml) - CSharp -             
                         CSharpStatement - (224:9,13 [27] ComplexTagHelpers.cshtml)
                             RazorIRToken - (224:9,13 [27] ComplexTagHelpers.cshtml) - CSharp - if (false)\n            {\n
-                        HtmlContent - (251:11,0 [16] ComplexTagHelpers.cshtml) -                 
+                        HtmlContent - (251:11,0 [16] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (251:11,0 [16] ComplexTagHelpers.cshtml) - Html -                 
                         TagHelper - (267:11,16 [83] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                HtmlContent - (270:11,19 [10] ComplexTagHelpers.cshtml) - New Time: 
+                                HtmlContent - (270:11,19 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (270:11,19 [10] ComplexTagHelpers.cshtml) - Html - New Time: 
                                 TagHelper - (280:11,29 [66] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -40,13 +53,16 @@ Document -
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
-                        HtmlContent - (350:11,99 [2] ComplexTagHelpers.cshtml) - \n
+                        HtmlContent - (350:11,99 [2] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (350:11,99 [2] ComplexTagHelpers.cshtml) - Html - \n
                         CSharpStatement - (352:12,0 [48] ComplexTagHelpers.cshtml)
                             RazorIRToken - (352:12,0 [48] ComplexTagHelpers.cshtml) - CSharp -             }\n            else\n            {\n
-                        HtmlContent - (400:15,0 [16] ComplexTagHelpers.cshtml) -                 
+                        HtmlContent - (400:15,0 [16] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (400:15,0 [16] ComplexTagHelpers.cshtml) - Html -                 
                         TagHelper - (416:15,16 [58] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                HtmlContent - (419:15,19 [14] ComplexTagHelpers.cshtml) - Current Time: 
+                                HtmlContent - (419:15,19 [14] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (419:15,19 [14] ComplexTagHelpers.cshtml) - Html - Current Time: 
                                 TagHelper - (433:15,33 [37] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -58,11 +74,14 @@ Document -
                                         CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
                                             RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
                                     SetTagHelperProperty - (463:15,63 [4] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (463:15,63 [4] ComplexTagHelpers.cshtml) - true
+                                        HtmlContent - (463:15,63 [4] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (463:15,63 [4] ComplexTagHelpers.cshtml) - Html - true
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
-                        HtmlContent - (474:15,74 [18] ComplexTagHelpers.cshtml) - \n                
+                        HtmlContent - (474:15,74 [18] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (474:15,74 [2] ComplexTagHelpers.cshtml) - Html - \n
+                            RazorIRToken - (476:16,0 [16] ComplexTagHelpers.cshtml) - Html -                 
                         TagHelper - (492:16,16 [50] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -74,7 +93,9 @@ Document -
                                 CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
                             ExecuteTagHelpers - 
-                        HtmlContent - (542:16,66 [18] ComplexTagHelpers.cshtml) - \n                
+                        HtmlContent - (542:16,66 [18] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (542:16,66 [2] ComplexTagHelpers.cshtml) - Html - \n
+                            RazorIRToken - (544:17,0 [16] ComplexTagHelpers.cshtml) - Html -                 
                         TagHelper - (560:17,16 [79] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -82,26 +103,32 @@ Document -
                             SetTagHelperProperty - (573:17,29 [64] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
                                 CSharpStatement - (574:17,30 [10] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (574:17,30 [10] ComplexTagHelpers.cshtml) - CSharp - if(true) {
-                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml) - checkbox
+                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (591:17,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
                                 CSharpStatement - (606:17,62 [9] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (606:17,62 [9] ComplexTagHelpers.cshtml) - CSharp -  } else {
-                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml) - anything
+                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (622:17,78 [8] ComplexTagHelpers.cshtml) - Html - anything
                                 CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (637:17,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
                             SetTagHelperProperty - (573:17,29 [64] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
                                 CSharpStatement - (574:17,30 [10] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (574:17,30 [10] ComplexTagHelpers.cshtml) - CSharp - if(true) {
-                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml) - checkbox
+                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (591:17,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
                                 CSharpStatement - (606:17,62 [9] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (606:17,62 [9] ComplexTagHelpers.cshtml) - CSharp -  } else {
-                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml) - anything
+                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (622:17,78 [8] ComplexTagHelpers.cshtml) - Html - anything
                                 CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml)
                                     RazorIRToken - (637:17,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
                             ExecuteTagHelpers - 
-                        HtmlContent - (641:17,97 [2] ComplexTagHelpers.cshtml) - \n
+                        HtmlContent - (641:17,97 [2] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (641:17,97 [2] ComplexTagHelpers.cshtml) - Html - \n
                         CSharpStatement - (643:18,0 [15] ComplexTagHelpers.cshtml)
                             RazorIRToken - (643:18,0 [15] ComplexTagHelpers.cshtml) - CSharp -             }\n
-                        HtmlContent - (658:19,0 [8] ComplexTagHelpers.cshtml) -         
+                        HtmlContent - (658:19,0 [8] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (658:19,0 [8] ComplexTagHelpers.cshtml) - Html -         
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - time - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlAttributeValue - (148:7,17 [7] ComplexTagHelpers.cshtml) -  - Current
@@ -110,38 +137,48 @@ Document -
                             CSharpExpression - (163:7,32 [12] ComplexTagHelpers.cshtml)
                                 RazorIRToken - (163:7,32 [12] ComplexTagHelpers.cshtml) - CSharp - DateTime.Now
                     ExecuteTagHelpers - 
-                HtmlContent - (670:19,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (670:19,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (670:19,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (680:20,8 [181] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (767:20,95 [2] ComplexTagHelpers.cshtml) - \n
+                        HtmlContent - (767:20,95 [2] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (767:20,95 [2] ComplexTagHelpers.cshtml) - Html - \n
                         CSharpStatement - (769:21,0 [12] ComplexTagHelpers.cshtml)
                             RazorIRToken - (769:21,0 [12] ComplexTagHelpers.cshtml) - CSharp -             
                         CSharpStatement - (783:21,14 [21] ComplexTagHelpers.cshtml)
                             RazorIRToken - (783:21,14 [21] ComplexTagHelpers.cshtml) - CSharp -  var @object = false;
-                        HtmlContent - (807:22,0 [12] ComplexTagHelpers.cshtml) -             
+                        HtmlContent - (807:22,0 [12] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (807:22,0 [12] ComplexTagHelpers.cshtml) - Html -             
                         TagHelper - (819:22,12 [28] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (835:22,28 [10] ComplexTagHelpers.cshtml) - ChecKED - Checked - HtmlAttributeValueStyle.DoubleQuotes
                                 CSharpExpression - (836:22,29 [9] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (836:22,29 [1] ComplexTagHelpers.cshtml) - (
+                                    HtmlContent - (836:22,29 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (836:22,29 [1] ComplexTagHelpers.cshtml) - Html - (
                                     RazorIRToken - (837:22,30 [7] ComplexTagHelpers.cshtml) - CSharp - @object
-                                    HtmlContent - (844:22,37 [1] ComplexTagHelpers.cshtml) - )
+                                    HtmlContent - (844:22,37 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (844:22,37 [1] ComplexTagHelpers.cshtml) - Html - )
                             ExecuteTagHelpers - 
-                        HtmlContent - (847:22,40 [10] ComplexTagHelpers.cshtml) - \n        
+                        HtmlContent - (847:22,40 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (847:22,40 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                     SetTagHelperProperty - (710:20,38 [31] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (711:20,39 [23] ComplexTagHelpers.cshtml)
                             RazorIRToken - (711:20,39 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
-                        HtmlContent - (734:20,62 [7] ComplexTagHelpers.cshtml) - \-1970
+                        HtmlContent - (734:20,62 [7] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (734:20,62 [2] ComplexTagHelpers.cshtml) - Html -  -
+                            RazorIRToken - (736:20,64 [5] ComplexTagHelpers.cshtml) - Html -  1970
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4
                     ExecuteTagHelpers - 
-                HtmlContent - (861:23,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (861:23,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (861:23,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (871:24,8 [155] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (913:24,50 [14] ComplexTagHelpers.cshtml) - \n            
+                        HtmlContent - (913:24,50 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (913:24,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
                         TagHelper - (927:25,12 [85] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -150,59 +187,85 @@ Document -
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_6
                             SetTagHelperProperty - (975:25,60 [33] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
                                 CSharpExpression - (976:25,61 [32] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (976:25,61 [1] ComplexTagHelpers.cshtml) - (
+                                    HtmlContent - (976:25,61 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (976:25,61 [1] ComplexTagHelpers.cshtml) - Html - (
                                     RazorIRToken - (977:25,62 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
-                                    HtmlContent - (1007:25,92 [1] ComplexTagHelpers.cshtml) - )
+                                    HtmlContent - (1007:25,92 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (1007:25,92 [1] ComplexTagHelpers.cshtml) - Html - )
                             ExecuteTagHelpers - 
-                        HtmlContent - (1012:25,97 [10] ComplexTagHelpers.cshtml) - \n        
+                        HtmlContent - (1012:25,97 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1012:25,97 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (879:24,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (879:24,16 [8] ComplexTagHelpers.cshtml) - -1970 + 
+                        HtmlContent - (879:24,16 [8] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (879:24,16 [5] ComplexTagHelpers.cshtml) - Html - -1970
+                            RazorIRToken - (884:24,21 [2] ComplexTagHelpers.cshtml) - Html -  +
+                            RazorIRToken - (886:24,23 [1] ComplexTagHelpers.cshtml) - Html -  
                         CSharpExpression - (887:24,24 [24] ComplexTagHelpers.cshtml)
-                            HtmlContent - (887:24,24 [1] ComplexTagHelpers.cshtml) - @
+                            HtmlContent - (887:24,24 [1] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (887:24,24 [1] ComplexTagHelpers.cshtml) - Html - @
                             RazorIRToken - (888:24,25 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
                     ExecuteTagHelpers - 
-                HtmlContent - (1026:26,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (1026:26,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1026:26,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (1036:27,8 [116] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (1076:27,48 [14] ComplexTagHelpers.cshtml) - \n            
+                        HtmlContent - (1076:27,48 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1076:27,48 [14] ComplexTagHelpers.cshtml) - Html - \n            
                         TagHelper - (1090:28,12 [48] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (1106:28,28 [30] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1106:28,28 [30] ComplexTagHelpers.cshtml) - DateTimeOffset.Now.Year > 2014
+                                HtmlContent - (1106:28,28 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1106:28,28 [30] ComplexTagHelpers.cshtml) - Html - DateTimeOffset.Now.Year > 2014
                             ExecuteTagHelpers - 
-                        HtmlContent - (1138:28,60 [10] ComplexTagHelpers.cshtml) - \n        
+                        HtmlContent - (1138:28,60 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1138:28,60 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (1044:27,16 [30] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (1044:27,16 [30] ComplexTagHelpers.cshtml) - DateTimeOffset.Now.Year\-1970
+                        HtmlContent - (1044:27,16 [30] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1044:27,16 [30] ComplexTagHelpers.cshtml) - Html - DateTimeOffset.Now.Year\-1970
                     ExecuteTagHelpers - 
-                HtmlContent - (1152:29,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (1152:29,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1152:29,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
                 TagHelper - (1162:30,8 [133] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (1204:30,50 [14] ComplexTagHelpers.cshtml) - \n            
+                        HtmlContent - (1204:30,50 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1204:30,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
                         TagHelper - (1218:31,12 [63] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (1234:31,28 [43] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1234:31,28 [3] ComplexTagHelpers.cshtml) -    
+                                HtmlContent - (1234:31,28 [3] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1234:31,28 [3] ComplexTagHelpers.cshtml) - Html -    
                                 CSharpExpression - (1237:31,31 [30] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (1237:31,31 [2] ComplexTagHelpers.cshtml) - @(
+                                    HtmlContent - (1237:31,31 [2] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (1237:31,31 [1] ComplexTagHelpers.cshtml) - Html - @
+                                        RazorIRToken - (1238:31,32 [1] ComplexTagHelpers.cshtml) - Html - (
                                     RazorIRToken - (1239:31,33 [27] ComplexTagHelpers.cshtml) - CSharp -   DateTimeOffset.Now.Year  
-                                    HtmlContent - (1266:31,60 [1] ComplexTagHelpers.cshtml) - )
-                                HtmlContent - (1267:31,61 [10] ComplexTagHelpers.cshtml) -  > 2014   
+                                    HtmlContent - (1266:31,60 [1] ComplexTagHelpers.cshtml)
+                                        RazorIRToken - (1266:31,60 [1] ComplexTagHelpers.cshtml) - Html - )
+                                HtmlContent - (1267:31,61 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1267:31,61 [2] ComplexTagHelpers.cshtml) - Html -  >
+                                    RazorIRToken - (1269:31,63 [5] ComplexTagHelpers.cshtml) - Html -  2014
+                                    RazorIRToken - (1274:31,68 [3] ComplexTagHelpers.cshtml) - Html -    
                             ExecuteTagHelpers - 
-                        HtmlContent - (1281:31,75 [10] ComplexTagHelpers.cshtml) - \n        
+                        HtmlContent - (1281:31,75 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1281:31,75 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (1170:30,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (1171:30,17 [31] ComplexTagHelpers.cshtml)
-                            HtmlContent - (1171:30,17 [1] ComplexTagHelpers.cshtml) - (
+                            HtmlContent - (1171:30,17 [1] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (1171:30,17 [1] ComplexTagHelpers.cshtml) - Html - (
                             RazorIRToken - (1172:30,18 [29] ComplexTagHelpers.cshtml) - CSharp - "My age is this long.".Length
-                            HtmlContent - (1201:30,47 [1] ComplexTagHelpers.cshtml) - )
+                            HtmlContent - (1201:30,47 [1] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (1201:30,47 [1] ComplexTagHelpers.cshtml) - Html - )
                     ExecuteTagHelpers - 
-                HtmlContent - (1295:32,12 [10] ComplexTagHelpers.cshtml) - \n        
+                HtmlContent - (1295:32,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1295:32,12 [2] ComplexTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (1297:33,0 [8] ComplexTagHelpers.cshtml) - Html -         
                 CSharpExpression - (1306:33,9 [69] ComplexTagHelpers.cshtml)
                     RazorIRToken - (1306:33,9 [11] ComplexTagHelpers.cshtml) - CSharp - someMethod(
                     Template - (1318:33,21 [57] ComplexTagHelpers.cshtml)
@@ -218,10 +281,14 @@ Document -
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             SetTagHelperProperty - (1326:33,29 [3] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1326:33,29 [3] ComplexTagHelpers.cshtml) - 123
+                                HtmlContent - (1326:33,29 [3] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1326:33,29 [3] ComplexTagHelpers.cshtml) - Html - 123
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7
                             ExecuteTagHelpers - 
                     RazorIRToken - (1375:33,78 [1] ComplexTagHelpers.cshtml) - CSharp - )
-                HtmlContent - (1376:33,79 [14] ComplexTagHelpers.cshtml) - \n    </div>\n
+                HtmlContent - (1376:33,79 [14] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1376:33,79 [6] ComplexTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (1382:34,4 [6] ComplexTagHelpers.cshtml) - Html - </div>
+                    RazorIRToken - (1388:34,10 [2] ComplexTagHelpers.cshtml) - Html - \n
                 CSharpStatement - (1390:35,0 [1] ComplexTagHelpers.cshtml)
                     RazorIRToken - (1390:35,0 [1] ComplexTagHelpers.cshtml) - CSharp - }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.ir.txt
@@ -18,53 +18,69 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [48] ConditionalAttributes.cshtml)
                     RazorIRToken - (2:0,2 [48] ConditionalAttributes.cshtml) - CSharp - \n    var ch = true;\n    var cls = "bar";\n    
-                HtmlContent - (50:3,4 [16] ConditionalAttributes.cshtml) - <a href="Foo" />
+                HtmlContent - (50:3,4 [16] ConditionalAttributes.cshtml)
+                    RazorIRToken - (50:3,4 [2] ConditionalAttributes.cshtml) - Html - <a
+                    RazorIRToken - (52:3,6 [11] ConditionalAttributes.cshtml) - Html -  href="Foo"
+                    RazorIRToken - (63:3,17 [3] ConditionalAttributes.cshtml) - Html -  />
                 CSharpStatement - (66:3,20 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (66:3,20 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (72:4,4 [2] ConditionalAttributes.cshtml) - <p
+                HtmlContent - (72:4,4 [2] ConditionalAttributes.cshtml)
+                    RazorIRToken - (72:4,4 [2] ConditionalAttributes.cshtml) - Html - <p
                 HtmlAttribute - (74:4,6 [13] ConditionalAttributes.cshtml) -  class=" - "
                     CSharpAttributeValue - (82:4,14 [4] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (83:4,15 [3] ConditionalAttributes.cshtml)
                             RazorIRToken - (83:4,15 [3] ConditionalAttributes.cshtml) - CSharp - cls
-                HtmlContent - (87:4,19 [3] ConditionalAttributes.cshtml) -  />
+                HtmlContent - (87:4,19 [3] ConditionalAttributes.cshtml)
+                    RazorIRToken - (87:4,19 [3] ConditionalAttributes.cshtml) - Html -  />
                 CSharpStatement - (90:4,22 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (90:4,22 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (96:5,4 [2] ConditionalAttributes.cshtml) - <p
+                HtmlContent - (96:5,4 [2] ConditionalAttributes.cshtml)
+                    RazorIRToken - (96:5,4 [2] ConditionalAttributes.cshtml) - Html - <p
                 HtmlAttribute - (98:5,6 [17] ConditionalAttributes.cshtml) -  class=" - "
                     HtmlAttributeValue - (106:5,14 [3] ConditionalAttributes.cshtml) -  - foo
                     CSharpAttributeValue - (109:5,17 [5] ConditionalAttributes.cshtml) -  
                         CSharpExpression - (111:5,19 [3] ConditionalAttributes.cshtml)
                             RazorIRToken - (111:5,19 [3] ConditionalAttributes.cshtml) - CSharp - cls
-                HtmlContent - (115:5,23 [3] ConditionalAttributes.cshtml) -  />
+                HtmlContent - (115:5,23 [3] ConditionalAttributes.cshtml)
+                    RazorIRToken - (115:5,23 [3] ConditionalAttributes.cshtml) - Html -  />
                 CSharpStatement - (118:5,26 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (118:5,26 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (124:6,4 [2] ConditionalAttributes.cshtml) - <p
+                HtmlContent - (124:6,4 [2] ConditionalAttributes.cshtml)
+                    RazorIRToken - (124:6,4 [2] ConditionalAttributes.cshtml) - Html - <p
                 HtmlAttribute - (126:6,6 [17] ConditionalAttributes.cshtml) -  class=" - "
                     CSharpAttributeValue - (134:6,14 [4] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (135:6,15 [3] ConditionalAttributes.cshtml)
                             RazorIRToken - (135:6,15 [3] ConditionalAttributes.cshtml) - CSharp - cls
                     HtmlAttributeValue - (138:6,18 [4] ConditionalAttributes.cshtml) -   - foo
-                HtmlContent - (143:6,23 [3] ConditionalAttributes.cshtml) -  />
+                HtmlContent - (143:6,23 [3] ConditionalAttributes.cshtml)
+                    RazorIRToken - (143:6,23 [3] ConditionalAttributes.cshtml) - Html -  />
                 CSharpStatement - (146:6,26 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (146:6,26 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (152:7,4 [22] ConditionalAttributes.cshtml) - <input type="checkbox"
+                HtmlContent - (152:7,4 [22] ConditionalAttributes.cshtml)
+                    RazorIRToken - (152:7,4 [6] ConditionalAttributes.cshtml) - Html - <input
+                    RazorIRToken - (158:7,10 [16] ConditionalAttributes.cshtml) - Html -  type="checkbox"
                 HtmlAttribute - (174:7,26 [14] ConditionalAttributes.cshtml) -  checked=" - "
                     CSharpAttributeValue - (184:7,36 [3] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (185:7,37 [2] ConditionalAttributes.cshtml)
                             RazorIRToken - (185:7,37 [2] ConditionalAttributes.cshtml) - CSharp - ch
-                HtmlContent - (188:7,40 [3] ConditionalAttributes.cshtml) -  />
+                HtmlContent - (188:7,40 [3] ConditionalAttributes.cshtml)
+                    RazorIRToken - (188:7,40 [3] ConditionalAttributes.cshtml) - Html -  />
                 CSharpStatement - (191:7,43 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (191:7,43 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (197:8,4 [22] ConditionalAttributes.cshtml) - <input type="checkbox"
+                HtmlContent - (197:8,4 [22] ConditionalAttributes.cshtml)
+                    RazorIRToken - (197:8,4 [6] ConditionalAttributes.cshtml) - Html - <input
+                    RazorIRToken - (203:8,10 [16] ConditionalAttributes.cshtml) - Html -  type="checkbox"
                 HtmlAttribute - (219:8,26 [18] ConditionalAttributes.cshtml) -  checked=" - "
                     HtmlAttributeValue - (229:8,36 [3] ConditionalAttributes.cshtml) -  - foo
                     CSharpAttributeValue - (232:8,39 [4] ConditionalAttributes.cshtml) -  
                         CSharpExpression - (234:8,41 [2] ConditionalAttributes.cshtml)
                             RazorIRToken - (234:8,41 [2] ConditionalAttributes.cshtml) - CSharp - ch
-                HtmlContent - (237:8,44 [3] ConditionalAttributes.cshtml) -  />
+                HtmlContent - (237:8,44 [3] ConditionalAttributes.cshtml)
+                    RazorIRToken - (237:8,44 [3] ConditionalAttributes.cshtml) - Html -  />
                 CSharpStatement - (240:8,47 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (240:8,47 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (246:9,4 [2] ConditionalAttributes.cshtml) - <p
+                HtmlContent - (246:9,4 [2] ConditionalAttributes.cshtml)
+                    RazorIRToken - (246:9,4 [2] ConditionalAttributes.cshtml) - Html - <p
                 HtmlAttribute - (248:9,6 [34] ConditionalAttributes.cshtml) -  class=" - "
                     CSharpAttributeValue - (256:9,14 [25] ConditionalAttributes.cshtml) - 
                         CSharpStatement - (257:9,15 [18] ConditionalAttributes.cshtml)
@@ -73,28 +89,45 @@ Document -
                             RazorIRToken - (276:9,34 [3] ConditionalAttributes.cshtml) - CSharp - cls
                         CSharpStatement - (279:9,37 [2] ConditionalAttributes.cshtml)
                             RazorIRToken - (279:9,37 [2] ConditionalAttributes.cshtml) - CSharp -  }
-                HtmlContent - (282:9,40 [3] ConditionalAttributes.cshtml) -  />
+                HtmlContent - (282:9,40 [3] ConditionalAttributes.cshtml)
+                    RazorIRToken - (282:9,40 [3] ConditionalAttributes.cshtml) - Html -  />
                 CSharpStatement - (285:9,43 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (285:9,43 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (291:10,4 [18] ConditionalAttributes.cshtml) - <a href="~/Foo" />
+                HtmlContent - (291:10,4 [18] ConditionalAttributes.cshtml)
+                    RazorIRToken - (291:10,4 [2] ConditionalAttributes.cshtml) - Html - <a
+                    RazorIRToken - (293:10,6 [13] ConditionalAttributes.cshtml) - Html -  href="~/Foo"
+                    RazorIRToken - (306:10,19 [3] ConditionalAttributes.cshtml) - Html -  />
                 CSharpStatement - (309:10,22 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (309:10,22 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (315:11,4 [7] ConditionalAttributes.cshtml) - <script
+                HtmlContent - (315:11,4 [7] ConditionalAttributes.cshtml)
+                    RazorIRToken - (315:11,4 [7] ConditionalAttributes.cshtml) - Html - <script
                 HtmlAttribute - (322:11,11 [52] ConditionalAttributes.cshtml) -  src=" - "
                     CSharpAttributeValue - (328:11,17 [45] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (329:11,18 [44] ConditionalAttributes.cshtml)
                             RazorIRToken - (329:11,18 [44] ConditionalAttributes.cshtml) - CSharp - Url.Content("~/Scripts/jquery-1.6.2.min.js")
-                HtmlContent - (374:11,63 [33] ConditionalAttributes.cshtml) -  type="text/javascript"></script>
+                HtmlContent - (374:11,63 [33] ConditionalAttributes.cshtml)
+                    RazorIRToken - (374:11,63 [23] ConditionalAttributes.cshtml) - Html -  type="text/javascript"
+                    RazorIRToken - (397:11,86 [1] ConditionalAttributes.cshtml) - Html - >
+                    RazorIRToken - (398:11,87 [9] ConditionalAttributes.cshtml) - Html - </script>
                 CSharpStatement - (407:11,96 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (407:11,96 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (413:12,4 [7] ConditionalAttributes.cshtml) - <script
+                HtmlContent - (413:12,4 [7] ConditionalAttributes.cshtml)
+                    RazorIRToken - (413:12,4 [7] ConditionalAttributes.cshtml) - Html - <script
                 HtmlAttribute - (420:12,11 [68] ConditionalAttributes.cshtml) -  src=" - "
                     CSharpAttributeValue - (426:12,17 [61] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (427:12,18 [60] ConditionalAttributes.cshtml)
                             RazorIRToken - (427:12,18 [60] ConditionalAttributes.cshtml) - CSharp - Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")
-                HtmlContent - (488:12,79 [33] ConditionalAttributes.cshtml) -  type="text/javascript"></script>
+                HtmlContent - (488:12,79 [33] ConditionalAttributes.cshtml)
+                    RazorIRToken - (488:12,79 [23] ConditionalAttributes.cshtml) - Html -  type="text/javascript"
+                    RazorIRToken - (511:12,102 [1] ConditionalAttributes.cshtml) - Html - >
+                    RazorIRToken - (512:12,103 [9] ConditionalAttributes.cshtml) - Html - </script>
                 CSharpStatement - (521:12,112 [6] ConditionalAttributes.cshtml)
                     RazorIRToken - (521:12,112 [6] ConditionalAttributes.cshtml) - CSharp - \n    
-                HtmlContent - (527:13,4 [111] ConditionalAttributes.cshtml) - <script src="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.16/jquery-ui.min.js" type="text/javascript"></script>
+                HtmlContent - (527:13,4 [111] ConditionalAttributes.cshtml)
+                    RazorIRToken - (527:13,4 [7] ConditionalAttributes.cshtml) - Html - <script
+                    RazorIRToken - (534:13,11 [71] ConditionalAttributes.cshtml) - Html -  src="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.16/jquery-ui.min.js"
+                    RazorIRToken - (605:13,82 [23] ConditionalAttributes.cshtml) - Html -  type="text/javascript"
+                    RazorIRToken - (628:13,105 [1] ConditionalAttributes.cshtml) - Html - >
+                    RazorIRToken - (629:13,106 [9] ConditionalAttributes.cshtml) - Html - </script>
                 CSharpStatement - (638:13,115 [2] ConditionalAttributes.cshtml)
                     RazorIRToken - (638:13,115 [2] ConditionalAttributes.cshtml) - CSharp - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_Runtime.ir.txt
@@ -7,35 +7,64 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [44] ConditionalAttributes.cshtml)
                     RazorIRToken - (2:0,2 [44] ConditionalAttributes.cshtml) - CSharp - \n    var ch = true;\n    var cls = "bar";\n
-                HtmlContent - (46:3,0 [28] ConditionalAttributes.cshtml) -     <a href="Foo" />\n    <p
+                HtmlContent - (46:3,0 [28] ConditionalAttributes.cshtml)
+                    RazorIRToken - (46:3,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (50:3,4 [2] ConditionalAttributes.cshtml) - Html - <a
+                    RazorIRToken - (52:3,6 [11] ConditionalAttributes.cshtml) - Html -  href="Foo"
+                    RazorIRToken - (63:3,17 [3] ConditionalAttributes.cshtml) - Html -  />
+                    RazorIRToken - (66:3,20 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (68:4,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (72:4,4 [2] ConditionalAttributes.cshtml) - Html - <p
                 HtmlAttribute - (74:4,6 [13] ConditionalAttributes.cshtml) -  class=" - "
                     CSharpAttributeValue - (82:4,14 [4] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (83:4,15 [3] ConditionalAttributes.cshtml)
                             RazorIRToken - (83:4,15 [3] ConditionalAttributes.cshtml) - CSharp - cls
-                HtmlContent - (87:4,19 [11] ConditionalAttributes.cshtml) -  />\n    <p
+                HtmlContent - (87:4,19 [11] ConditionalAttributes.cshtml)
+                    RazorIRToken - (87:4,19 [3] ConditionalAttributes.cshtml) - Html -  />
+                    RazorIRToken - (90:4,22 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (92:5,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (96:5,4 [2] ConditionalAttributes.cshtml) - Html - <p
                 HtmlAttribute - (98:5,6 [17] ConditionalAttributes.cshtml) -  class=" - "
                     HtmlAttributeValue - (106:5,14 [3] ConditionalAttributes.cshtml) -  - foo
                     CSharpAttributeValue - (109:5,17 [5] ConditionalAttributes.cshtml) -  
                         CSharpExpression - (111:5,19 [3] ConditionalAttributes.cshtml)
                             RazorIRToken - (111:5,19 [3] ConditionalAttributes.cshtml) - CSharp - cls
-                HtmlContent - (115:5,23 [11] ConditionalAttributes.cshtml) -  />\n    <p
+                HtmlContent - (115:5,23 [11] ConditionalAttributes.cshtml)
+                    RazorIRToken - (115:5,23 [3] ConditionalAttributes.cshtml) - Html -  />
+                    RazorIRToken - (118:5,26 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (120:6,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (124:6,4 [2] ConditionalAttributes.cshtml) - Html - <p
                 HtmlAttribute - (126:6,6 [17] ConditionalAttributes.cshtml) -  class=" - "
                     CSharpAttributeValue - (134:6,14 [4] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (135:6,15 [3] ConditionalAttributes.cshtml)
                             RazorIRToken - (135:6,15 [3] ConditionalAttributes.cshtml) - CSharp - cls
                     HtmlAttributeValue - (138:6,18 [4] ConditionalAttributes.cshtml) -   - foo
-                HtmlContent - (143:6,23 [31] ConditionalAttributes.cshtml) -  />\n    <input type="checkbox"
+                HtmlContent - (143:6,23 [31] ConditionalAttributes.cshtml)
+                    RazorIRToken - (143:6,23 [3] ConditionalAttributes.cshtml) - Html -  />
+                    RazorIRToken - (146:6,26 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (148:7,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (152:7,4 [6] ConditionalAttributes.cshtml) - Html - <input
+                    RazorIRToken - (158:7,10 [16] ConditionalAttributes.cshtml) - Html -  type="checkbox"
                 HtmlAttribute - (174:7,26 [14] ConditionalAttributes.cshtml) -  checked=" - "
                     CSharpAttributeValue - (184:7,36 [3] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (185:7,37 [2] ConditionalAttributes.cshtml)
                             RazorIRToken - (185:7,37 [2] ConditionalAttributes.cshtml) - CSharp - ch
-                HtmlContent - (188:7,40 [31] ConditionalAttributes.cshtml) -  />\n    <input type="checkbox"
+                HtmlContent - (188:7,40 [31] ConditionalAttributes.cshtml)
+                    RazorIRToken - (188:7,40 [3] ConditionalAttributes.cshtml) - Html -  />
+                    RazorIRToken - (191:7,43 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (193:8,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (197:8,4 [6] ConditionalAttributes.cshtml) - Html - <input
+                    RazorIRToken - (203:8,10 [16] ConditionalAttributes.cshtml) - Html -  type="checkbox"
                 HtmlAttribute - (219:8,26 [18] ConditionalAttributes.cshtml) -  checked=" - "
                     HtmlAttributeValue - (229:8,36 [3] ConditionalAttributes.cshtml) -  - foo
                     CSharpAttributeValue - (232:8,39 [4] ConditionalAttributes.cshtml) -  
                         CSharpExpression - (234:8,41 [2] ConditionalAttributes.cshtml)
                             RazorIRToken - (234:8,41 [2] ConditionalAttributes.cshtml) - CSharp - ch
-                HtmlContent - (237:8,44 [11] ConditionalAttributes.cshtml) -  />\n    <p
+                HtmlContent - (237:8,44 [11] ConditionalAttributes.cshtml)
+                    RazorIRToken - (237:8,44 [3] ConditionalAttributes.cshtml) - Html -  />
+                    RazorIRToken - (240:8,47 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (242:9,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (246:9,4 [2] ConditionalAttributes.cshtml) - Html - <p
                 HtmlAttribute - (248:9,6 [34] ConditionalAttributes.cshtml) -  class=" - "
                     CSharpAttributeValue - (256:9,14 [25] ConditionalAttributes.cshtml) - 
                         CSharpStatement - (257:9,15 [18] ConditionalAttributes.cshtml)
@@ -44,16 +73,42 @@ Document -
                             RazorIRToken - (276:9,34 [3] ConditionalAttributes.cshtml) - CSharp - cls
                         CSharpStatement - (279:9,37 [2] ConditionalAttributes.cshtml)
                             RazorIRToken - (279:9,37 [2] ConditionalAttributes.cshtml) - CSharp -  }
-                HtmlContent - (282:9,40 [40] ConditionalAttributes.cshtml) -  />\n    <a href="~/Foo" />\n    <script
+                HtmlContent - (282:9,40 [40] ConditionalAttributes.cshtml)
+                    RazorIRToken - (282:9,40 [3] ConditionalAttributes.cshtml) - Html -  />
+                    RazorIRToken - (285:9,43 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (287:10,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (291:10,4 [2] ConditionalAttributes.cshtml) - Html - <a
+                    RazorIRToken - (293:10,6 [13] ConditionalAttributes.cshtml) - Html -  href="~/Foo"
+                    RazorIRToken - (306:10,19 [3] ConditionalAttributes.cshtml) - Html -  />
+                    RazorIRToken - (309:10,22 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (311:11,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (315:11,4 [7] ConditionalAttributes.cshtml) - Html - <script
                 HtmlAttribute - (322:11,11 [52] ConditionalAttributes.cshtml) -  src=" - "
                     CSharpAttributeValue - (328:11,17 [45] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (329:11,18 [44] ConditionalAttributes.cshtml)
                             RazorIRToken - (329:11,18 [44] ConditionalAttributes.cshtml) - CSharp - Url.Content("~/Scripts/jquery-1.6.2.min.js")
-                HtmlContent - (374:11,63 [46] ConditionalAttributes.cshtml) -  type="text/javascript"></script>\n    <script
+                HtmlContent - (374:11,63 [46] ConditionalAttributes.cshtml)
+                    RazorIRToken - (374:11,63 [23] ConditionalAttributes.cshtml) - Html -  type="text/javascript"
+                    RazorIRToken - (397:11,86 [1] ConditionalAttributes.cshtml) - Html - >
+                    RazorIRToken - (398:11,87 [9] ConditionalAttributes.cshtml) - Html - </script>
+                    RazorIRToken - (407:11,96 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (409:12,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (413:12,4 [7] ConditionalAttributes.cshtml) - Html - <script
                 HtmlAttribute - (420:12,11 [68] ConditionalAttributes.cshtml) -  src=" - "
                     CSharpAttributeValue - (426:12,17 [61] ConditionalAttributes.cshtml) - 
                         CSharpExpression - (427:12,18 [60] ConditionalAttributes.cshtml)
                             RazorIRToken - (427:12,18 [60] ConditionalAttributes.cshtml) - CSharp - Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")
-                HtmlContent - (488:12,79 [152] ConditionalAttributes.cshtml) -  type="text/javascript"></script>\n    <script src="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.16/jquery-ui.min.js" type="text/javascript"></script>\n
+                HtmlContent - (488:12,79 [152] ConditionalAttributes.cshtml)
+                    RazorIRToken - (488:12,79 [23] ConditionalAttributes.cshtml) - Html -  type="text/javascript"
+                    RazorIRToken - (511:12,102 [1] ConditionalAttributes.cshtml) - Html - >
+                    RazorIRToken - (512:12,103 [9] ConditionalAttributes.cshtml) - Html - </script>
+                    RazorIRToken - (521:12,112 [2] ConditionalAttributes.cshtml) - Html - \n
+                    RazorIRToken - (523:13,0 [4] ConditionalAttributes.cshtml) - Html -     
+                    RazorIRToken - (527:13,4 [7] ConditionalAttributes.cshtml) - Html - <script
+                    RazorIRToken - (534:13,11 [71] ConditionalAttributes.cshtml) - Html -  src="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.16/jquery-ui.min.js"
+                    RazorIRToken - (605:13,82 [23] ConditionalAttributes.cshtml) - Html -  type="text/javascript"
+                    RazorIRToken - (628:13,105 [1] ConditionalAttributes.cshtml) - Html - >
+                    RazorIRToken - (629:13,106 [9] ConditionalAttributes.cshtml) - Html - </script>
+                    RazorIRToken - (638:13,115 [2] ConditionalAttributes.cshtml) - Html - \n
                 CSharpStatement - (640:14,0 [0] ConditionalAttributes.cshtml)
                     RazorIRToken - (640:14,0 [0] ConditionalAttributes.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.ir.txt
@@ -15,33 +15,41 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_8 - value - 2 TagHelper - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.ATagHelper - TestNamespace.CatchAllTagHelper - TestNamespace.ATagHelperMultipleSelectors - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2 - TestNamespace.CatchAllTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                HtmlContent - (33:1,0 [2] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (33:1,0 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (35:2,0 [30] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
-                        HtmlContent - (48:2,13 [13] CssSelectorTagHelperAttributes.cshtml) - 2 TagHelpers.
+                        HtmlContent - (48:2,13 [13] CssSelectorTagHelperAttributes.cshtml)
+                            RazorIRToken - (48:2,13 [13] CssSelectorTagHelperAttributes.cshtml) - Html - 2 TagHelpers.
                     CreateTagHelper -  - TestNamespace.ATagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     ExecuteTagHelpers - 
-                HtmlContent - (65:2,30 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                HtmlContent - (65:2,30 [2] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (65:2,30 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (67:3,0 [32] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
-                        HtmlContent - (83:3,16 [12] CssSelectorTagHelperAttributes.cshtml) - 1 TagHelper.
+                        HtmlContent - (83:3,16 [12] CssSelectorTagHelperAttributes.cshtml)
+                            RazorIRToken - (83:3,16 [12] CssSelectorTagHelperAttributes.cshtml) - Html - 1 TagHelper.
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     ExecuteTagHelpers - 
-                HtmlContent - (99:3,32 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                HtmlContent - (99:3,32 [2] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (99:3,32 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (101:4,0 [41] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
-                        HtmlContent - (126:4,25 [12] CssSelectorTagHelperAttributes.cshtml) - 2 TagHelpers
+                        HtmlContent - (126:4,25 [12] CssSelectorTagHelperAttributes.cshtml)
+                            RazorIRToken - (126:4,25 [12] CssSelectorTagHelperAttributes.cshtml) - Html - 2 TagHelpers
                     CreateTagHelper -  - TestNamespace.ATagHelperMultipleSelectors
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     ExecuteTagHelpers - 
-                HtmlContent - (142:4,41 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                HtmlContent - (142:4,41 [2] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (142:4,41 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (144:5,0 [47] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
-                        HtmlContent - (175:5,31 [12] CssSelectorTagHelperAttributes.cshtml) - 2 TagHelpers
+                        HtmlContent - (175:5,31 [12] CssSelectorTagHelperAttributes.cshtml)
+                            RazorIRToken - (175:5,31 [12] CssSelectorTagHelperAttributes.cshtml) - Html - 2 TagHelpers
                     CreateTagHelper -  - TestNamespace.ATagHelperMultipleSelectors
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - href - HtmlAttributeValueStyle.DoubleQuotes
@@ -51,10 +59,18 @@ Document -
                                 RazorIRToken - (156:5,12 [5] CssSelectorTagHelperAttributes.cshtml) - CSharp - false
                         HtmlAttributeValue - (161:5,17 [12] CssSelectorTagHelperAttributes.cshtml) -  - ?hello=world
                     ExecuteTagHelpers - 
-                HtmlContent - (191:5,47 [35] CssSelectorTagHelperAttributes.cshtml) - \n<a href=' ~/'>0 TagHelpers.</a>\n
+                HtmlContent - (191:5,47 [35] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (191:5,47 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
+                    RazorIRToken - (193:6,0 [2] CssSelectorTagHelperAttributes.cshtml) - Html - <a
+                    RazorIRToken - (195:6,2 [11] CssSelectorTagHelperAttributes.cshtml) - Html -  href=' ~/'
+                    RazorIRToken - (206:6,13 [1] CssSelectorTagHelperAttributes.cshtml) - Html - >
+                    RazorIRToken - (207:6,14 [13] CssSelectorTagHelperAttributes.cshtml) - Html - 0 TagHelpers.
+                    RazorIRToken - (220:6,27 [4] CssSelectorTagHelperAttributes.cshtml) - Html - </a>
+                    RazorIRToken - (224:6,31 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (226:7,0 [32] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
-                        HtmlContent - (243:7,17 [11] CssSelectorTagHelperAttributes.cshtml) - 1 TagHelper
+                        HtmlContent - (243:7,17 [11] CssSelectorTagHelperAttributes.cshtml)
+                            RazorIRToken - (243:7,17 [11] CssSelectorTagHelperAttributes.cshtml) - Html - 1 TagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - href - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlAttributeValue - (234:7,8 [2] CssSelectorTagHelperAttributes.cshtml) -  - ~/
@@ -62,17 +78,21 @@ Document -
                             CSharpExpression - (237:7,11 [5] CssSelectorTagHelperAttributes.cshtml)
                                 RazorIRToken - (237:7,11 [5] CssSelectorTagHelperAttributes.cshtml) - CSharp - false
                     ExecuteTagHelpers - 
-                HtmlContent - (258:7,32 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                HtmlContent - (258:7,32 [2] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (258:7,32 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (260:8,0 [46] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
-                        HtmlContent - (291:8,31 [11] CssSelectorTagHelperAttributes.cshtml) - 1 TagHelper
+                        HtmlContent - (291:8,31 [11] CssSelectorTagHelperAttributes.cshtml)
+                            RazorIRToken - (291:8,31 [11] CssSelectorTagHelperAttributes.cshtml) - Html - 1 TagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                     ExecuteTagHelpers - 
-                HtmlContent - (306:8,46 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                HtmlContent - (306:8,46 [2] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (306:8,46 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (308:9,0 [47] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - a - TagMode.StartTagAndEndTag
-                        HtmlContent - (340:9,32 [11] CssSelectorTagHelperAttributes.cshtml) - 1 TagHelper
+                        HtmlContent - (340:9,32 [11] CssSelectorTagHelperAttributes.cshtml)
+                            RazorIRToken - (340:9,32 [11] CssSelectorTagHelperAttributes.cshtml) - Html - 1 TagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - href - HtmlAttributeValueStyle.SingleQuotes
                         HtmlAttributeValue - (317:9,9 [14] CssSelectorTagHelperAttributes.cshtml) -  - ~/?hello=world
@@ -80,7 +100,8 @@ Document -
                             CSharpExpression - (333:9,25 [5] CssSelectorTagHelperAttributes.cshtml)
                                 RazorIRToken - (333:9,25 [5] CssSelectorTagHelperAttributes.cshtml) - CSharp - false
                     ExecuteTagHelpers - 
-                HtmlContent - (355:9,47 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                HtmlContent - (355:9,47 [2] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (355:9,47 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (357:10,0 [42] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -90,7 +111,8 @@ Document -
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
                     ExecuteTagHelpers - 
-                HtmlContent - (399:10,42 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                HtmlContent - (399:10,42 [2] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (399:10,42 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (401:11,0 [43] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
@@ -98,7 +120,8 @@ Document -
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - type - Type
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
                     ExecuteTagHelpers - 
-                HtmlContent - (444:11,43 [2] CssSelectorTagHelperAttributes.cshtml) - \n
+                HtmlContent - (444:11,43 [2] CssSelectorTagHelperAttributes.cshtml)
+                    RazorIRToken - (444:11,43 [2] CssSelectorTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (446:12,0 [45] CssSelectorTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper2

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.ir.txt
@@ -17,33 +17,57 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [19] DesignTime.cshtml) - <div>\n            
+                HtmlContent - (0:0,0 [19] DesignTime.cshtml)
+                    RazorIRToken - (0:0,0 [5] DesignTime.cshtml) - Html - <div>
+                    RazorIRToken - (5:0,5 [14] DesignTime.cshtml) - Html - \n            
                 CSharpStatement - (20:1,13 [36] DesignTime.cshtml)
                     RazorIRToken - (20:1,13 [36] DesignTime.cshtml) - CSharp - for(int i = 1; i <= 10; i++) {\n    
-                HtmlContent - (56:2,4 [17] DesignTime.cshtml) - <p>This is item #
+                HtmlContent - (56:2,4 [17] DesignTime.cshtml)
+                    RazorIRToken - (56:2,4 [3] DesignTime.cshtml) - Html - <p>
+                    RazorIRToken - (59:2,7 [14] DesignTime.cshtml) - Html - This is item #
                 CSharpExpression - (74:2,22 [1] DesignTime.cshtml)
                     RazorIRToken - (74:2,22 [1] DesignTime.cshtml) - CSharp - i
-                HtmlContent - (75:2,23 [4] DesignTime.cshtml) - </p>
+                HtmlContent - (75:2,23 [4] DesignTime.cshtml)
+                    RazorIRToken - (75:2,23 [4] DesignTime.cshtml) - Html - </p>
                 CSharpStatement - (79:2,27 [15] DesignTime.cshtml)
                     RazorIRToken - (79:2,27 [15] DesignTime.cshtml) - CSharp - \n            }
-                HtmlContent - (94:3,13 [17] DesignTime.cshtml) - \n</div>\n\n<p>\n
+                HtmlContent - (94:3,13 [17] DesignTime.cshtml)
+                    RazorIRToken - (94:3,13 [2] DesignTime.cshtml) - Html - \n
+                    RazorIRToken - (96:4,0 [6] DesignTime.cshtml) - Html - </div>
+                    RazorIRToken - (102:4,6 [4] DesignTime.cshtml) - Html - \n\n
+                    RazorIRToken - (106:6,0 [3] DesignTime.cshtml) - Html - <p>
+                    RazorIRToken - (109:6,3 [2] DesignTime.cshtml) - Html - \n
                 CSharpExpression - (113:7,2 [12] DesignTime.cshtml)
                     RazorIRToken - (113:7,2 [12] DesignTime.cshtml) - CSharp - Foo(Bar.Baz)
-                HtmlContent - (126:7,15 [2] DesignTime.cshtml) - \n
+                HtmlContent - (126:7,15 [2] DesignTime.cshtml)
+                    RazorIRToken - (126:7,15 [2] DesignTime.cshtml) - Html - \n
                 CSharpExpression - (129:8,1 [23] DesignTime.cshtml)
                     RazorIRToken - (129:8,1 [4] DesignTime.cshtml) - CSharp - Foo(
                     Template - (134:8,6 [18] DesignTime.cshtml)
-                        HtmlContent - (134:8,6 [7] DesignTime.cshtml) - <p>Bar 
+                        HtmlContent - (134:8,6 [7] DesignTime.cshtml)
+                            RazorIRToken - (134:8,6 [3] DesignTime.cshtml) - Html - <p>
+                            RazorIRToken - (137:8,9 [4] DesignTime.cshtml) - Html - Bar 
                         CSharpExpression - (142:8,14 [3] DesignTime.cshtml)
                             RazorIRToken - (142:8,14 [3] DesignTime.cshtml) - CSharp - baz
-                        HtmlContent - (145:8,17 [8] DesignTime.cshtml) -  Biz</p>
+                        HtmlContent - (145:8,17 [8] DesignTime.cshtml)
+                            RazorIRToken - (145:8,17 [4] DesignTime.cshtml) - Html -  Biz
+                            RazorIRToken - (149:8,21 [4] DesignTime.cshtml) - Html - </p>
                     RazorIRToken - (153:8,25 [1] DesignTime.cshtml) - CSharp - )
-                HtmlContent - (154:8,26 [10] DesignTime.cshtml) - \n</p>\n\n
+                HtmlContent - (154:8,26 [10] DesignTime.cshtml)
+                    RazorIRToken - (154:8,26 [2] DesignTime.cshtml) - Html - \n
+                    RazorIRToken - (156:9,0 [4] DesignTime.cshtml) - Html - </p>
+                    RazorIRToken - (160:9,4 [4] DesignTime.cshtml) - Html - \n\n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("Footer", async (__razor_section_writer) => {
-                HtmlContent - (181:11,17 [22] DesignTime.cshtml) - \n    <p>Foo</p>\n    
+                HtmlContent - (181:11,17 [22] DesignTime.cshtml)
+                    RazorIRToken - (181:11,17 [6] DesignTime.cshtml) - Html - \n    
+                    RazorIRToken - (187:12,4 [3] DesignTime.cshtml) - Html - <p>
+                    RazorIRToken - (190:12,7 [3] DesignTime.cshtml) - Html - Foo
+                    RazorIRToken - (193:12,10 [4] DesignTime.cshtml) - Html - </p>
+                    RazorIRToken - (197:12,14 [6] DesignTime.cshtml) - Html - \n    
                 CSharpExpression - (204:13,5 [3] DesignTime.cshtml)
                     RazorIRToken - (204:13,5 [3] DesignTime.cshtml) - CSharp - bar
-                HtmlContent - (207:13,8 [2] DesignTime.cshtml) - \n
+                HtmlContent - (207:13,8 [2] DesignTime.cshtml)
+                    RazorIRToken - (207:13,8 [2] DesignTime.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.ir.txt
@@ -18,63 +18,86 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] DuplicateAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] DuplicateAttributeTagHelpers.cshtml)
+                    RazorIRToken - (31:0,31 [4] DuplicateAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (35:2,0 [259] DuplicateAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (65:2,30 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        HtmlContent - (65:2,30 [6] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (65:2,30 [6] DuplicateAttributeTagHelpers.cshtml) - Html - \n    
                         TagHelper - (71:3,4 [39] DuplicateAttributeTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                                HtmlContent - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - Html - button
                             SetTagHelperProperty - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                                HtmlContent - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (84:3,17 [6] DuplicateAttributeTagHelpers.cshtml) - Html - button
                             AddTagHelperHtmlAttribute -  - TYPE - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (98:3,31 [8] DuplicateAttributeTagHelpers.cshtml) - checkbox
+                                HtmlContent - (98:3,31 [8] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (98:3,31 [8] DuplicateAttributeTagHelpers.cshtml) - Html - checkbox
                             ExecuteTagHelpers - 
-                        HtmlContent - (110:3,43 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        HtmlContent - (110:3,43 [6] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (110:3,43 [6] DuplicateAttributeTagHelpers.cshtml) - Html - \n    
                         TagHelper - (116:4,4 [70] DuplicateAttributeTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                                HtmlContent - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - Html - button
                             SetTagHelperProperty - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                                HtmlContent - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - Html - button
                             SetTagHelperProperty - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                                HtmlContent - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
                             AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (158:4,46 [8] DuplicateAttributeTagHelpers.cshtml) - checkbox
+                                HtmlContent - (158:4,46 [8] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (158:4,46 [8] DuplicateAttributeTagHelpers.cshtml) - Html - checkbox
                             AddTagHelperHtmlAttribute -  - checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (177:4,65 [5] DuplicateAttributeTagHelpers.cshtml) - false
+                                HtmlContent - (177:4,65 [5] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (177:4,65 [5] DuplicateAttributeTagHelpers.cshtml) - Html - false
                             ExecuteTagHelpers - 
-                        HtmlContent - (186:4,74 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        HtmlContent - (186:4,74 [6] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (186:4,74 [6] DuplicateAttributeTagHelpers.cshtml) - Html - \n    
                         TagHelper - (192:5,4 [96] DuplicateAttributeTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
-                                HtmlContent - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                                HtmlContent - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - Html - button
                             SetTagHelperProperty - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
-                                HtmlContent - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - button
+                                HtmlContent - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - Html - button
                             SetTagHelperProperty - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                                HtmlContent - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
                             AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (233:5,45 [8] DuplicateAttributeTagHelpers.cshtml) - checkbox
+                                HtmlContent - (233:5,45 [8] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (233:5,45 [8] DuplicateAttributeTagHelpers.cshtml) - Html - checkbox
                             AddTagHelperHtmlAttribute -  - checked - HtmlAttributeValueStyle.SingleQuotes
-                                HtmlContent - (251:5,63 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                                HtmlContent - (251:5,63 [4] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (251:5,63 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
                             AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (263:5,75 [8] DuplicateAttributeTagHelpers.cshtml) - checkbox
+                                HtmlContent - (263:5,75 [8] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (263:5,75 [8] DuplicateAttributeTagHelpers.cshtml) - Html - checkbox
                             AddTagHelperHtmlAttribute -  - checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (281:5,93 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                                HtmlContent - (281:5,93 [4] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (281:5,93 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml) - \n
+                        HtmlContent - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - 3
+                        HtmlContent - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - Html - 3
                     AddTagHelperHtmlAttribute -  - AGE - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (51:2,16 [2] DuplicateAttributeTagHelpers.cshtml) - 40
+                        HtmlContent - (51:2,16 [2] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (51:2,16 [2] DuplicateAttributeTagHelpers.cshtml) - Html - 40
                     AddTagHelperHtmlAttribute -  - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (60:2,25 [3] DuplicateAttributeTagHelpers.cshtml) - 500
+                        HtmlContent - (60:2,25 [3] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (60:2,25 [3] DuplicateAttributeTagHelpers.cshtml) - Html - 500
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.ir.txt
@@ -15,10 +15,12 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_8 - Age - 500 - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] DuplicateAttributeTagHelpers.cshtml) - \n
+                HtmlContent - (33:1,0 [2] DuplicateAttributeTagHelpers.cshtml)
+                    RazorIRToken - (33:1,0 [2] DuplicateAttributeTagHelpers.cshtml) - Html - \n
                 TagHelper - (35:2,0 [259] DuplicateAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (65:2,30 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        HtmlContent - (65:2,30 [6] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (65:2,30 [6] DuplicateAttributeTagHelpers.cshtml) - Html - \n    
                         TagHelper - (71:3,4 [39] DuplicateAttributeTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -27,7 +29,8 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                             ExecuteTagHelpers - 
-                        HtmlContent - (110:3,43 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        HtmlContent - (110:3,43 [6] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (110:3,43 [6] DuplicateAttributeTagHelpers.cshtml) - Html - \n    
                         TagHelper - (116:4,4 [70] DuplicateAttributeTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -35,11 +38,13 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetTagHelperProperty - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                                HtmlContent - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                             ExecuteTagHelpers - 
-                        HtmlContent - (186:4,74 [6] DuplicateAttributeTagHelpers.cshtml) - \n    
+                        HtmlContent - (186:4,74 [6] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (186:4,74 [6] DuplicateAttributeTagHelpers.cshtml) - Html - \n    
                         TagHelper - (192:5,4 [96] DuplicateAttributeTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -47,16 +52,19 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
                             SetTagHelperProperty - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - true
+                                HtmlContent - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_6
                             ExecuteTagHelpers - 
-                        HtmlContent - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml) - \n
+                        HtmlContent - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - 3
+                        HtmlContent - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml)
+                            RazorIRToken - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - Html - 3
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_8
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.ir.txt
@@ -18,7 +18,8 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (31:0,31 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (35:2,0 [40] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -28,7 +29,8 @@ Document -
                             CSharpExpression - (59:2,24 [12] DynamicAttributeTagHelpers.cshtml)
                                 RazorIRToken - (59:2,24 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
                     ExecuteTagHelpers - 
-                HtmlContent - (75:2,40 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (75:2,40 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (75:2,40 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (79:4,0 [71] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -46,15 +48,19 @@ Document -
                                 RazorIRToken - (137:4,58 [2] DynamicAttributeTagHelpers.cshtml) - CSharp -  }
                         HtmlAttributeValue - (139:4,60 [7] DynamicAttributeTagHelpers.cshtml) -   - suffix
                     ExecuteTagHelpers - 
-                HtmlContent - (150:4,71 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (150:4,71 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (150:4,71 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (154:6,0 [83] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     SetTagHelperProperty - (168:6,14 [27] DynamicAttributeTagHelpers.cshtml) - bound - Bound - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (168:6,14 [7] DynamicAttributeTagHelpers.cshtml) - prefix 
+                        HtmlContent - (168:6,14 [7] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (168:6,14 [6] DynamicAttributeTagHelpers.cshtml) - Html - prefix
+                            RazorIRToken - (174:6,20 [1] DynamicAttributeTagHelpers.cshtml) - Html -  
                         CSharpExpression - (176:6,22 [12] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (176:6,22 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
-                        HtmlContent - (188:6,34 [7] DynamicAttributeTagHelpers.cshtml) -  suffix
+                        HtmlContent - (188:6,34 [7] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (188:6,34 [7] DynamicAttributeTagHelpers.cshtml) - Html -  suffix
                     AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlAttributeValue - (206:6,52 [6] DynamicAttributeTagHelpers.cshtml) -  - prefix
                         CSharpAttributeValue - (212:6,58 [14] DynamicAttributeTagHelpers.cshtml) -  
@@ -62,14 +68,16 @@ Document -
                                 RazorIRToken - (214:6,60 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
                         HtmlAttributeValue - (226:6,72 [7] DynamicAttributeTagHelpers.cshtml) -   - suffix
                     ExecuteTagHelpers - 
-                HtmlContent - (237:6,83 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (237:6,83 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (237:6,83 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (241:8,0 [183] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     SetTagHelperProperty - (255:8,14 [73] DynamicAttributeTagHelpers.cshtml) - bound - Bound - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (256:8,15 [13] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (256:8,15 [13] DynamicAttributeTagHelpers.cshtml) - CSharp - long.MinValue
-                        HtmlContent - (269:8,28 [1] DynamicAttributeTagHelpers.cshtml) -  
+                        HtmlContent - (269:8,28 [1] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (269:8,28 [1] DynamicAttributeTagHelpers.cshtml) - Html -  
                         CSharpStatement - (271:8,30 [12] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (271:8,30 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - if (true) { 
                         CSharpExpression - (284:8,43 [12] DynamicAttributeTagHelpers.cshtml)
@@ -80,7 +88,8 @@ Document -
                             RazorIRToken - (307:8,66 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
                         CSharpStatement - (312:8,71 [2] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (312:8,71 [2] DynamicAttributeTagHelpers.cshtml) - CSharp -  }
-                        HtmlContent - (314:8,73 [1] DynamicAttributeTagHelpers.cshtml) -  
+                        HtmlContent - (314:8,73 [1] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (314:8,73 [1] DynamicAttributeTagHelpers.cshtml) - Html -  
                         CSharpExpression - (316:8,75 [12] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (316:8,75 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
                     AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
@@ -102,7 +111,8 @@ Document -
                             CSharpExpression - (408:9,77 [12] DynamicAttributeTagHelpers.cshtml)
                                 RazorIRToken - (408:9,77 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
                     ExecuteTagHelpers - 
-                HtmlContent - (424:9,93 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (424:9,93 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (424:9,93 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (428:11,0 [80] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -119,7 +129,8 @@ Document -
                             CSharpExpression - (492:11,64 [12] DynamicAttributeTagHelpers.cshtml)
                                 RazorIRToken - (492:11,64 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
                     ExecuteTagHelpers - 
-                HtmlContent - (508:11,80 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (508:11,80 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (508:11,80 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (512:13,0 [64] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.ir.txt
@@ -6,7 +6,8 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DynamicAttributeTagHelpers_Runtime -  - 
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] DynamicAttributeTagHelpers.cshtml) - \n
+                HtmlContent - (33:1,0 [2] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (33:1,0 [2] DynamicAttributeTagHelpers.cshtml) - Html - \n
                 TagHelper - (35:2,0 [40] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -16,7 +17,8 @@ Document -
                             CSharpExpression - (59:2,24 [12] DynamicAttributeTagHelpers.cshtml)
                                 RazorIRToken - (59:2,24 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
                     ExecuteTagHelpers - 
-                HtmlContent - (75:2,40 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (75:2,40 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (75:2,40 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (79:4,0 [71] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -34,15 +36,19 @@ Document -
                                 RazorIRToken - (137:4,58 [2] DynamicAttributeTagHelpers.cshtml) - CSharp -  }
                         HtmlAttributeValue - (139:4,60 [7] DynamicAttributeTagHelpers.cshtml) -   - suffix
                     ExecuteTagHelpers - 
-                HtmlContent - (150:4,71 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (150:4,71 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (150:4,71 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (154:6,0 [83] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     SetTagHelperProperty - (168:6,14 [27] DynamicAttributeTagHelpers.cshtml) - bound - Bound - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (168:6,14 [7] DynamicAttributeTagHelpers.cshtml) - prefix 
+                        HtmlContent - (168:6,14 [7] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (168:6,14 [6] DynamicAttributeTagHelpers.cshtml) - Html - prefix
+                            RazorIRToken - (174:6,20 [1] DynamicAttributeTagHelpers.cshtml) - Html -  
                         CSharpExpression - (176:6,22 [12] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (176:6,22 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
-                        HtmlContent - (188:6,34 [7] DynamicAttributeTagHelpers.cshtml) -  suffix
+                        HtmlContent - (188:6,34 [7] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (188:6,34 [7] DynamicAttributeTagHelpers.cshtml) - Html -  suffix
                     AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlAttributeValue - (206:6,52 [6] DynamicAttributeTagHelpers.cshtml) -  - prefix
                         CSharpAttributeValue - (212:6,58 [14] DynamicAttributeTagHelpers.cshtml) -  
@@ -50,14 +56,16 @@ Document -
                                 RazorIRToken - (214:6,60 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - DateTime.Now
                         HtmlAttributeValue - (226:6,72 [7] DynamicAttributeTagHelpers.cshtml) -   - suffix
                     ExecuteTagHelpers - 
-                HtmlContent - (237:6,83 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (237:6,83 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (237:6,83 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (241:8,0 [183] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     SetTagHelperProperty - (255:8,14 [73] DynamicAttributeTagHelpers.cshtml) - bound - Bound - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (256:8,15 [13] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (256:8,15 [13] DynamicAttributeTagHelpers.cshtml) - CSharp - long.MinValue
-                        HtmlContent - (269:8,28 [1] DynamicAttributeTagHelpers.cshtml) -  
+                        HtmlContent - (269:8,28 [1] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (269:8,28 [1] DynamicAttributeTagHelpers.cshtml) - Html -  
                         CSharpStatement - (271:8,30 [12] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (271:8,30 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - if (true) { 
                         CSharpExpression - (284:8,43 [12] DynamicAttributeTagHelpers.cshtml)
@@ -68,7 +76,8 @@ Document -
                             RazorIRToken - (307:8,66 [5] DynamicAttributeTagHelpers.cshtml) - CSharp - false
                         CSharpStatement - (312:8,71 [2] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (312:8,71 [2] DynamicAttributeTagHelpers.cshtml) - CSharp -  }
-                        HtmlContent - (314:8,73 [1] DynamicAttributeTagHelpers.cshtml) -  
+                        HtmlContent - (314:8,73 [1] DynamicAttributeTagHelpers.cshtml)
+                            RazorIRToken - (314:8,73 [1] DynamicAttributeTagHelpers.cshtml) - Html -  
                         CSharpExpression - (316:8,75 [12] DynamicAttributeTagHelpers.cshtml)
                             RazorIRToken - (316:8,75 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
                     AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
@@ -90,7 +99,8 @@ Document -
                             CSharpExpression - (408:9,77 [12] DynamicAttributeTagHelpers.cshtml)
                                 RazorIRToken - (408:9,77 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
                     ExecuteTagHelpers - 
-                HtmlContent - (424:9,93 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (424:9,93 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (424:9,93 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (428:11,0 [80] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -107,7 +117,8 @@ Document -
                             CSharpExpression - (492:11,64 [12] DynamicAttributeTagHelpers.cshtml)
                                 RazorIRToken - (492:11,64 [12] DynamicAttributeTagHelpers.cshtml) - CSharp - int.MaxValue
                     ExecuteTagHelpers - 
-                HtmlContent - (508:11,80 [4] DynamicAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (508:11,80 [4] DynamicAttributeTagHelpers.cshtml)
+                    RazorIRToken - (508:11,80 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (512:13,0 [64] DynamicAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
@@ -18,40 +18,57 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2 - TestNamespace.PTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (29:0,29 [15] EmptyAttributeTagHelpers.cshtml) - \n\n<div>\n    
+                HtmlContent - (29:0,29 [15] EmptyAttributeTagHelpers.cshtml)
+                    RazorIRToken - (29:0,29 [4] EmptyAttributeTagHelpers.cshtml) - Html - \n\n
+                    RazorIRToken - (33:2,0 [5] EmptyAttributeTagHelpers.cshtml) - Html - <div>
+                    RazorIRToken - (38:2,5 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (44:3,4 [34] EmptyAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     SetTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - 
+                        HtmlContent - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                     SetTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - 
+                        HtmlContent - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                     SetTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - 
+                        HtmlContent - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml) - 
+                        HtmlContent - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                     ExecuteTagHelpers - 
-                HtmlContent - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml) - \n    
+                HtmlContent - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml)
+                    RazorIRToken - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (84:4,4 [64] EmptyAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (94:4,14 [10] EmptyAttributeTagHelpers.cshtml) - \n        
+                        HtmlContent - (94:4,14 [10] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (94:4,14 [10] EmptyAttributeTagHelpers.cshtml) - Html - \n        
                         TagHelper - (104:5,8 [34] EmptyAttributeTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             SetTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - 
+                                HtmlContent - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                             SetTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - 
+                                HtmlContent - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                             SetTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - 
+                                HtmlContent - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                             AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml) - 
+                                HtmlContent - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                             ExecuteTagHelpers - 
-                        HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - \n    
+                        HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - 
+                        HtmlContent - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                     ExecuteTagHelpers - 
-                HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml) - \n</div>
+                HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml)
+                    RazorIRToken - (148:6,8 [2] EmptyAttributeTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (150:7,0 [6] EmptyAttributeTagHelpers.cshtml) - Html - </div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
@@ -8,7 +8,10 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - class -  - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2 - TestNamespace.PTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:1,0 [13] EmptyAttributeTagHelpers.cshtml) - \n<div>\n    
+                HtmlContent - (31:1,0 [13] EmptyAttributeTagHelpers.cshtml)
+                    RazorIRToken - (31:1,0 [2] EmptyAttributeTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (33:2,0 [5] EmptyAttributeTagHelpers.cshtml) - Html - <div>
+                    RazorIRToken - (38:2,5 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (44:3,4 [34] EmptyAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -16,13 +19,16 @@ Document -
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                     SetTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - 
+                        HtmlContent - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     ExecuteTagHelpers - 
-                HtmlContent - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml) - \n    
+                HtmlContent - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml)
+                    RazorIRToken - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (84:4,4 [64] EmptyAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (94:4,14 [10] EmptyAttributeTagHelpers.cshtml) - \n        
+                        HtmlContent - (94:4,14 [10] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (94:4,14 [10] EmptyAttributeTagHelpers.cshtml) - Html - \n        
                         TagHelper - (104:5,8 [34] EmptyAttributeTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -30,12 +36,17 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - 
+                                HtmlContent - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml)
+                                    RazorIRToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                             ExecuteTagHelpers - 
-                        HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - \n    
+                        HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - 
+                        HtmlContent - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml)
+                            RazorIRToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                     ExecuteTagHelpers - 
-                HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml) - \n</div>
+                HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml)
+                    RazorIRToken - (148:6,8 [2] EmptyAttributeTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (150:7,0 [6] EmptyAttributeTagHelpers.cshtml) - Html - </div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.ir.txt
@@ -16,6 +16,7 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] EmptyCodeBlock.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] EmptyCodeBlock.cshtml)
+                    RazorIRToken - (0:0,0 [18] EmptyCodeBlock.cshtml) - Html - This is markup\n\n
                 CSharpStatement - (20:2,2 [0] EmptyCodeBlock.cshtml)
                     RazorIRToken - (20:2,2 [0] EmptyCodeBlock.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_Runtime.ir.txt
@@ -5,6 +5,7 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyCodeBlock_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] EmptyCodeBlock.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] EmptyCodeBlock.cshtml)
+                    RazorIRToken - (0:0,0 [18] EmptyCodeBlock.cshtml) - Html - This is markup\n\n
                 CSharpStatement - (20:2,2 [0] EmptyCodeBlock.cshtml)
                     RazorIRToken - (20:2,2 [0] EmptyCodeBlock.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.ir.txt
@@ -16,6 +16,7 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] EmptyExplicitExpression.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] EmptyExplicitExpression.cshtml)
+                    RazorIRToken - (0:0,0 [18] EmptyExplicitExpression.cshtml) - Html - This is markup\n\n
                 CSharpExpression - (20:2,2 [0] EmptyExplicitExpression.cshtml)
                     RazorIRToken - (20:2,2 [0] EmptyExplicitExpression.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.ir.txt
@@ -5,6 +5,7 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyExplicitExpression_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] EmptyExplicitExpression.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] EmptyExplicitExpression.cshtml)
+                    RazorIRToken - (0:0,0 [18] EmptyExplicitExpression.cshtml) - Html - This is markup\n\n
                 CSharpExpression - (20:2,2 [0] EmptyExplicitExpression.cshtml)
                     RazorIRToken - (20:2,2 [0] EmptyExplicitExpression.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.ir.txt
@@ -16,7 +16,9 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] EmptyImplicitExpression.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] EmptyImplicitExpression.cshtml)
+                    RazorIRToken - (0:0,0 [18] EmptyImplicitExpression.cshtml) - Html - This is markup\n\n
                 CSharpExpression - (19:2,1 [0] EmptyImplicitExpression.cshtml)
                     RazorIRToken - (19:2,1 [0] EmptyImplicitExpression.cshtml) - CSharp - 
-                HtmlContent - (19:2,1 [1] EmptyImplicitExpression.cshtml) - !
+                HtmlContent - (19:2,1 [1] EmptyImplicitExpression.cshtml)
+                    RazorIRToken - (19:2,1 [1] EmptyImplicitExpression.cshtml) - Html - !

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.ir.txt
@@ -5,7 +5,9 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyImplicitExpression_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] EmptyImplicitExpression.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] EmptyImplicitExpression.cshtml)
+                    RazorIRToken - (0:0,0 [18] EmptyImplicitExpression.cshtml) - Html - This is markup\n\n
                 CSharpExpression - (19:2,1 [0] EmptyImplicitExpression.cshtml)
                     RazorIRToken - (19:2,1 [0] EmptyImplicitExpression.cshtml) - CSharp - 
-                HtmlContent - (19:2,1 [1] EmptyImplicitExpression.cshtml) - !
+                HtmlContent - (19:2,1 [1] EmptyImplicitExpression.cshtml)
+                    RazorIRToken - (19:2,1 [1] EmptyImplicitExpression.cshtml) - Html - !

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.ir.txt
@@ -18,10 +18,12 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.CatchAllTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] EnumTagHelpers.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] EnumTagHelpers.cshtml)
+                    RazorIRToken - (31:0,31 [4] EnumTagHelpers.cshtml) - Html - \n\n
                 CSharpStatement - (37:2,2 [39] EnumTagHelpers.cshtml)
                     RazorIRToken - (37:2,2 [39] EnumTagHelpers.cshtml) - CSharp - \n    var enumValue = MyEnum.MyValue;\n
-                HtmlContent - (79:5,0 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (79:5,0 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (79:5,0 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (81:6,0 [33] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -30,7 +32,8 @@ Document -
                         CSharpExpression - (96:6,15 [14] EnumTagHelpers.cshtml)
                             RazorIRToken - (96:6,15 [14] EnumTagHelpers.cshtml) - CSharp - MyEnum.MyValue
                     ExecuteTagHelpers - 
-                HtmlContent - (114:6,33 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (114:6,33 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (114:6,33 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (116:7,0 [39] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -40,25 +43,31 @@ Document -
                             CSharpExpression - (131:7,15 [20] EnumTagHelpers.cshtml)
                                 RazorIRToken - (131:7,15 [20] EnumTagHelpers.cshtml) - CSharp - MyEnum.MySecondValue
                     ExecuteTagHelpers - 
-                HtmlContent - (155:7,39 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (155:7,39 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (155:7,39 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (157:8,0 [25] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     SetTagHelperProperty - (171:8,14 [7] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (171:8,14 [7] EnumTagHelpers.cshtml) - MyValue
+                        HtmlContent - (171:8,14 [7] EnumTagHelpers.cshtml)
+                            RazorIRToken - (171:8,14 [7] EnumTagHelpers.cshtml) - Html - MyValue
                     ExecuteTagHelpers - 
-                HtmlContent - (182:8,25 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (182:8,25 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (182:8,25 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (184:9,0 [50] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     SetTagHelperProperty - (198:9,14 [13] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (198:9,14 [13] EnumTagHelpers.cshtml) - MySecondValue
+                        HtmlContent - (198:9,14 [13] EnumTagHelpers.cshtml)
+                            RazorIRToken - (198:9,14 [13] EnumTagHelpers.cshtml) - Html - MySecondValue
                     SetTagHelperProperty - (224:9,40 [7] EnumTagHelpers.cshtml) - catch-all - CatchAll - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (224:9,40 [7] EnumTagHelpers.cshtml) - MyValue
+                        HtmlContent - (224:9,40 [7] EnumTagHelpers.cshtml)
+                            RazorIRToken - (224:9,40 [7] EnumTagHelpers.cshtml) - Html - MyValue
                     ExecuteTagHelpers - 
-                HtmlContent - (234:9,50 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (234:9,50 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (234:9,50 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (236:10,0 [51] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -70,4 +79,5 @@ Document -
                         CSharpExpression - (274:10,38 [9] EnumTagHelpers.cshtml)
                             RazorIRToken - (274:10,38 [9] EnumTagHelpers.cshtml) - CSharp - enumValue
                     ExecuteTagHelpers - 
-                HtmlContent - (287:10,51 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (287:10,51 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (287:10,51 [2] EnumTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.ir.txt
@@ -6,10 +6,12 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EnumTagHelpers_Runtime -  - 
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.CatchAllTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (33:1,0 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (33:1,0 [2] EnumTagHelpers.cshtml) - Html - \n
                 CSharpStatement - (37:2,2 [39] EnumTagHelpers.cshtml)
                     RazorIRToken - (37:2,2 [39] EnumTagHelpers.cshtml) - CSharp - \n    var enumValue = MyEnum.MyValue;\n
-                HtmlContent - (79:5,0 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (79:5,0 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (79:5,0 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (81:6,0 [33] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -18,7 +20,8 @@ Document -
                         CSharpExpression - (96:6,15 [14] EnumTagHelpers.cshtml)
                             RazorIRToken - (96:6,15 [14] EnumTagHelpers.cshtml) - CSharp - MyEnum.MyValue
                     ExecuteTagHelpers - 
-                HtmlContent - (114:6,33 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (114:6,33 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (114:6,33 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (116:7,0 [39] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -28,25 +31,31 @@ Document -
                             CSharpExpression - (131:7,15 [20] EnumTagHelpers.cshtml)
                                 RazorIRToken - (131:7,15 [20] EnumTagHelpers.cshtml) - CSharp - MyEnum.MySecondValue
                     ExecuteTagHelpers - 
-                HtmlContent - (155:7,39 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (155:7,39 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (155:7,39 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (157:8,0 [25] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     SetTagHelperProperty - (171:8,14 [7] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (171:8,14 [7] EnumTagHelpers.cshtml) - MyValue
+                        HtmlContent - (171:8,14 [7] EnumTagHelpers.cshtml)
+                            RazorIRToken - (171:8,14 [7] EnumTagHelpers.cshtml) - Html - MyValue
                     ExecuteTagHelpers - 
-                HtmlContent - (182:8,25 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (182:8,25 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (182:8,25 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (184:9,0 [50] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     SetTagHelperProperty - (198:9,14 [13] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (198:9,14 [13] EnumTagHelpers.cshtml) - MySecondValue
+                        HtmlContent - (198:9,14 [13] EnumTagHelpers.cshtml)
+                            RazorIRToken - (198:9,14 [13] EnumTagHelpers.cshtml) - Html - MySecondValue
                     SetTagHelperProperty - (224:9,40 [7] EnumTagHelpers.cshtml) - catch-all - CatchAll - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (224:9,40 [7] EnumTagHelpers.cshtml) - MyValue
+                        HtmlContent - (224:9,40 [7] EnumTagHelpers.cshtml)
+                            RazorIRToken - (224:9,40 [7] EnumTagHelpers.cshtml) - Html - MyValue
                     ExecuteTagHelpers - 
-                HtmlContent - (234:9,50 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (234:9,50 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (234:9,50 [2] EnumTagHelpers.cshtml) - Html - \n
                 TagHelper - (236:10,0 [51] EnumTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -58,4 +67,5 @@ Document -
                         CSharpExpression - (274:10,38 [9] EnumTagHelpers.cshtml)
                             RazorIRToken - (274:10,38 [9] EnumTagHelpers.cshtml) - CSharp - enumValue
                     ExecuteTagHelpers - 
-                HtmlContent - (287:10,51 [2] EnumTagHelpers.cshtml) - \n
+                HtmlContent - (287:10,51 [2] EnumTagHelpers.cshtml)
+                    RazorIRToken - (287:10,51 [2] EnumTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.ir.txt
@@ -18,15 +18,38 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (29:0,29 [5] EscapedTagHelpers.cshtml) - \n\n<
-                HtmlContent - (35:2,2 [47] EscapedTagHelpers.cshtml) - div class="randomNonTagHelperAttribute">\n    <
-                HtmlContent - (83:3,6 [22] EscapedTagHelpers.cshtml) - p class="Hello World" 
+                HtmlContent - (29:0,29 [5] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (29:0,29 [4] EscapedTagHelpers.cshtml) - Html - \n\n
+                    RazorIRToken - (33:2,0 [1] EscapedTagHelpers.cshtml) - Html - <
+                HtmlContent - (35:2,2 [47] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (35:2,2 [3] EscapedTagHelpers.cshtml) - Html - div
+                    RazorIRToken - (38:2,5 [36] EscapedTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (74:2,41 [1] EscapedTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (75:2,42 [6] EscapedTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (81:3,4 [1] EscapedTagHelpers.cshtml) - Html - <
+                HtmlContent - (83:3,6 [22] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (83:3,6 [1] EscapedTagHelpers.cshtml) - Html - p
+                    RazorIRToken - (84:3,7 [20] EscapedTagHelpers.cshtml) - Html -  class="Hello World"
+                    RazorIRToken - (104:3,27 [1] EscapedTagHelpers.cshtml) - Html -  
                 CSharpExpression - (106:3,29 [12] EscapedTagHelpers.cshtml)
                     RazorIRToken - (106:3,29 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
-                HtmlContent - (118:3,41 [12] EscapedTagHelpers.cshtml) - >\n        <
-                HtmlContent - (131:4,10 [31] EscapedTagHelpers.cshtml) - input type="text" />\n        <
-                HtmlContent - (163:5,10 [22] EscapedTagHelpers.cshtml) - em>Not a TagHelper: </
-                HtmlContent - (186:5,33 [4] EscapedTagHelpers.cshtml) - em> 
+                HtmlContent - (118:3,41 [12] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (118:3,41 [1] EscapedTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (119:3,42 [10] EscapedTagHelpers.cshtml) - Html - \n        
+                    RazorIRToken - (129:4,8 [1] EscapedTagHelpers.cshtml) - Html - <
+                HtmlContent - (131:4,10 [31] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (131:4,10 [5] EscapedTagHelpers.cshtml) - Html - input
+                    RazorIRToken - (136:4,15 [12] EscapedTagHelpers.cshtml) - Html -  type="text"
+                    RazorIRToken - (148:4,27 [3] EscapedTagHelpers.cshtml) - Html -  />
+                    RazorIRToken - (151:4,30 [10] EscapedTagHelpers.cshtml) - Html - \n        
+                    RazorIRToken - (161:5,8 [1] EscapedTagHelpers.cshtml) - Html - <
+                HtmlContent - (163:5,10 [22] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (163:5,10 [3] EscapedTagHelpers.cshtml) - Html - em>
+                    RazorIRToken - (166:5,13 [17] EscapedTagHelpers.cshtml) - Html - Not a TagHelper: 
+                    RazorIRToken - (183:5,30 [2] EscapedTagHelpers.cshtml) - Html - </
+                HtmlContent - (186:5,33 [4] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (186:5,33 [3] EscapedTagHelpers.cshtml) - Html - em>
+                    RazorIRToken - (189:5,36 [1] EscapedTagHelpers.cshtml) - Html -  
                 TagHelper - (190:5,37 [45] EscapedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -38,8 +61,15 @@ Document -
                         CSharpExpression - (204:5,51 [12] EscapedTagHelpers.cshtml)
                             RazorIRToken - (204:5,51 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
                     SetTagHelperProperty - (227:5,74 [4] EscapedTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (227:5,74 [4] EscapedTagHelpers.cshtml) - true
+                        HtmlContent - (227:5,74 [4] EscapedTagHelpers.cshtml)
+                            RazorIRToken - (227:5,74 [4] EscapedTagHelpers.cshtml) - Html - true
                     ExecuteTagHelpers - 
-                HtmlContent - (235:5,82 [8] EscapedTagHelpers.cshtml) - \n    </
-                HtmlContent - (244:6,7 [6] EscapedTagHelpers.cshtml) - p>\n</
-                HtmlContent - (251:7,3 [4] EscapedTagHelpers.cshtml) - div>
+                HtmlContent - (235:5,82 [8] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (235:5,82 [6] EscapedTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (241:6,4 [2] EscapedTagHelpers.cshtml) - Html - </
+                HtmlContent - (244:6,7 [6] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (244:6,7 [2] EscapedTagHelpers.cshtml) - Html - p>
+                    RazorIRToken - (246:6,9 [2] EscapedTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (248:7,0 [2] EscapedTagHelpers.cshtml) - Html - </
+                HtmlContent - (251:7,3 [4] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (251:7,3 [4] EscapedTagHelpers.cshtml) - Html - div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.ir.txt
@@ -6,15 +6,38 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EscapedTagHelpers_Runtime -  - 
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:1,0 [3] EscapedTagHelpers.cshtml) - \n<
-                HtmlContent - (35:2,2 [47] EscapedTagHelpers.cshtml) - div class="randomNonTagHelperAttribute">\n    <
-                HtmlContent - (83:3,6 [22] EscapedTagHelpers.cshtml) - p class="Hello World" 
+                HtmlContent - (31:1,0 [3] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (31:1,0 [2] EscapedTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (33:2,0 [1] EscapedTagHelpers.cshtml) - Html - <
+                HtmlContent - (35:2,2 [47] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (35:2,2 [3] EscapedTagHelpers.cshtml) - Html - div
+                    RazorIRToken - (38:2,5 [36] EscapedTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (74:2,41 [1] EscapedTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (75:2,42 [6] EscapedTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (81:3,4 [1] EscapedTagHelpers.cshtml) - Html - <
+                HtmlContent - (83:3,6 [22] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (83:3,6 [1] EscapedTagHelpers.cshtml) - Html - p
+                    RazorIRToken - (84:3,7 [20] EscapedTagHelpers.cshtml) - Html -  class="Hello World"
+                    RazorIRToken - (104:3,27 [1] EscapedTagHelpers.cshtml) - Html -  
                 CSharpExpression - (106:3,29 [12] EscapedTagHelpers.cshtml)
                     RazorIRToken - (106:3,29 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
-                HtmlContent - (118:3,41 [12] EscapedTagHelpers.cshtml) - >\n        <
-                HtmlContent - (131:4,10 [31] EscapedTagHelpers.cshtml) - input type="text" />\n        <
-                HtmlContent - (163:5,10 [22] EscapedTagHelpers.cshtml) - em>Not a TagHelper: </
-                HtmlContent - (186:5,33 [4] EscapedTagHelpers.cshtml) - em> 
+                HtmlContent - (118:3,41 [12] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (118:3,41 [1] EscapedTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (119:3,42 [10] EscapedTagHelpers.cshtml) - Html - \n        
+                    RazorIRToken - (129:4,8 [1] EscapedTagHelpers.cshtml) - Html - <
+                HtmlContent - (131:4,10 [31] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (131:4,10 [5] EscapedTagHelpers.cshtml) - Html - input
+                    RazorIRToken - (136:4,15 [12] EscapedTagHelpers.cshtml) - Html -  type="text"
+                    RazorIRToken - (148:4,27 [3] EscapedTagHelpers.cshtml) - Html -  />
+                    RazorIRToken - (151:4,30 [10] EscapedTagHelpers.cshtml) - Html - \n        
+                    RazorIRToken - (161:5,8 [1] EscapedTagHelpers.cshtml) - Html - <
+                HtmlContent - (163:5,10 [22] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (163:5,10 [3] EscapedTagHelpers.cshtml) - Html - em>
+                    RazorIRToken - (166:5,13 [17] EscapedTagHelpers.cshtml) - Html - Not a TagHelper: 
+                    RazorIRToken - (183:5,30 [2] EscapedTagHelpers.cshtml) - Html - </
+                HtmlContent - (186:5,33 [4] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (186:5,33 [3] EscapedTagHelpers.cshtml) - Html - em>
+                    RazorIRToken - (189:5,36 [1] EscapedTagHelpers.cshtml) - Html -  
                 TagHelper - (190:5,37 [45] EscapedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -26,8 +49,15 @@ Document -
                         CSharpExpression - (204:5,51 [12] EscapedTagHelpers.cshtml)
                             RazorIRToken - (204:5,51 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
                     SetTagHelperProperty - (227:5,74 [4] EscapedTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (227:5,74 [4] EscapedTagHelpers.cshtml) - true
+                        HtmlContent - (227:5,74 [4] EscapedTagHelpers.cshtml)
+                            RazorIRToken - (227:5,74 [4] EscapedTagHelpers.cshtml) - Html - true
                     ExecuteTagHelpers - 
-                HtmlContent - (235:5,82 [8] EscapedTagHelpers.cshtml) - \n    </
-                HtmlContent - (244:6,7 [6] EscapedTagHelpers.cshtml) - p>\n</
-                HtmlContent - (251:7,3 [4] EscapedTagHelpers.cshtml) - div>
+                HtmlContent - (235:5,82 [8] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (235:5,82 [6] EscapedTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (241:6,4 [2] EscapedTagHelpers.cshtml) - Html - </
+                HtmlContent - (244:6,7 [6] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (244:6,7 [2] EscapedTagHelpers.cshtml) - Html - p>
+                    RazorIRToken - (246:6,9 [2] EscapedTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (248:7,0 [2] EscapedTagHelpers.cshtml) - Html - </
+                HtmlContent - (251:7,3 [4] EscapedTagHelpers.cshtml)
+                    RazorIRToken - (251:7,3 [4] EscapedTagHelpers.cshtml) - Html - div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.ir.txt
@@ -16,6 +16,7 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml)
+                    RazorIRToken - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml) - Html - This is markup\n\n
                 CSharpExpression - (20:2,2 [0] ExplicitExpressionAtEOF.cshtml)
                     RazorIRToken - (20:2,2 [0] ExplicitExpressionAtEOF.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.ir.txt
@@ -5,6 +5,7 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpressionAtEOF_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml)
+                    RazorIRToken - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml) - Html - This is markup\n\n
                 CSharpExpression - (20:2,2 [0] ExplicitExpressionAtEOF.cshtml)
                     RazorIRToken - (20:2,2 [0] ExplicitExpressionAtEOF.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.ir.txt
@@ -16,8 +16,10 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [5] ExplicitExpressionWithMarkup.cshtml) - <div>
+                HtmlContent - (0:0,0 [5] ExplicitExpressionWithMarkup.cshtml)
+                    RazorIRToken - (0:0,0 [5] ExplicitExpressionWithMarkup.cshtml) - Html - <div>
                 CSharpExpression - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml)
                     Template - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml)
-                        HtmlContent - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml) - </div>
+                        HtmlContent - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml)
+                            RazorIRToken - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml) - Html - </div>
                     RazorIRToken - (14:0,14 [0] ExplicitExpressionWithMarkup.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_Runtime.ir.txt
@@ -5,8 +5,10 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpressionWithMarkup_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [5] ExplicitExpressionWithMarkup.cshtml) - <div>
+                HtmlContent - (0:0,0 [5] ExplicitExpressionWithMarkup.cshtml)
+                    RazorIRToken - (0:0,0 [5] ExplicitExpressionWithMarkup.cshtml) - Html - <div>
                 CSharpExpression - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml)
                     Template - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml)
-                        HtmlContent - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml) - </div>
+                        HtmlContent - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml)
+                            RazorIRToken - (8:0,8 [6] ExplicitExpressionWithMarkup.cshtml) - Html - </div>
                     RazorIRToken - (14:0,14 [0] ExplicitExpressionWithMarkup.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.ir.txt
@@ -16,6 +16,7 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [8] ExplicitExpression.cshtml) - 1 + 1 = 
+                HtmlContent - (0:0,0 [8] ExplicitExpression.cshtml)
+                    RazorIRToken - (0:0,0 [8] ExplicitExpression.cshtml) - Html - 1 + 1 = 
                 CSharpExpression - (10:0,10 [3] ExplicitExpression.cshtml)
                     RazorIRToken - (10:0,10 [3] ExplicitExpression.cshtml) - CSharp - 1+1

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_Runtime.ir.txt
@@ -5,6 +5,7 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpression_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [8] ExplicitExpression.cshtml) - 1 + 1 = 
+                HtmlContent - (0:0,0 [8] ExplicitExpression.cshtml)
+                    RazorIRToken - (0:0,0 [8] ExplicitExpression.cshtml) - Html - 1 + 1 = 
                 CSharpExpression - (10:0,10 [3] ExplicitExpression.cshtml)
                     RazorIRToken - (10:0,10 [3] ExplicitExpression.cshtml) - CSharp - 1+1

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.ir.txt
@@ -18,21 +18,30 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [51] ExpressionsInCode.cshtml)
                     RazorIRToken - (2:0,2 [51] ExpressionsInCode.cshtml) - CSharp - \n    object foo = null;\n    string bar = "Foo";\n
-                HtmlContent - (56:4,0 [2] ExpressionsInCode.cshtml) - \n
+                HtmlContent - (56:4,0 [2] ExpressionsInCode.cshtml)
+                    RazorIRToken - (56:4,0 [2] ExpressionsInCode.cshtml) - Html - \n
                 CSharpStatement - (59:5,1 [23] ExpressionsInCode.cshtml)
                     RazorIRToken - (59:5,1 [23] ExpressionsInCode.cshtml) - CSharp - if(foo != null) {\n    
                 CSharpExpression - (83:6,5 [3] ExpressionsInCode.cshtml)
                     RazorIRToken - (83:6,5 [3] ExpressionsInCode.cshtml) - CSharp - foo
                 CSharpStatement - (86:6,8 [16] ExpressionsInCode.cshtml)
                     RazorIRToken - (86:6,8 [16] ExpressionsInCode.cshtml) - CSharp - \n} else {\n    
-                HtmlContent - (102:8,4 [19] ExpressionsInCode.cshtml) - <p>Foo is Null!</p>
+                HtmlContent - (102:8,4 [19] ExpressionsInCode.cshtml)
+                    RazorIRToken - (102:8,4 [3] ExpressionsInCode.cshtml) - Html - <p>
+                    RazorIRToken - (105:8,7 [12] ExpressionsInCode.cshtml) - Html - Foo is Null!
+                    RazorIRToken - (117:8,19 [4] ExpressionsInCode.cshtml) - Html - </p>
                 CSharpStatement - (121:8,23 [3] ExpressionsInCode.cshtml)
                     RazorIRToken - (121:8,23 [3] ExpressionsInCode.cshtml) - CSharp - \n}
-                HtmlContent - (124:9,1 [9] ExpressionsInCode.cshtml) - \n\n<p>\n
+                HtmlContent - (124:9,1 [9] ExpressionsInCode.cshtml)
+                    RazorIRToken - (124:9,1 [4] ExpressionsInCode.cshtml) - Html - \n\n
+                    RazorIRToken - (128:11,0 [3] ExpressionsInCode.cshtml) - Html - <p>
+                    RazorIRToken - (131:11,3 [2] ExpressionsInCode.cshtml) - Html - \n
                 CSharpStatement - (134:12,1 [38] ExpressionsInCode.cshtml)
                     RazorIRToken - (134:12,1 [38] ExpressionsInCode.cshtml) - CSharp - if(!String.IsNullOrEmpty(bar)) {\n    
                 CSharpExpression - (174:13,6 [21] ExpressionsInCode.cshtml)
                     RazorIRToken - (174:13,6 [21] ExpressionsInCode.cshtml) - CSharp - bar.Replace("F", "B")
                 CSharpStatement - (196:13,28 [3] ExpressionsInCode.cshtml)
                     RazorIRToken - (196:13,28 [3] ExpressionsInCode.cshtml) - CSharp - \n}
-                HtmlContent - (199:14,1 [6] ExpressionsInCode.cshtml) - \n</p>
+                HtmlContent - (199:14,1 [6] ExpressionsInCode.cshtml)
+                    RazorIRToken - (199:14,1 [2] ExpressionsInCode.cshtml) - Html - \n
+                    RazorIRToken - (201:15,0 [4] ExpressionsInCode.cshtml) - Html - </p>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_Runtime.ir.txt
@@ -7,21 +7,31 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [51] ExpressionsInCode.cshtml)
                     RazorIRToken - (2:0,2 [51] ExpressionsInCode.cshtml) - CSharp - \n    object foo = null;\n    string bar = "Foo";\n
-                HtmlContent - (56:4,0 [2] ExpressionsInCode.cshtml) - \n
+                HtmlContent - (56:4,0 [2] ExpressionsInCode.cshtml)
+                    RazorIRToken - (56:4,0 [2] ExpressionsInCode.cshtml) - Html - \n
                 CSharpStatement - (59:5,1 [23] ExpressionsInCode.cshtml)
                     RazorIRToken - (59:5,1 [23] ExpressionsInCode.cshtml) - CSharp - if(foo != null) {\n    
                 CSharpExpression - (83:6,5 [3] ExpressionsInCode.cshtml)
                     RazorIRToken - (83:6,5 [3] ExpressionsInCode.cshtml) - CSharp - foo
                 CSharpStatement - (86:6,8 [12] ExpressionsInCode.cshtml)
                     RazorIRToken - (86:6,8 [12] ExpressionsInCode.cshtml) - CSharp - \n} else {\n
-                HtmlContent - (98:8,0 [25] ExpressionsInCode.cshtml) -     <p>Foo is Null!</p>\n
+                HtmlContent - (98:8,0 [25] ExpressionsInCode.cshtml)
+                    RazorIRToken - (98:8,0 [4] ExpressionsInCode.cshtml) - Html -     
+                    RazorIRToken - (102:8,4 [3] ExpressionsInCode.cshtml) - Html - <p>
+                    RazorIRToken - (105:8,7 [12] ExpressionsInCode.cshtml) - Html - Foo is Null!
+                    RazorIRToken - (117:8,19 [4] ExpressionsInCode.cshtml) - Html - </p>
+                    RazorIRToken - (121:8,23 [2] ExpressionsInCode.cshtml) - Html - \n
                 CSharpStatement - (123:9,0 [3] ExpressionsInCode.cshtml)
                     RazorIRToken - (123:9,0 [3] ExpressionsInCode.cshtml) - CSharp - }\n
-                HtmlContent - (126:10,0 [7] ExpressionsInCode.cshtml) - \n<p>\n
+                HtmlContent - (126:10,0 [7] ExpressionsInCode.cshtml)
+                    RazorIRToken - (126:10,0 [2] ExpressionsInCode.cshtml) - Html - \n
+                    RazorIRToken - (128:11,0 [3] ExpressionsInCode.cshtml) - Html - <p>
+                    RazorIRToken - (131:11,3 [2] ExpressionsInCode.cshtml) - Html - \n
                 CSharpStatement - (134:12,1 [38] ExpressionsInCode.cshtml)
                     RazorIRToken - (134:12,1 [38] ExpressionsInCode.cshtml) - CSharp - if(!String.IsNullOrEmpty(bar)) {\n    
                 CSharpExpression - (174:13,6 [21] ExpressionsInCode.cshtml)
                     RazorIRToken - (174:13,6 [21] ExpressionsInCode.cshtml) - CSharp - bar.Replace("F", "B")
                 CSharpStatement - (196:13,28 [5] ExpressionsInCode.cshtml)
                     RazorIRToken - (196:13,28 [5] ExpressionsInCode.cshtml) - CSharp - \n}\n
-                HtmlContent - (201:15,0 [4] ExpressionsInCode.cshtml) - </p>
+                HtmlContent - (201:15,0 [4] ExpressionsInCode.cshtml)
+                    RazorIRToken - (201:15,0 [4] ExpressionsInCode.cshtml) - Html - </p>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.ir.txt
@@ -16,6 +16,7 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [5] FunctionsBlockMinimal.cshtml) - \n\n	
+                HtmlContent - (0:0,0 [5] FunctionsBlockMinimal.cshtml)
+                    RazorIRToken - (0:0,0 [5] FunctionsBlockMinimal.cshtml) - Html - \n\n	
             CSharpStatement - (16:2,12 [55] FunctionsBlockMinimal.cshtml)
                 RazorIRToken - (16:2,12 [55] FunctionsBlockMinimal.cshtml) - CSharp - \nstring foo(string input) {\n	return input + "!";\n}\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.ir.txt
@@ -5,7 +5,8 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_FunctionsBlockMinimal_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [4] FunctionsBlockMinimal.cshtml) - \n\n
+                HtmlContent - (0:0,0 [4] FunctionsBlockMinimal.cshtml)
+                    RazorIRToken - (0:0,0 [4] FunctionsBlockMinimal.cshtml) - Html - \n\n
             CSharpStatement - (4:2,0 [1] FunctionsBlockMinimal.cshtml)
                 RazorIRToken - (4:2,0 [1] FunctionsBlockMinimal.cshtml) - CSharp - 	
             CSharpStatement - (16:2,12 [55] FunctionsBlockMinimal.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.ir.txt
@@ -16,8 +16,10 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (17:2,1 [4] FunctionsBlock.cshtml) - \n\n
-                HtmlContent - (138:9,1 [28] FunctionsBlock.cshtml) - \n\nHere's a random number: 
+                HtmlContent - (17:2,1 [4] FunctionsBlock.cshtml)
+                    RazorIRToken - (17:2,1 [4] FunctionsBlock.cshtml) - Html - \n\n
+                HtmlContent - (138:9,1 [28] FunctionsBlock.cshtml)
+                    RazorIRToken - (138:9,1 [28] FunctionsBlock.cshtml) - Html - \n\nHere's a random number: 
                 CSharpExpression - (167:11,25 [11] FunctionsBlock.cshtml)
                     RazorIRToken - (167:11,25 [11] FunctionsBlock.cshtml) - CSharp - RandomInt()
             CSharpStatement - (12:0,12 [4] FunctionsBlock.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_Runtime.ir.txt
@@ -5,8 +5,10 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_FunctionsBlock_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (19:3,0 [2] FunctionsBlock.cshtml) - \n
-                HtmlContent - (140:10,0 [26] FunctionsBlock.cshtml) - \nHere's a random number: 
+                HtmlContent - (19:3,0 [2] FunctionsBlock.cshtml)
+                    RazorIRToken - (19:3,0 [2] FunctionsBlock.cshtml) - Html - \n
+                HtmlContent - (140:10,0 [26] FunctionsBlock.cshtml)
+                    RazorIRToken - (140:10,0 [26] FunctionsBlock.cshtml) - Html - \nHere's a random number: 
                 CSharpExpression - (167:11,25 [11] FunctionsBlock.cshtml)
                     RazorIRToken - (167:11,25 [11] FunctionsBlock.cshtml) - CSharp - RandomInt()
             CSharpStatement - (12:0,12 [4] FunctionsBlock.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_DesignTime.ir.txt
@@ -16,4 +16,8 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Double.cshtml) - <!-- " -->\n<img src="~/images/submit.png" />
+                HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Double.cshtml)
+                    RazorIRToken - (0:0,0 [12] HtmlCommentWithQuote_Double.cshtml) - Html - <!-- " -->\n
+                    RazorIRToken - (12:1,0 [4] HtmlCommentWithQuote_Double.cshtml) - Html - <img
+                    RazorIRToken - (16:1,4 [26] HtmlCommentWithQuote_Double.cshtml) - Html -  src="~/images/submit.png"
+                    RazorIRToken - (42:1,30 [3] HtmlCommentWithQuote_Double.cshtml) - Html -  />

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_Runtime.ir.txt
@@ -5,4 +5,8 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HtmlCommentWithQuote_Double_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Double.cshtml) - <!-- " -->\n<img src="~/images/submit.png" />
+                HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Double.cshtml)
+                    RazorIRToken - (0:0,0 [12] HtmlCommentWithQuote_Double.cshtml) - Html - <!-- " -->\n
+                    RazorIRToken - (12:1,0 [4] HtmlCommentWithQuote_Double.cshtml) - Html - <img
+                    RazorIRToken - (16:1,4 [26] HtmlCommentWithQuote_Double.cshtml) - Html -  src="~/images/submit.png"
+                    RazorIRToken - (42:1,30 [3] HtmlCommentWithQuote_Double.cshtml) - Html -  />

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_DesignTime.ir.txt
@@ -16,4 +16,8 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Single.cshtml) - <!-- ' -->\n<img src="~/images/submit.png" />
+                HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Single.cshtml)
+                    RazorIRToken - (0:0,0 [12] HtmlCommentWithQuote_Single.cshtml) - Html - <!-- ' -->\n
+                    RazorIRToken - (12:1,0 [4] HtmlCommentWithQuote_Single.cshtml) - Html - <img
+                    RazorIRToken - (16:1,4 [26] HtmlCommentWithQuote_Single.cshtml) - Html -  src="~/images/submit.png"
+                    RazorIRToken - (42:1,30 [3] HtmlCommentWithQuote_Single.cshtml) - Html -  />

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_Runtime.ir.txt
@@ -5,4 +5,8 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HtmlCommentWithQuote_Single_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Single.cshtml) - <!-- ' -->\n<img src="~/images/submit.png" />
+                HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Single.cshtml)
+                    RazorIRToken - (0:0,0 [12] HtmlCommentWithQuote_Single.cshtml) - Html - <!-- ' -->\n
+                    RazorIRToken - (12:1,0 [4] HtmlCommentWithQuote_Single.cshtml) - Html - <img
+                    RazorIRToken - (16:1,4 [26] HtmlCommentWithQuote_Single.cshtml) - Html -  src="~/images/submit.png"
+                    RazorIRToken - (42:1,30 [3] HtmlCommentWithQuote_Single.cshtml) - Html -  />

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.ir.txt
@@ -16,6 +16,7 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml)
+                    RazorIRToken - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml) - Html - This is markup\n\n
                 CSharpExpression - (19:2,1 [0] ImplicitExpressionAtEOF.cshtml)
                     RazorIRToken - (19:2,1 [0] ImplicitExpressionAtEOF.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.ir.txt
@@ -5,6 +5,7 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ImplicitExpressionAtEOF_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml) - This is markup\n\n
+                HtmlContent - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml)
+                    RazorIRToken - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml) - Html - This is markup\n\n
                 CSharpExpression - (19:2,1 [0] ImplicitExpressionAtEOF.cshtml)
                     RazorIRToken - (19:2,1 [0] ImplicitExpressionAtEOF.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.ir.txt
@@ -18,9 +18,12 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (1:0,1 [36] ImplicitExpression.cshtml)
                     RazorIRToken - (1:0,1 [36] ImplicitExpression.cshtml) - CSharp - for(int i = 1; i <= 10; i++) {\n    
-                HtmlContent - (37:1,4 [17] ImplicitExpression.cshtml) - <p>This is item #
+                HtmlContent - (37:1,4 [17] ImplicitExpression.cshtml)
+                    RazorIRToken - (37:1,4 [3] ImplicitExpression.cshtml) - Html - <p>
+                    RazorIRToken - (40:1,7 [14] ImplicitExpression.cshtml) - Html - This is item #
                 CSharpExpression - (55:1,22 [1] ImplicitExpression.cshtml)
                     RazorIRToken - (55:1,22 [1] ImplicitExpression.cshtml) - CSharp - i
-                HtmlContent - (56:1,23 [4] ImplicitExpression.cshtml) - </p>
+                HtmlContent - (56:1,23 [4] ImplicitExpression.cshtml)
+                    RazorIRToken - (56:1,23 [4] ImplicitExpression.cshtml) - Html - </p>
                 CSharpStatement - (60:1,27 [3] ImplicitExpression.cshtml)
                     RazorIRToken - (60:1,27 [3] ImplicitExpression.cshtml) - CSharp - \n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_Runtime.ir.txt
@@ -7,9 +7,14 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (1:0,1 [32] ImplicitExpression.cshtml)
                     RazorIRToken - (1:0,1 [32] ImplicitExpression.cshtml) - CSharp - for(int i = 1; i <= 10; i++) {\n
-                HtmlContent - (33:1,0 [21] ImplicitExpression.cshtml) -     <p>This is item #
+                HtmlContent - (33:1,0 [21] ImplicitExpression.cshtml)
+                    RazorIRToken - (33:1,0 [4] ImplicitExpression.cshtml) - Html -     
+                    RazorIRToken - (37:1,4 [3] ImplicitExpression.cshtml) - Html - <p>
+                    RazorIRToken - (40:1,7 [14] ImplicitExpression.cshtml) - Html - This is item #
                 CSharpExpression - (55:1,22 [1] ImplicitExpression.cshtml)
                     RazorIRToken - (55:1,22 [1] ImplicitExpression.cshtml) - CSharp - i
-                HtmlContent - (56:1,23 [6] ImplicitExpression.cshtml) - </p>\n
+                HtmlContent - (56:1,23 [6] ImplicitExpression.cshtml)
+                    RazorIRToken - (56:1,23 [4] ImplicitExpression.cshtml) - Html - </p>
+                    RazorIRToken - (60:1,27 [2] ImplicitExpression.cshtml) - Html - \n
                 CSharpStatement - (62:2,0 [1] ImplicitExpression.cshtml)
                     RazorIRToken - (62:2,0 [1] ImplicitExpression.cshtml) - CSharp - }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.ir.txt
@@ -18,10 +18,12 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] IncompleteTagHelper.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] IncompleteTagHelper.cshtml)
+                    RazorIRToken - (31:0,31 [4] IncompleteTagHelper.cshtml) - Html - \n\n
                 TagHelper - (35:2,0 [10] IncompleteTagHelper.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (45:2,10 [0] IncompleteTagHelper.cshtml) - 
+                        HtmlContent - (45:2,10 [0] IncompleteTagHelper.cshtml)
+                            RazorIRToken - (45:2,10 [0] IncompleteTagHelper.cshtml) - Html - 
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.ir.txt
@@ -7,7 +7,8 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - class -  - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] IncompleteTagHelper.cshtml) - \n
+                HtmlContent - (33:1,0 [2] IncompleteTagHelper.cshtml)
+                    RazorIRToken - (33:1,0 [2] IncompleteTagHelper.cshtml) - Html - \n
                 TagHelper - (35:2,0 [10] IncompleteTagHelper.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.ir.txt
@@ -19,5 +19,7 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpExpression - (1:0,1 [5] Inherits.cshtml)
                     RazorIRToken - (1:0,1 [5] Inherits.cshtml) - CSharp - foo()
-                HtmlContent - (6:0,6 [4] Inherits.cshtml) - \n\n
-                HtmlContent - (42:2,32 [5] Inherits.cshtml) - bar\n
+                HtmlContent - (6:0,6 [4] Inherits.cshtml)
+                    RazorIRToken - (6:0,6 [4] Inherits.cshtml) - Html - \n\n
+                HtmlContent - (42:2,32 [5] Inherits.cshtml)
+                    RazorIRToken - (42:2,32 [5] Inherits.cshtml) - Html - bar\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.ir.txt
@@ -7,5 +7,7 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpExpression - (1:0,1 [5] Inherits.cshtml)
                     RazorIRToken - (1:0,1 [5] Inherits.cshtml) - CSharp - foo()
-                HtmlContent - (6:0,6 [4] Inherits.cshtml) - \n\n
-                HtmlContent - (42:2,32 [5] Inherits.cshtml) - bar\n
+                HtmlContent - (6:0,6 [4] Inherits.cshtml)
+                    RazorIRToken - (6:0,6 [4] Inherits.cshtml) - Html - \n\n
+                HtmlContent - (42:2,32 [5] Inherits.cshtml)
+                    RazorIRToken - (42:2,32 [5] Inherits.cshtml) - Html - bar\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.ir.txt
@@ -21,7 +21,9 @@ Document -
                     RazorIRToken -  - CSharp - DefineSection("Link", async (__razor_section_writer) => {
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (13:0,13 [23] InlineBlocks.cshtml) - (string link) {\n    <a
+                HtmlContent - (13:0,13 [23] InlineBlocks.cshtml)
+                    RazorIRToken - (13:0,13 [21] InlineBlocks.cshtml) - Html - (string link) {\n    
+                    RazorIRToken - (34:1,4 [2] InlineBlocks.cshtml) - Html - <a
                 HtmlAttribute - (36:1,6 [59] InlineBlocks.cshtml) -  href=" - "
                     CSharpAttributeValue - (43:1,13 [51] InlineBlocks.cshtml) - 
                         CSharpStatement - (44:1,14 [19] InlineBlocks.cshtml)
@@ -30,7 +32,10 @@ Document -
                             RazorIRToken - (64:1,34 [4] InlineBlocks.cshtml) - CSharp - link
                         CSharpStatement - (68:1,38 [10] InlineBlocks.cshtml)
                             RazorIRToken - (68:1,38 [10] InlineBlocks.cshtml) - CSharp -  } else { 
-                        HtmlContent - (84:1,54 [1] InlineBlocks.cshtml) - #
+                        HtmlContent - (84:1,54 [1] InlineBlocks.cshtml)
+                            RazorIRToken - (84:1,54 [1] InlineBlocks.cshtml) - Html - #
                         CSharpStatement - (92:1,62 [2] InlineBlocks.cshtml)
                             RazorIRToken - (92:1,62 [2] InlineBlocks.cshtml) - CSharp -  }
-                HtmlContent - (95:1,65 [6] InlineBlocks.cshtml) -  />\n}
+                HtmlContent - (95:1,65 [6] InlineBlocks.cshtml)
+                    RazorIRToken - (95:1,65 [3] InlineBlocks.cshtml) - Html -  />
+                    RazorIRToken - (98:1,68 [3] InlineBlocks.cshtml) - Html - \n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.ir.txt
@@ -9,7 +9,9 @@ Document -
                     RazorIRToken -  - CSharp - DefineSection("Link", async () => {
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (13:0,13 [23] InlineBlocks.cshtml) - (string link) {\n    <a
+                HtmlContent - (13:0,13 [23] InlineBlocks.cshtml)
+                    RazorIRToken - (13:0,13 [21] InlineBlocks.cshtml) - Html - (string link) {\n    
+                    RazorIRToken - (34:1,4 [2] InlineBlocks.cshtml) - Html - <a
                 HtmlAttribute - (36:1,6 [58] InlineBlocks.cshtml) -  href=" - "
                     CSharpAttributeValue - (43:1,13 [50] InlineBlocks.cshtml) - 
                         CSharpStatement - (44:1,14 [19] InlineBlocks.cshtml)
@@ -18,7 +20,10 @@ Document -
                             RazorIRToken - (64:1,34 [4] InlineBlocks.cshtml) - CSharp - link
                         CSharpStatement - (68:1,38 [9] InlineBlocks.cshtml)
                             RazorIRToken - (68:1,38 [9] InlineBlocks.cshtml) - CSharp -  } else {
-                        HtmlContent - (84:1,54 [1] InlineBlocks.cshtml) - #
+                        HtmlContent - (84:1,54 [1] InlineBlocks.cshtml)
+                            RazorIRToken - (84:1,54 [1] InlineBlocks.cshtml) - Html - #
                         CSharpStatement - (92:1,62 [2] InlineBlocks.cshtml)
                             RazorIRToken - (92:1,62 [2] InlineBlocks.cshtml) - CSharp -  }
-                HtmlContent - (95:1,65 [6] InlineBlocks.cshtml) -  />\n}
+                HtmlContent - (95:1,65 [6] InlineBlocks.cshtml)
+                    RazorIRToken - (95:1,65 [3] InlineBlocks.cshtml) - Html -  />
+                    RazorIRToken - (98:1,68 [3] InlineBlocks.cshtml) - Html - \n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.ir.txt
@@ -19,63 +19,100 @@ Document -
                 CSharpStatement - (2:0,2 [32] Instrumented.cshtml)
                     RazorIRToken - (2:0,2 [32] Instrumented.cshtml) - CSharp - \n    int i = 1;\n    var foo = 
                 Template - (35:2,15 [10] Instrumented.cshtml)
-                    HtmlContent - (35:2,15 [10] Instrumented.cshtml) - <p>Bar</p>
+                    HtmlContent - (35:2,15 [10] Instrumented.cshtml)
+                        RazorIRToken - (35:2,15 [3] Instrumented.cshtml) - Html - <p>
+                        RazorIRToken - (38:2,18 [3] Instrumented.cshtml) - Html - Bar
+                        RazorIRToken - (41:2,21 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (45:2,25 [7] Instrumented.cshtml)
                     RazorIRToken - (45:2,25 [7] Instrumented.cshtml) - CSharp - ;\n    
-                HtmlContent - (54:3,6 [14] Instrumented.cshtml) - Hello, World\n
+                HtmlContent - (54:3,6 [14] Instrumented.cshtml)
+                    RazorIRToken - (54:3,6 [14] Instrumented.cshtml) - Html - Hello, World\n
                 CSharpStatement - (68:4,0 [4] Instrumented.cshtml)
                     RazorIRToken - (68:4,0 [4] Instrumented.cshtml) - CSharp -     
-                HtmlContent - (72:4,4 [19] Instrumented.cshtml) - <p>Hello, World</p>
+                HtmlContent - (72:4,4 [19] Instrumented.cshtml)
+                    RazorIRToken - (72:4,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (75:4,7 [12] Instrumented.cshtml) - Html - Hello, World
+                    RazorIRToken - (87:4,19 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (91:4,23 [2] Instrumented.cshtml)
                     RazorIRToken - (91:4,23 [2] Instrumented.cshtml) - CSharp - \n
-                HtmlContent - (96:6,0 [2] Instrumented.cshtml) - \n
+                HtmlContent - (96:6,0 [2] Instrumented.cshtml)
+                    RazorIRToken - (96:6,0 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (99:7,1 [22] Instrumented.cshtml)
                     RazorIRToken - (99:7,1 [22] Instrumented.cshtml) - CSharp - while(i <= 10) {\n    
-                HtmlContent - (121:8,4 [19] Instrumented.cshtml) - <p>Hello from C#, #
+                HtmlContent - (121:8,4 [19] Instrumented.cshtml)
+                    RazorIRToken - (121:8,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (124:8,7 [16] Instrumented.cshtml) - Html - Hello from C#, #
                 CSharpExpression - (142:8,25 [1] Instrumented.cshtml)
                     RazorIRToken - (142:8,25 [1] Instrumented.cshtml) - CSharp - i
-                HtmlContent - (144:8,27 [4] Instrumented.cshtml) - </p>
+                HtmlContent - (144:8,27 [4] Instrumented.cshtml)
+                    RazorIRToken - (144:8,27 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (148:8,31 [16] Instrumented.cshtml)
                     RazorIRToken - (148:8,31 [16] Instrumented.cshtml) - CSharp - \n    i += 1;\n}
-                HtmlContent - (164:10,1 [4] Instrumented.cshtml) - \n\n
+                HtmlContent - (164:10,1 [4] Instrumented.cshtml)
+                    RazorIRToken - (164:10,1 [4] Instrumented.cshtml) - Html - \n\n
                 CSharpStatement - (169:12,1 [19] Instrumented.cshtml)
                     RazorIRToken - (169:12,1 [19] Instrumented.cshtml) - CSharp - if(i == 11) {\n    
-                HtmlContent - (188:13,4 [25] Instrumented.cshtml) - <p>We wrote 10 lines!</p>
+                HtmlContent - (188:13,4 [25] Instrumented.cshtml)
+                    RazorIRToken - (188:13,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (191:13,7 [18] Instrumented.cshtml) - Html - We wrote 10 lines!
+                    RazorIRToken - (209:13,25 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (213:13,29 [3] Instrumented.cshtml)
                     RazorIRToken - (213:13,29 [3] Instrumented.cshtml) - CSharp - \n}
-                HtmlContent - (216:14,1 [4] Instrumented.cshtml) - \n\n
+                HtmlContent - (216:14,1 [4] Instrumented.cshtml)
+                    RazorIRToken - (216:14,1 [4] Instrumented.cshtml) - Html - \n\n
                 CSharpStatement - (221:16,1 [35] Instrumented.cshtml)
                     RazorIRToken - (221:16,1 [35] Instrumented.cshtml) - CSharp - switch(i) {\n    case 11:\n        
-                HtmlContent - (256:18,8 [36] Instrumented.cshtml) - <p>No really, we wrote 10 lines!</p>
+                HtmlContent - (256:18,8 [36] Instrumented.cshtml)
+                    RazorIRToken - (256:18,8 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (259:18,11 [29] Instrumented.cshtml) - Html - No really, we wrote 10 lines!
+                    RazorIRToken - (288:18,40 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (292:18,44 [40] Instrumented.cshtml)
                     RazorIRToken - (292:18,44 [40] Instrumented.cshtml) - CSharp - \n        break;\n    default:\n        
-                HtmlContent - (332:21,8 [29] Instrumented.cshtml) - <p>Actually, we didn't...</p>
+                HtmlContent - (332:21,8 [29] Instrumented.cshtml)
+                    RazorIRToken - (332:21,8 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (335:21,11 [22] Instrumented.cshtml) - Html - Actually, we didn't...
+                    RazorIRToken - (357:21,33 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (361:21,37 [19] Instrumented.cshtml)
                     RazorIRToken - (361:21,37 [19] Instrumented.cshtml) - CSharp - \n        break;\n}
-                HtmlContent - (380:23,1 [4] Instrumented.cshtml) - \n\n
+                HtmlContent - (380:23,1 [4] Instrumented.cshtml)
+                    RazorIRToken - (380:23,1 [4] Instrumented.cshtml) - Html - \n\n
                 CSharpStatement - (385:25,1 [39] Instrumented.cshtml)
                     RazorIRToken - (385:25,1 [39] Instrumented.cshtml) - CSharp - for(int j = 1; j <= 10; j += 2) {\n    
-                HtmlContent - (424:26,4 [25] Instrumented.cshtml) - <p>Hello again from C#, #
+                HtmlContent - (424:26,4 [25] Instrumented.cshtml)
+                    RazorIRToken - (424:26,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (427:26,7 [22] Instrumented.cshtml) - Html - Hello again from C#, #
                 CSharpExpression - (451:26,31 [1] Instrumented.cshtml)
                     RazorIRToken - (451:26,31 [1] Instrumented.cshtml) - CSharp - j
-                HtmlContent - (453:26,33 [4] Instrumented.cshtml) - </p>
+                HtmlContent - (453:26,33 [4] Instrumented.cshtml)
+                    RazorIRToken - (453:26,33 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (457:26,37 [3] Instrumented.cshtml)
                     RazorIRToken - (457:26,37 [3] Instrumented.cshtml) - CSharp - \n}
-                HtmlContent - (460:27,1 [4] Instrumented.cshtml) - \n\n
+                HtmlContent - (460:27,1 [4] Instrumented.cshtml)
+                    RazorIRToken - (460:27,1 [4] Instrumented.cshtml) - Html - \n\n
                 CSharpStatement - (465:29,1 [11] Instrumented.cshtml)
                     RazorIRToken - (465:29,1 [11] Instrumented.cshtml) - CSharp - try {\n    
-                HtmlContent - (476:30,4 [35] Instrumented.cshtml) - <p>That time, we wrote 5 lines!</p>
+                HtmlContent - (476:30,4 [35] Instrumented.cshtml)
+                    RazorIRToken - (476:30,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (479:30,7 [28] Instrumented.cshtml) - Html - That time, we wrote 5 lines!
+                    RazorIRToken - (507:30,35 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (511:30,39 [31] Instrumented.cshtml)
                     RazorIRToken - (511:30,39 [31] Instrumented.cshtml) - CSharp - \n} catch(Exception ex) {\n    
-                HtmlContent - (542:32,4 [29] Instrumented.cshtml) - <p>Oh no! An error occurred: 
+                HtmlContent - (542:32,4 [29] Instrumented.cshtml)
+                    RazorIRToken - (542:32,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (545:32,7 [26] Instrumented.cshtml) - Html - Oh no! An error occurred: 
                 CSharpExpression - (573:32,35 [10] Instrumented.cshtml)
                     RazorIRToken - (573:32,35 [10] Instrumented.cshtml) - CSharp - ex.Message
-                HtmlContent - (584:32,46 [4] Instrumented.cshtml) - </p>
+                HtmlContent - (584:32,46 [4] Instrumented.cshtml)
+                    RazorIRToken - (584:32,46 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (588:32,50 [3] Instrumented.cshtml)
                     RazorIRToken - (588:32,50 [3] Instrumented.cshtml) - CSharp - \n}
-                HtmlContent - (591:33,1 [4] Instrumented.cshtml) - \n\n
+                HtmlContent - (591:33,1 [4] Instrumented.cshtml)
+                    RazorIRToken - (591:33,1 [4] Instrumented.cshtml) - Html - \n\n
                 CSharpStatement - (596:35,1 [26] Instrumented.cshtml)
                     RazorIRToken - (596:35,1 [26] Instrumented.cshtml) - CSharp - lock(new object()) {\n    
-                HtmlContent - (622:36,4 [47] Instrumented.cshtml) - <p>This block is locked, for your security!</p>
+                HtmlContent - (622:36,4 [47] Instrumented.cshtml)
+                    RazorIRToken - (622:36,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (625:36,7 [40] Instrumented.cshtml) - Html - This block is locked, for your security!
+                    RazorIRToken - (665:36,47 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (669:36,51 [3] Instrumented.cshtml)
                     RazorIRToken - (669:36,51 [3] Instrumented.cshtml) - CSharp - \n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.ir.txt
@@ -8,61 +8,117 @@ Document -
                 CSharpStatement - (2:0,2 [32] Instrumented.cshtml)
                     RazorIRToken - (2:0,2 [32] Instrumented.cshtml) - CSharp - \n    int i = 1;\n    var foo = 
                 Template - (35:2,15 [10] Instrumented.cshtml)
-                    HtmlContent - (35:2,15 [10] Instrumented.cshtml) - <p>Bar</p>
+                    HtmlContent - (35:2,15 [10] Instrumented.cshtml)
+                        RazorIRToken - (35:2,15 [3] Instrumented.cshtml) - Html - <p>
+                        RazorIRToken - (38:2,18 [3] Instrumented.cshtml) - Html - Bar
+                        RazorIRToken - (41:2,21 [4] Instrumented.cshtml) - Html - </p>
                 CSharpStatement - (45:2,25 [3] Instrumented.cshtml)
                     RazorIRToken - (45:2,25 [3] Instrumented.cshtml) - CSharp - ;\n
-                HtmlContent - (48:3,0 [4] Instrumented.cshtml) -     
-                HtmlContent - (54:3,6 [39] Instrumented.cshtml) - Hello, World\n    <p>Hello, World</p>\n
+                HtmlContent - (48:3,0 [4] Instrumented.cshtml)
+                    RazorIRToken - (48:3,0 [4] Instrumented.cshtml) - Html -     
+                HtmlContent - (54:3,6 [39] Instrumented.cshtml)
+                    RazorIRToken - (54:3,6 [14] Instrumented.cshtml) - Html - Hello, World\n
+                    RazorIRToken - (68:4,0 [4] Instrumented.cshtml) - Html -     
+                    RazorIRToken - (72:4,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (75:4,7 [12] Instrumented.cshtml) - Html - Hello, World
+                    RazorIRToken - (87:4,19 [4] Instrumented.cshtml) - Html - </p>
+                    RazorIRToken - (91:4,23 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (93:5,0 [0] Instrumented.cshtml)
                     RazorIRToken - (93:5,0 [0] Instrumented.cshtml) - CSharp - 
-                HtmlContent - (96:6,0 [2] Instrumented.cshtml) - \n
+                HtmlContent - (96:6,0 [2] Instrumented.cshtml)
+                    RazorIRToken - (96:6,0 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (99:7,1 [18] Instrumented.cshtml)
                     RazorIRToken - (99:7,1 [18] Instrumented.cshtml) - CSharp - while(i <= 10) {\n
-                HtmlContent - (117:8,0 [23] Instrumented.cshtml) -     <p>Hello from C#, #
+                HtmlContent - (117:8,0 [23] Instrumented.cshtml)
+                    RazorIRToken - (117:8,0 [4] Instrumented.cshtml) - Html -     
+                    RazorIRToken - (121:8,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (124:8,7 [16] Instrumented.cshtml) - Html - Hello from C#, #
                 CSharpExpression - (142:8,25 [1] Instrumented.cshtml)
                     RazorIRToken - (142:8,25 [1] Instrumented.cshtml) - CSharp - i
-                HtmlContent - (144:8,27 [6] Instrumented.cshtml) - </p>\n
+                HtmlContent - (144:8,27 [6] Instrumented.cshtml)
+                    RazorIRToken - (144:8,27 [4] Instrumented.cshtml) - Html - </p>
+                    RazorIRToken - (148:8,31 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (150:9,0 [16] Instrumented.cshtml)
                     RazorIRToken - (150:9,0 [16] Instrumented.cshtml) - CSharp -     i += 1;\n}\n
-                HtmlContent - (166:11,0 [2] Instrumented.cshtml) - \n
+                HtmlContent - (166:11,0 [2] Instrumented.cshtml)
+                    RazorIRToken - (166:11,0 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (169:12,1 [15] Instrumented.cshtml)
                     RazorIRToken - (169:12,1 [15] Instrumented.cshtml) - CSharp - if(i == 11) {\n
-                HtmlContent - (184:13,0 [31] Instrumented.cshtml) -     <p>We wrote 10 lines!</p>\n
+                HtmlContent - (184:13,0 [31] Instrumented.cshtml)
+                    RazorIRToken - (184:13,0 [4] Instrumented.cshtml) - Html -     
+                    RazorIRToken - (188:13,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (191:13,7 [18] Instrumented.cshtml) - Html - We wrote 10 lines!
+                    RazorIRToken - (209:13,25 [4] Instrumented.cshtml) - Html - </p>
+                    RazorIRToken - (213:13,29 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (215:14,0 [3] Instrumented.cshtml)
                     RazorIRToken - (215:14,0 [3] Instrumented.cshtml) - CSharp - }\n
-                HtmlContent - (218:15,0 [2] Instrumented.cshtml) - \n
+                HtmlContent - (218:15,0 [2] Instrumented.cshtml)
+                    RazorIRToken - (218:15,0 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (221:16,1 [27] Instrumented.cshtml)
                     RazorIRToken - (221:16,1 [27] Instrumented.cshtml) - CSharp - switch(i) {\n    case 11:\n
-                HtmlContent - (248:18,0 [46] Instrumented.cshtml) -         <p>No really, we wrote 10 lines!</p>\n
+                HtmlContent - (248:18,0 [46] Instrumented.cshtml)
+                    RazorIRToken - (248:18,0 [8] Instrumented.cshtml) - Html -         
+                    RazorIRToken - (256:18,8 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (259:18,11 [29] Instrumented.cshtml) - Html - No really, we wrote 10 lines!
+                    RazorIRToken - (288:18,40 [4] Instrumented.cshtml) - Html - </p>
+                    RazorIRToken - (292:18,44 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (294:19,0 [30] Instrumented.cshtml)
                     RazorIRToken - (294:19,0 [30] Instrumented.cshtml) - CSharp -         break;\n    default:\n
-                HtmlContent - (324:21,0 [39] Instrumented.cshtml) -         <p>Actually, we didn't...</p>\n
+                HtmlContent - (324:21,0 [39] Instrumented.cshtml)
+                    RazorIRToken - (324:21,0 [8] Instrumented.cshtml) - Html -         
+                    RazorIRToken - (332:21,8 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (335:21,11 [22] Instrumented.cshtml) - Html - Actually, we didn't...
+                    RazorIRToken - (357:21,33 [4] Instrumented.cshtml) - Html - </p>
+                    RazorIRToken - (361:21,37 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (363:22,0 [19] Instrumented.cshtml)
                     RazorIRToken - (363:22,0 [19] Instrumented.cshtml) - CSharp -         break;\n}\n
-                HtmlContent - (382:24,0 [2] Instrumented.cshtml) - \n
+                HtmlContent - (382:24,0 [2] Instrumented.cshtml)
+                    RazorIRToken - (382:24,0 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (385:25,1 [35] Instrumented.cshtml)
                     RazorIRToken - (385:25,1 [35] Instrumented.cshtml) - CSharp - for(int j = 1; j <= 10; j += 2) {\n
-                HtmlContent - (420:26,0 [29] Instrumented.cshtml) -     <p>Hello again from C#, #
+                HtmlContent - (420:26,0 [29] Instrumented.cshtml)
+                    RazorIRToken - (420:26,0 [4] Instrumented.cshtml) - Html -     
+                    RazorIRToken - (424:26,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (427:26,7 [22] Instrumented.cshtml) - Html - Hello again from C#, #
                 CSharpExpression - (451:26,31 [1] Instrumented.cshtml)
                     RazorIRToken - (451:26,31 [1] Instrumented.cshtml) - CSharp - j
-                HtmlContent - (453:26,33 [6] Instrumented.cshtml) - </p>\n
+                HtmlContent - (453:26,33 [6] Instrumented.cshtml)
+                    RazorIRToken - (453:26,33 [4] Instrumented.cshtml) - Html - </p>
+                    RazorIRToken - (457:26,37 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (459:27,0 [3] Instrumented.cshtml)
                     RazorIRToken - (459:27,0 [3] Instrumented.cshtml) - CSharp - }\n
-                HtmlContent - (462:28,0 [2] Instrumented.cshtml) - \n
+                HtmlContent - (462:28,0 [2] Instrumented.cshtml)
+                    RazorIRToken - (462:28,0 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (465:29,1 [7] Instrumented.cshtml)
                     RazorIRToken - (465:29,1 [7] Instrumented.cshtml) - CSharp - try {\n
-                HtmlContent - (472:30,0 [41] Instrumented.cshtml) -     <p>That time, we wrote 5 lines!</p>\n
+                HtmlContent - (472:30,0 [41] Instrumented.cshtml)
+                    RazorIRToken - (472:30,0 [4] Instrumented.cshtml) - Html -     
+                    RazorIRToken - (476:30,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (479:30,7 [28] Instrumented.cshtml) - Html - That time, we wrote 5 lines!
+                    RazorIRToken - (507:30,35 [4] Instrumented.cshtml) - Html - </p>
+                    RazorIRToken - (511:30,39 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (513:31,0 [25] Instrumented.cshtml)
                     RazorIRToken - (513:31,0 [25] Instrumented.cshtml) - CSharp - } catch(Exception ex) {\n
-                HtmlContent - (538:32,0 [33] Instrumented.cshtml) -     <p>Oh no! An error occurred: 
+                HtmlContent - (538:32,0 [33] Instrumented.cshtml)
+                    RazorIRToken - (538:32,0 [4] Instrumented.cshtml) - Html -     
+                    RazorIRToken - (542:32,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (545:32,7 [26] Instrumented.cshtml) - Html - Oh no! An error occurred: 
                 CSharpExpression - (573:32,35 [10] Instrumented.cshtml)
                     RazorIRToken - (573:32,35 [10] Instrumented.cshtml) - CSharp - ex.Message
-                HtmlContent - (584:32,46 [6] Instrumented.cshtml) - </p>\n
+                HtmlContent - (584:32,46 [6] Instrumented.cshtml)
+                    RazorIRToken - (584:32,46 [4] Instrumented.cshtml) - Html - </p>
+                    RazorIRToken - (588:32,50 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (590:33,0 [3] Instrumented.cshtml)
                     RazorIRToken - (590:33,0 [3] Instrumented.cshtml) - CSharp - }\n
-                HtmlContent - (593:34,0 [2] Instrumented.cshtml) - \n
+                HtmlContent - (593:34,0 [2] Instrumented.cshtml)
+                    RazorIRToken - (593:34,0 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (596:35,1 [22] Instrumented.cshtml)
                     RazorIRToken - (596:35,1 [22] Instrumented.cshtml) - CSharp - lock(new object()) {\n
-                HtmlContent - (618:36,0 [53] Instrumented.cshtml) -     <p>This block is locked, for your security!</p>\n
+                HtmlContent - (618:36,0 [53] Instrumented.cshtml)
+                    RazorIRToken - (618:36,0 [4] Instrumented.cshtml) - Html -     
+                    RazorIRToken - (622:36,4 [3] Instrumented.cshtml) - Html - <p>
+                    RazorIRToken - (625:36,7 [40] Instrumented.cshtml) - Html - This block is locked, for your security!
+                    RazorIRToken - (665:36,47 [4] Instrumented.cshtml) - Html - </p>
+                    RazorIRToken - (669:36,51 [2] Instrumented.cshtml) - Html - \n
                 CSharpStatement - (671:37,0 [1] Instrumented.cshtml)
                     RazorIRToken - (671:37,0 [1] Instrumented.cshtml) - CSharp - }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.ir.txt
@@ -18,9 +18,12 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [46] MarkupInCodeBlock.cshtml)
                     RazorIRToken - (2:0,2 [46] MarkupInCodeBlock.cshtml) - CSharp - \n    for(int i = 1; i <= 10; i++) {\n        
-                HtmlContent - (48:2,8 [19] MarkupInCodeBlock.cshtml) - <p>Hello from C#, #
+                HtmlContent - (48:2,8 [19] MarkupInCodeBlock.cshtml)
+                    RazorIRToken - (48:2,8 [3] MarkupInCodeBlock.cshtml) - Html - <p>
+                    RazorIRToken - (51:2,11 [16] MarkupInCodeBlock.cshtml) - Html - Hello from C#, #
                 CSharpExpression - (69:2,29 [12] MarkupInCodeBlock.cshtml)
                     RazorIRToken - (69:2,29 [12] MarkupInCodeBlock.cshtml) - CSharp - i.ToString()
-                HtmlContent - (82:2,42 [4] MarkupInCodeBlock.cshtml) - </p>
+                HtmlContent - (82:2,42 [4] MarkupInCodeBlock.cshtml)
+                    RazorIRToken - (82:2,42 [4] MarkupInCodeBlock.cshtml) - Html - </p>
                 CSharpStatement - (86:2,46 [9] MarkupInCodeBlock.cshtml)
                     RazorIRToken - (86:2,46 [9] MarkupInCodeBlock.cshtml) - CSharp - \n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_Runtime.ir.txt
@@ -7,9 +7,14 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [38] MarkupInCodeBlock.cshtml)
                     RazorIRToken - (2:0,2 [38] MarkupInCodeBlock.cshtml) - CSharp - \n    for(int i = 1; i <= 10; i++) {\n
-                HtmlContent - (40:2,0 [27] MarkupInCodeBlock.cshtml) -         <p>Hello from C#, #
+                HtmlContent - (40:2,0 [27] MarkupInCodeBlock.cshtml)
+                    RazorIRToken - (40:2,0 [8] MarkupInCodeBlock.cshtml) - Html -         
+                    RazorIRToken - (48:2,8 [3] MarkupInCodeBlock.cshtml) - Html - <p>
+                    RazorIRToken - (51:2,11 [16] MarkupInCodeBlock.cshtml) - Html - Hello from C#, #
                 CSharpExpression - (69:2,29 [12] MarkupInCodeBlock.cshtml)
                     RazorIRToken - (69:2,29 [12] MarkupInCodeBlock.cshtml) - CSharp - i.ToString()
-                HtmlContent - (82:2,42 [6] MarkupInCodeBlock.cshtml) - </p>\n
+                HtmlContent - (82:2,42 [6] MarkupInCodeBlock.cshtml)
+                    RazorIRToken - (82:2,42 [4] MarkupInCodeBlock.cshtml) - Html - </p>
+                    RazorIRToken - (86:2,46 [2] MarkupInCodeBlock.cshtml) - Html - \n
                 CSharpStatement - (88:3,0 [7] MarkupInCodeBlock.cshtml)
                     RazorIRToken - (88:3,0 [7] MarkupInCodeBlock.cshtml) - CSharp -     }\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.ir.txt
@@ -18,59 +18,79 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.CatchAllTagHelper - TestNamespace.InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] MinimizedTagHelpers.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] MinimizedTagHelpers.cshtml)
+                    RazorIRToken - (31:0,31 [4] MinimizedTagHelpers.cshtml) - Html - \n\n
                 TagHelper - (35:2,0 [647] MinimizedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (64:2,29 [34] MinimizedTagHelpers.cshtml) - \n    <input nottaghelper />\n    
+                        HtmlContent - (64:2,29 [34] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (64:2,29 [6] MinimizedTagHelpers.cshtml) - Html - \n    
+                            RazorIRToken - (70:3,4 [6] MinimizedTagHelpers.cshtml) - Html - <input
+                            RazorIRToken - (76:3,10 [13] MinimizedTagHelpers.cshtml) - Html -  nottaghelper
+                            RazorIRToken - (89:3,23 [3] MinimizedTagHelpers.cshtml) - Html -  />
+                            RazorIRToken - (92:3,26 [6] MinimizedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (98:4,4 [59] MinimizedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                             AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (112:4,18 [3] MinimizedTagHelpers.cshtml) - btn
+                                HtmlContent - (112:4,18 [3] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (112:4,18 [3] MinimizedTagHelpers.cshtml) - Html - btn
                             AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
                             ExecuteTagHelpers - 
-                        HtmlContent - (157:5,39 [6] MinimizedTagHelpers.cshtml) - \n    
+                        HtmlContent - (157:5,39 [6] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (157:5,39 [6] MinimizedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (163:6,4 [119] MinimizedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                             AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (190:7,18 [3] MinimizedTagHelpers.cshtml) - btn
+                                HtmlContent - (190:7,18 [3] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (190:7,18 [3] MinimizedTagHelpers.cshtml) - Html - btn
                             AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
                             AddTagHelperHtmlAttribute -  - input-unbound-required - HtmlAttributeValueStyle.Minimized
                             SetTagHelperProperty - (273:7,101 [5] MinimizedTagHelpers.cshtml) - input-bound-required-string - BoundRequiredString - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (273:7,101 [5] MinimizedTagHelpers.cshtml) - hello
+                                HtmlContent - (273:7,101 [5] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (273:7,101 [5] MinimizedTagHelpers.cshtml) - Html - hello
                             ExecuteTagHelpers - 
-                        HtmlContent - (282:7,110 [6] MinimizedTagHelpers.cshtml) - \n    
+                        HtmlContent - (282:7,110 [6] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (282:7,110 [6] MinimizedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (288:8,4 [176] MinimizedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                             AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (315:9,18 [3] MinimizedTagHelpers.cshtml) - btn
+                                HtmlContent - (315:9,18 [3] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (315:9,18 [3] MinimizedTagHelpers.cshtml) - Html - btn
                             AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
                             AddTagHelperHtmlAttribute -  - input-unbound-required - HtmlAttributeValueStyle.Minimized
                             SetTagHelperProperty - (418:11,57 [5] MinimizedTagHelpers.cshtml) - catchall-bound-string - BoundRequiredString - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (418:11,57 [5] MinimizedTagHelpers.cshtml) - world
+                                HtmlContent - (418:11,57 [5] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (418:11,57 [5] MinimizedTagHelpers.cshtml) - Html - world
                             SetTagHelperProperty - (454:11,93 [6] MinimizedTagHelpers.cshtml) - input-bound-required-string - BoundRequiredString - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (454:11,93 [6] MinimizedTagHelpers.cshtml) - hello2
+                                HtmlContent - (454:11,93 [6] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (454:11,93 [6] MinimizedTagHelpers.cshtml) - Html - hello2
                             ExecuteTagHelpers - 
-                        HtmlContent - (464:11,103 [6] MinimizedTagHelpers.cshtml) - \n    
+                        HtmlContent - (464:11,103 [6] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (464:11,103 [6] MinimizedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (470:12,4 [206] MinimizedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                             AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (484:12,18 [3] MinimizedTagHelpers.cshtml) - btn
+                                HtmlContent - (484:12,18 [3] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (484:12,18 [3] MinimizedTagHelpers.cshtml) - Html - btn
                             AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (529:13,38 [5] MinimizedTagHelpers.cshtml) - hello
+                                HtmlContent - (529:13,38 [5] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (529:13,38 [5] MinimizedTagHelpers.cshtml) - Html - hello
                             AddTagHelperHtmlAttribute -  - input-unbound-required - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (578:14,40 [6] MinimizedTagHelpers.cshtml) - hello2
+                                HtmlContent - (578:14,40 [6] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (578:14,40 [6] MinimizedTagHelpers.cshtml) - Html - hello2
                             AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
                             SetTagHelperProperty - (667:16,40 [5] MinimizedTagHelpers.cshtml) - input-bound-required-string - BoundRequiredString - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (667:16,40 [5] MinimizedTagHelpers.cshtml) - world
+                                HtmlContent - (667:16,40 [5] MinimizedTagHelpers.cshtml)
+                                    RazorIRToken - (667:16,40 [5] MinimizedTagHelpers.cshtml) - Html - world
                             ExecuteTagHelpers - 
-                        HtmlContent - (676:16,49 [2] MinimizedTagHelpers.cshtml) - \n
+                        HtmlContent - (676:16,49 [2] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (676:16,49 [2] MinimizedTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.ir.txt
@@ -13,17 +13,24 @@ Document -
             DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_6 - input-bound-required-string - world - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.CatchAllTagHelper - TestNamespace.InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] MinimizedTagHelpers.cshtml) - \n
+                HtmlContent - (33:1,0 [2] MinimizedTagHelpers.cshtml)
+                    RazorIRToken - (33:1,0 [2] MinimizedTagHelpers.cshtml) - Html - \n
                 TagHelper - (35:2,0 [647] MinimizedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (64:2,29 [34] MinimizedTagHelpers.cshtml) - \n    <input nottaghelper />\n    
+                        HtmlContent - (64:2,29 [34] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (64:2,29 [6] MinimizedTagHelpers.cshtml) - Html - \n    
+                            RazorIRToken - (70:3,4 [6] MinimizedTagHelpers.cshtml) - Html - <input
+                            RazorIRToken - (76:3,10 [13] MinimizedTagHelpers.cshtml) - Html -  nottaghelper
+                            RazorIRToken - (89:3,23 [3] MinimizedTagHelpers.cshtml) - Html -  />
+                            RazorIRToken - (92:3,26 [6] MinimizedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (98:4,4 [59] MinimizedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                             AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
                             ExecuteTagHelpers - 
-                        HtmlContent - (157:5,39 [6] MinimizedTagHelpers.cshtml) - \n    
+                        HtmlContent - (157:5,39 [6] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (157:5,39 [6] MinimizedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (163:6,4 [119] MinimizedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -33,7 +40,8 @@ Document -
                             AddTagHelperHtmlAttribute -  - input-unbound-required - HtmlAttributeValueStyle.Minimized
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - input-bound-required-string - BoundRequiredString
                             ExecuteTagHelpers - 
-                        HtmlContent - (282:7,110 [6] MinimizedTagHelpers.cshtml) - \n    
+                        HtmlContent - (282:7,110 [6] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (282:7,110 [6] MinimizedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (288:8,4 [176] MinimizedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -44,7 +52,8 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_2 - catchall-bound-string - BoundRequiredString
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_3 - input-bound-required-string - BoundRequiredString
                             ExecuteTagHelpers - 
-                        HtmlContent - (464:11,103 [6] MinimizedTagHelpers.cshtml) - \n    
+                        HtmlContent - (464:11,103 [6] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (464:11,103 [6] MinimizedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (470:12,4 [206] MinimizedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -55,7 +64,8 @@ Document -
                             AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - input-bound-required-string - BoundRequiredString
                             ExecuteTagHelpers - 
-                        HtmlContent - (676:16,49 [2] MinimizedTagHelpers.cshtml) - \n
+                        HtmlContent - (676:16,49 [2] MinimizedTagHelpers.cshtml)
+                            RazorIRToken - (676:16,49 [2] MinimizedTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - catchall-unbound-required - HtmlAttributeValueStyle.Minimized
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.ir.txt
@@ -20,10 +20,14 @@ Document -
                     RazorIRToken - (2:0,2 [6] NestedCSharp.cshtml) - CSharp - \n    
                 CSharpStatement - (9:1,5 [53] NestedCSharp.cshtml)
                     RazorIRToken - (9:1,5 [53] NestedCSharp.cshtml) - CSharp - foreach (var result in (dynamic)Url)\n    {\n        
-                HtmlContent - (62:3,8 [19] NestedCSharp.cshtml) - <div>\n            
+                HtmlContent - (62:3,8 [19] NestedCSharp.cshtml)
+                    RazorIRToken - (62:3,8 [5] NestedCSharp.cshtml) - Html - <div>
+                    RazorIRToken - (67:3,13 [14] NestedCSharp.cshtml) - Html - \n            
                 CSharpExpression - (82:4,13 [16] NestedCSharp.cshtml)
                     RazorIRToken - (82:4,13 [16] NestedCSharp.cshtml) - CSharp - result.SomeValue
-                HtmlContent - (98:4,29 [17] NestedCSharp.cshtml) - .\n        </div>
+                HtmlContent - (98:4,29 [17] NestedCSharp.cshtml)
+                    RazorIRToken - (98:4,29 [11] NestedCSharp.cshtml) - Html - .\n        
+                    RazorIRToken - (109:5,8 [6] NestedCSharp.cshtml) - Html - </div>
                 CSharpStatement - (115:5,14 [7] NestedCSharp.cshtml)
                     RazorIRToken - (115:5,14 [7] NestedCSharp.cshtml) - CSharp - \n    }
                 CSharpStatement - (122:6,5 [2] NestedCSharp.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_Runtime.ir.txt
@@ -9,10 +9,17 @@ Document -
                     RazorIRToken - (2:0,2 [6] NestedCSharp.cshtml) - CSharp - \n    
                 CSharpStatement - (9:1,5 [45] NestedCSharp.cshtml)
                     RazorIRToken - (9:1,5 [45] NestedCSharp.cshtml) - CSharp - foreach (var result in (dynamic)Url)\n    {\n
-                HtmlContent - (54:3,0 [27] NestedCSharp.cshtml) -         <div>\n            
+                HtmlContent - (54:3,0 [27] NestedCSharp.cshtml)
+                    RazorIRToken - (54:3,0 [8] NestedCSharp.cshtml) - Html -         
+                    RazorIRToken - (62:3,8 [5] NestedCSharp.cshtml) - Html - <div>
+                    RazorIRToken - (67:3,13 [2] NestedCSharp.cshtml) - Html - \n
+                    RazorIRToken - (69:4,0 [12] NestedCSharp.cshtml) - Html -             
                 CSharpExpression - (82:4,13 [16] NestedCSharp.cshtml)
                     RazorIRToken - (82:4,13 [16] NestedCSharp.cshtml) - CSharp - result.SomeValue
-                HtmlContent - (98:4,29 [19] NestedCSharp.cshtml) - .\n        </div>\n
+                HtmlContent - (98:4,29 [19] NestedCSharp.cshtml)
+                    RazorIRToken - (98:4,29 [11] NestedCSharp.cshtml) - Html - .\n        
+                    RazorIRToken - (109:5,8 [6] NestedCSharp.cshtml) - Html - </div>
+                    RazorIRToken - (115:5,14 [2] NestedCSharp.cshtml) - Html - \n
                 CSharpStatement - (117:6,0 [5] NestedCSharp.cshtml)
                     RazorIRToken - (117:6,0 [5] NestedCSharp.cshtml) - CSharp -     }
                 CSharpStatement - (122:6,5 [2] NestedCSharp.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.ir.txt
@@ -18,37 +18,75 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [108] NestedScriptTagTagHelpers.cshtml) - \n\n<script type="text/html">\n    <div data-animation="fade" class="randomNonTagHelperAttribute">\n        
+                HtmlContent - (31:0,31 [108] NestedScriptTagTagHelpers.cshtml)
+                    RazorIRToken - (31:0,31 [4] NestedScriptTagTagHelpers.cshtml) - Html - \n\n
+                    RazorIRToken - (35:2,0 [7] NestedScriptTagTagHelpers.cshtml) - Html - <script
+                    RazorIRToken - (42:2,7 [17] NestedScriptTagTagHelpers.cshtml) - Html -  type="text/html"
+                    RazorIRToken - (59:2,24 [1] NestedScriptTagTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (60:2,25 [6] NestedScriptTagTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (66:3,4 [4] NestedScriptTagTagHelpers.cshtml) - Html - <div
+                    RazorIRToken - (70:3,8 [17] NestedScriptTagTagHelpers.cshtml) - Html -  data-animation="
+                    RazorIRToken - (87:3,25 [4] NestedScriptTagTagHelpers.cshtml) - Html - fade
+                    RazorIRToken - (91:3,29 [1] NestedScriptTagTagHelpers.cshtml) - Html - "
+                    RazorIRToken - (92:3,30 [36] NestedScriptTagTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (128:3,66 [1] NestedScriptTagTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (129:3,67 [10] NestedScriptTagTagHelpers.cshtml) - Html - \n        
                 TagHelper - (139:4,8 [433] NestedScriptTagTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (180:4,49 [14] NestedScriptTagTagHelpers.cshtml) - \n            
+                        HtmlContent - (180:4,49 [14] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (180:4,49 [14] NestedScriptTagTagHelpers.cshtml) - Html - \n            
                         CSharpStatement - (195:5,13 [46] NestedScriptTagTagHelpers.cshtml)
                             RazorIRToken - (195:5,13 [46] NestedScriptTagTagHelpers.cshtml) - CSharp - for(var i = 0; i < 5; i++) {\n                
-                        HtmlContent - (241:6,16 [68] NestedScriptTagTagHelpers.cshtml) - <script id="nestedScriptTag" type="text/html">\n                    
+                        HtmlContent - (241:6,16 [68] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (241:6,16 [7] NestedScriptTagTagHelpers.cshtml) - Html - <script
+                            RazorIRToken - (248:6,23 [21] NestedScriptTagTagHelpers.cshtml) - Html -  id="nestedScriptTag"
+                            RazorIRToken - (269:6,44 [17] NestedScriptTagTagHelpers.cshtml) - Html -  type="text/html"
+                            RazorIRToken - (286:6,61 [1] NestedScriptTagTagHelpers.cshtml) - Html - >
+                            RazorIRToken - (287:6,62 [22] NestedScriptTagTagHelpers.cshtml) - Html - \n                    
                         TagHelper - (309:7,20 [86] NestedScriptTagTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             AddTagHelperHtmlAttribute -  - data-interval - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (331:7,42 [7] NestedScriptTagTagHelpers.cshtml) - 2000 + 
+                                HtmlContent - (331:7,42 [7] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (331:7,42 [7] NestedScriptTagTagHelpers.cshtml) - Html - 2000 + 
                                 CSharpExpression - (339:7,50 [23] NestedScriptTagTagHelpers.cshtml)
                                     RazorIRToken - (339:7,50 [23] NestedScriptTagTagHelpers.cshtml) - CSharp - ViewBag.DefaultInterval
-                                HtmlContent - (362:7,73 [4] NestedScriptTagTagHelpers.cshtml) -  + 1
+                                HtmlContent - (362:7,73 [4] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (362:7,73 [4] NestedScriptTagTagHelpers.cshtml) - Html -  + 1
                             SetTagHelperProperty - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - text
+                                HtmlContent - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - Html - text
                             SetTagHelperProperty - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - text
+                                HtmlContent - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - Html - text
                             SetTagHelperProperty - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - true
+                                HtmlContent - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (395:7,106 [27] NestedScriptTagTagHelpers.cshtml) - \n                </script>
+                        HtmlContent - (395:7,106 [27] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (395:7,106 [18] NestedScriptTagTagHelpers.cshtml) - Html - \n                
+                            RazorIRToken - (413:8,16 [9] NestedScriptTagTagHelpers.cshtml) - Html - </script>
                         CSharpStatement - (422:8,25 [15] NestedScriptTagTagHelpers.cshtml)
                             RazorIRToken - (422:8,25 [15] NestedScriptTagTagHelpers.cshtml) - CSharp - \n            }
-                        HtmlContent - (437:9,13 [131] NestedScriptTagTagHelpers.cshtml) - \n            <script type="text/javascript">\n                var tag = '<input checked="true">';\n            </script>\n        
+                        HtmlContent - (437:9,13 [131] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (437:9,13 [14] NestedScriptTagTagHelpers.cshtml) - Html - \n            
+                            RazorIRToken - (451:10,12 [7] NestedScriptTagTagHelpers.cshtml) - Html - <script
+                            RazorIRToken - (458:10,19 [23] NestedScriptTagTagHelpers.cshtml) - Html -  type="text/javascript"
+                            RazorIRToken - (481:10,42 [1] NestedScriptTagTagHelpers.cshtml) - Html - >
+                            RazorIRToken - (482:10,43 [67] NestedScriptTagTagHelpers.cshtml) - Html - \n                var tag = '<input checked="true">';\n            
+                            RazorIRToken - (549:12,12 [9] NestedScriptTagTagHelpers.cshtml) - Html - </script>
+                            RazorIRToken - (558:12,21 [10] NestedScriptTagTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (149:4,18 [11] NestedScriptTagTagHelpers.cshtml) - Hello World
+                        HtmlContent - (149:4,18 [11] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (149:4,18 [11] NestedScriptTagTagHelpers.cshtml) - Html - Hello World
                     AddTagHelperHtmlAttribute -  - data-delay - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (174:4,43 [4] NestedScriptTagTagHelpers.cshtml) - 1000
+                        HtmlContent - (174:4,43 [4] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (174:4,43 [4] NestedScriptTagTagHelpers.cshtml) - Html - 1000
                     ExecuteTagHelpers - 
-                HtmlContent - (572:13,12 [23] NestedScriptTagTagHelpers.cshtml) - \n    </div>\n</script>
+                HtmlContent - (572:13,12 [23] NestedScriptTagTagHelpers.cshtml)
+                    RazorIRToken - (572:13,12 [6] NestedScriptTagTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (578:14,4 [6] NestedScriptTagTagHelpers.cshtml) - Html - </div>
+                    RazorIRToken - (584:14,10 [2] NestedScriptTagTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (586:15,0 [9] NestedScriptTagTagHelpers.cshtml) - Html - </script>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.ir.txt
@@ -9,35 +9,71 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - data-delay - 1000 - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [106] NestedScriptTagTagHelpers.cshtml) - \n<script type="text/html">\n    <div data-animation="fade" class="randomNonTagHelperAttribute">\n        
+                HtmlContent - (33:1,0 [106] NestedScriptTagTagHelpers.cshtml)
+                    RazorIRToken - (33:1,0 [2] NestedScriptTagTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (35:2,0 [7] NestedScriptTagTagHelpers.cshtml) - Html - <script
+                    RazorIRToken - (42:2,7 [17] NestedScriptTagTagHelpers.cshtml) - Html -  type="text/html"
+                    RazorIRToken - (59:2,24 [1] NestedScriptTagTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (60:2,25 [6] NestedScriptTagTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (66:3,4 [4] NestedScriptTagTagHelpers.cshtml) - Html - <div
+                    RazorIRToken - (70:3,8 [17] NestedScriptTagTagHelpers.cshtml) - Html -  data-animation="
+                    RazorIRToken - (87:3,25 [4] NestedScriptTagTagHelpers.cshtml) - Html - fade
+                    RazorIRToken - (91:3,29 [1] NestedScriptTagTagHelpers.cshtml) - Html - "
+                    RazorIRToken - (92:3,30 [36] NestedScriptTagTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (128:3,66 [1] NestedScriptTagTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (129:3,67 [10] NestedScriptTagTagHelpers.cshtml) - Html - \n        
                 TagHelper - (139:4,8 [433] NestedScriptTagTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (180:4,49 [2] NestedScriptTagTagHelpers.cshtml) - \n
+                        HtmlContent - (180:4,49 [2] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (180:4,49 [2] NestedScriptTagTagHelpers.cshtml) - Html - \n
                         CSharpStatement - (182:5,0 [12] NestedScriptTagTagHelpers.cshtml)
                             RazorIRToken - (182:5,0 [12] NestedScriptTagTagHelpers.cshtml) - CSharp -             
                         CSharpStatement - (195:5,13 [30] NestedScriptTagTagHelpers.cshtml)
                             RazorIRToken - (195:5,13 [30] NestedScriptTagTagHelpers.cshtml) - CSharp - for(var i = 0; i < 5; i++) {\n
-                        HtmlContent - (225:6,0 [84] NestedScriptTagTagHelpers.cshtml) -                 <script id="nestedScriptTag" type="text/html">\n                    
+                        HtmlContent - (225:6,0 [84] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (225:6,0 [16] NestedScriptTagTagHelpers.cshtml) - Html -                 
+                            RazorIRToken - (241:6,16 [7] NestedScriptTagTagHelpers.cshtml) - Html - <script
+                            RazorIRToken - (248:6,23 [21] NestedScriptTagTagHelpers.cshtml) - Html -  id="nestedScriptTag"
+                            RazorIRToken - (269:6,44 [17] NestedScriptTagTagHelpers.cshtml) - Html -  type="text/html"
+                            RazorIRToken - (286:6,61 [1] NestedScriptTagTagHelpers.cshtml) - Html - >
+                            RazorIRToken - (287:6,62 [22] NestedScriptTagTagHelpers.cshtml) - Html - \n                    
                         TagHelper - (309:7,20 [86] NestedScriptTagTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             AddTagHelperHtmlAttribute -  - data-interval - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (331:7,42 [7] NestedScriptTagTagHelpers.cshtml) - 2000 + 
+                                HtmlContent - (331:7,42 [7] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (331:7,42 [7] NestedScriptTagTagHelpers.cshtml) - Html - 2000 + 
                                 CSharpExpression - (339:7,50 [23] NestedScriptTagTagHelpers.cshtml)
                                     RazorIRToken - (339:7,50 [23] NestedScriptTagTagHelpers.cshtml) - CSharp - ViewBag.DefaultInterval
-                                HtmlContent - (362:7,73 [4] NestedScriptTagTagHelpers.cshtml) -  + 1
+                                HtmlContent - (362:7,73 [4] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (362:7,73 [4] NestedScriptTagTagHelpers.cshtml) - Html -  + 1
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetTagHelperProperty - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - true
+                                HtmlContent - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml)
+                                    RazorIRToken - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - Html - true
                             ExecuteTagHelpers - 
-                        HtmlContent - (395:7,106 [29] NestedScriptTagTagHelpers.cshtml) - \n                </script>\n
+                        HtmlContent - (395:7,106 [29] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (395:7,106 [18] NestedScriptTagTagHelpers.cshtml) - Html - \n                
+                            RazorIRToken - (413:8,16 [9] NestedScriptTagTagHelpers.cshtml) - Html - </script>
+                            RazorIRToken - (422:8,25 [2] NestedScriptTagTagHelpers.cshtml) - Html - \n
                         CSharpStatement - (424:9,0 [15] NestedScriptTagTagHelpers.cshtml)
                             RazorIRToken - (424:9,0 [15] NestedScriptTagTagHelpers.cshtml) - CSharp -             }\n
-                        HtmlContent - (439:10,0 [129] NestedScriptTagTagHelpers.cshtml) -             <script type="text/javascript">\n                var tag = '<input checked="true">';\n            </script>\n        
+                        HtmlContent - (439:10,0 [129] NestedScriptTagTagHelpers.cshtml)
+                            RazorIRToken - (439:10,0 [12] NestedScriptTagTagHelpers.cshtml) - Html -             
+                            RazorIRToken - (451:10,12 [7] NestedScriptTagTagHelpers.cshtml) - Html - <script
+                            RazorIRToken - (458:10,19 [23] NestedScriptTagTagHelpers.cshtml) - Html -  type="text/javascript"
+                            RazorIRToken - (481:10,42 [1] NestedScriptTagTagHelpers.cshtml) - Html - >
+                            RazorIRToken - (482:10,43 [67] NestedScriptTagTagHelpers.cshtml) - Html - \n                var tag = '<input checked="true">';\n            
+                            RazorIRToken - (549:12,12 [9] NestedScriptTagTagHelpers.cshtml) - Html - </script>
+                            RazorIRToken - (558:12,21 [10] NestedScriptTagTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     ExecuteTagHelpers - 
-                HtmlContent - (572:13,12 [23] NestedScriptTagTagHelpers.cshtml) - \n    </div>\n</script>
+                HtmlContent - (572:13,12 [23] NestedScriptTagTagHelpers.cshtml)
+                    RazorIRToken - (572:13,12 [6] NestedScriptTagTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (578:14,4 [6] NestedScriptTagTagHelpers.cshtml) - Html - </div>
+                    RazorIRToken - (584:14,10 [2] NestedScriptTagTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (586:15,0 [9] NestedScriptTagTagHelpers.cshtml) - Html - </script>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.ir.txt
@@ -18,27 +18,35 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - SpanTagHelper - DivTagHelper - InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (29:0,29 [2] NestedTagHelpers.cshtml) - \n
+                HtmlContent - (29:0,29 [2] NestedTagHelpers.cshtml)
+                    RazorIRToken - (29:0,29 [2] NestedTagHelpers.cshtml) - Html - \n
                 TagHelper - (31:1,0 [26] NestedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - span - TagMode.StartTagAndEndTag
-                        HtmlContent - (46:1,15 [4] NestedTagHelpers.cshtml) - Hola
+                        HtmlContent - (46:1,15 [4] NestedTagHelpers.cshtml)
+                            RazorIRToken - (46:1,15 [4] NestedTagHelpers.cshtml) - Html - Hola
                     CreateTagHelper -  - SpanTagHelper
                     AddTagHelperHtmlAttribute -  - someattr - HtmlAttributeValueStyle.Minimized
                     ExecuteTagHelpers - 
-                HtmlContent - (57:1,26 [2] NestedTagHelpers.cshtml) - \n
+                HtmlContent - (57:1,26 [2] NestedTagHelpers.cshtml)
+                    RazorIRToken - (57:1,26 [2] NestedTagHelpers.cshtml) - Html - \n
                 TagHelper - (59:2,0 [66] NestedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
-                        HtmlContent - (78:2,19 [6] NestedTagHelpers.cshtml) - \n    
+                        HtmlContent - (78:2,19 [6] NestedTagHelpers.cshtml)
+                            RazorIRToken - (78:2,19 [6] NestedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (84:3,4 [33] NestedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - InputTagHelper
                             SetTagHelperProperty - (97:3,17 [5] NestedTagHelpers.cshtml) - value - FooProp - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (97:3,17 [5] NestedTagHelpers.cshtml) - Hello
+                                HtmlContent - (97:3,17 [5] NestedTagHelpers.cshtml)
+                                    RazorIRToken - (97:3,17 [5] NestedTagHelpers.cshtml) - Html - Hello
                             AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.SingleQuotes
-                                HtmlContent - (109:3,29 [4] NestedTagHelpers.cshtml) - text
+                                HtmlContent - (109:3,29 [4] NestedTagHelpers.cshtml)
+                                    RazorIRToken - (109:3,29 [4] NestedTagHelpers.cshtml) - Html - text
                             ExecuteTagHelpers - 
-                        HtmlContent - (117:3,37 [2] NestedTagHelpers.cshtml) - \n
+                        HtmlContent - (117:3,37 [2] NestedTagHelpers.cshtml)
+                            RazorIRToken - (117:3,37 [2] NestedTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - DivTagHelper
                     AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (73:2,14 [3] NestedTagHelpers.cshtml) - foo
+                        HtmlContent - (73:2,14 [3] NestedTagHelpers.cshtml)
+                            RazorIRToken - (73:2,14 [3] NestedTagHelpers.cshtml) - Html - foo
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.ir.txt
@@ -11,21 +11,25 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 TagHelper - (31:1,0 [26] NestedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - span - TagMode.StartTagAndEndTag
-                        HtmlContent - (46:1,15 [4] NestedTagHelpers.cshtml) - Hola
+                        HtmlContent - (46:1,15 [4] NestedTagHelpers.cshtml)
+                            RazorIRToken - (46:1,15 [4] NestedTagHelpers.cshtml) - Html - Hola
                     CreateTagHelper -  - SpanTagHelper
                     AddTagHelperHtmlAttribute -  - someattr - HtmlAttributeValueStyle.Minimized
                     ExecuteTagHelpers - 
-                HtmlContent - (57:1,26 [2] NestedTagHelpers.cshtml) - \n
+                HtmlContent - (57:1,26 [2] NestedTagHelpers.cshtml)
+                    RazorIRToken - (57:1,26 [2] NestedTagHelpers.cshtml) - Html - \n
                 TagHelper - (59:2,0 [66] NestedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
-                        HtmlContent - (78:2,19 [6] NestedTagHelpers.cshtml) - \n    
+                        HtmlContent - (78:2,19 [6] NestedTagHelpers.cshtml)
+                            RazorIRToken - (78:2,19 [6] NestedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (84:3,4 [33] NestedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - InputTagHelper
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - value - FooProp
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                             ExecuteTagHelpers - 
-                        HtmlContent - (117:3,37 [2] NestedTagHelpers.cshtml) - \n
+                        HtmlContent - (117:3,37 [2] NestedTagHelpers.cshtml)
+                            RazorIRToken - (117:3,37 [2] NestedTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - DivTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.ir.txt
@@ -18,59 +18,93 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [18] NoLinePragmas.cshtml)
                     RazorIRToken - (2:0,2 [18] NoLinePragmas.cshtml) - CSharp - \n    int i = 1;\n
-                HtmlContent - (23:3,0 [2] NoLinePragmas.cshtml) - \n
+                HtmlContent - (23:3,0 [2] NoLinePragmas.cshtml)
+                    RazorIRToken - (23:3,0 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (26:4,1 [22] NoLinePragmas.cshtml)
                     RazorIRToken - (26:4,1 [22] NoLinePragmas.cshtml) - CSharp - while(i <= 10) {\n    
-                HtmlContent - (48:5,4 [19] NoLinePragmas.cshtml) - <p>Hello from C#, #
+                HtmlContent - (48:5,4 [19] NoLinePragmas.cshtml)
+                    RazorIRToken - (48:5,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (51:5,7 [16] NoLinePragmas.cshtml) - Html - Hello from C#, #
                 CSharpExpression - (69:5,25 [1] NoLinePragmas.cshtml)
                     RazorIRToken - (69:5,25 [1] NoLinePragmas.cshtml) - CSharp - i
-                HtmlContent - (71:5,27 [4] NoLinePragmas.cshtml) - </p>
+                HtmlContent - (71:5,27 [4] NoLinePragmas.cshtml)
+                    RazorIRToken - (71:5,27 [4] NoLinePragmas.cshtml) - Html - </p>
                 CSharpStatement - (75:5,31 [16] NoLinePragmas.cshtml)
                     RazorIRToken - (75:5,31 [16] NoLinePragmas.cshtml) - CSharp - \n    i += 1;\n}
-                HtmlContent - (91:7,1 [4] NoLinePragmas.cshtml) - \n\n
+                HtmlContent - (91:7,1 [4] NoLinePragmas.cshtml)
+                    RazorIRToken - (91:7,1 [4] NoLinePragmas.cshtml) - Html - \n\n
                 CSharpStatement - (96:9,1 [19] NoLinePragmas.cshtml)
                     RazorIRToken - (96:9,1 [19] NoLinePragmas.cshtml) - CSharp - if(i == 11) {\n    
-                HtmlContent - (115:10,4 [25] NoLinePragmas.cshtml) - <p>We wrote 10 lines!</p>
+                HtmlContent - (115:10,4 [25] NoLinePragmas.cshtml)
+                    RazorIRToken - (115:10,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (118:10,7 [18] NoLinePragmas.cshtml) - Html - We wrote 10 lines!
+                    RazorIRToken - (136:10,25 [4] NoLinePragmas.cshtml) - Html - </p>
                 CSharpStatement - (140:10,29 [3] NoLinePragmas.cshtml)
                     RazorIRToken - (140:10,29 [3] NoLinePragmas.cshtml) - CSharp - \n}
-                HtmlContent - (143:11,1 [4] NoLinePragmas.cshtml) - \n\n
+                HtmlContent - (143:11,1 [4] NoLinePragmas.cshtml)
+                    RazorIRToken - (143:11,1 [4] NoLinePragmas.cshtml) - Html - \n\n
                 CSharpStatement - (148:13,1 [35] NoLinePragmas.cshtml)
                     RazorIRToken - (148:13,1 [35] NoLinePragmas.cshtml) - CSharp - switch(i) {\n    case 11:\n        
-                HtmlContent - (183:15,8 [36] NoLinePragmas.cshtml) - <p>No really, we wrote 10 lines!</p>
+                HtmlContent - (183:15,8 [36] NoLinePragmas.cshtml)
+                    RazorIRToken - (183:15,8 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (186:15,11 [29] NoLinePragmas.cshtml) - Html - No really, we wrote 10 lines!
+                    RazorIRToken - (215:15,40 [4] NoLinePragmas.cshtml) - Html - </p>
                 CSharpStatement - (219:15,44 [40] NoLinePragmas.cshtml)
                     RazorIRToken - (219:15,44 [40] NoLinePragmas.cshtml) - CSharp - \n        break;\n    default:\n        
-                HtmlContent - (259:18,8 [29] NoLinePragmas.cshtml) - <p>Actually, we didn't...</p>
+                HtmlContent - (259:18,8 [29] NoLinePragmas.cshtml)
+                    RazorIRToken - (259:18,8 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (262:18,11 [22] NoLinePragmas.cshtml) - Html - Actually, we didn't...
+                    RazorIRToken - (284:18,33 [4] NoLinePragmas.cshtml) - Html - </p>
                 CSharpStatement - (288:18,37 [19] NoLinePragmas.cshtml)
                     RazorIRToken - (288:18,37 [19] NoLinePragmas.cshtml) - CSharp - \n        break;\n}
-                HtmlContent - (307:20,1 [4] NoLinePragmas.cshtml) - \n\n
+                HtmlContent - (307:20,1 [4] NoLinePragmas.cshtml)
+                    RazorIRToken - (307:20,1 [4] NoLinePragmas.cshtml) - Html - \n\n
                 CSharpStatement - (312:22,1 [39] NoLinePragmas.cshtml)
                     RazorIRToken - (312:22,1 [39] NoLinePragmas.cshtml) - CSharp - for(int j = 1; j <= 10; j += 2) {\n    
-                HtmlContent - (351:23,4 [25] NoLinePragmas.cshtml) - <p>Hello again from C#, #
+                HtmlContent - (351:23,4 [25] NoLinePragmas.cshtml)
+                    RazorIRToken - (351:23,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (354:23,7 [22] NoLinePragmas.cshtml) - Html - Hello again from C#, #
                 CSharpExpression - (378:23,31 [1] NoLinePragmas.cshtml)
                     RazorIRToken - (378:23,31 [1] NoLinePragmas.cshtml) - CSharp - j
-                HtmlContent - (380:23,33 [4] NoLinePragmas.cshtml) - </p>
+                HtmlContent - (380:23,33 [4] NoLinePragmas.cshtml)
+                    RazorIRToken - (380:23,33 [4] NoLinePragmas.cshtml) - Html - </p>
                 CSharpStatement - (384:23,37 [3] NoLinePragmas.cshtml)
                     RazorIRToken - (384:23,37 [3] NoLinePragmas.cshtml) - CSharp - \n}
-                HtmlContent - (387:24,1 [4] NoLinePragmas.cshtml) - \n\n
+                HtmlContent - (387:24,1 [4] NoLinePragmas.cshtml)
+                    RazorIRToken - (387:24,1 [4] NoLinePragmas.cshtml) - Html - \n\n
                 CSharpStatement - (392:26,1 [11] NoLinePragmas.cshtml)
                     RazorIRToken - (392:26,1 [11] NoLinePragmas.cshtml) - CSharp - try {\n    
-                HtmlContent - (403:27,4 [35] NoLinePragmas.cshtml) - <p>That time, we wrote 5 lines!</p>
+                HtmlContent - (403:27,4 [35] NoLinePragmas.cshtml)
+                    RazorIRToken - (403:27,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (406:27,7 [28] NoLinePragmas.cshtml) - Html - That time, we wrote 5 lines!
+                    RazorIRToken - (434:27,35 [4] NoLinePragmas.cshtml) - Html - </p>
                 CSharpStatement - (438:27,39 [31] NoLinePragmas.cshtml)
                     RazorIRToken - (438:27,39 [31] NoLinePragmas.cshtml) - CSharp - \n} catch(Exception ex) {\n    
-                HtmlContent - (469:29,4 [29] NoLinePragmas.cshtml) - <p>Oh no! An error occurred: 
+                HtmlContent - (469:29,4 [29] NoLinePragmas.cshtml)
+                    RazorIRToken - (469:29,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (472:29,7 [26] NoLinePragmas.cshtml) - Html - Oh no! An error occurred: 
                 CSharpExpression - (500:29,35 [10] NoLinePragmas.cshtml)
                     RazorIRToken - (500:29,35 [10] NoLinePragmas.cshtml) - CSharp - ex.Message
-                HtmlContent - (511:29,46 [4] NoLinePragmas.cshtml) - </p>
+                HtmlContent - (511:29,46 [4] NoLinePragmas.cshtml)
+                    RazorIRToken - (511:29,46 [4] NoLinePragmas.cshtml) - Html - </p>
                 CSharpStatement - (515:29,50 [7] NoLinePragmas.cshtml)
                     RazorIRToken - (515:29,50 [7] NoLinePragmas.cshtml) - CSharp - \n}\n\n
                 CSharpStatement - (556:32,34 [0] NoLinePragmas.cshtml)
                     RazorIRToken - (556:32,34 [0] NoLinePragmas.cshtml) - CSharp - 
-                HtmlContent - (556:32,34 [14] NoLinePragmas.cshtml) - \n<p>i is now 
+                HtmlContent - (556:32,34 [14] NoLinePragmas.cshtml)
+                    RazorIRToken - (556:32,34 [2] NoLinePragmas.cshtml) - Html - \n
+                    RazorIRToken - (558:33,0 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (561:33,3 [9] NoLinePragmas.cshtml) - Html - i is now 
                 CSharpExpression - (571:33,13 [1] NoLinePragmas.cshtml)
                     RazorIRToken - (571:33,13 [1] NoLinePragmas.cshtml) - CSharp - i
-                HtmlContent - (572:33,14 [8] NoLinePragmas.cshtml) - </p>\n\n
+                HtmlContent - (572:33,14 [8] NoLinePragmas.cshtml)
+                    RazorIRToken - (572:33,14 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (576:33,18 [4] NoLinePragmas.cshtml) - Html - \n\n
                 CSharpStatement - (581:35,1 [26] NoLinePragmas.cshtml)
                     RazorIRToken - (581:35,1 [26] NoLinePragmas.cshtml) - CSharp - lock(new object()) {\n    
-                HtmlContent - (607:36,4 [47] NoLinePragmas.cshtml) - <p>This block is locked, for your security!</p>
+                HtmlContent - (607:36,4 [47] NoLinePragmas.cshtml)
+                    RazorIRToken - (607:36,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (610:36,7 [40] NoLinePragmas.cshtml) - Html - This block is locked, for your security!
+                    RazorIRToken - (650:36,47 [4] NoLinePragmas.cshtml) - Html - </p>
                 CSharpStatement - (654:36,51 [3] NoLinePragmas.cshtml)
                     RazorIRToken - (654:36,51 [3] NoLinePragmas.cshtml) - CSharp - \n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_Runtime.ir.txt
@@ -7,59 +7,108 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [18] NoLinePragmas.cshtml)
                     RazorIRToken - (2:0,2 [18] NoLinePragmas.cshtml) - CSharp - \n    int i = 1;\n
-                HtmlContent - (23:3,0 [2] NoLinePragmas.cshtml) - \n
+                HtmlContent - (23:3,0 [2] NoLinePragmas.cshtml)
+                    RazorIRToken - (23:3,0 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (26:4,1 [18] NoLinePragmas.cshtml)
                     RazorIRToken - (26:4,1 [18] NoLinePragmas.cshtml) - CSharp - while(i <= 10) {\n
-                HtmlContent - (44:5,0 [23] NoLinePragmas.cshtml) -     <p>Hello from C#, #
+                HtmlContent - (44:5,0 [23] NoLinePragmas.cshtml)
+                    RazorIRToken - (44:5,0 [4] NoLinePragmas.cshtml) - Html -     
+                    RazorIRToken - (48:5,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (51:5,7 [16] NoLinePragmas.cshtml) - Html - Hello from C#, #
                 CSharpExpression - (69:5,25 [1] NoLinePragmas.cshtml)
                     RazorIRToken - (69:5,25 [1] NoLinePragmas.cshtml) - CSharp - i
-                HtmlContent - (71:5,27 [6] NoLinePragmas.cshtml) - </p>\n
+                HtmlContent - (71:5,27 [6] NoLinePragmas.cshtml)
+                    RazorIRToken - (71:5,27 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (75:5,31 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (77:6,0 [16] NoLinePragmas.cshtml)
                     RazorIRToken - (77:6,0 [16] NoLinePragmas.cshtml) - CSharp -     i += 1;\n}\n
-                HtmlContent - (93:8,0 [2] NoLinePragmas.cshtml) - \n
+                HtmlContent - (93:8,0 [2] NoLinePragmas.cshtml)
+                    RazorIRToken - (93:8,0 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (96:9,1 [15] NoLinePragmas.cshtml)
                     RazorIRToken - (96:9,1 [15] NoLinePragmas.cshtml) - CSharp - if(i == 11) {\n
-                HtmlContent - (111:10,0 [31] NoLinePragmas.cshtml) -     <p>We wrote 10 lines!</p>\n
+                HtmlContent - (111:10,0 [31] NoLinePragmas.cshtml)
+                    RazorIRToken - (111:10,0 [4] NoLinePragmas.cshtml) - Html -     
+                    RazorIRToken - (115:10,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (118:10,7 [18] NoLinePragmas.cshtml) - Html - We wrote 10 lines!
+                    RazorIRToken - (136:10,25 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (140:10,29 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (142:11,0 [3] NoLinePragmas.cshtml)
                     RazorIRToken - (142:11,0 [3] NoLinePragmas.cshtml) - CSharp - }\n
-                HtmlContent - (145:12,0 [2] NoLinePragmas.cshtml) - \n
+                HtmlContent - (145:12,0 [2] NoLinePragmas.cshtml)
+                    RazorIRToken - (145:12,0 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (148:13,1 [27] NoLinePragmas.cshtml)
                     RazorIRToken - (148:13,1 [27] NoLinePragmas.cshtml) - CSharp - switch(i) {\n    case 11:\n
-                HtmlContent - (175:15,0 [46] NoLinePragmas.cshtml) -         <p>No really, we wrote 10 lines!</p>\n
+                HtmlContent - (175:15,0 [46] NoLinePragmas.cshtml)
+                    RazorIRToken - (175:15,0 [8] NoLinePragmas.cshtml) - Html -         
+                    RazorIRToken - (183:15,8 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (186:15,11 [29] NoLinePragmas.cshtml) - Html - No really, we wrote 10 lines!
+                    RazorIRToken - (215:15,40 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (219:15,44 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (221:16,0 [30] NoLinePragmas.cshtml)
                     RazorIRToken - (221:16,0 [30] NoLinePragmas.cshtml) - CSharp -         break;\n    default:\n
-                HtmlContent - (251:18,0 [39] NoLinePragmas.cshtml) -         <p>Actually, we didn't...</p>\n
+                HtmlContent - (251:18,0 [39] NoLinePragmas.cshtml)
+                    RazorIRToken - (251:18,0 [8] NoLinePragmas.cshtml) - Html -         
+                    RazorIRToken - (259:18,8 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (262:18,11 [22] NoLinePragmas.cshtml) - Html - Actually, we didn't...
+                    RazorIRToken - (284:18,33 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (288:18,37 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (290:19,0 [19] NoLinePragmas.cshtml)
                     RazorIRToken - (290:19,0 [19] NoLinePragmas.cshtml) - CSharp -         break;\n}\n
-                HtmlContent - (309:21,0 [2] NoLinePragmas.cshtml) - \n
+                HtmlContent - (309:21,0 [2] NoLinePragmas.cshtml)
+                    RazorIRToken - (309:21,0 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (312:22,1 [35] NoLinePragmas.cshtml)
                     RazorIRToken - (312:22,1 [35] NoLinePragmas.cshtml) - CSharp - for(int j = 1; j <= 10; j += 2) {\n
-                HtmlContent - (347:23,0 [29] NoLinePragmas.cshtml) -     <p>Hello again from C#, #
+                HtmlContent - (347:23,0 [29] NoLinePragmas.cshtml)
+                    RazorIRToken - (347:23,0 [4] NoLinePragmas.cshtml) - Html -     
+                    RazorIRToken - (351:23,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (354:23,7 [22] NoLinePragmas.cshtml) - Html - Hello again from C#, #
                 CSharpExpression - (378:23,31 [1] NoLinePragmas.cshtml)
                     RazorIRToken - (378:23,31 [1] NoLinePragmas.cshtml) - CSharp - j
-                HtmlContent - (380:23,33 [6] NoLinePragmas.cshtml) - </p>\n
+                HtmlContent - (380:23,33 [6] NoLinePragmas.cshtml)
+                    RazorIRToken - (380:23,33 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (384:23,37 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (386:24,0 [3] NoLinePragmas.cshtml)
                     RazorIRToken - (386:24,0 [3] NoLinePragmas.cshtml) - CSharp - }\n
-                HtmlContent - (389:25,0 [2] NoLinePragmas.cshtml) - \n
+                HtmlContent - (389:25,0 [2] NoLinePragmas.cshtml)
+                    RazorIRToken - (389:25,0 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (392:26,1 [7] NoLinePragmas.cshtml)
                     RazorIRToken - (392:26,1 [7] NoLinePragmas.cshtml) - CSharp - try {\n
-                HtmlContent - (399:27,0 [41] NoLinePragmas.cshtml) -     <p>That time, we wrote 5 lines!</p>\n
+                HtmlContent - (399:27,0 [41] NoLinePragmas.cshtml)
+                    RazorIRToken - (399:27,0 [4] NoLinePragmas.cshtml) - Html -     
+                    RazorIRToken - (403:27,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (406:27,7 [28] NoLinePragmas.cshtml) - Html - That time, we wrote 5 lines!
+                    RazorIRToken - (434:27,35 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (438:27,39 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (440:28,0 [25] NoLinePragmas.cshtml)
                     RazorIRToken - (440:28,0 [25] NoLinePragmas.cshtml) - CSharp - } catch(Exception ex) {\n
-                HtmlContent - (465:29,0 [33] NoLinePragmas.cshtml) -     <p>Oh no! An error occurred: 
+                HtmlContent - (465:29,0 [33] NoLinePragmas.cshtml)
+                    RazorIRToken - (465:29,0 [4] NoLinePragmas.cshtml) - Html -     
+                    RazorIRToken - (469:29,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (472:29,7 [26] NoLinePragmas.cshtml) - Html - Oh no! An error occurred: 
                 CSharpExpression - (500:29,35 [10] NoLinePragmas.cshtml)
                     RazorIRToken - (500:29,35 [10] NoLinePragmas.cshtml) - CSharp - ex.Message
-                HtmlContent - (511:29,46 [6] NoLinePragmas.cshtml) - </p>\n
+                HtmlContent - (511:29,46 [6] NoLinePragmas.cshtml)
+                    RazorIRToken - (511:29,46 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (515:29,50 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (517:30,0 [5] NoLinePragmas.cshtml)
                     RazorIRToken - (517:30,0 [5] NoLinePragmas.cshtml) - CSharp - }\n\n
                 CSharpStatement - (556:32,34 [2] NoLinePragmas.cshtml)
                     RazorIRToken - (556:32,34 [2] NoLinePragmas.cshtml) - CSharp - \n
-                HtmlContent - (558:33,0 [12] NoLinePragmas.cshtml) - <p>i is now 
+                HtmlContent - (558:33,0 [12] NoLinePragmas.cshtml)
+                    RazorIRToken - (558:33,0 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (561:33,3 [9] NoLinePragmas.cshtml) - Html - i is now 
                 CSharpExpression - (571:33,13 [1] NoLinePragmas.cshtml)
                     RazorIRToken - (571:33,13 [1] NoLinePragmas.cshtml) - CSharp - i
-                HtmlContent - (572:33,14 [8] NoLinePragmas.cshtml) - </p>\n\n
+                HtmlContent - (572:33,14 [8] NoLinePragmas.cshtml)
+                    RazorIRToken - (572:33,14 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (576:33,18 [4] NoLinePragmas.cshtml) - Html - \n\n
                 CSharpStatement - (581:35,1 [22] NoLinePragmas.cshtml)
                     RazorIRToken - (581:35,1 [22] NoLinePragmas.cshtml) - CSharp - lock(new object()) {\n
-                HtmlContent - (603:36,0 [53] NoLinePragmas.cshtml) -     <p>This block is locked, for your security!</p>\n
+                HtmlContent - (603:36,0 [53] NoLinePragmas.cshtml)
+                    RazorIRToken - (603:36,0 [4] NoLinePragmas.cshtml) - Html -     
+                    RazorIRToken - (607:36,4 [3] NoLinePragmas.cshtml) - Html - <p>
+                    RazorIRToken - (610:36,7 [40] NoLinePragmas.cshtml) - Html - This block is locked, for your security!
+                    RazorIRToken - (650:36,47 [4] NoLinePragmas.cshtml) - Html - </p>
+                    RazorIRToken - (654:36,51 [2] NoLinePragmas.cshtml) - Html - \n
                 CSharpStatement - (656:37,0 [1] NoLinePragmas.cshtml)
                     RazorIRToken - (656:37,0 [1] NoLinePragmas.cshtml) - CSharp - }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.ir.txt
@@ -34,15 +34,19 @@ Document -
                     RazorIRToken - (91:4,5 [41] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Method(Value?[23]?.More)?["key"]
                 CSharpStatement - (132:4,46 [2] NullConditionalExpressions.cshtml)
                     RazorIRToken - (132:4,46 [2] NullConditionalExpressions.cshtml) - CSharp - \n
-                HtmlContent - (137:6,0 [2] NullConditionalExpressions.cshtml) - \n
+                HtmlContent - (137:6,0 [2] NullConditionalExpressions.cshtml)
+                    RazorIRToken - (137:6,0 [2] NullConditionalExpressions.cshtml) - Html - \n
                 CSharpExpression - (140:7,1 [13] NullConditionalExpressions.cshtml)
                     RazorIRToken - (140:7,1 [13] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Data
-                HtmlContent - (153:7,14 [2] NullConditionalExpressions.cshtml) - \n
+                HtmlContent - (153:7,14 [2] NullConditionalExpressions.cshtml)
+                    RazorIRToken - (153:7,14 [2] NullConditionalExpressions.cshtml) - Html - \n
                 CSharpExpression - (156:8,1 [22] NullConditionalExpressions.cshtml)
                     RazorIRToken - (156:8,1 [22] NullConditionalExpressions.cshtml) - CSharp - ViewBag.IntIndexer?[0]
-                HtmlContent - (178:8,23 [2] NullConditionalExpressions.cshtml) - \n
+                HtmlContent - (178:8,23 [2] NullConditionalExpressions.cshtml)
+                    RazorIRToken - (178:8,23 [2] NullConditionalExpressions.cshtml) - Html - \n
                 CSharpExpression - (181:9,1 [26] NullConditionalExpressions.cshtml)
                     RazorIRToken - (181:9,1 [26] NullConditionalExpressions.cshtml) - CSharp - ViewBag.StrIndexer?["key"]
-                HtmlContent - (207:9,27 [2] NullConditionalExpressions.cshtml) - \n
+                HtmlContent - (207:9,27 [2] NullConditionalExpressions.cshtml)
+                    RazorIRToken - (207:9,27 [2] NullConditionalExpressions.cshtml) - Html - \n
                 CSharpExpression - (210:10,1 [41] NullConditionalExpressions.cshtml)
                     RazorIRToken - (210:10,1 [41] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Method(Value?[23]?.More)?["key"]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_Runtime.ir.txt
@@ -23,15 +23,19 @@ Document -
                     RazorIRToken - (91:4,5 [41] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Method(Value?[23]?.More)?["key"]
                 CSharpStatement - (132:4,46 [2] NullConditionalExpressions.cshtml)
                     RazorIRToken - (132:4,46 [2] NullConditionalExpressions.cshtml) - CSharp - \n
-                HtmlContent - (137:6,0 [2] NullConditionalExpressions.cshtml) - \n
+                HtmlContent - (137:6,0 [2] NullConditionalExpressions.cshtml)
+                    RazorIRToken - (137:6,0 [2] NullConditionalExpressions.cshtml) - Html - \n
                 CSharpExpression - (140:7,1 [13] NullConditionalExpressions.cshtml)
                     RazorIRToken - (140:7,1 [13] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Data
-                HtmlContent - (153:7,14 [2] NullConditionalExpressions.cshtml) - \n
+                HtmlContent - (153:7,14 [2] NullConditionalExpressions.cshtml)
+                    RazorIRToken - (153:7,14 [2] NullConditionalExpressions.cshtml) - Html - \n
                 CSharpExpression - (156:8,1 [22] NullConditionalExpressions.cshtml)
                     RazorIRToken - (156:8,1 [22] NullConditionalExpressions.cshtml) - CSharp - ViewBag.IntIndexer?[0]
-                HtmlContent - (178:8,23 [2] NullConditionalExpressions.cshtml) - \n
+                HtmlContent - (178:8,23 [2] NullConditionalExpressions.cshtml)
+                    RazorIRToken - (178:8,23 [2] NullConditionalExpressions.cshtml) - Html - \n
                 CSharpExpression - (181:9,1 [26] NullConditionalExpressions.cshtml)
                     RazorIRToken - (181:9,1 [26] NullConditionalExpressions.cshtml) - CSharp - ViewBag.StrIndexer?["key"]
-                HtmlContent - (207:9,27 [2] NullConditionalExpressions.cshtml) - \n
+                HtmlContent - (207:9,27 [2] NullConditionalExpressions.cshtml)
+                    RazorIRToken - (207:9,27 [2] NullConditionalExpressions.cshtml) - Html - \n
                 CSharpExpression - (210:10,1 [41] NullConditionalExpressions.cshtml)
                     RazorIRToken - (210:10,1 [41] NullConditionalExpressions.cshtml) - CSharp - ViewBag?.Method(Value?[23]?.More)?["key"]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.ir.txt
@@ -16,12 +16,18 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [16] OpenedIf.cshtml) - <html>\n<body>\n
+                HtmlContent - (0:0,0 [16] OpenedIf.cshtml)
+                    RazorIRToken - (0:0,0 [6] OpenedIf.cshtml) - Html - <html>
+                    RazorIRToken - (6:0,6 [2] OpenedIf.cshtml) - Html - \n
+                    RazorIRToken - (8:1,0 [6] OpenedIf.cshtml) - Html - <body>
+                    RazorIRToken - (14:1,6 [2] OpenedIf.cshtml) - Html - \n
                 CSharpStatement - (17:2,1 [14] OpenedIf.cshtml)
                     RazorIRToken - (17:2,1 [14] OpenedIf.cshtml) - CSharp - if (true) { \n
-                HtmlContent - (31:3,0 [7] OpenedIf.cshtml) - </body>
+                HtmlContent - (31:3,0 [7] OpenedIf.cshtml)
+                    RazorIRToken - (31:3,0 [7] OpenedIf.cshtml) - Html - </body>
                 CSharpStatement - (38:3,7 [2] OpenedIf.cshtml)
                     RazorIRToken - (38:3,7 [2] OpenedIf.cshtml) - CSharp - \n
-                HtmlContent - (40:4,0 [7] OpenedIf.cshtml) - </html>
+                HtmlContent - (40:4,0 [7] OpenedIf.cshtml)
+                    RazorIRToken - (40:4,0 [7] OpenedIf.cshtml) - Html - </html>
                 CSharpStatement - (47:4,7 [0] OpenedIf.cshtml)
                     RazorIRToken - (47:4,7 [0] OpenedIf.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_Runtime.ir.txt
@@ -5,9 +5,16 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_OpenedIf_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [16] OpenedIf.cshtml) - <html>\n<body>\n
+                HtmlContent - (0:0,0 [16] OpenedIf.cshtml)
+                    RazorIRToken - (0:0,0 [6] OpenedIf.cshtml) - Html - <html>
+                    RazorIRToken - (6:0,6 [2] OpenedIf.cshtml) - Html - \n
+                    RazorIRToken - (8:1,0 [6] OpenedIf.cshtml) - Html - <body>
+                    RazorIRToken - (14:1,6 [2] OpenedIf.cshtml) - Html - \n
                 CSharpStatement - (17:2,1 [14] OpenedIf.cshtml)
                     RazorIRToken - (17:2,1 [14] OpenedIf.cshtml) - CSharp - if (true) { \n
-                HtmlContent - (31:3,0 [16] OpenedIf.cshtml) - </body>\n</html>
+                HtmlContent - (31:3,0 [16] OpenedIf.cshtml)
+                    RazorIRToken - (31:3,0 [7] OpenedIf.cshtml) - Html - </body>
+                    RazorIRToken - (38:3,7 [2] OpenedIf.cshtml) - Html - \n
+                    RazorIRToken - (40:4,0 [7] OpenedIf.cshtml) - Html - </html>
                 CSharpStatement - (47:4,7 [0] OpenedIf.cshtml)
                     RazorIRToken - (47:4,7 [0] OpenedIf.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.ir.txt
@@ -18,97 +18,142 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper1 - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] PrefixedAttributeTagHelpers.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (31:0,31 [4] PrefixedAttributeTagHelpers.cshtml) - Html - \n\n
                 CSharpStatement - (37:2,2 [242] PrefixedAttributeTagHelpers.cshtml)
                     RazorIRToken - (37:2,2 [242] PrefixedAttributeTagHelpers.cshtml) - CSharp - \n    var literate = "or illiterate";\n    var intDictionary = new Dictionary<string, int>\n    {\n        { "three", 3 },\n    };\n    var stringDictionary = new SortedDictionary<string, string>\n    {\n        { "name", "value" },\n    };\n
-                HtmlContent - (282:13,0 [49] PrefixedAttributeTagHelpers.cshtml) - \n<div class="randomNonTagHelperAttribute">\n    
+                HtmlContent - (282:13,0 [49] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (282:13,0 [2] PrefixedAttributeTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (284:14,0 [4] PrefixedAttributeTagHelpers.cshtml) - Html - <div
+                    RazorIRToken - (288:14,4 [36] PrefixedAttributeTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (324:14,40 [1] PrefixedAttributeTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (325:14,41 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (331:15,4 [92] PrefixedAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (344:15,17 [8] PrefixedAttributeTagHelpers.cshtml) - checkbox
+                        HtmlContent - (344:15,17 [8] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (344:15,17 [8] PrefixedAttributeTagHelpers.cshtml) - Html - checkbox
                     SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
                     SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
                     SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - stringDictionary
+                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - Html - stringDictionary
                     SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - stringDictionary
+                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - Html - stringDictionary
                     ExecuteTagHelpers - 
-                HtmlContent - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                HtmlContent - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (429:16,4 [103] PrefixedAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (442:16,17 [8] PrefixedAttributeTagHelpers.cshtml) - password
+                        HtmlContent - (442:16,17 [8] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (442:16,17 [8] PrefixedAttributeTagHelpers.cshtml) - Html - password
                     SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
                     SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
                     SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
                     SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
                     ExecuteTagHelpers - 
-                HtmlContent - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                HtmlContent - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (538:17,4 [257] PrefixedAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (551:17,17 [5] PrefixedAttributeTagHelpers.cshtml) - radio
+                        HtmlContent - (551:17,17 [5] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (551:17,17 [5] PrefixedAttributeTagHelpers.cshtml) - Html - radio
                     SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
                     SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
                     SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - 98
+                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 98
                     SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - 98
+                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 98
                     AddTagHelperHtmlAttribute -  - int-prefix-salt - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (655:18,96 [1] PrefixedAttributeTagHelpers.cshtml) - 8
+                        HtmlContent - (655:18,96 [1] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (655:18,96 [1] PrefixedAttributeTagHelpers.cshtml) - Html - 8
                     SetTagHelperProperty - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - string-prefix-grabber - StringProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - string
+                        HtmlContent - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - Html - string
                     SetTagHelperProperty - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - string-prefix-grabber - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - string
+                        HtmlContent - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (693:19,34 [6] PrefixedAttributeTagHelpers.cshtml) - Html - string
                     SetTagHelperProperty - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - string-prefix-paprika - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - another string
+                        HtmlContent - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - Html - another string
                     SetTagHelperProperty - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - string-prefix-paprika - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - another string
+                        HtmlContent - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (724:19,65 [14] PrefixedAttributeTagHelpers.cshtml) - Html - another string
                     SetTagHelperProperty - (773:20,32 [19] PrefixedAttributeTagHelpers.cshtml) - string-prefix-cumin - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml) - literate 
+                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (773:20,32 [8] PrefixedAttributeTagHelpers.cshtml) - Html - literate
+                            RazorIRToken - (781:20,40 [1] PrefixedAttributeTagHelpers.cshtml) - Html -  
                         CSharpExpression - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml)
                             RazorIRToken - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml) - CSharp - literate
-                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - ?
+                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - Html - ?
                     SetTagHelperProperty - (773:20,32 [19] PrefixedAttributeTagHelpers.cshtml) - string-prefix-cumin - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml) - literate 
+                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (773:20,32 [8] PrefixedAttributeTagHelpers.cshtml) - Html - literate
+                            RazorIRToken - (781:20,40 [1] PrefixedAttributeTagHelpers.cshtml) - Html -  
                         CSharpExpression - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml)
                             RazorIRToken - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml) - CSharp - literate
-                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - ?
+                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - Html - ?
                     ExecuteTagHelpers - 
-                HtmlContent - (795:20,54 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                HtmlContent - (795:20,54 [6] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (795:20,54 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (801:21,4 [60] PrefixedAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - string-prefix-thyme - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - string
+                        HtmlContent - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - Html - string
                     SetTagHelperProperty - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - string-prefix-thyme - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - string
+                        HtmlContent - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - Html - string
                     ExecuteTagHelpers - 
-                HtmlContent - (861:21,64 [8] PrefixedAttributeTagHelpers.cshtml) - \n</div>
+                HtmlContent - (861:21,64 [8] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (861:21,64 [2] PrefixedAttributeTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (863:22,0 [6] PrefixedAttributeTagHelpers.cshtml) - Html - </div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.ir.txt
@@ -13,87 +13,122 @@ Document -
             DeclarePreallocatedTagHelperAttribute -  - __tagHelperAttribute_6 - string-prefix-thyme - string - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.InputTagHelper1 - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] PrefixedAttributeTagHelpers.cshtml) - \n
+                HtmlContent - (33:1,0 [2] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (33:1,0 [2] PrefixedAttributeTagHelpers.cshtml) - Html - \n
                 CSharpStatement - (37:2,2 [242] PrefixedAttributeTagHelpers.cshtml)
                     RazorIRToken - (37:2,2 [242] PrefixedAttributeTagHelpers.cshtml) - CSharp - \n    var literate = "or illiterate";\n    var intDictionary = new Dictionary<string, int>\n    {\n        { "three", 3 },\n    };\n    var stringDictionary = new SortedDictionary<string, string>\n    {\n        { "name", "value" },\n    };\n
-                HtmlContent - (282:13,0 [49] PrefixedAttributeTagHelpers.cshtml) - \n<div class="randomNonTagHelperAttribute">\n    
+                HtmlContent - (282:13,0 [49] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (282:13,0 [2] PrefixedAttributeTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (284:14,0 [4] PrefixedAttributeTagHelpers.cshtml) - Html - <div
+                    RazorIRToken - (288:14,4 [36] PrefixedAttributeTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
+                    RazorIRToken - (324:14,40 [1] PrefixedAttributeTagHelpers.cshtml) - Html - >
+                    RazorIRToken - (325:14,41 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (331:15,4 [92] PrefixedAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
                     SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
                     SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - stringDictionary
+                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - Html - stringDictionary
                     SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - stringDictionary
+                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - Html - stringDictionary
                     ExecuteTagHelpers - 
-                HtmlContent - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                HtmlContent - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (429:16,4 [103] PrefixedAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
                     SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - intDictionary
+                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
                     SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
                     SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
                     ExecuteTagHelpers - 
-                HtmlContent - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                HtmlContent - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (538:17,4 [257] PrefixedAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
                     SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - 42
+                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
                     SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - 98
+                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 98
                     SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - 98
+                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 98
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - string-prefix-grabber - StringProperty
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - string-prefix-grabber - StringDictionaryProperty
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_5 - string-prefix-paprika - StringDictionaryProperty
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_5 - string-prefix-paprika - StringDictionaryProperty
                     SetTagHelperProperty - (773:20,32 [19] PrefixedAttributeTagHelpers.cshtml) - string-prefix-cumin - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml) - literate 
+                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (773:20,32 [8] PrefixedAttributeTagHelpers.cshtml) - Html - literate
+                            RazorIRToken - (781:20,40 [1] PrefixedAttributeTagHelpers.cshtml) - Html -  
                         CSharpExpression - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml)
                             RazorIRToken - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml) - CSharp - literate
-                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - ?
+                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - Html - ?
                     SetTagHelperProperty - (773:20,32 [19] PrefixedAttributeTagHelpers.cshtml) - string-prefix-cumin - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml) - literate 
+                        HtmlContent - (773:20,32 [9] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (773:20,32 [8] PrefixedAttributeTagHelpers.cshtml) - Html - literate
+                            RazorIRToken - (781:20,40 [1] PrefixedAttributeTagHelpers.cshtml) - Html -  
                         CSharpExpression - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml)
                             RazorIRToken - (783:20,42 [8] PrefixedAttributeTagHelpers.cshtml) - CSharp - literate
-                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - ?
+                        HtmlContent - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (791:20,50 [1] PrefixedAttributeTagHelpers.cshtml) - Html - ?
                     ExecuteTagHelpers - 
-                HtmlContent - (795:20,54 [6] PrefixedAttributeTagHelpers.cshtml) - \n    
+                HtmlContent - (795:20,54 [6] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (795:20,54 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
                 TagHelper - (801:21,4 [60] PrefixedAttributeTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - 37
+                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml)
+                            RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - string-prefix-thyme - StringDictionaryProperty
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - string-prefix-thyme - StringDictionaryProperty
                     ExecuteTagHelpers - 
-                HtmlContent - (861:21,64 [8] PrefixedAttributeTagHelpers.cshtml) - \n</div>
+                HtmlContent - (861:21,64 [8] PrefixedAttributeTagHelpers.cshtml)
+                    RazorIRToken - (861:21,64 [2] PrefixedAttributeTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (863:22,0 [6] PrefixedAttributeTagHelpers.cshtml) - Html - </div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.ir.txt
@@ -16,22 +16,34 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (36:0,36 [17] RazorComments.cshtml) - \n<p>This should 
-                HtmlContent - (62:1,24 [17] RazorComments.cshtml) -  be shown</p>\n\n
+                HtmlContent - (36:0,36 [17] RazorComments.cshtml)
+                    RazorIRToken - (36:0,36 [2] RazorComments.cshtml) - Html - \n
+                    RazorIRToken - (38:1,0 [3] RazorComments.cshtml) - Html - <p>
+                    RazorIRToken - (41:1,3 [12] RazorComments.cshtml) - Html - This should 
+                HtmlContent - (62:1,24 [17] RazorComments.cshtml)
+                    RazorIRToken - (62:1,24 [9] RazorComments.cshtml) - Html -  be shown
+                    RazorIRToken - (71:1,33 [4] RazorComments.cshtml) - Html - </p>
+                    RazorIRToken - (75:1,37 [4] RazorComments.cshtml) - Html - \n\n
                 CSharpStatement - (81:3,2 [6] RazorComments.cshtml)
                     RazorIRToken - (81:3,2 [6] RazorComments.cshtml) - CSharp - \n    
                 CSharpStatement - (122:4,39 [22] RazorComments.cshtml)
                     RazorIRToken - (122:4,39 [22] RazorComments.cshtml) - CSharp - \n    Exception foo = 
                 CSharpStatement - (173:5,49 [58] RazorComments.cshtml)
                     RazorIRToken - (173:5,49 [58] RazorComments.cshtml) - CSharp -  null;\n    if(foo != null) {\n        throw foo;\n    }\n
-                HtmlContent - (234:10,0 [2] RazorComments.cshtml) - \n
+                HtmlContent - (234:10,0 [2] RazorComments.cshtml)
+                    RazorIRToken - (234:10,0 [2] RazorComments.cshtml) - Html - \n
                 CSharpStatement - (238:11,2 [24] RazorComments.cshtml)
                     RazorIRToken - (238:11,2 [24] RazorComments.cshtml) - CSharp -  var bar = "@* bar *@"; 
-                HtmlContent - (265:12,0 [44] RazorComments.cshtml) - <p>But this should show the comment syntax: 
+                HtmlContent - (265:12,0 [44] RazorComments.cshtml)
+                    RazorIRToken - (265:12,0 [3] RazorComments.cshtml) - Html - <p>
+                    RazorIRToken - (268:12,3 [41] RazorComments.cshtml) - Html - But this should show the comment syntax: 
                 CSharpExpression - (310:12,45 [3] RazorComments.cshtml)
                     RazorIRToken - (310:12,45 [3] RazorComments.cshtml) - CSharp - bar
-                HtmlContent - (313:12,48 [8] RazorComments.cshtml) - </p>\n\n
+                HtmlContent - (313:12,48 [8] RazorComments.cshtml)
+                    RazorIRToken - (313:12,48 [4] RazorComments.cshtml) - Html - </p>
+                    RazorIRToken - (317:12,52 [4] RazorComments.cshtml) - Html - \n\n
                 CSharpExpression - (323:14,2 [2] RazorComments.cshtml)
                     RazorIRToken - (323:14,2 [1] RazorComments.cshtml) - CSharp - a
                     RazorIRToken - (328:14,7 [1] RazorComments.cshtml) - CSharp - b
-                HtmlContent - (330:14,9 [2] RazorComments.cshtml) - \n
+                HtmlContent - (330:14,9 [2] RazorComments.cshtml)
+                    RazorIRToken - (330:14,9 [2] RazorComments.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.ir.txt
@@ -5,22 +5,34 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorComments_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (36:0,36 [17] RazorComments.cshtml) - \n<p>This should 
-                HtmlContent - (62:1,24 [17] RazorComments.cshtml) -  be shown</p>\n\n
+                HtmlContent - (36:0,36 [17] RazorComments.cshtml)
+                    RazorIRToken - (36:0,36 [2] RazorComments.cshtml) - Html - \n
+                    RazorIRToken - (38:1,0 [3] RazorComments.cshtml) - Html - <p>
+                    RazorIRToken - (41:1,3 [12] RazorComments.cshtml) - Html - This should 
+                HtmlContent - (62:1,24 [17] RazorComments.cshtml)
+                    RazorIRToken - (62:1,24 [9] RazorComments.cshtml) - Html -  be shown
+                    RazorIRToken - (71:1,33 [4] RazorComments.cshtml) - Html - </p>
+                    RazorIRToken - (75:1,37 [4] RazorComments.cshtml) - Html - \n\n
                 CSharpStatement - (81:3,2 [6] RazorComments.cshtml)
                     RazorIRToken - (81:3,2 [6] RazorComments.cshtml) - CSharp - \n    
                 CSharpStatement - (122:4,39 [22] RazorComments.cshtml)
                     RazorIRToken - (122:4,39 [22] RazorComments.cshtml) - CSharp - \n    Exception foo = 
                 CSharpStatement - (173:5,49 [58] RazorComments.cshtml)
                     RazorIRToken - (173:5,49 [58] RazorComments.cshtml) - CSharp -  null;\n    if(foo != null) {\n        throw foo;\n    }\n
-                HtmlContent - (234:10,0 [2] RazorComments.cshtml) - \n
+                HtmlContent - (234:10,0 [2] RazorComments.cshtml)
+                    RazorIRToken - (234:10,0 [2] RazorComments.cshtml) - Html - \n
                 CSharpStatement - (238:11,2 [24] RazorComments.cshtml)
                     RazorIRToken - (238:11,2 [24] RazorComments.cshtml) - CSharp -  var bar = "@* bar *@"; 
-                HtmlContent - (265:12,0 [44] RazorComments.cshtml) - <p>But this should show the comment syntax: 
+                HtmlContent - (265:12,0 [44] RazorComments.cshtml)
+                    RazorIRToken - (265:12,0 [3] RazorComments.cshtml) - Html - <p>
+                    RazorIRToken - (268:12,3 [41] RazorComments.cshtml) - Html - But this should show the comment syntax: 
                 CSharpExpression - (310:12,45 [3] RazorComments.cshtml)
                     RazorIRToken - (310:12,45 [3] RazorComments.cshtml) - CSharp - bar
-                HtmlContent - (313:12,48 [8] RazorComments.cshtml) - </p>\n\n
+                HtmlContent - (313:12,48 [8] RazorComments.cshtml)
+                    RazorIRToken - (313:12,48 [4] RazorComments.cshtml) - Html - </p>
+                    RazorIRToken - (317:12,52 [4] RazorComments.cshtml) - Html - \n\n
                 CSharpExpression - (323:14,2 [2] RazorComments.cshtml)
                     RazorIRToken - (323:14,2 [1] RazorComments.cshtml) - CSharp - a
                     RazorIRToken - (328:14,7 [1] RazorComments.cshtml) - CSharp - b
-                HtmlContent - (330:14,9 [2] RazorComments.cshtml) - \n
+                HtmlContent - (330:14,9 [2] RazorComments.cshtml)
+                    RazorIRToken - (330:14,9 [2] RazorComments.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.ir.txt
@@ -17,4 +17,5 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (32:0,32 [2] RemoveTagHelperDirective.cshtml) - \n
+                HtmlContent - (32:0,32 [2] RemoveTagHelperDirective.cshtml)
+                    RazorIRToken - (32:0,32 [2] RemoveTagHelperDirective.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.ir.txt
@@ -21,35 +21,54 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [44] Sections.cshtml)
                     RazorIRToken - (2:0,2 [44] Sections.cshtml) - CSharp - \n    Layout = "_SectionTestLayout.cshtml"\n
-                HtmlContent - (49:3,0 [31] Sections.cshtml) - \n<div>This is in the Body>\n\n
+                HtmlContent - (49:3,0 [31] Sections.cshtml)
+                    RazorIRToken - (49:3,0 [2] Sections.cshtml) - Html - \n
+                    RazorIRToken - (51:4,0 [5] Sections.cshtml) - Html - <div>
+                    RazorIRToken - (56:4,5 [24] Sections.cshtml) - Html - This is in the Body>\n\n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("Section2", async (__razor_section_writer) => {
-                HtmlContent - (99:6,19 [10] Sections.cshtml) - \n    <div
+                HtmlContent - (99:6,19 [10] Sections.cshtml)
+                    RazorIRToken - (99:6,19 [6] Sections.cshtml) - Html - \n    
+                    RazorIRToken - (105:7,4 [4] Sections.cshtml) - Html - <div
                 HtmlAttribute - (109:7,8 [20] Sections.cshtml) -  class=" - "
                     HtmlAttributeValue - (117:7,16 [4] Sections.cshtml) -  - some
                     CSharpAttributeValue - (121:7,20 [7] Sections.cshtml) -  
                         CSharpExpression - (123:7,22 [5] Sections.cshtml)
                             RazorIRToken - (123:7,22 [5] Sections.cshtml) - CSharp - thing
-                HtmlContent - (129:7,28 [29] Sections.cshtml) - >This is in Section 2</div>\n
+                HtmlContent - (129:7,28 [29] Sections.cshtml)
+                    RazorIRToken - (129:7,28 [1] Sections.cshtml) - Html - >
+                    RazorIRToken - (130:7,29 [20] Sections.cshtml) - Html - This is in Section 2
+                    RazorIRToken - (150:7,49 [6] Sections.cshtml) - Html - </div>
+                    RazorIRToken - (156:7,55 [2] Sections.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (159:8,1 [4] Sections.cshtml) - \n\n
+                HtmlContent - (159:8,1 [4] Sections.cshtml)
+                    RazorIRToken - (159:8,1 [4] Sections.cshtml) - Html - \n\n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("Section1", async (__razor_section_writer) => {
-                HtmlContent - (182:10,19 [39] Sections.cshtml) - \n    <div>This is in Section 1</div>\n
+                HtmlContent - (182:10,19 [39] Sections.cshtml)
+                    RazorIRToken - (182:10,19 [6] Sections.cshtml) - Html - \n    
+                    RazorIRToken - (188:11,4 [5] Sections.cshtml) - Html - <div>
+                    RazorIRToken - (193:11,9 [20] Sections.cshtml) - Html - This is in Section 1
+                    RazorIRToken - (213:11,29 [6] Sections.cshtml) - Html - </div>
+                    RazorIRToken - (219:11,35 [2] Sections.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (222:12,1 [4] Sections.cshtml) - \n\n
+                HtmlContent - (222:12,1 [4] Sections.cshtml)
+                    RazorIRToken - (222:12,1 [4] Sections.cshtml) - Html - \n\n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("NestedDelegates", async (__razor_section_writer) => {
-                HtmlContent - (252:14,26 [6] Sections.cshtml) - \n    
+                HtmlContent - (252:14,26 [6] Sections.cshtml)
+                    RazorIRToken - (252:14,26 [6] Sections.cshtml) - Html - \n    
                 CSharpStatement - (260:15,6 [27] Sections.cshtml)
                     RazorIRToken - (260:15,6 [27] Sections.cshtml) - CSharp -  Func<dynamic, object> f = 
                 Template - (288:15,34 [17] Sections.cshtml)
-                    HtmlContent - (288:15,34 [6] Sections.cshtml) - <span>
+                    HtmlContent - (288:15,34 [6] Sections.cshtml)
+                        RazorIRToken - (288:15,34 [6] Sections.cshtml) - Html - <span>
                     CSharpExpression - (295:15,41 [4] Sections.cshtml)
                         RazorIRToken - (295:15,41 [4] Sections.cshtml) - CSharp - item
-                    HtmlContent - (299:15,45 [7] Sections.cshtml) - </span>
+                    HtmlContent - (299:15,45 [7] Sections.cshtml)
+                        RazorIRToken - (299:15,45 [7] Sections.cshtml) - Html - </span>
                 CSharpStatement - (306:15,52 [2] Sections.cshtml)
                     RazorIRToken - (306:15,52 [2] Sections.cshtml) - CSharp - ; 
                 CSharpStatement - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.ir.txt
@@ -7,37 +7,56 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (2:0,2 [44] Sections.cshtml)
                     RazorIRToken - (2:0,2 [44] Sections.cshtml) - CSharp - \n    Layout = "_SectionTestLayout.cshtml"\n
-                HtmlContent - (49:3,0 [31] Sections.cshtml) - \n<div>This is in the Body>\n\n
+                HtmlContent - (49:3,0 [31] Sections.cshtml)
+                    RazorIRToken - (49:3,0 [2] Sections.cshtml) - Html - \n
+                    RazorIRToken - (51:4,0 [5] Sections.cshtml) - Html - <div>
+                    RazorIRToken - (56:4,5 [24] Sections.cshtml) - Html - This is in the Body>\n\n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("Section2", async () => {
-                HtmlContent - (99:6,19 [10] Sections.cshtml) - \n    <div
+                HtmlContent - (99:6,19 [10] Sections.cshtml)
+                    RazorIRToken - (99:6,19 [6] Sections.cshtml) - Html - \n    
+                    RazorIRToken - (105:7,4 [4] Sections.cshtml) - Html - <div
                 HtmlAttribute - (109:7,8 [20] Sections.cshtml) -  class=" - "
                     HtmlAttributeValue - (117:7,16 [4] Sections.cshtml) -  - some
                     CSharpAttributeValue - (121:7,20 [7] Sections.cshtml) -  
                         CSharpExpression - (123:7,22 [5] Sections.cshtml)
                             RazorIRToken - (123:7,22 [5] Sections.cshtml) - CSharp - thing
-                HtmlContent - (129:7,28 [29] Sections.cshtml) - >This is in Section 2</div>\n
+                HtmlContent - (129:7,28 [29] Sections.cshtml)
+                    RazorIRToken - (129:7,28 [1] Sections.cshtml) - Html - >
+                    RazorIRToken - (130:7,29 [20] Sections.cshtml) - Html - This is in Section 2
+                    RazorIRToken - (150:7,49 [6] Sections.cshtml) - Html - </div>
+                    RazorIRToken - (156:7,55 [2] Sections.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (161:9,0 [2] Sections.cshtml) - \n
+                HtmlContent - (161:9,0 [2] Sections.cshtml)
+                    RazorIRToken - (161:9,0 [2] Sections.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("Section1", async () => {
-                HtmlContent - (182:10,19 [39] Sections.cshtml) - \n    <div>This is in Section 1</div>\n
+                HtmlContent - (182:10,19 [39] Sections.cshtml)
+                    RazorIRToken - (182:10,19 [6] Sections.cshtml) - Html - \n    
+                    RazorIRToken - (188:11,4 [5] Sections.cshtml) - Html - <div>
+                    RazorIRToken - (193:11,9 [20] Sections.cshtml) - Html - This is in Section 1
+                    RazorIRToken - (213:11,29 [6] Sections.cshtml) - Html - </div>
+                    RazorIRToken - (219:11,35 [2] Sections.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (224:13,0 [2] Sections.cshtml) - \n
+                HtmlContent - (224:13,0 [2] Sections.cshtml)
+                    RazorIRToken - (224:13,0 [2] Sections.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("NestedDelegates", async () => {
-                HtmlContent - (252:14,26 [2] Sections.cshtml) - \n
+                HtmlContent - (252:14,26 [2] Sections.cshtml)
+                    RazorIRToken - (252:14,26 [2] Sections.cshtml) - Html - \n
                 CSharpStatement - (254:15,0 [4] Sections.cshtml)
                     RazorIRToken - (254:15,0 [4] Sections.cshtml) - CSharp -     
                 CSharpStatement - (260:15,6 [27] Sections.cshtml)
                     RazorIRToken - (260:15,6 [27] Sections.cshtml) - CSharp -  Func<dynamic, object> f = 
                 Template - (288:15,34 [17] Sections.cshtml)
-                    HtmlContent - (288:15,34 [6] Sections.cshtml) - <span>
+                    HtmlContent - (288:15,34 [6] Sections.cshtml)
+                        RazorIRToken - (288:15,34 [6] Sections.cshtml) - Html - <span>
                     CSharpExpression - (295:15,41 [4] Sections.cshtml)
                         RazorIRToken - (295:15,41 [4] Sections.cshtml) - CSharp - item
-                    HtmlContent - (299:15,45 [7] Sections.cshtml) - </span>
+                    HtmlContent - (299:15,45 [7] Sections.cshtml)
+                        RazorIRToken - (299:15,45 [7] Sections.cshtml) - Html - </span>
                 CSharpStatement - (306:15,52 [2] Sections.cshtml)
                     RazorIRToken - (306:15,52 [2] Sections.cshtml) - CSharp - ; 
                 CSharpStatement - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.ir.txt
@@ -18,13 +18,24 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (29:0,29 [27] SimpleTagHelpers.cshtml) - \n<p>Hola</p>\n<form>\n    
+                HtmlContent - (29:0,29 [27] SimpleTagHelpers.cshtml)
+                    RazorIRToken - (29:0,29 [2] SimpleTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (31:1,0 [3] SimpleTagHelpers.cshtml) - Html - <p>
+                    RazorIRToken - (34:1,3 [4] SimpleTagHelpers.cshtml) - Html - Hola
+                    RazorIRToken - (38:1,7 [4] SimpleTagHelpers.cshtml) - Html - </p>
+                    RazorIRToken - (42:1,11 [2] SimpleTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (44:2,0 [6] SimpleTagHelpers.cshtml) - Html - <form>
+                    RazorIRToken - (50:2,6 [6] SimpleTagHelpers.cshtml) - Html - \n    
                 TagHelper - (56:3,4 [35] SimpleTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - InputTagHelper
                     SetTagHelperProperty - (70:3,18 [5] SimpleTagHelpers.cshtml) - value - FooProp - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (70:3,18 [5] SimpleTagHelpers.cshtml) - Hello
+                        HtmlContent - (70:3,18 [5] SimpleTagHelpers.cshtml)
+                            RazorIRToken - (70:3,18 [5] SimpleTagHelpers.cshtml) - Html - Hello
                     AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (83:3,31 [4] SimpleTagHelpers.cshtml) - text
+                        HtmlContent - (83:3,31 [4] SimpleTagHelpers.cshtml)
+                            RazorIRToken - (83:3,31 [4] SimpleTagHelpers.cshtml) - Html - text
                     ExecuteTagHelpers - 
-                HtmlContent - (91:3,39 [9] SimpleTagHelpers.cshtml) - \n</form>
+                HtmlContent - (91:3,39 [9] SimpleTagHelpers.cshtml)
+                    RazorIRToken - (91:3,39 [2] SimpleTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (93:4,0 [7] SimpleTagHelpers.cshtml) - Html - </form>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.ir.txt
@@ -8,11 +8,19 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - type - text - HtmlAttributeValueStyle.SingleQuotes
             DeclareTagHelperFields -  - InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:1,0 [25] SimpleTagHelpers.cshtml) - <p>Hola</p>\n<form>\n    
+                HtmlContent - (31:1,0 [25] SimpleTagHelpers.cshtml)
+                    RazorIRToken - (31:1,0 [3] SimpleTagHelpers.cshtml) - Html - <p>
+                    RazorIRToken - (34:1,3 [4] SimpleTagHelpers.cshtml) - Html - Hola
+                    RazorIRToken - (38:1,7 [4] SimpleTagHelpers.cshtml) - Html - </p>
+                    RazorIRToken - (42:1,11 [2] SimpleTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (44:2,0 [6] SimpleTagHelpers.cshtml) - Html - <form>
+                    RazorIRToken - (50:2,6 [6] SimpleTagHelpers.cshtml) - Html - \n    
                 TagHelper - (56:3,4 [35] SimpleTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - InputTagHelper
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - value - FooProp
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     ExecuteTagHelpers - 
-                HtmlContent - (91:3,39 [9] SimpleTagHelpers.cshtml) - \n</form>
+                HtmlContent - (91:3,39 [9] SimpleTagHelpers.cshtml)
+                    RazorIRToken - (91:3,39 [2] SimpleTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (93:4,0 [7] SimpleTagHelpers.cshtml) - Html - </form>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.ir.txt
@@ -18,6 +18,8 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (1:0,1 [15] SimpleUnspacedIf.cshtml)
                     RazorIRToken - (1:0,1 [15] SimpleUnspacedIf.cshtml) - CSharp - if (true)\n{\n	
-                HtmlContent - (16:2,1 [11] SimpleUnspacedIf.cshtml) - <div></div>
+                HtmlContent - (16:2,1 [11] SimpleUnspacedIf.cshtml)
+                    RazorIRToken - (16:2,1 [5] SimpleUnspacedIf.cshtml) - Html - <div>
+                    RazorIRToken - (21:2,6 [6] SimpleUnspacedIf.cshtml) - Html - </div>
                 CSharpStatement - (27:2,12 [3] SimpleUnspacedIf.cshtml)
                     RazorIRToken - (27:2,12 [3] SimpleUnspacedIf.cshtml) - CSharp - \n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_Runtime.ir.txt
@@ -7,6 +7,10 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (1:0,1 [14] SimpleUnspacedIf.cshtml)
                     RazorIRToken - (1:0,1 [14] SimpleUnspacedIf.cshtml) - CSharp - if (true)\n{\n
-                HtmlContent - (15:2,0 [14] SimpleUnspacedIf.cshtml) - 	<div></div>\n
+                HtmlContent - (15:2,0 [14] SimpleUnspacedIf.cshtml)
+                    RazorIRToken - (15:2,0 [1] SimpleUnspacedIf.cshtml) - Html - 	
+                    RazorIRToken - (16:2,1 [5] SimpleUnspacedIf.cshtml) - Html - <div>
+                    RazorIRToken - (21:2,6 [6] SimpleUnspacedIf.cshtml) - Html - </div>
+                    RazorIRToken - (27:2,12 [2] SimpleUnspacedIf.cshtml) - Html - \n
                 CSharpStatement - (29:3,0 [1] SimpleUnspacedIf.cshtml)
                     RazorIRToken - (29:3,0 [1] SimpleUnspacedIf.cshtml) - CSharp - }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.ir.txt
@@ -18,13 +18,17 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
+                    RazorIRToken - (31:0,31 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - \n\n
                 TagHelper - (35:2,0 [53] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (73:3,34 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Body of Tag
+                        HtmlContent - (73:3,34 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
+                            RazorIRToken - (73:3,34 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - Body of Tag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (49:3,10 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Hello World
+                        HtmlContent - (49:3,10 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
+                            RazorIRToken - (49:3,10 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - Hello World
                     SetTagHelperProperty - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - 1337
+                        HtmlContent - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
+                            RazorIRToken - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - 1337
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.ir.txt
@@ -7,12 +7,15 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - \n
+                HtmlContent - (33:1,0 [2] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
+                    RazorIRToken - (33:1,0 [2] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - \n
                 TagHelper - (35:2,0 [53] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (73:3,34 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Body of Tag
+                        HtmlContent - (73:3,34 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
+                            RazorIRToken - (73:3,34 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - Body of Tag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - 1337
+                        HtmlContent - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
+                            RazorIRToken - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - 1337
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.ir.txt
@@ -18,13 +18,17 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] SingleTagHelper.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] SingleTagHelper.cshtml)
+                    RazorIRToken - (31:0,31 [4] SingleTagHelper.cshtml) - Html - \n\n
                 TagHelper - (35:2,0 [49] SingleTagHelper.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (69:2,34 [11] SingleTagHelper.cshtml) - Body of Tag
+                        HtmlContent - (69:2,34 [11] SingleTagHelper.cshtml)
+                            RazorIRToken - (69:2,34 [11] SingleTagHelper.cshtml) - Html - Body of Tag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (45:2,10 [11] SingleTagHelper.cshtml) - Hello World
+                        HtmlContent - (45:2,10 [11] SingleTagHelper.cshtml)
+                            RazorIRToken - (45:2,10 [11] SingleTagHelper.cshtml) - Html - Hello World
                     SetTagHelperProperty - (63:2,28 [4] SingleTagHelper.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (63:2,28 [4] SingleTagHelper.cshtml) - 1337
+                        HtmlContent - (63:2,28 [4] SingleTagHelper.cshtml)
+                            RazorIRToken - (63:2,28 [4] SingleTagHelper.cshtml) - Html - 1337
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.ir.txt
@@ -7,12 +7,15 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - class - Hello World - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] SingleTagHelper.cshtml) - \n
+                HtmlContent - (33:1,0 [2] SingleTagHelper.cshtml)
+                    RazorIRToken - (33:1,0 [2] SingleTagHelper.cshtml) - Html - \n
                 TagHelper - (35:2,0 [49] SingleTagHelper.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (69:2,34 [11] SingleTagHelper.cshtml) - Body of Tag
+                        HtmlContent - (69:2,34 [11] SingleTagHelper.cshtml)
+                            RazorIRToken - (69:2,34 [11] SingleTagHelper.cshtml) - Html - Body of Tag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (63:2,28 [4] SingleTagHelper.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (63:2,28 [4] SingleTagHelper.cshtml) - 1337
+                        HtmlContent - (63:2,28 [4] SingleTagHelper.cshtml)
+                            RazorIRToken - (63:2,28 [4] SingleTagHelper.cshtml) - Html - 1337
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.ir.txt
@@ -18,16 +18,949 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [2013] StringLiterals.cshtml) - <p>This is line 1</p>\n<p>This is line 2</p>\n<p>This is line 3</p>\n<p>This is line 4</p>\n<p>This is line 5</p>\n<p>This is line 6</p>\n<p>This is line 7</p>\n<p>This is line 8</p>\n<p>This is line 9</p>\n<p>This is line 10</p>\n<p>This is line 11</p>\n<p>This is line 12</p>\n<p>This is line 13</p>\n<p>This is line 14</p>\n<p>This is line 15</p>\n<p>This is line 16</p>\n<p>This is line 17</p>\n<p>This is line 18</p>\n<p>This is line 19</p>\n<p>This is line 20</p>\n<p>This is line 21</p>\n<p>This is line 22</p>\n<p>This is line 23</p>\n<p>This is line 24</p>\n<p>This is line 25</p>\n<p>This is line 26</p>\n<p>This is line 27</p>\n<p>This is line 28</p>\n<p>This is line 29</p>\n<p>This is line 30</p>\n<p>This is line 31</p>\n<p>This is line 32</p>\n<p>This is line 33</p>\n<p>This is line 34</p>\n<p>This is line 35</p>\n<p>This is line 36</p>\n<p>This is line 37</p>\n<p>This is line 38</p>\n<p>This is line 39</p>\n<p>This is line 40</p>\n<p>This is line 41</p>\n<p>This is line 42</p>\n<p>This is line 43</p>\n<p>This is line 44</p>\n<p>This is line 45</p>\n<p>This is line 46</p>\n<p>This is line 47</p>\n<p>This is line 48</p>\n<p>This is line 49</p>\n<p>This is line 50</p>\n<p>This is line 51</p>\n<p>This is line 52</p>\n<p>This is line 53</p>\n<p>This is line 54</p>\n<p>This is line 55</p>\n<p>This is line 56</p>\n<p>This is line 57</p>\n<p>This is line 58</p>\n<p>This is line 59</p>\n<p>This is line 60</p>\n<p>This is line 61</p>\n<p>This is line 62</p>\n<p>This is line 63</p>\n<p>This is line 64</p>\n<p>This is line 65</p>\n<p>This is line 66</p>\n<p>This is line 67</p>\n<p>This is line 68</p>\n<p>This is line 69</p>\n<p>This is line 70</p>\n<p>This is line 71</p>\n<p>This is line 72</p>\n<p>This is line 73</p>\n<p>This is line 74</p>\n<p>This is line 75</p>\n<p>This is line 76</p>\n<p>This is line 77</p>\n<p>This is line 78</p>\n<p>This is line 79</p>\n<p>This is line 80</p>\n<p>This is line 81</p>\n<p>This is line 82</p>\n<p>This is line 83</p>\n<p>This is line 84</p><br>\n\n
+                HtmlContent - (0:0,0 [2013] StringLiterals.cshtml)
+                    RazorIRToken - (0:0,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3:0,3 [14] StringLiterals.cshtml) - Html - This is line 1
+                    RazorIRToken - (17:0,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (21:0,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (23:1,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (26:1,3 [14] StringLiterals.cshtml) - Html - This is line 2
+                    RazorIRToken - (40:1,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (44:1,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (46:2,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (49:2,3 [14] StringLiterals.cshtml) - Html - This is line 3
+                    RazorIRToken - (63:2,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (67:2,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (69:3,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (72:3,3 [14] StringLiterals.cshtml) - Html - This is line 4
+                    RazorIRToken - (86:3,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (90:3,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (92:4,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (95:4,3 [14] StringLiterals.cshtml) - Html - This is line 5
+                    RazorIRToken - (109:4,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (113:4,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (115:5,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (118:5,3 [14] StringLiterals.cshtml) - Html - This is line 6
+                    RazorIRToken - (132:5,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (136:5,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (138:6,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (141:6,3 [14] StringLiterals.cshtml) - Html - This is line 7
+                    RazorIRToken - (155:6,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (159:6,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (161:7,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (164:7,3 [14] StringLiterals.cshtml) - Html - This is line 8
+                    RazorIRToken - (178:7,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (182:7,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (184:8,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (187:8,3 [14] StringLiterals.cshtml) - Html - This is line 9
+                    RazorIRToken - (201:8,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (205:8,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (207:9,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (210:9,3 [15] StringLiterals.cshtml) - Html - This is line 10
+                    RazorIRToken - (225:9,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (229:9,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (231:10,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (234:10,3 [15] StringLiterals.cshtml) - Html - This is line 11
+                    RazorIRToken - (249:10,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (253:10,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (255:11,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (258:11,3 [15] StringLiterals.cshtml) - Html - This is line 12
+                    RazorIRToken - (273:11,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (277:11,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (279:12,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (282:12,3 [15] StringLiterals.cshtml) - Html - This is line 13
+                    RazorIRToken - (297:12,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (301:12,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (303:13,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (306:13,3 [15] StringLiterals.cshtml) - Html - This is line 14
+                    RazorIRToken - (321:13,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (325:13,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (327:14,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (330:14,3 [15] StringLiterals.cshtml) - Html - This is line 15
+                    RazorIRToken - (345:14,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (349:14,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (351:15,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (354:15,3 [15] StringLiterals.cshtml) - Html - This is line 16
+                    RazorIRToken - (369:15,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (373:15,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (375:16,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (378:16,3 [15] StringLiterals.cshtml) - Html - This is line 17
+                    RazorIRToken - (393:16,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (397:16,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (399:17,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (402:17,3 [15] StringLiterals.cshtml) - Html - This is line 18
+                    RazorIRToken - (417:17,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (421:17,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (423:18,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (426:18,3 [15] StringLiterals.cshtml) - Html - This is line 19
+                    RazorIRToken - (441:18,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (445:18,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (447:19,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (450:19,3 [15] StringLiterals.cshtml) - Html - This is line 20
+                    RazorIRToken - (465:19,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (469:19,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (471:20,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (474:20,3 [15] StringLiterals.cshtml) - Html - This is line 21
+                    RazorIRToken - (489:20,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (493:20,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (495:21,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (498:21,3 [15] StringLiterals.cshtml) - Html - This is line 22
+                    RazorIRToken - (513:21,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (517:21,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (519:22,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (522:22,3 [15] StringLiterals.cshtml) - Html - This is line 23
+                    RazorIRToken - (537:22,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (541:22,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (543:23,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (546:23,3 [15] StringLiterals.cshtml) - Html - This is line 24
+                    RazorIRToken - (561:23,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (565:23,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (567:24,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (570:24,3 [15] StringLiterals.cshtml) - Html - This is line 25
+                    RazorIRToken - (585:24,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (589:24,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (591:25,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (594:25,3 [15] StringLiterals.cshtml) - Html - This is line 26
+                    RazorIRToken - (609:25,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (613:25,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (615:26,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (618:26,3 [15] StringLiterals.cshtml) - Html - This is line 27
+                    RazorIRToken - (633:26,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (637:26,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (639:27,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (642:27,3 [15] StringLiterals.cshtml) - Html - This is line 28
+                    RazorIRToken - (657:27,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (661:27,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (663:28,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (666:28,3 [15] StringLiterals.cshtml) - Html - This is line 29
+                    RazorIRToken - (681:28,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (685:28,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (687:29,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (690:29,3 [15] StringLiterals.cshtml) - Html - This is line 30
+                    RazorIRToken - (705:29,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (709:29,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (711:30,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (714:30,3 [15] StringLiterals.cshtml) - Html - This is line 31
+                    RazorIRToken - (729:30,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (733:30,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (735:31,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (738:31,3 [15] StringLiterals.cshtml) - Html - This is line 32
+                    RazorIRToken - (753:31,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (757:31,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (759:32,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (762:32,3 [15] StringLiterals.cshtml) - Html - This is line 33
+                    RazorIRToken - (777:32,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (781:32,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (783:33,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (786:33,3 [15] StringLiterals.cshtml) - Html - This is line 34
+                    RazorIRToken - (801:33,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (805:33,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (807:34,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (810:34,3 [15] StringLiterals.cshtml) - Html - This is line 35
+                    RazorIRToken - (825:34,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (829:34,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (831:35,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (834:35,3 [15] StringLiterals.cshtml) - Html - This is line 36
+                    RazorIRToken - (849:35,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (853:35,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (855:36,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (858:36,3 [15] StringLiterals.cshtml) - Html - This is line 37
+                    RazorIRToken - (873:36,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (877:36,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (879:37,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (882:37,3 [15] StringLiterals.cshtml) - Html - This is line 38
+                    RazorIRToken - (897:37,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (901:37,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (903:38,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (906:38,3 [15] StringLiterals.cshtml) - Html - This is line 39
+                    RazorIRToken - (921:38,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (925:38,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (927:39,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (930:39,3 [15] StringLiterals.cshtml) - Html - This is line 40
+                    RazorIRToken - (945:39,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (949:39,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (951:40,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (954:40,3 [15] StringLiterals.cshtml) - Html - This is line 41
+                    RazorIRToken - (969:40,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (973:40,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (975:41,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (978:41,3 [15] StringLiterals.cshtml) - Html - This is line 42
+                    RazorIRToken - (993:41,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (997:41,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (999:42,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1002:42,3 [15] StringLiterals.cshtml) - Html - This is line 43
+                    RazorIRToken - (1017:42,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1021:42,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1023:43,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1026:43,3 [15] StringLiterals.cshtml) - Html - This is line 44
+                    RazorIRToken - (1041:43,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1045:43,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1047:44,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1050:44,3 [15] StringLiterals.cshtml) - Html - This is line 45
+                    RazorIRToken - (1065:44,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1069:44,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1071:45,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1074:45,3 [15] StringLiterals.cshtml) - Html - This is line 46
+                    RazorIRToken - (1089:45,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1093:45,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1095:46,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1098:46,3 [15] StringLiterals.cshtml) - Html - This is line 47
+                    RazorIRToken - (1113:46,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1117:46,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1119:47,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1122:47,3 [15] StringLiterals.cshtml) - Html - This is line 48
+                    RazorIRToken - (1137:47,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1141:47,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1143:48,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1146:48,3 [15] StringLiterals.cshtml) - Html - This is line 49
+                    RazorIRToken - (1161:48,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1165:48,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1167:49,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1170:49,3 [15] StringLiterals.cshtml) - Html - This is line 50
+                    RazorIRToken - (1185:49,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1189:49,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1191:50,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1194:50,3 [15] StringLiterals.cshtml) - Html - This is line 51
+                    RazorIRToken - (1209:50,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1213:50,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1215:51,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1218:51,3 [15] StringLiterals.cshtml) - Html - This is line 52
+                    RazorIRToken - (1233:51,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1237:51,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1239:52,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1242:52,3 [15] StringLiterals.cshtml) - Html - This is line 53
+                    RazorIRToken - (1257:52,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1261:52,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1263:53,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1266:53,3 [15] StringLiterals.cshtml) - Html - This is line 54
+                    RazorIRToken - (1281:53,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1285:53,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1287:54,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1290:54,3 [15] StringLiterals.cshtml) - Html - This is line 55
+                    RazorIRToken - (1305:54,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1309:54,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1311:55,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1314:55,3 [15] StringLiterals.cshtml) - Html - This is line 56
+                    RazorIRToken - (1329:55,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1333:55,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1335:56,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1338:56,3 [15] StringLiterals.cshtml) - Html - This is line 57
+                    RazorIRToken - (1353:56,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1357:56,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1359:57,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1362:57,3 [15] StringLiterals.cshtml) - Html - This is line 58
+                    RazorIRToken - (1377:57,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1381:57,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1383:58,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1386:58,3 [15] StringLiterals.cshtml) - Html - This is line 59
+                    RazorIRToken - (1401:58,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1405:58,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1407:59,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1410:59,3 [15] StringLiterals.cshtml) - Html - This is line 60
+                    RazorIRToken - (1425:59,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1429:59,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1431:60,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1434:60,3 [15] StringLiterals.cshtml) - Html - This is line 61
+                    RazorIRToken - (1449:60,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1453:60,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1455:61,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1458:61,3 [15] StringLiterals.cshtml) - Html - This is line 62
+                    RazorIRToken - (1473:61,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1477:61,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1479:62,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1482:62,3 [15] StringLiterals.cshtml) - Html - This is line 63
+                    RazorIRToken - (1497:62,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1501:62,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1503:63,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1506:63,3 [15] StringLiterals.cshtml) - Html - This is line 64
+                    RazorIRToken - (1521:63,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1525:63,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1527:64,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1530:64,3 [15] StringLiterals.cshtml) - Html - This is line 65
+                    RazorIRToken - (1545:64,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1549:64,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1551:65,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1554:65,3 [15] StringLiterals.cshtml) - Html - This is line 66
+                    RazorIRToken - (1569:65,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1573:65,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1575:66,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1578:66,3 [15] StringLiterals.cshtml) - Html - This is line 67
+                    RazorIRToken - (1593:66,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1597:66,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1599:67,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1602:67,3 [15] StringLiterals.cshtml) - Html - This is line 68
+                    RazorIRToken - (1617:67,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1621:67,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1623:68,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1626:68,3 [15] StringLiterals.cshtml) - Html - This is line 69
+                    RazorIRToken - (1641:68,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1645:68,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1647:69,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1650:69,3 [15] StringLiterals.cshtml) - Html - This is line 70
+                    RazorIRToken - (1665:69,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1669:69,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1671:70,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1674:70,3 [15] StringLiterals.cshtml) - Html - This is line 71
+                    RazorIRToken - (1689:70,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1693:70,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1695:71,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1698:71,3 [15] StringLiterals.cshtml) - Html - This is line 72
+                    RazorIRToken - (1713:71,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1717:71,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1719:72,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1722:72,3 [15] StringLiterals.cshtml) - Html - This is line 73
+                    RazorIRToken - (1737:72,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1741:72,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1743:73,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1746:73,3 [15] StringLiterals.cshtml) - Html - This is line 74
+                    RazorIRToken - (1761:73,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1765:73,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1767:74,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1770:74,3 [15] StringLiterals.cshtml) - Html - This is line 75
+                    RazorIRToken - (1785:74,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1789:74,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1791:75,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1794:75,3 [15] StringLiterals.cshtml) - Html - This is line 76
+                    RazorIRToken - (1809:75,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1813:75,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1815:76,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1818:76,3 [15] StringLiterals.cshtml) - Html - This is line 77
+                    RazorIRToken - (1833:76,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1837:76,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1839:77,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1842:77,3 [15] StringLiterals.cshtml) - Html - This is line 78
+                    RazorIRToken - (1857:77,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1861:77,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1863:78,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1866:78,3 [15] StringLiterals.cshtml) - Html - This is line 79
+                    RazorIRToken - (1881:78,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1885:78,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1887:79,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1890:79,3 [15] StringLiterals.cshtml) - Html - This is line 80
+                    RazorIRToken - (1905:79,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1909:79,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1911:80,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1914:80,3 [15] StringLiterals.cshtml) - Html - This is line 81
+                    RazorIRToken - (1929:80,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1933:80,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1935:81,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1938:81,3 [15] StringLiterals.cshtml) - Html - This is line 82
+                    RazorIRToken - (1953:81,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1957:81,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1959:82,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1962:82,3 [15] StringLiterals.cshtml) - Html - This is line 83
+                    RazorIRToken - (1977:82,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1981:82,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1983:83,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1986:83,3 [15] StringLiterals.cshtml) - Html - This is line 84
+                    RazorIRToken - (2001:83,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2005:83,22 [4] StringLiterals.cshtml) - Html - <br>
+                    RazorIRToken - (2009:83,26 [4] StringLiterals.cshtml) - Html - \n\n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("WriteLiteralsToInHere", async (__razor_section_writer) => {
-                HtmlContent - (2045:85,32 [2618] StringLiterals.cshtml) - \n    <p>This is line 1 nested</p>\n    <p>This is line 2 nested</p>\n    <p>This is line 3 nested</p>\n    <p>This is line 4 nested</p>\n    <p>This is line 5 nested</p>\n    <p>This is line 6 nested</p>\n    <p>This is line 7 nested</p>\n    <p>This is line 8 nested</p>\n    <p>This is line 9 nested</p>\n    <p>This is line 10 nested</p>\n    <p>This is line 11 nested</p>\n    <p>This is line 12 nested</p>\n    <p>This is line 13 nested</p>\n    <p>This is line 14 nested</p>\n    <p>This is line 15 nested</p>\n    <p>This is line 16 nested</p>\n    <p>This is line 17 nested</p>\n    <p>This is line 18 nested</p>\n    <p>This is line 19 nested</p>\n    <p>This is line 20 nested</p>\n    <p>This is line 21 nested</p>\n    <p>This is line 22 nested</p>\n    <p>This is line 23 nested</p>\n    <p>This is line 24 nested</p>\n    <p>This is line 25 nested</p>\n    <p>This is line 26 nested</p>\n    <p>This is line 27 nested</p>\n    <p>This is line 28 nested</p>\n    <p>This is line 29 nested</p>\n    <p>This is line 30 nested</p>\n    <p>This is line 31 nested</p>\n    <p>This is line 32 nested</p>\n    <p>This is line 33 nested</p>\n    <p>This is line 34 nested</p>\n    <p>This is line 35 nested</p>\n    <p>This is line 36 nested</p>\n    <p>This is line 37 nested</p>\n    <p>This is line 38 nested</p>\n    <p>This is line 39 nested</p>\n    <p>This is line 40 nested</p>\n    <p>This is line 41 nested</p>\n    <p>This is line 42 nested</p>\n    <p>This is line 43 nested</p>\n    <p>This is line 44 nested</p>\n    <p>This is line 45 nested</p>\n    <p>This is line 46 nested</p>\n    <p>This is line 47 nested</p>\n    <p>This is line 48 nested</p>\n    <p>This is line 49 nested</p>\n    <p>This is line 50 nested</p>\n    <p>This is line 51 nested</p>\n    <p>This is line 52 nested</p>\n    <p>This is line 53 nested</p>\n    <p>This is line 54 nested</p>\n    <p>This is line 55 nested</p>\n    <p>This is line 56 nested</p>\n    <p>This is line 57 nested</p>\n    <p>This is line 58 nested</p>\n    <p>This is line 59 nested</p>\n    <p>This is line 60 nested</p>\n    <p>This is line 61 nested</p>\n    <p>This is line 62 nested</p>\n    <p>This is line 63 nested</p>\n    <p>This is line 64 nested</p>\n    <p>This is line 65 nested</p>\n    <p>This is line 66 nested</p>\n    <p>This is line 67 nested</p>\n    <p>This is line 68 nested</p>\n    <p>This is line 69 nested</p>\n    <p>This is line 70 nested</p>\n    <p>This is line 71 nested</p>\n    <p>This is line 72 nested</p>\n    <p>This is line 73 nested</p>\n    <p>This is line 74 nested</p>\n    <p>This is line 75 nested</p>\n
+                HtmlContent - (2045:85,32 [2618] StringLiterals.cshtml)
+                    RazorIRToken - (2045:85,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2051:86,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2054:86,7 [21] StringLiterals.cshtml) - Html - This is line 1 nested
+                    RazorIRToken - (2075:86,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2079:86,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2085:87,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2088:87,7 [21] StringLiterals.cshtml) - Html - This is line 2 nested
+                    RazorIRToken - (2109:87,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2113:87,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2119:88,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2122:88,7 [21] StringLiterals.cshtml) - Html - This is line 3 nested
+                    RazorIRToken - (2143:88,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2147:88,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2153:89,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2156:89,7 [21] StringLiterals.cshtml) - Html - This is line 4 nested
+                    RazorIRToken - (2177:89,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2181:89,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2187:90,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2190:90,7 [21] StringLiterals.cshtml) - Html - This is line 5 nested
+                    RazorIRToken - (2211:90,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2215:90,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2221:91,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2224:91,7 [21] StringLiterals.cshtml) - Html - This is line 6 nested
+                    RazorIRToken - (2245:91,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2249:91,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2255:92,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2258:92,7 [21] StringLiterals.cshtml) - Html - This is line 7 nested
+                    RazorIRToken - (2279:92,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2283:92,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2289:93,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2292:93,7 [21] StringLiterals.cshtml) - Html - This is line 8 nested
+                    RazorIRToken - (2313:93,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2317:93,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2323:94,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2326:94,7 [21] StringLiterals.cshtml) - Html - This is line 9 nested
+                    RazorIRToken - (2347:94,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2351:94,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2357:95,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2360:95,7 [22] StringLiterals.cshtml) - Html - This is line 10 nested
+                    RazorIRToken - (2382:95,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2386:95,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2392:96,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2395:96,7 [22] StringLiterals.cshtml) - Html - This is line 11 nested
+                    RazorIRToken - (2417:96,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2421:96,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2427:97,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2430:97,7 [22] StringLiterals.cshtml) - Html - This is line 12 nested
+                    RazorIRToken - (2452:97,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2456:97,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2462:98,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2465:98,7 [22] StringLiterals.cshtml) - Html - This is line 13 nested
+                    RazorIRToken - (2487:98,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2491:98,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2497:99,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2500:99,7 [22] StringLiterals.cshtml) - Html - This is line 14 nested
+                    RazorIRToken - (2522:99,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2526:99,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2532:100,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2535:100,7 [22] StringLiterals.cshtml) - Html - This is line 15 nested
+                    RazorIRToken - (2557:100,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2561:100,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2567:101,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2570:101,7 [22] StringLiterals.cshtml) - Html - This is line 16 nested
+                    RazorIRToken - (2592:101,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2596:101,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2602:102,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2605:102,7 [22] StringLiterals.cshtml) - Html - This is line 17 nested
+                    RazorIRToken - (2627:102,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2631:102,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2637:103,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2640:103,7 [22] StringLiterals.cshtml) - Html - This is line 18 nested
+                    RazorIRToken - (2662:103,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2666:103,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2672:104,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2675:104,7 [22] StringLiterals.cshtml) - Html - This is line 19 nested
+                    RazorIRToken - (2697:104,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2701:104,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2707:105,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2710:105,7 [22] StringLiterals.cshtml) - Html - This is line 20 nested
+                    RazorIRToken - (2732:105,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2736:105,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2742:106,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2745:106,7 [22] StringLiterals.cshtml) - Html - This is line 21 nested
+                    RazorIRToken - (2767:106,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2771:106,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2777:107,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2780:107,7 [22] StringLiterals.cshtml) - Html - This is line 22 nested
+                    RazorIRToken - (2802:107,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2806:107,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2812:108,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2815:108,7 [22] StringLiterals.cshtml) - Html - This is line 23 nested
+                    RazorIRToken - (2837:108,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2841:108,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2847:109,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2850:109,7 [22] StringLiterals.cshtml) - Html - This is line 24 nested
+                    RazorIRToken - (2872:109,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2876:109,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2882:110,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2885:110,7 [22] StringLiterals.cshtml) - Html - This is line 25 nested
+                    RazorIRToken - (2907:110,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2911:110,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2917:111,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2920:111,7 [22] StringLiterals.cshtml) - Html - This is line 26 nested
+                    RazorIRToken - (2942:111,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2946:111,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2952:112,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2955:112,7 [22] StringLiterals.cshtml) - Html - This is line 27 nested
+                    RazorIRToken - (2977:112,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2981:112,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2987:113,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2990:113,7 [22] StringLiterals.cshtml) - Html - This is line 28 nested
+                    RazorIRToken - (3012:113,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3016:113,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3022:114,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3025:114,7 [22] StringLiterals.cshtml) - Html - This is line 29 nested
+                    RazorIRToken - (3047:114,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3051:114,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3057:115,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3060:115,7 [22] StringLiterals.cshtml) - Html - This is line 30 nested
+                    RazorIRToken - (3082:115,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3086:115,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3092:116,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3095:116,7 [22] StringLiterals.cshtml) - Html - This is line 31 nested
+                    RazorIRToken - (3117:116,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3121:116,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3127:117,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3130:117,7 [22] StringLiterals.cshtml) - Html - This is line 32 nested
+                    RazorIRToken - (3152:117,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3156:117,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3162:118,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3165:118,7 [22] StringLiterals.cshtml) - Html - This is line 33 nested
+                    RazorIRToken - (3187:118,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3191:118,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3197:119,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3200:119,7 [22] StringLiterals.cshtml) - Html - This is line 34 nested
+                    RazorIRToken - (3222:119,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3226:119,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3232:120,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3235:120,7 [22] StringLiterals.cshtml) - Html - This is line 35 nested
+                    RazorIRToken - (3257:120,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3261:120,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3267:121,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3270:121,7 [22] StringLiterals.cshtml) - Html - This is line 36 nested
+                    RazorIRToken - (3292:121,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3296:121,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3302:122,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3305:122,7 [22] StringLiterals.cshtml) - Html - This is line 37 nested
+                    RazorIRToken - (3327:122,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3331:122,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3337:123,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3340:123,7 [22] StringLiterals.cshtml) - Html - This is line 38 nested
+                    RazorIRToken - (3362:123,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3366:123,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3372:124,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3375:124,7 [22] StringLiterals.cshtml) - Html - This is line 39 nested
+                    RazorIRToken - (3397:124,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3401:124,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3407:125,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3410:125,7 [22] StringLiterals.cshtml) - Html - This is line 40 nested
+                    RazorIRToken - (3432:125,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3436:125,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3442:126,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3445:126,7 [22] StringLiterals.cshtml) - Html - This is line 41 nested
+                    RazorIRToken - (3467:126,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3471:126,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3477:127,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3480:127,7 [22] StringLiterals.cshtml) - Html - This is line 42 nested
+                    RazorIRToken - (3502:127,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3506:127,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3512:128,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3515:128,7 [22] StringLiterals.cshtml) - Html - This is line 43 nested
+                    RazorIRToken - (3537:128,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3541:128,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3547:129,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3550:129,7 [22] StringLiterals.cshtml) - Html - This is line 44 nested
+                    RazorIRToken - (3572:129,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3576:129,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3582:130,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3585:130,7 [22] StringLiterals.cshtml) - Html - This is line 45 nested
+                    RazorIRToken - (3607:130,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3611:130,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3617:131,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3620:131,7 [22] StringLiterals.cshtml) - Html - This is line 46 nested
+                    RazorIRToken - (3642:131,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3646:131,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3652:132,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3655:132,7 [22] StringLiterals.cshtml) - Html - This is line 47 nested
+                    RazorIRToken - (3677:132,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3681:132,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3687:133,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3690:133,7 [22] StringLiterals.cshtml) - Html - This is line 48 nested
+                    RazorIRToken - (3712:133,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3716:133,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3722:134,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3725:134,7 [22] StringLiterals.cshtml) - Html - This is line 49 nested
+                    RazorIRToken - (3747:134,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3751:134,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3757:135,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3760:135,7 [22] StringLiterals.cshtml) - Html - This is line 50 nested
+                    RazorIRToken - (3782:135,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3786:135,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3792:136,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3795:136,7 [22] StringLiterals.cshtml) - Html - This is line 51 nested
+                    RazorIRToken - (3817:136,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3821:136,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3827:137,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3830:137,7 [22] StringLiterals.cshtml) - Html - This is line 52 nested
+                    RazorIRToken - (3852:137,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3856:137,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3862:138,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3865:138,7 [22] StringLiterals.cshtml) - Html - This is line 53 nested
+                    RazorIRToken - (3887:138,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3891:138,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3897:139,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3900:139,7 [22] StringLiterals.cshtml) - Html - This is line 54 nested
+                    RazorIRToken - (3922:139,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3926:139,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3932:140,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3935:140,7 [22] StringLiterals.cshtml) - Html - This is line 55 nested
+                    RazorIRToken - (3957:140,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3961:140,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3967:141,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3970:141,7 [22] StringLiterals.cshtml) - Html - This is line 56 nested
+                    RazorIRToken - (3992:141,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3996:141,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4002:142,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4005:142,7 [22] StringLiterals.cshtml) - Html - This is line 57 nested
+                    RazorIRToken - (4027:142,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4031:142,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4037:143,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4040:143,7 [22] StringLiterals.cshtml) - Html - This is line 58 nested
+                    RazorIRToken - (4062:143,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4066:143,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4072:144,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4075:144,7 [22] StringLiterals.cshtml) - Html - This is line 59 nested
+                    RazorIRToken - (4097:144,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4101:144,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4107:145,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4110:145,7 [22] StringLiterals.cshtml) - Html - This is line 60 nested
+                    RazorIRToken - (4132:145,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4136:145,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4142:146,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4145:146,7 [22] StringLiterals.cshtml) - Html - This is line 61 nested
+                    RazorIRToken - (4167:146,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4171:146,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4177:147,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4180:147,7 [22] StringLiterals.cshtml) - Html - This is line 62 nested
+                    RazorIRToken - (4202:147,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4206:147,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4212:148,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4215:148,7 [22] StringLiterals.cshtml) - Html - This is line 63 nested
+                    RazorIRToken - (4237:148,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4241:148,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4247:149,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4250:149,7 [22] StringLiterals.cshtml) - Html - This is line 64 nested
+                    RazorIRToken - (4272:149,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4276:149,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4282:150,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4285:150,7 [22] StringLiterals.cshtml) - Html - This is line 65 nested
+                    RazorIRToken - (4307:150,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4311:150,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4317:151,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4320:151,7 [22] StringLiterals.cshtml) - Html - This is line 66 nested
+                    RazorIRToken - (4342:151,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4346:151,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4352:152,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4355:152,7 [22] StringLiterals.cshtml) - Html - This is line 67 nested
+                    RazorIRToken - (4377:152,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4381:152,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4387:153,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4390:153,7 [22] StringLiterals.cshtml) - Html - This is line 68 nested
+                    RazorIRToken - (4412:153,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4416:153,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4422:154,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4425:154,7 [22] StringLiterals.cshtml) - Html - This is line 69 nested
+                    RazorIRToken - (4447:154,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4451:154,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4457:155,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4460:155,7 [22] StringLiterals.cshtml) - Html - This is line 70 nested
+                    RazorIRToken - (4482:155,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4486:155,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4492:156,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4495:156,7 [22] StringLiterals.cshtml) - Html - This is line 71 nested
+                    RazorIRToken - (4517:156,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4521:156,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4527:157,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4530:157,7 [22] StringLiterals.cshtml) - Html - This is line 72 nested
+                    RazorIRToken - (4552:157,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4556:157,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4562:158,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4565:158,7 [22] StringLiterals.cshtml) - Html - This is line 73 nested
+                    RazorIRToken - (4587:158,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4591:158,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4597:159,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4600:159,7 [22] StringLiterals.cshtml) - Html - This is line 74 nested
+                    RazorIRToken - (4622:159,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4626:159,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4632:160,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4635:160,7 [22] StringLiterals.cshtml) - Html - This is line 75 nested
+                    RazorIRToken - (4657:160,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4661:160,33 [2] StringLiterals.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (4664:161,1 [1028] StringLiterals.cshtml) - \n<p>This is line 1</p>\n<p>This is line 2</p>\n<p>This is line 3</p>\n<p>This is line 4</p>\n<p>This is line 5</p>\n<p>This is line 6</p>\n<p>This is line 7</p>\n<p>This is line 8</p>\n<p>This is line 9</p>\n<p>This is line 10</p>\n<p>This is line 11</p>\n<p>This is line 12</p>\n<p>This is line 13</p>\n<p>This is line 14</p>\n<p>This is line 15</p>\n<p>This is line 16</p>\n<p>This is line 17</p>\n<p>This is line 18</p>\n<p>This is line 19</p>\n<p>This is line 20</p>\n<p>This is line 21</p>\n<p>This is line 22</p>\n<p>This is line 23</p>\n<p>This is line 24</p>\n<p>This is line 25</p>\n<p>This is line 26</p>\n<p>This is line 27</p>\n<p>This is line 28</p>\n<p>This is line 29</p>\n<p>This is line 30</p>\n<p>This is line 31</p>\n<p>This is line 32</p>\n<p>This is line 33</p>\n<p>This is line 34</p>\n<p>This is line 35</p>\n<p>This is line 36</p>\n<p>This is line 37</p>\n<p>This is line 38</p>\n<p>This is line 39</p>\n<p>This is line 40</p>\n<p>This is line 41</p>\n<p>This is line 42</p>\n<p>This is line 43</p>hi!\n
+                HtmlContent - (4664:161,1 [1028] StringLiterals.cshtml)
+                    RazorIRToken - (4664:161,1 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4666:162,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4669:162,3 [14] StringLiterals.cshtml) - Html - This is line 1
+                    RazorIRToken - (4683:162,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4687:162,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4689:163,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4692:163,3 [14] StringLiterals.cshtml) - Html - This is line 2
+                    RazorIRToken - (4706:163,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4710:163,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4712:164,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4715:164,3 [14] StringLiterals.cshtml) - Html - This is line 3
+                    RazorIRToken - (4729:164,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4733:164,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4735:165,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4738:165,3 [14] StringLiterals.cshtml) - Html - This is line 4
+                    RazorIRToken - (4752:165,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4756:165,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4758:166,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4761:166,3 [14] StringLiterals.cshtml) - Html - This is line 5
+                    RazorIRToken - (4775:166,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4779:166,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4781:167,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4784:167,3 [14] StringLiterals.cshtml) - Html - This is line 6
+                    RazorIRToken - (4798:167,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4802:167,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4804:168,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4807:168,3 [14] StringLiterals.cshtml) - Html - This is line 7
+                    RazorIRToken - (4821:168,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4825:168,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4827:169,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4830:169,3 [14] StringLiterals.cshtml) - Html - This is line 8
+                    RazorIRToken - (4844:169,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4848:169,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4850:170,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4853:170,3 [14] StringLiterals.cshtml) - Html - This is line 9
+                    RazorIRToken - (4867:170,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4871:170,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4873:171,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4876:171,3 [15] StringLiterals.cshtml) - Html - This is line 10
+                    RazorIRToken - (4891:171,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4895:171,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4897:172,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4900:172,3 [15] StringLiterals.cshtml) - Html - This is line 11
+                    RazorIRToken - (4915:172,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4919:172,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4921:173,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4924:173,3 [15] StringLiterals.cshtml) - Html - This is line 12
+                    RazorIRToken - (4939:173,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4943:173,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4945:174,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4948:174,3 [15] StringLiterals.cshtml) - Html - This is line 13
+                    RazorIRToken - (4963:174,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4967:174,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4969:175,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4972:175,3 [15] StringLiterals.cshtml) - Html - This is line 14
+                    RazorIRToken - (4987:175,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4991:175,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4993:176,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4996:176,3 [15] StringLiterals.cshtml) - Html - This is line 15
+                    RazorIRToken - (5011:176,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5015:176,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5017:177,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5020:177,3 [15] StringLiterals.cshtml) - Html - This is line 16
+                    RazorIRToken - (5035:177,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5039:177,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5041:178,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5044:178,3 [15] StringLiterals.cshtml) - Html - This is line 17
+                    RazorIRToken - (5059:178,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5063:178,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5065:179,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5068:179,3 [15] StringLiterals.cshtml) - Html - This is line 18
+                    RazorIRToken - (5083:179,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5087:179,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5089:180,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5092:180,3 [15] StringLiterals.cshtml) - Html - This is line 19
+                    RazorIRToken - (5107:180,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5111:180,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5113:181,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5116:181,3 [15] StringLiterals.cshtml) - Html - This is line 20
+                    RazorIRToken - (5131:181,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5135:181,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5137:182,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5140:182,3 [15] StringLiterals.cshtml) - Html - This is line 21
+                    RazorIRToken - (5155:182,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5159:182,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5161:183,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5164:183,3 [15] StringLiterals.cshtml) - Html - This is line 22
+                    RazorIRToken - (5179:183,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5183:183,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5185:184,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5188:184,3 [15] StringLiterals.cshtml) - Html - This is line 23
+                    RazorIRToken - (5203:184,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5207:184,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5209:185,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5212:185,3 [15] StringLiterals.cshtml) - Html - This is line 24
+                    RazorIRToken - (5227:185,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5231:185,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5233:186,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5236:186,3 [15] StringLiterals.cshtml) - Html - This is line 25
+                    RazorIRToken - (5251:186,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5255:186,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5257:187,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5260:187,3 [15] StringLiterals.cshtml) - Html - This is line 26
+                    RazorIRToken - (5275:187,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5279:187,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5281:188,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5284:188,3 [15] StringLiterals.cshtml) - Html - This is line 27
+                    RazorIRToken - (5299:188,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5303:188,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5305:189,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5308:189,3 [15] StringLiterals.cshtml) - Html - This is line 28
+                    RazorIRToken - (5323:189,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5327:189,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5329:190,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5332:190,3 [15] StringLiterals.cshtml) - Html - This is line 29
+                    RazorIRToken - (5347:190,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5351:190,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5353:191,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5356:191,3 [15] StringLiterals.cshtml) - Html - This is line 30
+                    RazorIRToken - (5371:191,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5375:191,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5377:192,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5380:192,3 [15] StringLiterals.cshtml) - Html - This is line 31
+                    RazorIRToken - (5395:192,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5399:192,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5401:193,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5404:193,3 [15] StringLiterals.cshtml) - Html - This is line 32
+                    RazorIRToken - (5419:193,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5423:193,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5425:194,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5428:194,3 [15] StringLiterals.cshtml) - Html - This is line 33
+                    RazorIRToken - (5443:194,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5447:194,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5449:195,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5452:195,3 [15] StringLiterals.cshtml) - Html - This is line 34
+                    RazorIRToken - (5467:195,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5471:195,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5473:196,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5476:196,3 [15] StringLiterals.cshtml) - Html - This is line 35
+                    RazorIRToken - (5491:196,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5495:196,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5497:197,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5500:197,3 [15] StringLiterals.cshtml) - Html - This is line 36
+                    RazorIRToken - (5515:197,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5519:197,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5521:198,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5524:198,3 [15] StringLiterals.cshtml) - Html - This is line 37
+                    RazorIRToken - (5539:198,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5543:198,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5545:199,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5548:199,3 [15] StringLiterals.cshtml) - Html - This is line 38
+                    RazorIRToken - (5563:199,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5567:199,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5569:200,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5572:200,3 [15] StringLiterals.cshtml) - Html - This is line 39
+                    RazorIRToken - (5587:200,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5591:200,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5593:201,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5596:201,3 [15] StringLiterals.cshtml) - Html - This is line 40
+                    RazorIRToken - (5611:201,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5615:201,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5617:202,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5620:202,3 [15] StringLiterals.cshtml) - Html - This is line 41
+                    RazorIRToken - (5635:202,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5639:202,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5641:203,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5644:203,3 [15] StringLiterals.cshtml) - Html - This is line 42
+                    RazorIRToken - (5659:203,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5663:203,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5665:204,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5668:204,3 [15] StringLiterals.cshtml) - Html - This is line 43
+                    RazorIRToken - (5683:204,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5687:204,22 [5] StringLiterals.cshtml) - Html - hi!\n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("WriteLiteralsToInHereAlso", async (__razor_section_writer) => {
-                HtmlContent - (5728:205,36 [1023] StringLiterals.cshtml) - \n    <p>This is line 1 nested</p>\n    <p>This is line 2 nested</p>\n    <p>This is line 3 nested</p>\n    <p>This is line 4 nested</p>\n    <p>This is line 5 nested</p>\n    <p>This is line 6 nested</p>\n    <p>This is line 7 nested</p>\n    <p>This is line 8 nested</p>\n    <p>This is line 9 nested</p>\n    <p>This is line 10 nested</p>\n    <p>This is line 11 nested</p>\n    <p>This is line 12 nested</p>\n    <p>This is line 13 nested</p>\n    <p>This is line 14 nested</p>\n    <p>This is line 15 nested</p>\n    <p>This is line 16 nested</p>\n    <p>This is line 17 nested</p>\n    <p>This is line 18 nested</p>\n    <p>This is line 19 nested</p>\n    <p>This is line 20 nested</p>\n    <p>This is line 21 nested</p>\n    <p>This is line 22 nested</p>\n    <p>This is line 23 nested</p>\n    <p>This is line 24 nested</p>\n    <p>This is line 25 nested</p>\n    <p>This is line 26 nested</p>\n    <p>This is line 27 nested</p>\n    <p>This is line 28 nested</p>\n    <p>This is line 29 nested</p>\n    <p>30</p>\n
+                HtmlContent - (5728:205,36 [1023] StringLiterals.cshtml)
+                    RazorIRToken - (5728:205,36 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5734:206,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5737:206,7 [21] StringLiterals.cshtml) - Html - This is line 1 nested
+                    RazorIRToken - (5758:206,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5762:206,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5768:207,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5771:207,7 [21] StringLiterals.cshtml) - Html - This is line 2 nested
+                    RazorIRToken - (5792:207,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5796:207,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5802:208,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5805:208,7 [21] StringLiterals.cshtml) - Html - This is line 3 nested
+                    RazorIRToken - (5826:208,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5830:208,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5836:209,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5839:209,7 [21] StringLiterals.cshtml) - Html - This is line 4 nested
+                    RazorIRToken - (5860:209,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5864:209,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5870:210,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5873:210,7 [21] StringLiterals.cshtml) - Html - This is line 5 nested
+                    RazorIRToken - (5894:210,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5898:210,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5904:211,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5907:211,7 [21] StringLiterals.cshtml) - Html - This is line 6 nested
+                    RazorIRToken - (5928:211,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5932:211,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5938:212,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5941:212,7 [21] StringLiterals.cshtml) - Html - This is line 7 nested
+                    RazorIRToken - (5962:212,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5966:212,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5972:213,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5975:213,7 [21] StringLiterals.cshtml) - Html - This is line 8 nested
+                    RazorIRToken - (5996:213,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6000:213,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6006:214,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6009:214,7 [21] StringLiterals.cshtml) - Html - This is line 9 nested
+                    RazorIRToken - (6030:214,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6034:214,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6040:215,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6043:215,7 [22] StringLiterals.cshtml) - Html - This is line 10 nested
+                    RazorIRToken - (6065:215,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6069:215,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6075:216,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6078:216,7 [22] StringLiterals.cshtml) - Html - This is line 11 nested
+                    RazorIRToken - (6100:216,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6104:216,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6110:217,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6113:217,7 [22] StringLiterals.cshtml) - Html - This is line 12 nested
+                    RazorIRToken - (6135:217,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6139:217,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6145:218,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6148:218,7 [22] StringLiterals.cshtml) - Html - This is line 13 nested
+                    RazorIRToken - (6170:218,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6174:218,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6180:219,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6183:219,7 [22] StringLiterals.cshtml) - Html - This is line 14 nested
+                    RazorIRToken - (6205:219,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6209:219,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6215:220,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6218:220,7 [22] StringLiterals.cshtml) - Html - This is line 15 nested
+                    RazorIRToken - (6240:220,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6244:220,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6250:221,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6253:221,7 [22] StringLiterals.cshtml) - Html - This is line 16 nested
+                    RazorIRToken - (6275:221,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6279:221,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6285:222,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6288:222,7 [22] StringLiterals.cshtml) - Html - This is line 17 nested
+                    RazorIRToken - (6310:222,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6314:222,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6320:223,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6323:223,7 [22] StringLiterals.cshtml) - Html - This is line 18 nested
+                    RazorIRToken - (6345:223,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6349:223,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6355:224,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6358:224,7 [22] StringLiterals.cshtml) - Html - This is line 19 nested
+                    RazorIRToken - (6380:224,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6384:224,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6390:225,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6393:225,7 [22] StringLiterals.cshtml) - Html - This is line 20 nested
+                    RazorIRToken - (6415:225,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6419:225,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6425:226,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6428:226,7 [22] StringLiterals.cshtml) - Html - This is line 21 nested
+                    RazorIRToken - (6450:226,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6454:226,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6460:227,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6463:227,7 [22] StringLiterals.cshtml) - Html - This is line 22 nested
+                    RazorIRToken - (6485:227,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6489:227,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6495:228,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6498:228,7 [22] StringLiterals.cshtml) - Html - This is line 23 nested
+                    RazorIRToken - (6520:228,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6524:228,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6530:229,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6533:229,7 [22] StringLiterals.cshtml) - Html - This is line 24 nested
+                    RazorIRToken - (6555:229,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6559:229,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6565:230,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6568:230,7 [22] StringLiterals.cshtml) - Html - This is line 25 nested
+                    RazorIRToken - (6590:230,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6594:230,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6600:231,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6603:231,7 [22] StringLiterals.cshtml) - Html - This is line 26 nested
+                    RazorIRToken - (6625:231,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6629:231,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6635:232,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6638:232,7 [22] StringLiterals.cshtml) - Html - This is line 27 nested
+                    RazorIRToken - (6660:232,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6664:232,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6670:233,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6673:233,7 [22] StringLiterals.cshtml) - Html - This is line 28 nested
+                    RazorIRToken - (6695:233,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6699:233,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6705:234,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6708:234,7 [22] StringLiterals.cshtml) - Html - This is line 29 nested
+                    RazorIRToken - (6730:234,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6734:234,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6740:235,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6743:235,7 [2] StringLiterals.cshtml) - Html - 30
+                    RazorIRToken - (6745:235,9 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6749:235,13 [2] StringLiterals.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (6752:236,1 [1] StringLiterals.cshtml) - !
+                HtmlContent - (6752:236,1 [1] StringLiterals.cshtml)
+                    RazorIRToken - (6752:236,1 [1] StringLiterals.cshtml) - Html - !

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_Runtime.ir.txt
@@ -5,16 +5,948 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_StringLiterals_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [2013] StringLiterals.cshtml) - <p>This is line 1</p>\n<p>This is line 2</p>\n<p>This is line 3</p>\n<p>This is line 4</p>\n<p>This is line 5</p>\n<p>This is line 6</p>\n<p>This is line 7</p>\n<p>This is line 8</p>\n<p>This is line 9</p>\n<p>This is line 10</p>\n<p>This is line 11</p>\n<p>This is line 12</p>\n<p>This is line 13</p>\n<p>This is line 14</p>\n<p>This is line 15</p>\n<p>This is line 16</p>\n<p>This is line 17</p>\n<p>This is line 18</p>\n<p>This is line 19</p>\n<p>This is line 20</p>\n<p>This is line 21</p>\n<p>This is line 22</p>\n<p>This is line 23</p>\n<p>This is line 24</p>\n<p>This is line 25</p>\n<p>This is line 26</p>\n<p>This is line 27</p>\n<p>This is line 28</p>\n<p>This is line 29</p>\n<p>This is line 30</p>\n<p>This is line 31</p>\n<p>This is line 32</p>\n<p>This is line 33</p>\n<p>This is line 34</p>\n<p>This is line 35</p>\n<p>This is line 36</p>\n<p>This is line 37</p>\n<p>This is line 38</p>\n<p>This is line 39</p>\n<p>This is line 40</p>\n<p>This is line 41</p>\n<p>This is line 42</p>\n<p>This is line 43</p>\n<p>This is line 44</p>\n<p>This is line 45</p>\n<p>This is line 46</p>\n<p>This is line 47</p>\n<p>This is line 48</p>\n<p>This is line 49</p>\n<p>This is line 50</p>\n<p>This is line 51</p>\n<p>This is line 52</p>\n<p>This is line 53</p>\n<p>This is line 54</p>\n<p>This is line 55</p>\n<p>This is line 56</p>\n<p>This is line 57</p>\n<p>This is line 58</p>\n<p>This is line 59</p>\n<p>This is line 60</p>\n<p>This is line 61</p>\n<p>This is line 62</p>\n<p>This is line 63</p>\n<p>This is line 64</p>\n<p>This is line 65</p>\n<p>This is line 66</p>\n<p>This is line 67</p>\n<p>This is line 68</p>\n<p>This is line 69</p>\n<p>This is line 70</p>\n<p>This is line 71</p>\n<p>This is line 72</p>\n<p>This is line 73</p>\n<p>This is line 74</p>\n<p>This is line 75</p>\n<p>This is line 76</p>\n<p>This is line 77</p>\n<p>This is line 78</p>\n<p>This is line 79</p>\n<p>This is line 80</p>\n<p>This is line 81</p>\n<p>This is line 82</p>\n<p>This is line 83</p>\n<p>This is line 84</p><br>\n\n
+                HtmlContent - (0:0,0 [2013] StringLiterals.cshtml)
+                    RazorIRToken - (0:0,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3:0,3 [14] StringLiterals.cshtml) - Html - This is line 1
+                    RazorIRToken - (17:0,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (21:0,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (23:1,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (26:1,3 [14] StringLiterals.cshtml) - Html - This is line 2
+                    RazorIRToken - (40:1,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (44:1,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (46:2,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (49:2,3 [14] StringLiterals.cshtml) - Html - This is line 3
+                    RazorIRToken - (63:2,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (67:2,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (69:3,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (72:3,3 [14] StringLiterals.cshtml) - Html - This is line 4
+                    RazorIRToken - (86:3,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (90:3,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (92:4,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (95:4,3 [14] StringLiterals.cshtml) - Html - This is line 5
+                    RazorIRToken - (109:4,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (113:4,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (115:5,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (118:5,3 [14] StringLiterals.cshtml) - Html - This is line 6
+                    RazorIRToken - (132:5,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (136:5,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (138:6,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (141:6,3 [14] StringLiterals.cshtml) - Html - This is line 7
+                    RazorIRToken - (155:6,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (159:6,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (161:7,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (164:7,3 [14] StringLiterals.cshtml) - Html - This is line 8
+                    RazorIRToken - (178:7,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (182:7,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (184:8,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (187:8,3 [14] StringLiterals.cshtml) - Html - This is line 9
+                    RazorIRToken - (201:8,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (205:8,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (207:9,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (210:9,3 [15] StringLiterals.cshtml) - Html - This is line 10
+                    RazorIRToken - (225:9,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (229:9,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (231:10,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (234:10,3 [15] StringLiterals.cshtml) - Html - This is line 11
+                    RazorIRToken - (249:10,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (253:10,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (255:11,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (258:11,3 [15] StringLiterals.cshtml) - Html - This is line 12
+                    RazorIRToken - (273:11,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (277:11,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (279:12,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (282:12,3 [15] StringLiterals.cshtml) - Html - This is line 13
+                    RazorIRToken - (297:12,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (301:12,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (303:13,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (306:13,3 [15] StringLiterals.cshtml) - Html - This is line 14
+                    RazorIRToken - (321:13,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (325:13,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (327:14,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (330:14,3 [15] StringLiterals.cshtml) - Html - This is line 15
+                    RazorIRToken - (345:14,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (349:14,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (351:15,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (354:15,3 [15] StringLiterals.cshtml) - Html - This is line 16
+                    RazorIRToken - (369:15,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (373:15,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (375:16,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (378:16,3 [15] StringLiterals.cshtml) - Html - This is line 17
+                    RazorIRToken - (393:16,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (397:16,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (399:17,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (402:17,3 [15] StringLiterals.cshtml) - Html - This is line 18
+                    RazorIRToken - (417:17,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (421:17,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (423:18,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (426:18,3 [15] StringLiterals.cshtml) - Html - This is line 19
+                    RazorIRToken - (441:18,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (445:18,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (447:19,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (450:19,3 [15] StringLiterals.cshtml) - Html - This is line 20
+                    RazorIRToken - (465:19,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (469:19,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (471:20,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (474:20,3 [15] StringLiterals.cshtml) - Html - This is line 21
+                    RazorIRToken - (489:20,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (493:20,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (495:21,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (498:21,3 [15] StringLiterals.cshtml) - Html - This is line 22
+                    RazorIRToken - (513:21,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (517:21,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (519:22,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (522:22,3 [15] StringLiterals.cshtml) - Html - This is line 23
+                    RazorIRToken - (537:22,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (541:22,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (543:23,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (546:23,3 [15] StringLiterals.cshtml) - Html - This is line 24
+                    RazorIRToken - (561:23,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (565:23,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (567:24,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (570:24,3 [15] StringLiterals.cshtml) - Html - This is line 25
+                    RazorIRToken - (585:24,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (589:24,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (591:25,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (594:25,3 [15] StringLiterals.cshtml) - Html - This is line 26
+                    RazorIRToken - (609:25,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (613:25,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (615:26,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (618:26,3 [15] StringLiterals.cshtml) - Html - This is line 27
+                    RazorIRToken - (633:26,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (637:26,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (639:27,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (642:27,3 [15] StringLiterals.cshtml) - Html - This is line 28
+                    RazorIRToken - (657:27,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (661:27,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (663:28,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (666:28,3 [15] StringLiterals.cshtml) - Html - This is line 29
+                    RazorIRToken - (681:28,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (685:28,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (687:29,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (690:29,3 [15] StringLiterals.cshtml) - Html - This is line 30
+                    RazorIRToken - (705:29,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (709:29,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (711:30,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (714:30,3 [15] StringLiterals.cshtml) - Html - This is line 31
+                    RazorIRToken - (729:30,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (733:30,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (735:31,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (738:31,3 [15] StringLiterals.cshtml) - Html - This is line 32
+                    RazorIRToken - (753:31,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (757:31,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (759:32,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (762:32,3 [15] StringLiterals.cshtml) - Html - This is line 33
+                    RazorIRToken - (777:32,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (781:32,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (783:33,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (786:33,3 [15] StringLiterals.cshtml) - Html - This is line 34
+                    RazorIRToken - (801:33,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (805:33,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (807:34,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (810:34,3 [15] StringLiterals.cshtml) - Html - This is line 35
+                    RazorIRToken - (825:34,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (829:34,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (831:35,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (834:35,3 [15] StringLiterals.cshtml) - Html - This is line 36
+                    RazorIRToken - (849:35,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (853:35,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (855:36,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (858:36,3 [15] StringLiterals.cshtml) - Html - This is line 37
+                    RazorIRToken - (873:36,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (877:36,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (879:37,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (882:37,3 [15] StringLiterals.cshtml) - Html - This is line 38
+                    RazorIRToken - (897:37,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (901:37,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (903:38,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (906:38,3 [15] StringLiterals.cshtml) - Html - This is line 39
+                    RazorIRToken - (921:38,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (925:38,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (927:39,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (930:39,3 [15] StringLiterals.cshtml) - Html - This is line 40
+                    RazorIRToken - (945:39,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (949:39,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (951:40,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (954:40,3 [15] StringLiterals.cshtml) - Html - This is line 41
+                    RazorIRToken - (969:40,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (973:40,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (975:41,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (978:41,3 [15] StringLiterals.cshtml) - Html - This is line 42
+                    RazorIRToken - (993:41,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (997:41,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (999:42,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1002:42,3 [15] StringLiterals.cshtml) - Html - This is line 43
+                    RazorIRToken - (1017:42,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1021:42,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1023:43,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1026:43,3 [15] StringLiterals.cshtml) - Html - This is line 44
+                    RazorIRToken - (1041:43,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1045:43,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1047:44,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1050:44,3 [15] StringLiterals.cshtml) - Html - This is line 45
+                    RazorIRToken - (1065:44,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1069:44,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1071:45,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1074:45,3 [15] StringLiterals.cshtml) - Html - This is line 46
+                    RazorIRToken - (1089:45,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1093:45,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1095:46,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1098:46,3 [15] StringLiterals.cshtml) - Html - This is line 47
+                    RazorIRToken - (1113:46,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1117:46,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1119:47,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1122:47,3 [15] StringLiterals.cshtml) - Html - This is line 48
+                    RazorIRToken - (1137:47,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1141:47,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1143:48,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1146:48,3 [15] StringLiterals.cshtml) - Html - This is line 49
+                    RazorIRToken - (1161:48,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1165:48,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1167:49,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1170:49,3 [15] StringLiterals.cshtml) - Html - This is line 50
+                    RazorIRToken - (1185:49,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1189:49,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1191:50,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1194:50,3 [15] StringLiterals.cshtml) - Html - This is line 51
+                    RazorIRToken - (1209:50,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1213:50,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1215:51,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1218:51,3 [15] StringLiterals.cshtml) - Html - This is line 52
+                    RazorIRToken - (1233:51,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1237:51,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1239:52,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1242:52,3 [15] StringLiterals.cshtml) - Html - This is line 53
+                    RazorIRToken - (1257:52,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1261:52,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1263:53,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1266:53,3 [15] StringLiterals.cshtml) - Html - This is line 54
+                    RazorIRToken - (1281:53,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1285:53,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1287:54,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1290:54,3 [15] StringLiterals.cshtml) - Html - This is line 55
+                    RazorIRToken - (1305:54,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1309:54,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1311:55,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1314:55,3 [15] StringLiterals.cshtml) - Html - This is line 56
+                    RazorIRToken - (1329:55,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1333:55,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1335:56,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1338:56,3 [15] StringLiterals.cshtml) - Html - This is line 57
+                    RazorIRToken - (1353:56,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1357:56,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1359:57,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1362:57,3 [15] StringLiterals.cshtml) - Html - This is line 58
+                    RazorIRToken - (1377:57,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1381:57,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1383:58,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1386:58,3 [15] StringLiterals.cshtml) - Html - This is line 59
+                    RazorIRToken - (1401:58,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1405:58,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1407:59,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1410:59,3 [15] StringLiterals.cshtml) - Html - This is line 60
+                    RazorIRToken - (1425:59,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1429:59,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1431:60,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1434:60,3 [15] StringLiterals.cshtml) - Html - This is line 61
+                    RazorIRToken - (1449:60,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1453:60,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1455:61,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1458:61,3 [15] StringLiterals.cshtml) - Html - This is line 62
+                    RazorIRToken - (1473:61,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1477:61,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1479:62,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1482:62,3 [15] StringLiterals.cshtml) - Html - This is line 63
+                    RazorIRToken - (1497:62,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1501:62,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1503:63,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1506:63,3 [15] StringLiterals.cshtml) - Html - This is line 64
+                    RazorIRToken - (1521:63,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1525:63,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1527:64,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1530:64,3 [15] StringLiterals.cshtml) - Html - This is line 65
+                    RazorIRToken - (1545:64,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1549:64,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1551:65,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1554:65,3 [15] StringLiterals.cshtml) - Html - This is line 66
+                    RazorIRToken - (1569:65,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1573:65,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1575:66,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1578:66,3 [15] StringLiterals.cshtml) - Html - This is line 67
+                    RazorIRToken - (1593:66,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1597:66,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1599:67,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1602:67,3 [15] StringLiterals.cshtml) - Html - This is line 68
+                    RazorIRToken - (1617:67,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1621:67,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1623:68,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1626:68,3 [15] StringLiterals.cshtml) - Html - This is line 69
+                    RazorIRToken - (1641:68,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1645:68,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1647:69,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1650:69,3 [15] StringLiterals.cshtml) - Html - This is line 70
+                    RazorIRToken - (1665:69,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1669:69,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1671:70,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1674:70,3 [15] StringLiterals.cshtml) - Html - This is line 71
+                    RazorIRToken - (1689:70,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1693:70,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1695:71,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1698:71,3 [15] StringLiterals.cshtml) - Html - This is line 72
+                    RazorIRToken - (1713:71,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1717:71,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1719:72,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1722:72,3 [15] StringLiterals.cshtml) - Html - This is line 73
+                    RazorIRToken - (1737:72,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1741:72,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1743:73,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1746:73,3 [15] StringLiterals.cshtml) - Html - This is line 74
+                    RazorIRToken - (1761:73,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1765:73,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1767:74,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1770:74,3 [15] StringLiterals.cshtml) - Html - This is line 75
+                    RazorIRToken - (1785:74,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1789:74,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1791:75,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1794:75,3 [15] StringLiterals.cshtml) - Html - This is line 76
+                    RazorIRToken - (1809:75,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1813:75,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1815:76,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1818:76,3 [15] StringLiterals.cshtml) - Html - This is line 77
+                    RazorIRToken - (1833:76,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1837:76,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1839:77,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1842:77,3 [15] StringLiterals.cshtml) - Html - This is line 78
+                    RazorIRToken - (1857:77,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1861:77,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1863:78,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1866:78,3 [15] StringLiterals.cshtml) - Html - This is line 79
+                    RazorIRToken - (1881:78,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1885:78,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1887:79,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1890:79,3 [15] StringLiterals.cshtml) - Html - This is line 80
+                    RazorIRToken - (1905:79,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1909:79,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1911:80,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1914:80,3 [15] StringLiterals.cshtml) - Html - This is line 81
+                    RazorIRToken - (1929:80,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1933:80,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1935:81,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1938:81,3 [15] StringLiterals.cshtml) - Html - This is line 82
+                    RazorIRToken - (1953:81,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1957:81,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1959:82,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1962:82,3 [15] StringLiterals.cshtml) - Html - This is line 83
+                    RazorIRToken - (1977:82,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (1981:82,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (1983:83,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (1986:83,3 [15] StringLiterals.cshtml) - Html - This is line 84
+                    RazorIRToken - (2001:83,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2005:83,22 [4] StringLiterals.cshtml) - Html - <br>
+                    RazorIRToken - (2009:83,26 [4] StringLiterals.cshtml) - Html - \n\n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("WriteLiteralsToInHere", async () => {
-                HtmlContent - (2045:85,32 [2618] StringLiterals.cshtml) - \n    <p>This is line 1 nested</p>\n    <p>This is line 2 nested</p>\n    <p>This is line 3 nested</p>\n    <p>This is line 4 nested</p>\n    <p>This is line 5 nested</p>\n    <p>This is line 6 nested</p>\n    <p>This is line 7 nested</p>\n    <p>This is line 8 nested</p>\n    <p>This is line 9 nested</p>\n    <p>This is line 10 nested</p>\n    <p>This is line 11 nested</p>\n    <p>This is line 12 nested</p>\n    <p>This is line 13 nested</p>\n    <p>This is line 14 nested</p>\n    <p>This is line 15 nested</p>\n    <p>This is line 16 nested</p>\n    <p>This is line 17 nested</p>\n    <p>This is line 18 nested</p>\n    <p>This is line 19 nested</p>\n    <p>This is line 20 nested</p>\n    <p>This is line 21 nested</p>\n    <p>This is line 22 nested</p>\n    <p>This is line 23 nested</p>\n    <p>This is line 24 nested</p>\n    <p>This is line 25 nested</p>\n    <p>This is line 26 nested</p>\n    <p>This is line 27 nested</p>\n    <p>This is line 28 nested</p>\n    <p>This is line 29 nested</p>\n    <p>This is line 30 nested</p>\n    <p>This is line 31 nested</p>\n    <p>This is line 32 nested</p>\n    <p>This is line 33 nested</p>\n    <p>This is line 34 nested</p>\n    <p>This is line 35 nested</p>\n    <p>This is line 36 nested</p>\n    <p>This is line 37 nested</p>\n    <p>This is line 38 nested</p>\n    <p>This is line 39 nested</p>\n    <p>This is line 40 nested</p>\n    <p>This is line 41 nested</p>\n    <p>This is line 42 nested</p>\n    <p>This is line 43 nested</p>\n    <p>This is line 44 nested</p>\n    <p>This is line 45 nested</p>\n    <p>This is line 46 nested</p>\n    <p>This is line 47 nested</p>\n    <p>This is line 48 nested</p>\n    <p>This is line 49 nested</p>\n    <p>This is line 50 nested</p>\n    <p>This is line 51 nested</p>\n    <p>This is line 52 nested</p>\n    <p>This is line 53 nested</p>\n    <p>This is line 54 nested</p>\n    <p>This is line 55 nested</p>\n    <p>This is line 56 nested</p>\n    <p>This is line 57 nested</p>\n    <p>This is line 58 nested</p>\n    <p>This is line 59 nested</p>\n    <p>This is line 60 nested</p>\n    <p>This is line 61 nested</p>\n    <p>This is line 62 nested</p>\n    <p>This is line 63 nested</p>\n    <p>This is line 64 nested</p>\n    <p>This is line 65 nested</p>\n    <p>This is line 66 nested</p>\n    <p>This is line 67 nested</p>\n    <p>This is line 68 nested</p>\n    <p>This is line 69 nested</p>\n    <p>This is line 70 nested</p>\n    <p>This is line 71 nested</p>\n    <p>This is line 72 nested</p>\n    <p>This is line 73 nested</p>\n    <p>This is line 74 nested</p>\n    <p>This is line 75 nested</p>\n
+                HtmlContent - (2045:85,32 [2618] StringLiterals.cshtml)
+                    RazorIRToken - (2045:85,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2051:86,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2054:86,7 [21] StringLiterals.cshtml) - Html - This is line 1 nested
+                    RazorIRToken - (2075:86,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2079:86,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2085:87,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2088:87,7 [21] StringLiterals.cshtml) - Html - This is line 2 nested
+                    RazorIRToken - (2109:87,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2113:87,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2119:88,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2122:88,7 [21] StringLiterals.cshtml) - Html - This is line 3 nested
+                    RazorIRToken - (2143:88,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2147:88,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2153:89,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2156:89,7 [21] StringLiterals.cshtml) - Html - This is line 4 nested
+                    RazorIRToken - (2177:89,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2181:89,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2187:90,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2190:90,7 [21] StringLiterals.cshtml) - Html - This is line 5 nested
+                    RazorIRToken - (2211:90,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2215:90,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2221:91,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2224:91,7 [21] StringLiterals.cshtml) - Html - This is line 6 nested
+                    RazorIRToken - (2245:91,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2249:91,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2255:92,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2258:92,7 [21] StringLiterals.cshtml) - Html - This is line 7 nested
+                    RazorIRToken - (2279:92,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2283:92,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2289:93,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2292:93,7 [21] StringLiterals.cshtml) - Html - This is line 8 nested
+                    RazorIRToken - (2313:93,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2317:93,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2323:94,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2326:94,7 [21] StringLiterals.cshtml) - Html - This is line 9 nested
+                    RazorIRToken - (2347:94,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2351:94,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2357:95,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2360:95,7 [22] StringLiterals.cshtml) - Html - This is line 10 nested
+                    RazorIRToken - (2382:95,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2386:95,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2392:96,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2395:96,7 [22] StringLiterals.cshtml) - Html - This is line 11 nested
+                    RazorIRToken - (2417:96,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2421:96,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2427:97,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2430:97,7 [22] StringLiterals.cshtml) - Html - This is line 12 nested
+                    RazorIRToken - (2452:97,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2456:97,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2462:98,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2465:98,7 [22] StringLiterals.cshtml) - Html - This is line 13 nested
+                    RazorIRToken - (2487:98,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2491:98,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2497:99,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2500:99,7 [22] StringLiterals.cshtml) - Html - This is line 14 nested
+                    RazorIRToken - (2522:99,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2526:99,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2532:100,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2535:100,7 [22] StringLiterals.cshtml) - Html - This is line 15 nested
+                    RazorIRToken - (2557:100,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2561:100,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2567:101,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2570:101,7 [22] StringLiterals.cshtml) - Html - This is line 16 nested
+                    RazorIRToken - (2592:101,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2596:101,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2602:102,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2605:102,7 [22] StringLiterals.cshtml) - Html - This is line 17 nested
+                    RazorIRToken - (2627:102,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2631:102,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2637:103,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2640:103,7 [22] StringLiterals.cshtml) - Html - This is line 18 nested
+                    RazorIRToken - (2662:103,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2666:103,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2672:104,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2675:104,7 [22] StringLiterals.cshtml) - Html - This is line 19 nested
+                    RazorIRToken - (2697:104,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2701:104,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2707:105,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2710:105,7 [22] StringLiterals.cshtml) - Html - This is line 20 nested
+                    RazorIRToken - (2732:105,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2736:105,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2742:106,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2745:106,7 [22] StringLiterals.cshtml) - Html - This is line 21 nested
+                    RazorIRToken - (2767:106,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2771:106,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2777:107,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2780:107,7 [22] StringLiterals.cshtml) - Html - This is line 22 nested
+                    RazorIRToken - (2802:107,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2806:107,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2812:108,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2815:108,7 [22] StringLiterals.cshtml) - Html - This is line 23 nested
+                    RazorIRToken - (2837:108,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2841:108,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2847:109,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2850:109,7 [22] StringLiterals.cshtml) - Html - This is line 24 nested
+                    RazorIRToken - (2872:109,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2876:109,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2882:110,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2885:110,7 [22] StringLiterals.cshtml) - Html - This is line 25 nested
+                    RazorIRToken - (2907:110,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2911:110,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2917:111,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2920:111,7 [22] StringLiterals.cshtml) - Html - This is line 26 nested
+                    RazorIRToken - (2942:111,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2946:111,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2952:112,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2955:112,7 [22] StringLiterals.cshtml) - Html - This is line 27 nested
+                    RazorIRToken - (2977:112,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (2981:112,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (2987:113,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (2990:113,7 [22] StringLiterals.cshtml) - Html - This is line 28 nested
+                    RazorIRToken - (3012:113,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3016:113,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3022:114,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3025:114,7 [22] StringLiterals.cshtml) - Html - This is line 29 nested
+                    RazorIRToken - (3047:114,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3051:114,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3057:115,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3060:115,7 [22] StringLiterals.cshtml) - Html - This is line 30 nested
+                    RazorIRToken - (3082:115,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3086:115,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3092:116,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3095:116,7 [22] StringLiterals.cshtml) - Html - This is line 31 nested
+                    RazorIRToken - (3117:116,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3121:116,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3127:117,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3130:117,7 [22] StringLiterals.cshtml) - Html - This is line 32 nested
+                    RazorIRToken - (3152:117,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3156:117,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3162:118,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3165:118,7 [22] StringLiterals.cshtml) - Html - This is line 33 nested
+                    RazorIRToken - (3187:118,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3191:118,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3197:119,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3200:119,7 [22] StringLiterals.cshtml) - Html - This is line 34 nested
+                    RazorIRToken - (3222:119,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3226:119,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3232:120,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3235:120,7 [22] StringLiterals.cshtml) - Html - This is line 35 nested
+                    RazorIRToken - (3257:120,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3261:120,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3267:121,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3270:121,7 [22] StringLiterals.cshtml) - Html - This is line 36 nested
+                    RazorIRToken - (3292:121,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3296:121,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3302:122,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3305:122,7 [22] StringLiterals.cshtml) - Html - This is line 37 nested
+                    RazorIRToken - (3327:122,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3331:122,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3337:123,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3340:123,7 [22] StringLiterals.cshtml) - Html - This is line 38 nested
+                    RazorIRToken - (3362:123,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3366:123,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3372:124,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3375:124,7 [22] StringLiterals.cshtml) - Html - This is line 39 nested
+                    RazorIRToken - (3397:124,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3401:124,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3407:125,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3410:125,7 [22] StringLiterals.cshtml) - Html - This is line 40 nested
+                    RazorIRToken - (3432:125,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3436:125,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3442:126,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3445:126,7 [22] StringLiterals.cshtml) - Html - This is line 41 nested
+                    RazorIRToken - (3467:126,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3471:126,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3477:127,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3480:127,7 [22] StringLiterals.cshtml) - Html - This is line 42 nested
+                    RazorIRToken - (3502:127,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3506:127,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3512:128,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3515:128,7 [22] StringLiterals.cshtml) - Html - This is line 43 nested
+                    RazorIRToken - (3537:128,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3541:128,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3547:129,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3550:129,7 [22] StringLiterals.cshtml) - Html - This is line 44 nested
+                    RazorIRToken - (3572:129,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3576:129,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3582:130,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3585:130,7 [22] StringLiterals.cshtml) - Html - This is line 45 nested
+                    RazorIRToken - (3607:130,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3611:130,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3617:131,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3620:131,7 [22] StringLiterals.cshtml) - Html - This is line 46 nested
+                    RazorIRToken - (3642:131,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3646:131,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3652:132,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3655:132,7 [22] StringLiterals.cshtml) - Html - This is line 47 nested
+                    RazorIRToken - (3677:132,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3681:132,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3687:133,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3690:133,7 [22] StringLiterals.cshtml) - Html - This is line 48 nested
+                    RazorIRToken - (3712:133,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3716:133,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3722:134,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3725:134,7 [22] StringLiterals.cshtml) - Html - This is line 49 nested
+                    RazorIRToken - (3747:134,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3751:134,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3757:135,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3760:135,7 [22] StringLiterals.cshtml) - Html - This is line 50 nested
+                    RazorIRToken - (3782:135,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3786:135,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3792:136,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3795:136,7 [22] StringLiterals.cshtml) - Html - This is line 51 nested
+                    RazorIRToken - (3817:136,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3821:136,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3827:137,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3830:137,7 [22] StringLiterals.cshtml) - Html - This is line 52 nested
+                    RazorIRToken - (3852:137,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3856:137,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3862:138,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3865:138,7 [22] StringLiterals.cshtml) - Html - This is line 53 nested
+                    RazorIRToken - (3887:138,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3891:138,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3897:139,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3900:139,7 [22] StringLiterals.cshtml) - Html - This is line 54 nested
+                    RazorIRToken - (3922:139,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3926:139,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3932:140,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3935:140,7 [22] StringLiterals.cshtml) - Html - This is line 55 nested
+                    RazorIRToken - (3957:140,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3961:140,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (3967:141,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (3970:141,7 [22] StringLiterals.cshtml) - Html - This is line 56 nested
+                    RazorIRToken - (3992:141,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (3996:141,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4002:142,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4005:142,7 [22] StringLiterals.cshtml) - Html - This is line 57 nested
+                    RazorIRToken - (4027:142,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4031:142,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4037:143,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4040:143,7 [22] StringLiterals.cshtml) - Html - This is line 58 nested
+                    RazorIRToken - (4062:143,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4066:143,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4072:144,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4075:144,7 [22] StringLiterals.cshtml) - Html - This is line 59 nested
+                    RazorIRToken - (4097:144,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4101:144,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4107:145,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4110:145,7 [22] StringLiterals.cshtml) - Html - This is line 60 nested
+                    RazorIRToken - (4132:145,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4136:145,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4142:146,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4145:146,7 [22] StringLiterals.cshtml) - Html - This is line 61 nested
+                    RazorIRToken - (4167:146,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4171:146,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4177:147,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4180:147,7 [22] StringLiterals.cshtml) - Html - This is line 62 nested
+                    RazorIRToken - (4202:147,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4206:147,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4212:148,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4215:148,7 [22] StringLiterals.cshtml) - Html - This is line 63 nested
+                    RazorIRToken - (4237:148,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4241:148,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4247:149,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4250:149,7 [22] StringLiterals.cshtml) - Html - This is line 64 nested
+                    RazorIRToken - (4272:149,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4276:149,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4282:150,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4285:150,7 [22] StringLiterals.cshtml) - Html - This is line 65 nested
+                    RazorIRToken - (4307:150,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4311:150,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4317:151,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4320:151,7 [22] StringLiterals.cshtml) - Html - This is line 66 nested
+                    RazorIRToken - (4342:151,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4346:151,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4352:152,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4355:152,7 [22] StringLiterals.cshtml) - Html - This is line 67 nested
+                    RazorIRToken - (4377:152,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4381:152,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4387:153,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4390:153,7 [22] StringLiterals.cshtml) - Html - This is line 68 nested
+                    RazorIRToken - (4412:153,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4416:153,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4422:154,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4425:154,7 [22] StringLiterals.cshtml) - Html - This is line 69 nested
+                    RazorIRToken - (4447:154,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4451:154,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4457:155,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4460:155,7 [22] StringLiterals.cshtml) - Html - This is line 70 nested
+                    RazorIRToken - (4482:155,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4486:155,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4492:156,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4495:156,7 [22] StringLiterals.cshtml) - Html - This is line 71 nested
+                    RazorIRToken - (4517:156,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4521:156,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4527:157,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4530:157,7 [22] StringLiterals.cshtml) - Html - This is line 72 nested
+                    RazorIRToken - (4552:157,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4556:157,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4562:158,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4565:158,7 [22] StringLiterals.cshtml) - Html - This is line 73 nested
+                    RazorIRToken - (4587:158,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4591:158,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4597:159,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4600:159,7 [22] StringLiterals.cshtml) - Html - This is line 74 nested
+                    RazorIRToken - (4622:159,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4626:159,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (4632:160,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4635:160,7 [22] StringLiterals.cshtml) - Html - This is line 75 nested
+                    RazorIRToken - (4657:160,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4661:160,33 [2] StringLiterals.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (4666:162,0 [1026] StringLiterals.cshtml) - <p>This is line 1</p>\n<p>This is line 2</p>\n<p>This is line 3</p>\n<p>This is line 4</p>\n<p>This is line 5</p>\n<p>This is line 6</p>\n<p>This is line 7</p>\n<p>This is line 8</p>\n<p>This is line 9</p>\n<p>This is line 10</p>\n<p>This is line 11</p>\n<p>This is line 12</p>\n<p>This is line 13</p>\n<p>This is line 14</p>\n<p>This is line 15</p>\n<p>This is line 16</p>\n<p>This is line 17</p>\n<p>This is line 18</p>\n<p>This is line 19</p>\n<p>This is line 20</p>\n<p>This is line 21</p>\n<p>This is line 22</p>\n<p>This is line 23</p>\n<p>This is line 24</p>\n<p>This is line 25</p>\n<p>This is line 26</p>\n<p>This is line 27</p>\n<p>This is line 28</p>\n<p>This is line 29</p>\n<p>This is line 30</p>\n<p>This is line 31</p>\n<p>This is line 32</p>\n<p>This is line 33</p>\n<p>This is line 34</p>\n<p>This is line 35</p>\n<p>This is line 36</p>\n<p>This is line 37</p>\n<p>This is line 38</p>\n<p>This is line 39</p>\n<p>This is line 40</p>\n<p>This is line 41</p>\n<p>This is line 42</p>\n<p>This is line 43</p>hi!\n
+                HtmlContent - (4666:162,0 [1026] StringLiterals.cshtml)
+                    RazorIRToken - (4666:162,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4669:162,3 [14] StringLiterals.cshtml) - Html - This is line 1
+                    RazorIRToken - (4683:162,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4687:162,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4689:163,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4692:163,3 [14] StringLiterals.cshtml) - Html - This is line 2
+                    RazorIRToken - (4706:163,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4710:163,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4712:164,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4715:164,3 [14] StringLiterals.cshtml) - Html - This is line 3
+                    RazorIRToken - (4729:164,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4733:164,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4735:165,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4738:165,3 [14] StringLiterals.cshtml) - Html - This is line 4
+                    RazorIRToken - (4752:165,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4756:165,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4758:166,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4761:166,3 [14] StringLiterals.cshtml) - Html - This is line 5
+                    RazorIRToken - (4775:166,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4779:166,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4781:167,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4784:167,3 [14] StringLiterals.cshtml) - Html - This is line 6
+                    RazorIRToken - (4798:167,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4802:167,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4804:168,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4807:168,3 [14] StringLiterals.cshtml) - Html - This is line 7
+                    RazorIRToken - (4821:168,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4825:168,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4827:169,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4830:169,3 [14] StringLiterals.cshtml) - Html - This is line 8
+                    RazorIRToken - (4844:169,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4848:169,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4850:170,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4853:170,3 [14] StringLiterals.cshtml) - Html - This is line 9
+                    RazorIRToken - (4867:170,17 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4871:170,21 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4873:171,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4876:171,3 [15] StringLiterals.cshtml) - Html - This is line 10
+                    RazorIRToken - (4891:171,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4895:171,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4897:172,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4900:172,3 [15] StringLiterals.cshtml) - Html - This is line 11
+                    RazorIRToken - (4915:172,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4919:172,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4921:173,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4924:173,3 [15] StringLiterals.cshtml) - Html - This is line 12
+                    RazorIRToken - (4939:173,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4943:173,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4945:174,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4948:174,3 [15] StringLiterals.cshtml) - Html - This is line 13
+                    RazorIRToken - (4963:174,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4967:174,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4969:175,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4972:175,3 [15] StringLiterals.cshtml) - Html - This is line 14
+                    RazorIRToken - (4987:175,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (4991:175,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (4993:176,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (4996:176,3 [15] StringLiterals.cshtml) - Html - This is line 15
+                    RazorIRToken - (5011:176,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5015:176,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5017:177,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5020:177,3 [15] StringLiterals.cshtml) - Html - This is line 16
+                    RazorIRToken - (5035:177,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5039:177,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5041:178,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5044:178,3 [15] StringLiterals.cshtml) - Html - This is line 17
+                    RazorIRToken - (5059:178,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5063:178,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5065:179,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5068:179,3 [15] StringLiterals.cshtml) - Html - This is line 18
+                    RazorIRToken - (5083:179,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5087:179,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5089:180,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5092:180,3 [15] StringLiterals.cshtml) - Html - This is line 19
+                    RazorIRToken - (5107:180,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5111:180,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5113:181,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5116:181,3 [15] StringLiterals.cshtml) - Html - This is line 20
+                    RazorIRToken - (5131:181,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5135:181,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5137:182,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5140:182,3 [15] StringLiterals.cshtml) - Html - This is line 21
+                    RazorIRToken - (5155:182,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5159:182,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5161:183,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5164:183,3 [15] StringLiterals.cshtml) - Html - This is line 22
+                    RazorIRToken - (5179:183,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5183:183,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5185:184,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5188:184,3 [15] StringLiterals.cshtml) - Html - This is line 23
+                    RazorIRToken - (5203:184,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5207:184,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5209:185,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5212:185,3 [15] StringLiterals.cshtml) - Html - This is line 24
+                    RazorIRToken - (5227:185,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5231:185,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5233:186,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5236:186,3 [15] StringLiterals.cshtml) - Html - This is line 25
+                    RazorIRToken - (5251:186,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5255:186,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5257:187,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5260:187,3 [15] StringLiterals.cshtml) - Html - This is line 26
+                    RazorIRToken - (5275:187,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5279:187,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5281:188,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5284:188,3 [15] StringLiterals.cshtml) - Html - This is line 27
+                    RazorIRToken - (5299:188,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5303:188,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5305:189,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5308:189,3 [15] StringLiterals.cshtml) - Html - This is line 28
+                    RazorIRToken - (5323:189,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5327:189,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5329:190,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5332:190,3 [15] StringLiterals.cshtml) - Html - This is line 29
+                    RazorIRToken - (5347:190,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5351:190,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5353:191,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5356:191,3 [15] StringLiterals.cshtml) - Html - This is line 30
+                    RazorIRToken - (5371:191,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5375:191,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5377:192,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5380:192,3 [15] StringLiterals.cshtml) - Html - This is line 31
+                    RazorIRToken - (5395:192,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5399:192,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5401:193,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5404:193,3 [15] StringLiterals.cshtml) - Html - This is line 32
+                    RazorIRToken - (5419:193,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5423:193,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5425:194,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5428:194,3 [15] StringLiterals.cshtml) - Html - This is line 33
+                    RazorIRToken - (5443:194,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5447:194,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5449:195,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5452:195,3 [15] StringLiterals.cshtml) - Html - This is line 34
+                    RazorIRToken - (5467:195,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5471:195,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5473:196,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5476:196,3 [15] StringLiterals.cshtml) - Html - This is line 35
+                    RazorIRToken - (5491:196,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5495:196,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5497:197,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5500:197,3 [15] StringLiterals.cshtml) - Html - This is line 36
+                    RazorIRToken - (5515:197,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5519:197,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5521:198,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5524:198,3 [15] StringLiterals.cshtml) - Html - This is line 37
+                    RazorIRToken - (5539:198,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5543:198,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5545:199,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5548:199,3 [15] StringLiterals.cshtml) - Html - This is line 38
+                    RazorIRToken - (5563:199,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5567:199,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5569:200,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5572:200,3 [15] StringLiterals.cshtml) - Html - This is line 39
+                    RazorIRToken - (5587:200,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5591:200,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5593:201,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5596:201,3 [15] StringLiterals.cshtml) - Html - This is line 40
+                    RazorIRToken - (5611:201,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5615:201,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5617:202,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5620:202,3 [15] StringLiterals.cshtml) - Html - This is line 41
+                    RazorIRToken - (5635:202,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5639:202,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5641:203,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5644:203,3 [15] StringLiterals.cshtml) - Html - This is line 42
+                    RazorIRToken - (5659:203,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5663:203,22 [2] StringLiterals.cshtml) - Html - \n
+                    RazorIRToken - (5665:204,0 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5668:204,3 [15] StringLiterals.cshtml) - Html - This is line 43
+                    RazorIRToken - (5683:204,18 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5687:204,22 [5] StringLiterals.cshtml) - Html - hi!\n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("WriteLiteralsToInHereAlso", async () => {
-                HtmlContent - (5728:205,36 [1023] StringLiterals.cshtml) - \n    <p>This is line 1 nested</p>\n    <p>This is line 2 nested</p>\n    <p>This is line 3 nested</p>\n    <p>This is line 4 nested</p>\n    <p>This is line 5 nested</p>\n    <p>This is line 6 nested</p>\n    <p>This is line 7 nested</p>\n    <p>This is line 8 nested</p>\n    <p>This is line 9 nested</p>\n    <p>This is line 10 nested</p>\n    <p>This is line 11 nested</p>\n    <p>This is line 12 nested</p>\n    <p>This is line 13 nested</p>\n    <p>This is line 14 nested</p>\n    <p>This is line 15 nested</p>\n    <p>This is line 16 nested</p>\n    <p>This is line 17 nested</p>\n    <p>This is line 18 nested</p>\n    <p>This is line 19 nested</p>\n    <p>This is line 20 nested</p>\n    <p>This is line 21 nested</p>\n    <p>This is line 22 nested</p>\n    <p>This is line 23 nested</p>\n    <p>This is line 24 nested</p>\n    <p>This is line 25 nested</p>\n    <p>This is line 26 nested</p>\n    <p>This is line 27 nested</p>\n    <p>This is line 28 nested</p>\n    <p>This is line 29 nested</p>\n    <p>30</p>\n
+                HtmlContent - (5728:205,36 [1023] StringLiterals.cshtml)
+                    RazorIRToken - (5728:205,36 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5734:206,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5737:206,7 [21] StringLiterals.cshtml) - Html - This is line 1 nested
+                    RazorIRToken - (5758:206,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5762:206,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5768:207,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5771:207,7 [21] StringLiterals.cshtml) - Html - This is line 2 nested
+                    RazorIRToken - (5792:207,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5796:207,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5802:208,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5805:208,7 [21] StringLiterals.cshtml) - Html - This is line 3 nested
+                    RazorIRToken - (5826:208,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5830:208,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5836:209,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5839:209,7 [21] StringLiterals.cshtml) - Html - This is line 4 nested
+                    RazorIRToken - (5860:209,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5864:209,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5870:210,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5873:210,7 [21] StringLiterals.cshtml) - Html - This is line 5 nested
+                    RazorIRToken - (5894:210,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5898:210,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5904:211,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5907:211,7 [21] StringLiterals.cshtml) - Html - This is line 6 nested
+                    RazorIRToken - (5928:211,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5932:211,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5938:212,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5941:212,7 [21] StringLiterals.cshtml) - Html - This is line 7 nested
+                    RazorIRToken - (5962:212,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (5966:212,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (5972:213,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (5975:213,7 [21] StringLiterals.cshtml) - Html - This is line 8 nested
+                    RazorIRToken - (5996:213,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6000:213,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6006:214,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6009:214,7 [21] StringLiterals.cshtml) - Html - This is line 9 nested
+                    RazorIRToken - (6030:214,28 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6034:214,32 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6040:215,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6043:215,7 [22] StringLiterals.cshtml) - Html - This is line 10 nested
+                    RazorIRToken - (6065:215,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6069:215,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6075:216,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6078:216,7 [22] StringLiterals.cshtml) - Html - This is line 11 nested
+                    RazorIRToken - (6100:216,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6104:216,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6110:217,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6113:217,7 [22] StringLiterals.cshtml) - Html - This is line 12 nested
+                    RazorIRToken - (6135:217,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6139:217,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6145:218,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6148:218,7 [22] StringLiterals.cshtml) - Html - This is line 13 nested
+                    RazorIRToken - (6170:218,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6174:218,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6180:219,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6183:219,7 [22] StringLiterals.cshtml) - Html - This is line 14 nested
+                    RazorIRToken - (6205:219,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6209:219,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6215:220,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6218:220,7 [22] StringLiterals.cshtml) - Html - This is line 15 nested
+                    RazorIRToken - (6240:220,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6244:220,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6250:221,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6253:221,7 [22] StringLiterals.cshtml) - Html - This is line 16 nested
+                    RazorIRToken - (6275:221,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6279:221,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6285:222,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6288:222,7 [22] StringLiterals.cshtml) - Html - This is line 17 nested
+                    RazorIRToken - (6310:222,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6314:222,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6320:223,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6323:223,7 [22] StringLiterals.cshtml) - Html - This is line 18 nested
+                    RazorIRToken - (6345:223,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6349:223,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6355:224,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6358:224,7 [22] StringLiterals.cshtml) - Html - This is line 19 nested
+                    RazorIRToken - (6380:224,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6384:224,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6390:225,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6393:225,7 [22] StringLiterals.cshtml) - Html - This is line 20 nested
+                    RazorIRToken - (6415:225,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6419:225,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6425:226,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6428:226,7 [22] StringLiterals.cshtml) - Html - This is line 21 nested
+                    RazorIRToken - (6450:226,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6454:226,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6460:227,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6463:227,7 [22] StringLiterals.cshtml) - Html - This is line 22 nested
+                    RazorIRToken - (6485:227,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6489:227,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6495:228,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6498:228,7 [22] StringLiterals.cshtml) - Html - This is line 23 nested
+                    RazorIRToken - (6520:228,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6524:228,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6530:229,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6533:229,7 [22] StringLiterals.cshtml) - Html - This is line 24 nested
+                    RazorIRToken - (6555:229,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6559:229,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6565:230,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6568:230,7 [22] StringLiterals.cshtml) - Html - This is line 25 nested
+                    RazorIRToken - (6590:230,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6594:230,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6600:231,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6603:231,7 [22] StringLiterals.cshtml) - Html - This is line 26 nested
+                    RazorIRToken - (6625:231,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6629:231,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6635:232,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6638:232,7 [22] StringLiterals.cshtml) - Html - This is line 27 nested
+                    RazorIRToken - (6660:232,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6664:232,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6670:233,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6673:233,7 [22] StringLiterals.cshtml) - Html - This is line 28 nested
+                    RazorIRToken - (6695:233,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6699:233,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6705:234,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6708:234,7 [22] StringLiterals.cshtml) - Html - This is line 29 nested
+                    RazorIRToken - (6730:234,29 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6734:234,33 [6] StringLiterals.cshtml) - Html - \n    
+                    RazorIRToken - (6740:235,4 [3] StringLiterals.cshtml) - Html - <p>
+                    RazorIRToken - (6743:235,7 [2] StringLiterals.cshtml) - Html - 30
+                    RazorIRToken - (6745:235,9 [4] StringLiterals.cshtml) - Html - </p>
+                    RazorIRToken - (6749:235,13 [2] StringLiterals.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });
-                HtmlContent - (6752:236,1 [1] StringLiterals.cshtml) - !
+                HtmlContent - (6752:236,1 [1] StringLiterals.cshtml)
+                    RazorIRToken - (6752:236,1 [1] StringLiterals.cshtml) - Html - !

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.ir.txt
@@ -18,73 +18,133 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.CatchAllTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (29:0,29 [255] SymbolBoundAttributes.cshtml) - \n\n<ul [item]="items"></ul>\n<ul [(item)]="items"></ul>\n<button (click)="doSomething()">Click Me</button>\n<button (^click)="doSomething()">Click Me</button>\n<template *something="value">\n</template>\n<div #local></div>\n<div #local="value"></div>\n\n
+                HtmlContent - (29:0,29 [255] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (29:0,29 [4] SymbolBoundAttributes.cshtml) - Html - \n\n
+                    RazorIRToken - (33:2,0 [3] SymbolBoundAttributes.cshtml) - Html - <ul
+                    RazorIRToken - (36:2,3 [15] SymbolBoundAttributes.cshtml) - Html -  [item]="items"
+                    RazorIRToken - (51:2,18 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (52:2,19 [5] SymbolBoundAttributes.cshtml) - Html - </ul>
+                    RazorIRToken - (57:2,24 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (59:3,0 [3] SymbolBoundAttributes.cshtml) - Html - <ul
+                    RazorIRToken - (62:3,3 [17] SymbolBoundAttributes.cshtml) - Html -  [(item)]="items"
+                    RazorIRToken - (79:3,20 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (80:3,21 [5] SymbolBoundAttributes.cshtml) - Html - </ul>
+                    RazorIRToken - (85:3,26 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (87:4,0 [7] SymbolBoundAttributes.cshtml) - Html - <button
+                    RazorIRToken - (94:4,7 [24] SymbolBoundAttributes.cshtml) - Html -  (click)="doSomething()"
+                    RazorIRToken - (118:4,31 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (119:4,32 [8] SymbolBoundAttributes.cshtml) - Html - Click Me
+                    RazorIRToken - (127:4,40 [9] SymbolBoundAttributes.cshtml) - Html - </button>
+                    RazorIRToken - (136:4,49 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (138:5,0 [7] SymbolBoundAttributes.cshtml) - Html - <button
+                    RazorIRToken - (145:5,7 [25] SymbolBoundAttributes.cshtml) - Html -  (^click)="doSomething()"
+                    RazorIRToken - (170:5,32 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (171:5,33 [8] SymbolBoundAttributes.cshtml) - Html - Click Me
+                    RazorIRToken - (179:5,41 [9] SymbolBoundAttributes.cshtml) - Html - </button>
+                    RazorIRToken - (188:5,50 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (190:6,0 [9] SymbolBoundAttributes.cshtml) - Html - <template
+                    RazorIRToken - (199:6,9 [19] SymbolBoundAttributes.cshtml) - Html -  *something="value"
+                    RazorIRToken - (218:6,28 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (219:6,29 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (221:7,0 [11] SymbolBoundAttributes.cshtml) - Html - </template>
+                    RazorIRToken - (232:7,11 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (234:8,0 [4] SymbolBoundAttributes.cshtml) - Html - <div
+                    RazorIRToken - (238:8,4 [7] SymbolBoundAttributes.cshtml) - Html -  #local
+                    RazorIRToken - (245:8,11 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (246:8,12 [6] SymbolBoundAttributes.cshtml) - Html - </div>
+                    RazorIRToken - (252:8,18 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (254:9,0 [4] SymbolBoundAttributes.cshtml) - Html - <div
+                    RazorIRToken - (258:9,4 [15] SymbolBoundAttributes.cshtml) - Html -  #local="value"
+                    RazorIRToken - (273:9,19 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (274:9,20 [6] SymbolBoundAttributes.cshtml) - Html - </div>
+                    RazorIRToken - (280:9,26 [4] SymbolBoundAttributes.cshtml) - Html - \n\n
                 TagHelper - (284:11,0 [45] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - ul - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (302:11,18 [5] SymbolBoundAttributes.cshtml) - [item] - ListItems - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (302:11,18 [5] SymbolBoundAttributes.cshtml) - items
+                        HtmlContent - (302:11,18 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (302:11,18 [5] SymbolBoundAttributes.cshtml) - Html - items
                     AddTagHelperHtmlAttribute -  - [item] - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (317:11,33 [5] SymbolBoundAttributes.cshtml) - items
+                        HtmlContent - (317:11,33 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (317:11,33 [5] SymbolBoundAttributes.cshtml) - Html - items
                     ExecuteTagHelpers - 
-                HtmlContent - (329:11,45 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (329:11,45 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (329:11,45 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (331:12,0 [49] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - ul - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (351:12,20 [5] SymbolBoundAttributes.cshtml) - [(item)] - ArrayItems - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (351:12,20 [5] SymbolBoundAttributes.cshtml) - items
+                        HtmlContent - (351:12,20 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (351:12,20 [5] SymbolBoundAttributes.cshtml) - Html - items
                     AddTagHelperHtmlAttribute -  - [(item)] - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (368:12,37 [5] SymbolBoundAttributes.cshtml) - items
+                        HtmlContent - (368:12,37 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (368:12,37 [5] SymbolBoundAttributes.cshtml) - Html - items
                     ExecuteTagHelpers - 
-                HtmlContent - (380:12,49 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (380:12,49 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (380:12,49 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (382:13,0 [79] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - button - TagMode.StartTagAndEndTag
-                        HtmlContent - (444:13,62 [8] SymbolBoundAttributes.cshtml) - Click Me
+                        HtmlContent - (444:13,62 [8] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (444:13,62 [8] SymbolBoundAttributes.cshtml) - Html - Click Me
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (405:13,23 [13] SymbolBoundAttributes.cshtml) - (click) - Event1 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (405:13,23 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                        HtmlContent - (405:13,23 [13] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (405:13,23 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
                     AddTagHelperHtmlAttribute -  - (click) - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (429:13,47 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                        HtmlContent - (429:13,47 [13] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (429:13,47 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
                     ExecuteTagHelpers - 
-                HtmlContent - (461:13,79 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (461:13,79 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (461:13,79 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (463:14,0 [81] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - button - TagMode.StartTagAndEndTag
-                        HtmlContent - (527:14,64 [8] SymbolBoundAttributes.cshtml) - Click Me
+                        HtmlContent - (527:14,64 [8] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (527:14,64 [8] SymbolBoundAttributes.cshtml) - Html - Click Me
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (487:14,24 [13] SymbolBoundAttributes.cshtml) - (^click) - Event2 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (487:14,24 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                        HtmlContent - (487:14,24 [13] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (487:14,24 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
                     AddTagHelperHtmlAttribute -  - (^click) - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (512:14,49 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                        HtmlContent - (512:14,49 [13] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (512:14,49 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
                     ExecuteTagHelpers - 
-                HtmlContent - (544:14,81 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (544:14,81 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (544:14,81 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (546:15,0 [67] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - template - TagMode.StartTagAndEndTag
-                        HtmlContent - (600:15,54 [2] SymbolBoundAttributes.cshtml) - \n
+                        HtmlContent - (600:15,54 [2] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (600:15,54 [2] SymbolBoundAttributes.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (574:15,28 [5] SymbolBoundAttributes.cshtml) - *something - StringProperty1 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (574:15,28 [5] SymbolBoundAttributes.cshtml) - value
+                        HtmlContent - (574:15,28 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (574:15,28 [5] SymbolBoundAttributes.cshtml) - Html - value
                     AddTagHelperHtmlAttribute -  - *something - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (593:15,47 [5] SymbolBoundAttributes.cshtml) - value
+                        HtmlContent - (593:15,47 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (593:15,47 [5] SymbolBoundAttributes.cshtml) - Html - value
                     ExecuteTagHelpers - 
-                HtmlContent - (613:16,11 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (613:16,11 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (613:16,11 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (615:17,0 [33] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     AddTagHelperHtmlAttribute -  - #localminimized - HtmlAttributeValueStyle.Minimized
                     ExecuteTagHelpers - 
-                HtmlContent - (648:17,33 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (648:17,33 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (648:17,33 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (650:18,0 [47] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (669:18,19 [5] SymbolBoundAttributes.cshtml) - #local - StringProperty2 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (669:18,19 [5] SymbolBoundAttributes.cshtml) - value
+                        HtmlContent - (669:18,19 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (669:18,19 [5] SymbolBoundAttributes.cshtml) - Html - value
                     AddTagHelperHtmlAttribute -  - #local - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (684:18,34 [5] SymbolBoundAttributes.cshtml) - value
+                        HtmlContent - (684:18,34 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (684:18,34 [5] SymbolBoundAttributes.cshtml) - Html - value
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.ir.txt
@@ -14,61 +14,113 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7 - #local - value - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.CatchAllTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:1,0 [253] SymbolBoundAttributes.cshtml) - \n<ul [item]="items"></ul>\n<ul [(item)]="items"></ul>\n<button (click)="doSomething()">Click Me</button>\n<button (^click)="doSomething()">Click Me</button>\n<template *something="value">\n</template>\n<div #local></div>\n<div #local="value"></div>\n\n
+                HtmlContent - (31:1,0 [253] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (31:1,0 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (33:2,0 [3] SymbolBoundAttributes.cshtml) - Html - <ul
+                    RazorIRToken - (36:2,3 [15] SymbolBoundAttributes.cshtml) - Html -  [item]="items"
+                    RazorIRToken - (51:2,18 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (52:2,19 [5] SymbolBoundAttributes.cshtml) - Html - </ul>
+                    RazorIRToken - (57:2,24 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (59:3,0 [3] SymbolBoundAttributes.cshtml) - Html - <ul
+                    RazorIRToken - (62:3,3 [17] SymbolBoundAttributes.cshtml) - Html -  [(item)]="items"
+                    RazorIRToken - (79:3,20 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (80:3,21 [5] SymbolBoundAttributes.cshtml) - Html - </ul>
+                    RazorIRToken - (85:3,26 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (87:4,0 [7] SymbolBoundAttributes.cshtml) - Html - <button
+                    RazorIRToken - (94:4,7 [24] SymbolBoundAttributes.cshtml) - Html -  (click)="doSomething()"
+                    RazorIRToken - (118:4,31 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (119:4,32 [8] SymbolBoundAttributes.cshtml) - Html - Click Me
+                    RazorIRToken - (127:4,40 [9] SymbolBoundAttributes.cshtml) - Html - </button>
+                    RazorIRToken - (136:4,49 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (138:5,0 [7] SymbolBoundAttributes.cshtml) - Html - <button
+                    RazorIRToken - (145:5,7 [25] SymbolBoundAttributes.cshtml) - Html -  (^click)="doSomething()"
+                    RazorIRToken - (170:5,32 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (171:5,33 [8] SymbolBoundAttributes.cshtml) - Html - Click Me
+                    RazorIRToken - (179:5,41 [9] SymbolBoundAttributes.cshtml) - Html - </button>
+                    RazorIRToken - (188:5,50 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (190:6,0 [9] SymbolBoundAttributes.cshtml) - Html - <template
+                    RazorIRToken - (199:6,9 [19] SymbolBoundAttributes.cshtml) - Html -  *something="value"
+                    RazorIRToken - (218:6,28 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (219:6,29 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (221:7,0 [11] SymbolBoundAttributes.cshtml) - Html - </template>
+                    RazorIRToken - (232:7,11 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (234:8,0 [4] SymbolBoundAttributes.cshtml) - Html - <div
+                    RazorIRToken - (238:8,4 [7] SymbolBoundAttributes.cshtml) - Html -  #local
+                    RazorIRToken - (245:8,11 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (246:8,12 [6] SymbolBoundAttributes.cshtml) - Html - </div>
+                    RazorIRToken - (252:8,18 [2] SymbolBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (254:9,0 [4] SymbolBoundAttributes.cshtml) - Html - <div
+                    RazorIRToken - (258:9,4 [15] SymbolBoundAttributes.cshtml) - Html -  #local="value"
+                    RazorIRToken - (273:9,19 [1] SymbolBoundAttributes.cshtml) - Html - >
+                    RazorIRToken - (274:9,20 [6] SymbolBoundAttributes.cshtml) - Html - </div>
+                    RazorIRToken - (280:9,26 [4] SymbolBoundAttributes.cshtml) - Html - \n\n
                 TagHelper - (284:11,0 [45] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - ul - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (302:11,18 [5] SymbolBoundAttributes.cshtml) - [item] - ListItems - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (302:11,18 [5] SymbolBoundAttributes.cshtml) - items
+                        HtmlContent - (302:11,18 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (302:11,18 [5] SymbolBoundAttributes.cshtml) - Html - items
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     ExecuteTagHelpers - 
-                HtmlContent - (329:11,45 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (329:11,45 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (329:11,45 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (331:12,0 [49] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - ul - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (351:12,20 [5] SymbolBoundAttributes.cshtml) - [(item)] - ArrayItems - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (351:12,20 [5] SymbolBoundAttributes.cshtml) - items
+                        HtmlContent - (351:12,20 [5] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (351:12,20 [5] SymbolBoundAttributes.cshtml) - Html - items
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     ExecuteTagHelpers - 
-                HtmlContent - (380:12,49 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (380:12,49 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (380:12,49 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (382:13,0 [79] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - button - TagMode.StartTagAndEndTag
-                        HtmlContent - (444:13,62 [8] SymbolBoundAttributes.cshtml) - Click Me
+                        HtmlContent - (444:13,62 [8] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (444:13,62 [8] SymbolBoundAttributes.cshtml) - Html - Click Me
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (405:13,23 [13] SymbolBoundAttributes.cshtml) - (click) - Event1 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (405:13,23 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                        HtmlContent - (405:13,23 [13] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (405:13,23 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     ExecuteTagHelpers - 
-                HtmlContent - (461:13,79 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (461:13,79 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (461:13,79 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (463:14,0 [81] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - button - TagMode.StartTagAndEndTag
-                        HtmlContent - (527:14,64 [8] SymbolBoundAttributes.cshtml) - Click Me
+                        HtmlContent - (527:14,64 [8] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (527:14,64 [8] SymbolBoundAttributes.cshtml) - Html - Click Me
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (487:14,24 [13] SymbolBoundAttributes.cshtml) - (^click) - Event2 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (487:14,24 [13] SymbolBoundAttributes.cshtml) - doSomething()
+                        HtmlContent - (487:14,24 [13] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (487:14,24 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                     ExecuteTagHelpers - 
-                HtmlContent - (544:14,81 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (544:14,81 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (544:14,81 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (546:15,0 [67] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - template - TagMode.StartTagAndEndTag
-                        HtmlContent - (600:15,54 [2] SymbolBoundAttributes.cshtml) - \n
+                        HtmlContent - (600:15,54 [2] SymbolBoundAttributes.cshtml)
+                            RazorIRToken - (600:15,54 [2] SymbolBoundAttributes.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - *something - StringProperty1
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
                     ExecuteTagHelpers - 
-                HtmlContent - (613:16,11 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (613:16,11 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (613:16,11 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (615:17,0 [33] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     AddTagHelperHtmlAttribute -  - #localminimized - HtmlAttributeValueStyle.Minimized
                     ExecuteTagHelpers - 
-                HtmlContent - (648:17,33 [2] SymbolBoundAttributes.cshtml) - \n
+                HtmlContent - (648:17,33 [2] SymbolBoundAttributes.cshtml)
+                    RazorIRToken - (648:17,33 [2] SymbolBoundAttributes.cshtml) - Html - \n
                 TagHelper - (650:18,0 [47] SymbolBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.ir.txt
@@ -6,27 +6,38 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersInSection_Runtime -  - 
             DeclareTagHelperFields -  - TestNamespace.MyTagHelper - TestNamespace.NestedTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] TagHelpersInSection.cshtml) - \n
+                HtmlContent - (33:1,0 [2] TagHelpersInSection.cshtml)
+                    RazorIRToken - (33:1,0 [2] TagHelpersInSection.cshtml) - Html - \n
                 CSharpStatement - (37:2,2 [31] TagHelpersInSection.cshtml)
                     RazorIRToken - (37:2,2 [31] TagHelpersInSection.cshtml) - CSharp - \n    var code = "some code";\n
-                HtmlContent - (71:5,0 [2] TagHelpersInSection.cshtml) - \n
+                HtmlContent - (71:5,0 [2] TagHelpersInSection.cshtml)
+                    RazorIRToken - (71:5,0 [2] TagHelpersInSection.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - DefineSection("MySection", async () => {
-                HtmlContent - (93:6,20 [21] TagHelpersInSection.cshtml) - \n    <div>\n        
+                HtmlContent - (93:6,20 [21] TagHelpersInSection.cshtml)
+                    RazorIRToken - (93:6,20 [6] TagHelpersInSection.cshtml) - Html - \n    
+                    RazorIRToken - (99:7,4 [5] TagHelpersInSection.cshtml) - Html - <div>
+                    RazorIRToken - (104:7,9 [10] TagHelpersInSection.cshtml) - Html - \n        
                 TagHelper - (114:8,8 [245] TagHelpersInSection.cshtml)
                     InitializeTagHelperStructure -  - mytaghelper - TagMode.StartTagAndEndTag
-                        HtmlContent - (217:8,111 [52] TagHelpersInSection.cshtml) - \n            In None ContentBehavior.\n            
+                        HtmlContent - (217:8,111 [52] TagHelpersInSection.cshtml)
+                            RazorIRToken - (217:8,111 [52] TagHelpersInSection.cshtml) - Html - \n            In None ContentBehavior.\n            
                         TagHelper - (269:10,12 [66] TagHelpersInSection.cshtml)
                             InitializeTagHelperStructure -  - nestedtaghelper - TagMode.StartTagAndEndTag
-                                HtmlContent - (286:10,29 [26] TagHelpersInSection.cshtml) - Some buffered values with 
+                                HtmlContent - (286:10,29 [26] TagHelpersInSection.cshtml)
+                                    RazorIRToken - (286:10,29 [26] TagHelpersInSection.cshtml) - Html - Some buffered values with 
                                 CSharpExpression - (313:10,56 [4] TagHelpersInSection.cshtml)
                                     RazorIRToken - (313:10,56 [4] TagHelpersInSection.cshtml) - CSharp - code
                             CreateTagHelper -  - TestNamespace.NestedTagHelper
                             ExecuteTagHelpers - 
-                        HtmlContent - (335:10,78 [10] TagHelpersInSection.cshtml) - \n        
+                        HtmlContent - (335:10,78 [10] TagHelpersInSection.cshtml)
+                            RazorIRToken - (335:10,78 [10] TagHelpersInSection.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.MyTagHelper
                     SetTagHelperProperty - (142:8,36 [27] TagHelpersInSection.cshtml) - boundproperty - BoundProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (142:8,36 [14] TagHelpersInSection.cshtml) - Current Time: 
+                        HtmlContent - (142:8,36 [14] TagHelpersInSection.cshtml)
+                            RazorIRToken - (142:8,36 [7] TagHelpersInSection.cshtml) - Html - Current
+                            RazorIRToken - (149:8,43 [6] TagHelpersInSection.cshtml) - Html -  Time:
+                            RazorIRToken - (155:8,49 [1] TagHelpersInSection.cshtml) - Html -  
                         CSharpExpression - (157:8,51 [12] TagHelpersInSection.cshtml)
                             RazorIRToken - (157:8,51 [12] TagHelpersInSection.cshtml) - CSharp - DateTime.Now
                     AddTagHelperHtmlAttribute -  - unboundproperty - HtmlAttributeValueStyle.DoubleQuotes
@@ -36,6 +47,9 @@ Document -
                             CSharpExpression - (203:8,97 [12] TagHelpersInSection.cshtml)
                                 RazorIRToken - (203:8,97 [12] TagHelpersInSection.cshtml) - CSharp - DateTime.Now
                     ExecuteTagHelpers - 
-                HtmlContent - (359:11,22 [14] TagHelpersInSection.cshtml) - \n    </div>\n
+                HtmlContent - (359:11,22 [14] TagHelpersInSection.cshtml)
+                    RazorIRToken - (359:11,22 [6] TagHelpersInSection.cshtml) - Html - \n    
+                    RazorIRToken - (365:12,4 [6] TagHelpersInSection.cshtml) - Html - </div>
+                    RazorIRToken - (371:12,10 [2] TagHelpersInSection.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - });

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.ir.txt
@@ -18,7 +18,10 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (29:0,29 [14] TagHelpersWithBoundAttributes.cshtml) - \n<form>\n    
+                HtmlContent - (29:0,29 [14] TagHelpersWithBoundAttributes.cshtml)
+                    RazorIRToken - (29:0,29 [2] TagHelpersWithBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (31:1,0 [6] TagHelpersWithBoundAttributes.cshtml) - Html - <form>
+                    RazorIRToken - (37:1,6 [6] TagHelpersWithBoundAttributes.cshtml) - Html - \n    
                 TagHelper - (43:2,4 [34] TagHelpersWithBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - InputTagHelper
@@ -26,6 +29,9 @@ Document -
                         CSharpExpression - (57:2,18 [5] TagHelpersWithBoundAttributes.cshtml)
                             RazorIRToken - (57:2,18 [5] TagHelpersWithBoundAttributes.cshtml) - CSharp - Hello
                     AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (69:2,30 [4] TagHelpersWithBoundAttributes.cshtml) - text
+                        HtmlContent - (69:2,30 [4] TagHelpersWithBoundAttributes.cshtml)
+                            RazorIRToken - (69:2,30 [4] TagHelpersWithBoundAttributes.cshtml) - Html - text
                     ExecuteTagHelpers - 
-                HtmlContent - (77:2,38 [9] TagHelpersWithBoundAttributes.cshtml) - \n</form>
+                HtmlContent - (77:2,38 [9] TagHelpersWithBoundAttributes.cshtml)
+                    RazorIRToken - (77:2,38 [2] TagHelpersWithBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (79:3,0 [7] TagHelpersWithBoundAttributes.cshtml) - Html - </form>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.ir.txt
@@ -7,7 +7,9 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - type - text - HtmlAttributeValueStyle.SingleQuotes
             DeclareTagHelperFields -  - InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:1,0 [12] TagHelpersWithBoundAttributes.cshtml) - <form>\n    
+                HtmlContent - (31:1,0 [12] TagHelpersWithBoundAttributes.cshtml)
+                    RazorIRToken - (31:1,0 [6] TagHelpersWithBoundAttributes.cshtml) - Html - <form>
+                    RazorIRToken - (37:1,6 [6] TagHelpersWithBoundAttributes.cshtml) - Html - \n    
                 TagHelper - (43:2,4 [34] TagHelpersWithBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - InputTagHelper
@@ -16,4 +18,6 @@ Document -
                             RazorIRToken - (57:2,18 [5] TagHelpersWithBoundAttributes.cshtml) - CSharp - Hello
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     ExecuteTagHelpers - 
-                HtmlContent - (77:2,38 [9] TagHelpersWithBoundAttributes.cshtml) - \n</form>
+                HtmlContent - (77:2,38 [9] TagHelpersWithBoundAttributes.cshtml)
+                    RazorIRToken - (77:2,38 [2] TagHelpersWithBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (79:3,0 [7] TagHelpersWithBoundAttributes.cshtml) - Html - </form>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.ir.txt
@@ -19,8 +19,12 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (29:0,29 [2] TagHelpersWithPrefix.cshtml) - \n
-                HtmlContent - (53:1,22 [14] TagHelpersWithPrefix.cshtml) - \n<form>\n    
+                HtmlContent - (29:0,29 [2] TagHelpersWithPrefix.cshtml)
+                    RazorIRToken - (29:0,29 [2] TagHelpersWithPrefix.cshtml) - Html - \n
+                HtmlContent - (53:1,22 [14] TagHelpersWithPrefix.cshtml)
+                    RazorIRToken - (53:1,22 [2] TagHelpersWithPrefix.cshtml) - Html - \n
+                    RazorIRToken - (55:2,0 [6] TagHelpersWithPrefix.cshtml) - Html - <form>
+                    RazorIRToken - (61:2,6 [6] TagHelpersWithPrefix.cshtml) - Html - \n    
                 TagHelper - (67:3,4 [39] TagHelpersWithPrefix.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - InputTagHelper
@@ -28,6 +32,9 @@ Document -
                         CSharpExpression - (86:3,23 [5] TagHelpersWithPrefix.cshtml)
                             RazorIRToken - (86:3,23 [5] TagHelpersWithPrefix.cshtml) - CSharp - Hello
                     AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (98:3,35 [4] TagHelpersWithPrefix.cshtml) - text
+                        HtmlContent - (98:3,35 [4] TagHelpersWithPrefix.cshtml)
+                            RazorIRToken - (98:3,35 [4] TagHelpersWithPrefix.cshtml) - Html - text
                     ExecuteTagHelpers - 
-                HtmlContent - (106:3,43 [9] TagHelpersWithPrefix.cshtml) - \n</form>
+                HtmlContent - (106:3,43 [9] TagHelpersWithPrefix.cshtml)
+                    RazorIRToken - (106:3,43 [2] TagHelpersWithPrefix.cshtml) - Html - \n
+                    RazorIRToken - (108:4,0 [7] TagHelpersWithPrefix.cshtml) - Html - </form>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.ir.txt
@@ -7,7 +7,9 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - type - text - HtmlAttributeValueStyle.SingleQuotes
             DeclareTagHelperFields -  - InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (55:2,0 [12] TagHelpersWithPrefix.cshtml) - <form>\n    
+                HtmlContent - (55:2,0 [12] TagHelpersWithPrefix.cshtml)
+                    RazorIRToken - (55:2,0 [6] TagHelpersWithPrefix.cshtml) - Html - <form>
+                    RazorIRToken - (61:2,6 [6] TagHelpersWithPrefix.cshtml) - Html - \n    
                 TagHelper - (67:3,4 [39] TagHelpersWithPrefix.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - InputTagHelper
@@ -16,4 +18,6 @@ Document -
                             RazorIRToken - (86:3,23 [5] TagHelpersWithPrefix.cshtml) - CSharp - Hello
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     ExecuteTagHelpers - 
-                HtmlContent - (106:3,43 [9] TagHelpersWithPrefix.cshtml) - \n</form>
+                HtmlContent - (106:3,43 [9] TagHelpersWithPrefix.cshtml)
+                    RazorIRToken - (106:3,43 [2] TagHelpersWithPrefix.cshtml) - Html - \n
+                    RazorIRToken - (108:4,0 [7] TagHelpersWithPrefix.cshtml) - Html - </form>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.ir.txt
@@ -18,36 +18,45 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - DivTagHelper - InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] TagHelpersWithTemplate.cshtml) - \n\n
-                HtmlContent - (316:9,1 [4] TagHelpersWithTemplate.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] TagHelpersWithTemplate.cshtml)
+                    RazorIRToken - (31:0,31 [4] TagHelpersWithTemplate.cshtml) - Html - \n\n
+                HtmlContent - (316:9,1 [4] TagHelpersWithTemplate.cshtml)
+                    RazorIRToken - (316:9,1 [4] TagHelpersWithTemplate.cshtml) - Html - \n\n
                 TagHelper - (320:11,0 [179] TagHelpersWithTemplate.cshtml)
                     InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
-                        HtmlContent - (325:11,5 [6] TagHelpersWithTemplate.cshtml) - \n    
+                        HtmlContent - (325:11,5 [6] TagHelpersWithTemplate.cshtml)
+                            RazorIRToken - (325:11,5 [6] TagHelpersWithTemplate.cshtml) - Html - \n    
                         CSharpStatement - (333:12,6 [66] TagHelpersWithTemplate.cshtml)
                             RazorIRToken - (333:12,6 [66] TagHelpersWithTemplate.cshtml) - CSharp - \n        RenderTemplate(\n            "Template: ",\n            
                         Template - (400:15,13 [82] TagHelpersWithTemplate.cshtml)
                             TagHelper - (400:15,13 [82] TagHelpersWithTemplate.cshtml)
                                 InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
-                                    HtmlContent - (422:15,35 [4] TagHelpersWithTemplate.cshtml) - <h3>
+                                    HtmlContent - (422:15,35 [4] TagHelpersWithTemplate.cshtml)
+                                        RazorIRToken - (422:15,35 [4] TagHelpersWithTemplate.cshtml) - Html - <h3>
                                     CSharpExpression - (427:15,40 [4] TagHelpersWithTemplate.cshtml)
                                         RazorIRToken - (427:15,40 [4] TagHelpersWithTemplate.cshtml) - CSharp - item
-                                    HtmlContent - (431:15,44 [5] TagHelpersWithTemplate.cshtml) - </h3>
+                                    HtmlContent - (431:15,44 [5] TagHelpersWithTemplate.cshtml)
+                                        RazorIRToken - (431:15,44 [5] TagHelpersWithTemplate.cshtml) - Html - </h3>
                                     TagHelper - (436:15,49 [40] TagHelpersWithTemplate.cshtml)
                                         InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                         CreateTagHelper -  - InputTagHelper
                                         AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
-                                            HtmlContent - (449:15,62 [8] TagHelpersWithTemplate.cshtml) - checkbox
+                                            HtmlContent - (449:15,62 [8] TagHelpersWithTemplate.cshtml)
+                                                RazorIRToken - (449:15,62 [8] TagHelpersWithTemplate.cshtml) - Html - checkbox
                                         AddTagHelperHtmlAttribute -  - checked - HtmlAttributeValueStyle.DoubleQuotes
-                                            HtmlContent - (468:15,81 [4] TagHelpersWithTemplate.cshtml) - true
+                                            HtmlContent - (468:15,81 [4] TagHelpersWithTemplate.cshtml)
+                                                RazorIRToken - (468:15,81 [4] TagHelpersWithTemplate.cshtml) - Html - true
                                         ExecuteTagHelpers - 
                                 CreateTagHelper -  - DivTagHelper
                                 AddTagHelperHtmlAttribute -  - condition - HtmlAttributeValueStyle.DoubleQuotes
-                                    HtmlContent - (416:15,29 [4] TagHelpersWithTemplate.cshtml) - true
+                                    HtmlContent - (416:15,29 [4] TagHelpersWithTemplate.cshtml)
+                                        RazorIRToken - (416:15,29 [4] TagHelpersWithTemplate.cshtml) - Html - true
                                 ExecuteTagHelpers - 
                         CSharpStatement - (482:15,95 [8] TagHelpersWithTemplate.cshtml)
                             RazorIRToken - (482:15,95 [8] TagHelpersWithTemplate.cshtml) - CSharp - );\n    
                     CreateTagHelper -  - DivTagHelper
                     ExecuteTagHelpers - 
-                HtmlContent - (499:17,6 [4] TagHelpersWithTemplate.cshtml) - \n\n
+                HtmlContent - (499:17,6 [4] TagHelpersWithTemplate.cshtml)
+                    RazorIRToken - (499:17,6 [4] TagHelpersWithTemplate.cshtml) - Html - \n\n
             CSharpStatement - (47:2,12 [268] TagHelpersWithTemplate.cshtml)
                 RazorIRToken - (47:2,12 [268] TagHelpersWithTemplate.cshtml) - CSharp - \n    public void RenderTemplate(string title, Func<string, HelperResult> template)\n    {\n        Output.WriteLine("<br /><p><em>Rendering Template:</em></p>");\n        var helperResult = template(title);\n        helperResult.WriteTo(Output, HtmlEncoder);\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.ir.txt
@@ -9,11 +9,14 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2 - condition - true - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - DivTagHelper - InputTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] TagHelpersWithTemplate.cshtml) - \n
-                HtmlContent - (318:10,0 [2] TagHelpersWithTemplate.cshtml) - \n
+                HtmlContent - (33:1,0 [2] TagHelpersWithTemplate.cshtml)
+                    RazorIRToken - (33:1,0 [2] TagHelpersWithTemplate.cshtml) - Html - \n
+                HtmlContent - (318:10,0 [2] TagHelpersWithTemplate.cshtml)
+                    RazorIRToken - (318:10,0 [2] TagHelpersWithTemplate.cshtml) - Html - \n
                 TagHelper - (320:11,0 [179] TagHelpersWithTemplate.cshtml)
                     InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
-                        HtmlContent - (325:11,5 [2] TagHelpersWithTemplate.cshtml) - \n
+                        HtmlContent - (325:11,5 [2] TagHelpersWithTemplate.cshtml)
+                            RazorIRToken - (325:11,5 [2] TagHelpersWithTemplate.cshtml) - Html - \n
                         CSharpStatement - (327:12,0 [4] TagHelpersWithTemplate.cshtml)
                             RazorIRToken - (327:12,0 [4] TagHelpersWithTemplate.cshtml) - CSharp -     
                         CSharpStatement - (333:12,6 [66] TagHelpersWithTemplate.cshtml)
@@ -21,10 +24,12 @@ Document -
                         Template - (400:15,13 [82] TagHelpersWithTemplate.cshtml)
                             TagHelper - (400:15,13 [82] TagHelpersWithTemplate.cshtml)
                                 InitializeTagHelperStructure -  - div - TagMode.StartTagAndEndTag
-                                    HtmlContent - (422:15,35 [4] TagHelpersWithTemplate.cshtml) - <h3>
+                                    HtmlContent - (422:15,35 [4] TagHelpersWithTemplate.cshtml)
+                                        RazorIRToken - (422:15,35 [4] TagHelpersWithTemplate.cshtml) - Html - <h3>
                                     CSharpExpression - (427:15,40 [4] TagHelpersWithTemplate.cshtml)
                                         RazorIRToken - (427:15,40 [4] TagHelpersWithTemplate.cshtml) - CSharp - item
-                                    HtmlContent - (431:15,44 [5] TagHelpersWithTemplate.cshtml) - </h3>
+                                    HtmlContent - (431:15,44 [5] TagHelpersWithTemplate.cshtml)
+                                        RazorIRToken - (431:15,44 [5] TagHelpersWithTemplate.cshtml) - Html - </h3>
                                     TagHelper - (436:15,49 [40] TagHelpersWithTemplate.cshtml)
                                         InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                         CreateTagHelper -  - InputTagHelper
@@ -38,6 +43,7 @@ Document -
                             RazorIRToken - (482:15,95 [8] TagHelpersWithTemplate.cshtml) - CSharp - );\n    
                     CreateTagHelper -  - DivTagHelper
                     ExecuteTagHelpers - 
-                HtmlContent - (499:17,6 [4] TagHelpersWithTemplate.cshtml) - \n\n
+                HtmlContent - (499:17,6 [4] TagHelpersWithTemplate.cshtml)
+                    RazorIRToken - (499:17,6 [4] TagHelpersWithTemplate.cshtml) - Html - \n\n
             CSharpStatement - (47:2,12 [268] TagHelpersWithTemplate.cshtml)
                 RazorIRToken - (47:2,12 [268] TagHelpersWithTemplate.cshtml) - CSharp - \n    public void RenderTemplate(string title, Func<string, HelperResult> template)\n    {\n        Output.WriteLine("<br /><p><em>Rendering Template:</em></p>");\n        var helperResult = template(title);\n        helperResult.WriteTo(Output, HtmlEncoder);\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.ir.txt
@@ -18,49 +18,64 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                HtmlContent - (31:0,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    RazorIRToken - (31:0,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - \n\n
                 TagHelper - (35:2,0 [85] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (105:6,25 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Body of Tag
+                        HtmlContent - (105:6,25 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (105:6,25 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - Body of Tag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (54:5,1 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Hello World
+                        HtmlContent - (54:5,1 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (54:5,1 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - Hello World
                     SetTagHelperProperty - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - 1337
+                        HtmlContent - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - 1337
                     AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                             RazorIRToken - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - true
                     ExecuteTagHelpers - 
-                HtmlContent - (120:6,40 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                HtmlContent - (120:6,40 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    RazorIRToken - (120:6,40 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - \n\n
                 TagHelper - (124:8,0 [47] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     SetTagHelperProperty - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - text
+                        HtmlContent - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - text
                     SetTagHelperProperty - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - text
+                        HtmlContent - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (140:8,16 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - text
                     AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (162:8,38 [5] TagHelpersWithWeirdlySpacedAttributes.cshtml) - hello
+                        HtmlContent - (162:8,38 [5] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (162:8,38 [5] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - hello
                     ExecuteTagHelpers - 
-                HtmlContent - (171:8,47 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                HtmlContent - (171:8,47 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    RazorIRToken - (171:8,47 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - \n\n
                 TagHelper - (175:10,0 [46] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - 1234
+                        HtmlContent - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - 1234
                     AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (209:11,3 [6] TagHelpersWithWeirdlySpacedAttributes.cshtml) - hello2
+                        HtmlContent - (209:11,3 [6] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (209:11,3 [6] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - hello2
                     ExecuteTagHelpers - 
-                HtmlContent - (221:11,15 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                HtmlContent - (221:11,15 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    RazorIRToken - (221:11,15 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - \n\n
                 TagHelper - (225:13,0 [51] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     SetTagHelperProperty - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - password
+                        HtmlContent - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - password
                     SetTagHelperProperty - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - password
+                        HtmlContent - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (247:14,8 [8] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - password
                     AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (270:14,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - blah
+                        HtmlContent - (270:14,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (270:14,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - blah
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.ir.txt
@@ -12,19 +12,23 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5 - data-content - blah - HtmlAttributeValueStyle.DoubleQuotes
             DeclareTagHelperFields -  - TestNamespace.PTagHelper - TestNamespace.InputTagHelper - TestNamespace.InputTagHelper2
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (33:1,0 [2] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n
+                HtmlContent - (33:1,0 [2] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    RazorIRToken - (33:1,0 [2] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - \n
                 TagHelper - (35:2,0 [85] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (105:6,25 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Body of Tag
+                        HtmlContent - (105:6,25 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (105:6,25 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - Body of Tag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - 1337
+                        HtmlContent - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - 1337
                     AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                             RazorIRToken - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - true
                     ExecuteTagHelpers - 
-                HtmlContent - (120:6,40 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                HtmlContent - (120:6,40 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    RazorIRToken - (120:6,40 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - \n\n
                 TagHelper - (124:8,0 [47] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper
@@ -33,15 +37,18 @@ Document -
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     ExecuteTagHelpers - 
-                HtmlContent - (171:8,47 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                HtmlContent - (171:8,47 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    RazorIRToken - (171:8,47 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - \n\n
                 TagHelper - (175:10,0 [46] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - 1234
+                        HtmlContent - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                            RazorIRToken - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - 1234
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                     ExecuteTagHelpers - 
-                HtmlContent - (221:11,15 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - \n\n
+                HtmlContent - (221:11,15 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
+                    RazorIRToken - (221:11,15 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - \n\n
                 TagHelper - (225:13,0 [51] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - TestNamespace.InputTagHelper

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.ir.txt
@@ -16,69 +16,121 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (278:8,1 [4] Templates.cshtml) - \n\n
+                HtmlContent - (278:8,1 [4] Templates.cshtml)
+                    RazorIRToken - (278:8,1 [4] Templates.cshtml) - Html - \n\n
                 CSharpStatement - (284:10,2 [34] Templates.cshtml)
                     RazorIRToken - (284:10,2 [34] Templates.cshtml) - CSharp - \n    Func<dynamic, object> foo = 
                 Template - (325:11,39 [16] Templates.cshtml)
-                    HtmlContent - (325:11,39 [11] Templates.cshtml) - This works 
+                    HtmlContent - (325:11,39 [11] Templates.cshtml)
+                        RazorIRToken - (325:11,39 [11] Templates.cshtml) - Html - This works 
                     CSharpExpression - (337:11,51 [4] Templates.cshtml)
                         RazorIRToken - (337:11,51 [4] Templates.cshtml) - CSharp - item
-                    HtmlContent - (341:11,55 [1] Templates.cshtml) - !
+                    HtmlContent - (341:11,55 [1] Templates.cshtml)
+                        RazorIRToken - (341:11,55 [1] Templates.cshtml) - Html - !
                 CSharpStatement - (349:11,63 [7] Templates.cshtml)
                     RazorIRToken - (349:11,63 [7] Templates.cshtml) - CSharp - ;\n    
                 CSharpExpression - (357:12,5 [7] Templates.cshtml)
                     RazorIRToken - (357:12,5 [7] Templates.cshtml) - CSharp - foo("")
                 CSharpStatement - (364:12,12 [2] Templates.cshtml)
                     RazorIRToken - (364:12,12 [2] Templates.cshtml) - CSharp - \n
-                HtmlContent - (369:14,0 [8] Templates.cshtml) - \n<ul>\n
+                HtmlContent - (369:14,0 [8] Templates.cshtml)
+                    RazorIRToken - (369:14,0 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (371:15,0 [4] Templates.cshtml) - Html - <ul>
+                    RazorIRToken - (375:15,4 [2] Templates.cshtml) - Html - \n
                 CSharpExpression - (379:16,2 [31] Templates.cshtml)
                     RazorIRToken - (379:16,2 [11] Templates.cshtml) - CSharp - Repeat(10, 
                     Template - (391:16,14 [19] Templates.cshtml)
-                        HtmlContent - (391:16,14 [10] Templates.cshtml) - <li>Item #
+                        HtmlContent - (391:16,14 [10] Templates.cshtml)
+                            RazorIRToken - (391:16,14 [4] Templates.cshtml) - Html - <li>
+                            RazorIRToken - (395:16,18 [6] Templates.cshtml) - Html - Item #
                         CSharpExpression - (402:16,25 [4] Templates.cshtml)
                             RazorIRToken - (402:16,25 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (406:16,29 [5] Templates.cshtml) - </li>
+                        HtmlContent - (406:16,29 [5] Templates.cshtml)
+                            RazorIRToken - (406:16,29 [5] Templates.cshtml) - Html - </li>
                     RazorIRToken - (411:16,34 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (413:16,36 [16] Templates.cshtml) - \n</ul>\n\n<p>\n
+                HtmlContent - (413:16,36 [16] Templates.cshtml)
+                    RazorIRToken - (413:16,36 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (415:17,0 [5] Templates.cshtml) - Html - </ul>
+                    RazorIRToken - (420:17,5 [4] Templates.cshtml) - Html - \n\n
+                    RazorIRToken - (424:19,0 [3] Templates.cshtml) - Html - <p>
+                    RazorIRToken - (427:19,3 [2] Templates.cshtml) - Html - \n
                 CSharpExpression - (430:20,1 [52] Templates.cshtml)
                     RazorIRToken - (430:20,1 [16] Templates.cshtml) - CSharp - Repeat(10,\n    
                     Template - (448:21,6 [35] Templates.cshtml)
-                        HtmlContent - (448:21,6 [14] Templates.cshtml) -  This is line#
+                        HtmlContent - (448:21,6 [14] Templates.cshtml)
+                            RazorIRToken - (448:21,6 [14] Templates.cshtml) - Html -  This is line#
                         CSharpExpression - (463:21,21 [4] Templates.cshtml)
                             RazorIRToken - (463:21,21 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (467:21,25 [17] Templates.cshtml) -  of markup<br/>\n
+                        HtmlContent - (467:21,25 [17] Templates.cshtml)
+                            RazorIRToken - (467:21,25 [17] Templates.cshtml) - Html -  of markup<br/>\n
                     RazorIRToken - (484:22,0 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (485:22,1 [15] Templates.cshtml) - \n</p>\n\n<p>\n
+                HtmlContent - (485:22,1 [15] Templates.cshtml)
+                    RazorIRToken - (485:22,1 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (487:23,0 [4] Templates.cshtml) - Html - </p>
+                    RazorIRToken - (491:23,4 [4] Templates.cshtml) - Html - \n\n
+                    RazorIRToken - (495:25,0 [3] Templates.cshtml) - Html - <p>
+                    RazorIRToken - (498:25,3 [2] Templates.cshtml) - Html - \n
                 CSharpExpression - (501:26,1 [54] Templates.cshtml)
                     RazorIRToken - (501:26,1 [16] Templates.cshtml) - CSharp - Repeat(10,\n    
                     Template - (519:27,6 [37] Templates.cshtml)
-                        HtmlContent - (519:27,6 [15] Templates.cshtml) - : This is line#
+                        HtmlContent - (519:27,6 [15] Templates.cshtml)
+                            RazorIRToken - (519:27,6 [15] Templates.cshtml) - Html - : This is line#
                         CSharpExpression - (535:27,22 [4] Templates.cshtml)
                             RazorIRToken - (535:27,22 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (539:27,26 [18] Templates.cshtml) -  of markup<br />\n
+                        HtmlContent - (539:27,26 [18] Templates.cshtml)
+                            RazorIRToken - (539:27,26 [18] Templates.cshtml) - Html -  of markup<br />\n
                     RazorIRToken - (557:28,0 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (558:28,1 [15] Templates.cshtml) - \n</p>\n\n<p>\n
+                HtmlContent - (558:28,1 [15] Templates.cshtml)
+                    RazorIRToken - (558:28,1 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (560:29,0 [4] Templates.cshtml) - Html - </p>
+                    RazorIRToken - (564:29,4 [4] Templates.cshtml) - Html - \n\n
+                    RazorIRToken - (568:31,0 [3] Templates.cshtml) - Html - <p>
+                    RazorIRToken - (571:31,3 [2] Templates.cshtml) - Html - \n
                 CSharpExpression - (574:32,1 [55] Templates.cshtml)
                     RazorIRToken - (574:32,1 [16] Templates.cshtml) - CSharp - Repeat(10,\n    
                     Template - (592:33,6 [38] Templates.cshtml)
-                        HtmlContent - (592:33,6 [16] Templates.cshtml) - :: This is line#
+                        HtmlContent - (592:33,6 [16] Templates.cshtml)
+                            RazorIRToken - (592:33,6 [16] Templates.cshtml) - Html - :: This is line#
                         CSharpExpression - (609:33,23 [4] Templates.cshtml)
                             RazorIRToken - (609:33,23 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (613:33,27 [18] Templates.cshtml) -  of markup<br />\n
+                        HtmlContent - (613:33,27 [18] Templates.cshtml)
+                            RazorIRToken - (613:33,27 [18] Templates.cshtml) - Html -  of markup<br />\n
                     RazorIRToken - (631:34,0 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (632:34,1 [22] Templates.cshtml) - \n</p>\n\n\n<ul>\n    
+                HtmlContent - (632:34,1 [22] Templates.cshtml)
+                    RazorIRToken - (632:34,1 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (634:35,0 [4] Templates.cshtml) - Html - </p>
+                    RazorIRToken - (638:35,4 [6] Templates.cshtml) - Html - \n\n\n
+                    RazorIRToken - (644:38,0 [4] Templates.cshtml) - Html - <ul>
+                    RazorIRToken - (648:38,4 [6] Templates.cshtml) - Html - \n    
                 CSharpExpression - (655:39,5 [141] Templates.cshtml)
                     RazorIRToken - (655:39,5 [11] Templates.cshtml) - CSharp - Repeat(10, 
                     Template - (667:39,17 [129] Templates.cshtml)
-                        HtmlContent - (667:39,17 [20] Templates.cshtml) - <li>\n        Item #
+                        HtmlContent - (667:39,17 [20] Templates.cshtml)
+                            RazorIRToken - (667:39,17 [4] Templates.cshtml) - Html - <li>
+                            RazorIRToken - (671:39,21 [16] Templates.cshtml) - Html - \n        Item #
                         CSharpExpression - (688:40,15 [4] Templates.cshtml)
                             RazorIRToken - (688:40,15 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (692:40,19 [10] Templates.cshtml) - \n        
+                        HtmlContent - (692:40,19 [10] Templates.cshtml)
+                            RazorIRToken - (692:40,19 [10] Templates.cshtml) - Html - \n        
                         CSharpStatement - (704:41,10 [18] Templates.cshtml)
                             RazorIRToken - (704:41,10 [18] Templates.cshtml) - CSharp - var parent = item;
-                        HtmlContent - (725:42,0 [53] Templates.cshtml) -         <ul>\n            <li>Child Items... ?</li>\n
-                        HtmlContent - (839:45,0 [24] Templates.cshtml) -         </ul>\n    </li>
+                        HtmlContent - (725:42,0 [53] Templates.cshtml)
+                            RazorIRToken - (725:42,0 [8] Templates.cshtml) - Html -         
+                            RazorIRToken - (733:42,8 [4] Templates.cshtml) - Html - <ul>
+                            RazorIRToken - (737:42,12 [14] Templates.cshtml) - Html - \n            
+                            RazorIRToken - (751:43,12 [4] Templates.cshtml) - Html - <li>
+                            RazorIRToken - (755:43,16 [16] Templates.cshtml) - Html - Child Items... ?
+                            RazorIRToken - (771:43,32 [5] Templates.cshtml) - Html - </li>
+                            RazorIRToken - (776:43,37 [2] Templates.cshtml) - Html - \n
+                        HtmlContent - (839:45,0 [24] Templates.cshtml)
+                            RazorIRToken - (839:45,0 [8] Templates.cshtml) - Html -         
+                            RazorIRToken - (847:45,8 [5] Templates.cshtml) - Html - </ul>
+                            RazorIRToken - (852:45,13 [6] Templates.cshtml) - Html - \n    
+                            RazorIRToken - (858:46,4 [5] Templates.cshtml) - Html - </li>
                     RazorIRToken - (863:46,9 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (864:46,10 [8] Templates.cshtml) - \n</ul> 
+                HtmlContent - (864:46,10 [8] Templates.cshtml)
+                    RazorIRToken - (864:46,10 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (866:47,0 [5] Templates.cshtml) - Html - </ul>
+                    RazorIRToken - (871:47,5 [1] Templates.cshtml) - Html -  
             CSharpStatement - (12:0,12 [265] Templates.cshtml)
                 RazorIRToken - (12:0,12 [265] Templates.cshtml) - CSharp - \n    public HelperResult Repeat(int times, Func<int, object> template) {\n        return new HelperResult((writer) => {\n            for(int i = 0; i < times; i++) {\n                ((HelperResult)template(i)).WriteTo(writer);\n            }\n        });\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.ir.txt
@@ -5,71 +5,124 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Templates_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (280:9,0 [2] Templates.cshtml) - \n
+                HtmlContent - (280:9,0 [2] Templates.cshtml)
+                    RazorIRToken - (280:9,0 [2] Templates.cshtml) - Html - \n
                 CSharpStatement - (284:10,2 [34] Templates.cshtml)
                     RazorIRToken - (284:10,2 [34] Templates.cshtml) - CSharp - \n    Func<dynamic, object> foo = 
                 Template - (325:11,39 [16] Templates.cshtml)
-                    HtmlContent - (325:11,39 [11] Templates.cshtml) - This works 
+                    HtmlContent - (325:11,39 [11] Templates.cshtml)
+                        RazorIRToken - (325:11,39 [11] Templates.cshtml) - Html - This works 
                     CSharpExpression - (337:11,51 [4] Templates.cshtml)
                         RazorIRToken - (337:11,51 [4] Templates.cshtml) - CSharp - item
-                    HtmlContent - (341:11,55 [1] Templates.cshtml) - !
+                    HtmlContent - (341:11,55 [1] Templates.cshtml)
+                        RazorIRToken - (341:11,55 [1] Templates.cshtml) - Html - !
                 CSharpStatement - (349:11,63 [7] Templates.cshtml)
                     RazorIRToken - (349:11,63 [7] Templates.cshtml) - CSharp - ;\n    
                 CSharpExpression - (357:12,5 [7] Templates.cshtml)
                     RazorIRToken - (357:12,5 [7] Templates.cshtml) - CSharp - foo("")
                 CSharpStatement - (364:12,12 [2] Templates.cshtml)
                     RazorIRToken - (364:12,12 [2] Templates.cshtml) - CSharp - \n
-                HtmlContent - (369:14,0 [8] Templates.cshtml) - \n<ul>\n
+                HtmlContent - (369:14,0 [8] Templates.cshtml)
+                    RazorIRToken - (369:14,0 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (371:15,0 [4] Templates.cshtml) - Html - <ul>
+                    RazorIRToken - (375:15,4 [2] Templates.cshtml) - Html - \n
                 CSharpExpression - (379:16,2 [31] Templates.cshtml)
                     RazorIRToken - (379:16,2 [11] Templates.cshtml) - CSharp - Repeat(10, 
                     Template - (391:16,14 [19] Templates.cshtml)
-                        HtmlContent - (391:16,14 [10] Templates.cshtml) - <li>Item #
+                        HtmlContent - (391:16,14 [10] Templates.cshtml)
+                            RazorIRToken - (391:16,14 [4] Templates.cshtml) - Html - <li>
+                            RazorIRToken - (395:16,18 [6] Templates.cshtml) - Html - Item #
                         CSharpExpression - (402:16,25 [4] Templates.cshtml)
                             RazorIRToken - (402:16,25 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (406:16,29 [5] Templates.cshtml) - </li>
+                        HtmlContent - (406:16,29 [5] Templates.cshtml)
+                            RazorIRToken - (406:16,29 [5] Templates.cshtml) - Html - </li>
                     RazorIRToken - (411:16,34 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (413:16,36 [16] Templates.cshtml) - \n</ul>\n\n<p>\n
+                HtmlContent - (413:16,36 [16] Templates.cshtml)
+                    RazorIRToken - (413:16,36 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (415:17,0 [5] Templates.cshtml) - Html - </ul>
+                    RazorIRToken - (420:17,5 [4] Templates.cshtml) - Html - \n\n
+                    RazorIRToken - (424:19,0 [3] Templates.cshtml) - Html - <p>
+                    RazorIRToken - (427:19,3 [2] Templates.cshtml) - Html - \n
                 CSharpExpression - (430:20,1 [52] Templates.cshtml)
                     RazorIRToken - (430:20,1 [16] Templates.cshtml) - CSharp - Repeat(10,\n    
                     Template - (448:21,6 [35] Templates.cshtml)
-                        HtmlContent - (448:21,6 [14] Templates.cshtml) -  This is line#
+                        HtmlContent - (448:21,6 [14] Templates.cshtml)
+                            RazorIRToken - (448:21,6 [14] Templates.cshtml) - Html -  This is line#
                         CSharpExpression - (463:21,21 [4] Templates.cshtml)
                             RazorIRToken - (463:21,21 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (467:21,25 [17] Templates.cshtml) -  of markup<br/>\n
+                        HtmlContent - (467:21,25 [17] Templates.cshtml)
+                            RazorIRToken - (467:21,25 [17] Templates.cshtml) - Html -  of markup<br/>\n
                     RazorIRToken - (484:22,0 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (485:22,1 [15] Templates.cshtml) - \n</p>\n\n<p>\n
+                HtmlContent - (485:22,1 [15] Templates.cshtml)
+                    RazorIRToken - (485:22,1 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (487:23,0 [4] Templates.cshtml) - Html - </p>
+                    RazorIRToken - (491:23,4 [4] Templates.cshtml) - Html - \n\n
+                    RazorIRToken - (495:25,0 [3] Templates.cshtml) - Html - <p>
+                    RazorIRToken - (498:25,3 [2] Templates.cshtml) - Html - \n
                 CSharpExpression - (501:26,1 [54] Templates.cshtml)
                     RazorIRToken - (501:26,1 [16] Templates.cshtml) - CSharp - Repeat(10,\n    
                     Template - (519:27,6 [37] Templates.cshtml)
-                        HtmlContent - (519:27,6 [15] Templates.cshtml) - : This is line#
+                        HtmlContent - (519:27,6 [15] Templates.cshtml)
+                            RazorIRToken - (519:27,6 [15] Templates.cshtml) - Html - : This is line#
                         CSharpExpression - (535:27,22 [4] Templates.cshtml)
                             RazorIRToken - (535:27,22 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (539:27,26 [18] Templates.cshtml) -  of markup<br />\n
+                        HtmlContent - (539:27,26 [18] Templates.cshtml)
+                            RazorIRToken - (539:27,26 [18] Templates.cshtml) - Html -  of markup<br />\n
                     RazorIRToken - (557:28,0 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (558:28,1 [15] Templates.cshtml) - \n</p>\n\n<p>\n
+                HtmlContent - (558:28,1 [15] Templates.cshtml)
+                    RazorIRToken - (558:28,1 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (560:29,0 [4] Templates.cshtml) - Html - </p>
+                    RazorIRToken - (564:29,4 [4] Templates.cshtml) - Html - \n\n
+                    RazorIRToken - (568:31,0 [3] Templates.cshtml) - Html - <p>
+                    RazorIRToken - (571:31,3 [2] Templates.cshtml) - Html - \n
                 CSharpExpression - (574:32,1 [55] Templates.cshtml)
                     RazorIRToken - (574:32,1 [16] Templates.cshtml) - CSharp - Repeat(10,\n    
                     Template - (592:33,6 [38] Templates.cshtml)
-                        HtmlContent - (592:33,6 [16] Templates.cshtml) - :: This is line#
+                        HtmlContent - (592:33,6 [16] Templates.cshtml)
+                            RazorIRToken - (592:33,6 [16] Templates.cshtml) - Html - :: This is line#
                         CSharpExpression - (609:33,23 [4] Templates.cshtml)
                             RazorIRToken - (609:33,23 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (613:33,27 [18] Templates.cshtml) -  of markup<br />\n
+                        HtmlContent - (613:33,27 [18] Templates.cshtml)
+                            RazorIRToken - (613:33,27 [18] Templates.cshtml) - Html -  of markup<br />\n
                     RazorIRToken - (631:34,0 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (632:34,1 [22] Templates.cshtml) - \n</p>\n\n\n<ul>\n    
+                HtmlContent - (632:34,1 [22] Templates.cshtml)
+                    RazorIRToken - (632:34,1 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (634:35,0 [4] Templates.cshtml) - Html - </p>
+                    RazorIRToken - (638:35,4 [6] Templates.cshtml) - Html - \n\n\n
+                    RazorIRToken - (644:38,0 [4] Templates.cshtml) - Html - <ul>
+                    RazorIRToken - (648:38,4 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (650:39,0 [4] Templates.cshtml) - Html -     
                 CSharpExpression - (655:39,5 [141] Templates.cshtml)
                     RazorIRToken - (655:39,5 [11] Templates.cshtml) - CSharp - Repeat(10, 
                     Template - (667:39,17 [129] Templates.cshtml)
-                        HtmlContent - (667:39,17 [20] Templates.cshtml) - <li>\n        Item #
+                        HtmlContent - (667:39,17 [20] Templates.cshtml)
+                            RazorIRToken - (667:39,17 [4] Templates.cshtml) - Html - <li>
+                            RazorIRToken - (671:39,21 [16] Templates.cshtml) - Html - \n        Item #
                         CSharpExpression - (688:40,15 [4] Templates.cshtml)
                             RazorIRToken - (688:40,15 [4] Templates.cshtml) - CSharp - item
-                        HtmlContent - (692:40,19 [2] Templates.cshtml) - \n
+                        HtmlContent - (692:40,19 [2] Templates.cshtml)
+                            RazorIRToken - (692:40,19 [2] Templates.cshtml) - Html - \n
                         CSharpStatement - (694:41,0 [8] Templates.cshtml)
                             RazorIRToken - (694:41,0 [8] Templates.cshtml) - CSharp -         
                         CSharpStatement - (704:41,10 [18] Templates.cshtml)
                             RazorIRToken - (704:41,10 [18] Templates.cshtml) - CSharp - var parent = item;
-                        HtmlContent - (725:42,0 [53] Templates.cshtml) -         <ul>\n            <li>Child Items... ?</li>\n
-                        HtmlContent - (839:45,0 [24] Templates.cshtml) -         </ul>\n    </li>
+                        HtmlContent - (725:42,0 [53] Templates.cshtml)
+                            RazorIRToken - (725:42,0 [8] Templates.cshtml) - Html -         
+                            RazorIRToken - (733:42,8 [4] Templates.cshtml) - Html - <ul>
+                            RazorIRToken - (737:42,12 [14] Templates.cshtml) - Html - \n            
+                            RazorIRToken - (751:43,12 [4] Templates.cshtml) - Html - <li>
+                            RazorIRToken - (755:43,16 [16] Templates.cshtml) - Html - Child Items... ?
+                            RazorIRToken - (771:43,32 [5] Templates.cshtml) - Html - </li>
+                            RazorIRToken - (776:43,37 [2] Templates.cshtml) - Html - \n
+                        HtmlContent - (839:45,0 [24] Templates.cshtml)
+                            RazorIRToken - (839:45,0 [8] Templates.cshtml) - Html -         
+                            RazorIRToken - (847:45,8 [5] Templates.cshtml) - Html - </ul>
+                            RazorIRToken - (852:45,13 [6] Templates.cshtml) - Html - \n    
+                            RazorIRToken - (858:46,4 [5] Templates.cshtml) - Html - </li>
                     RazorIRToken - (863:46,9 [1] Templates.cshtml) - CSharp - )
-                HtmlContent - (864:46,10 [8] Templates.cshtml) - \n</ul> 
+                HtmlContent - (864:46,10 [8] Templates.cshtml)
+                    RazorIRToken - (864:46,10 [2] Templates.cshtml) - Html - \n
+                    RazorIRToken - (866:47,0 [5] Templates.cshtml) - Html - </ul>
+                    RazorIRToken - (871:47,5 [1] Templates.cshtml) - Html -  
             CSharpStatement - (12:0,12 [265] Templates.cshtml)
                 RazorIRToken - (12:0,12 [265] Templates.cshtml) - CSharp - \n    public HelperResult Repeat(int times, Func<int, object> template) {\n        return new HelperResult((writer) => {\n            for(int i = 0; i < times; i++) {\n                ((HelperResult)template(i)).WriteTo(writer);\n            }\n        });\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.ir.txt
@@ -18,20 +18,25 @@ Document -
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             DeclareTagHelperFields -  - TestNamespace.PTagHelper
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:0,31 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (31:0,31 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (31:0,31 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 CSharpStatement - (35:1,2 [59] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (35:1,2 [59] TransitionsInTagHelperAttributes.cshtml) - CSharp -  \n    var @class = "container-fluid";\n    var @int = 1;\n
-                HtmlContent - (97:5,0 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (97:5,0 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (97:5,0 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (99:6,0 [44] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (128:6,29 [11] TransitionsInTagHelperAttributes.cshtml) - Body of Tag
+                        HtmlContent - (128:6,29 [11] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (128:6,29 [11] TransitionsInTagHelperAttributes.cshtml) - Html - Body of Tag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpAttributeValue - (109:6,10 [6] TransitionsInTagHelperAttributes.cshtml) - 
                     SetTagHelperProperty - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - 1337
+                        HtmlContent - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - Html - 1337
                     ExecuteTagHelpers - 
-                HtmlContent - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (145:7,0 [34] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
@@ -40,43 +45,57 @@ Document -
                             CSharpExpression - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml)
                                 RazorIRToken - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
                     SetTagHelperProperty - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - 42
+                        HtmlContent - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - Html - 42
                     ExecuteTagHelpers - 
-                HtmlContent - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (181:8,0 [36] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (191:8,10 [4] TransitionsInTagHelperAttributes.cshtml) - test
+                        HtmlContent - (191:8,10 [4] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (191:8,10 [4] TransitionsInTagHelperAttributes.cshtml) - Html - test
                     SetTagHelperProperty - (202:8,21 [9] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (202:8,21 [5] TransitionsInTagHelperAttributes.cshtml) - 42 + 
+                        HtmlContent - (202:8,21 [5] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (202:8,21 [2] TransitionsInTagHelperAttributes.cshtml) - Html - 42
+                            RazorIRToken - (204:8,23 [2] TransitionsInTagHelperAttributes.cshtml) - Html -  +
+                            RazorIRToken - (206:8,25 [1] TransitionsInTagHelperAttributes.cshtml) - Html -  
                         CSharpExpression - (207:8,26 [4] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - @
+                            HtmlContent - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - Html - @
                             RazorIRToken - (208:8,27 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
                     ExecuteTagHelpers - 
-                HtmlContent - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (219:9,0 [31] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (229:9,10 [4] TransitionsInTagHelperAttributes.cshtml) - test
+                        HtmlContent - (229:9,10 [4] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (229:9,10 [4] TransitionsInTagHelperAttributes.cshtml) - Html - test
                     SetTagHelperProperty - (240:9,21 [4] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (241:9,22 [3] TransitionsInTagHelperAttributes.cshtml)
                             RazorIRToken - (241:9,22 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
                     ExecuteTagHelpers - 
-                HtmlContent - (250:9,31 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (250:9,31 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (250:9,31 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (252:10,0 [34] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (262:10,10 [4] TransitionsInTagHelperAttributes.cshtml) - test
+                        HtmlContent - (262:10,10 [4] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (262:10,10 [4] TransitionsInTagHelperAttributes.cshtml) - Html - test
                     SetTagHelperProperty - (273:10,21 [7] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (274:10,22 [6] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - (
+                            HtmlContent - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - Html - (
                             RazorIRToken - (275:10,23 [4] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int
-                            HtmlContent - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - )
+                            HtmlContent - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - Html - )
                     ExecuteTagHelpers - 
-                HtmlContent - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (288:11,0 [54] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
@@ -86,10 +105,17 @@ Document -
                             CSharpExpression - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml)
                                 RazorIRToken - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
                     SetTagHelperProperty - (321:11,33 [15] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (321:11,33 [4] TransitionsInTagHelperAttributes.cshtml) - 4 * 
+                        HtmlContent - (321:11,33 [4] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (321:11,33 [1] TransitionsInTagHelperAttributes.cshtml) - Html - 4
+                            RazorIRToken - (322:11,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html -  *
+                            RazorIRToken - (324:11,36 [1] TransitionsInTagHelperAttributes.cshtml) - Html -  
                         CSharpExpression - (325:11,37 [11] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (325:11,37 [2] TransitionsInTagHelperAttributes.cshtml) - @(
+                            HtmlContent - (325:11,37 [2] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (325:11,37 [1] TransitionsInTagHelperAttributes.cshtml) - Html - @
+                                RazorIRToken - (326:11,38 [1] TransitionsInTagHelperAttributes.cshtml) - Html - (
                             RazorIRToken - (327:11,39 [8] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int + 2
-                            HtmlContent - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - )
+                            HtmlContent - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - Html - )
                     ExecuteTagHelpers - 
-                HtmlContent - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
@@ -29,10 +29,20 @@ Source Location: (171:7,26 [2] TestFiles/IntegrationTests/CodeGenerationIntegrat
 Generated Location: (1653:40,33 [2] )
 |42|
 
-Source Location: (202:8,21 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
-|42 + |
-Generated Location: (1925:46,33 [5] )
-|42 + |
+Source Location: (202:8,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
+|42|
+Generated Location: (1925:46,33 [2] )
+|42|
+
+Source Location: (204:8,23 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
+| +|
+Generated Location: (1927:46,35 [2] )
+| +|
+
+Source Location: (206:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
+| |
+Generated Location: (1929:46,37 [1] )
+| |
 
 Source Location: (207:8,26 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
@@ -69,15 +79,30 @@ Source Location: (307:11,19 [6] TestFiles/IntegrationTests/CodeGenerationIntegra
 Generated Location: (2742:64,19 [6] )
 |@class|
 
-Source Location: (321:11,33 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
-|4 * |
-Generated Location: (2924:69,33 [4] )
-|4 * |
+Source Location: (321:11,33 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
+|4|
+Generated Location: (2924:69,33 [1] )
+|4|
 
-Source Location: (325:11,37 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
-|@(|
-Generated Location: (2928:69,37 [2] )
-|@(|
+Source Location: (322:11,34 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
+| *|
+Generated Location: (2925:69,34 [2] )
+| *|
+
+Source Location: (324:11,36 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
+| |
+Generated Location: (2927:69,36 [1] )
+| |
+
+Source Location: (325:11,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
+|@|
+Generated Location: (2928:69,37 [1] )
+|@|
+
+Source Location: (326:11,38 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
+|(|
+Generated Location: (2929:69,38 [1] )
+|(|
 
 Source Location: (327:11,39 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int + 2|

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.ir.txt
@@ -9,17 +9,21 @@ Document -
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - (35:1,2 [59] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (35:1,2 [59] TransitionsInTagHelperAttributes.cshtml) - CSharp -  \n    var @class = "container-fluid";\n    var @int = 1;\n
-                HtmlContent - (97:5,0 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (97:5,0 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (97:5,0 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (99:6,0 [44] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (128:6,29 [11] TransitionsInTagHelperAttributes.cshtml) - Body of Tag
+                        HtmlContent - (128:6,29 [11] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (128:6,29 [11] TransitionsInTagHelperAttributes.cshtml) - Html - Body of Tag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpAttributeValue - (109:6,10 [6] TransitionsInTagHelperAttributes.cshtml) - 
                     SetTagHelperProperty - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - 1337
+                        HtmlContent - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - Html - 1337
                     ExecuteTagHelpers - 
-                HtmlContent - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (145:7,0 [34] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
@@ -28,20 +32,27 @@ Document -
                             CSharpExpression - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml)
                                 RazorIRToken - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
                     SetTagHelperProperty - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - 42
+                        HtmlContent - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - Html - 42
                     ExecuteTagHelpers - 
-                HtmlContent - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (181:8,0 [36] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (202:8,21 [9] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (202:8,21 [5] TransitionsInTagHelperAttributes.cshtml) - 42 + 
+                        HtmlContent - (202:8,21 [5] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (202:8,21 [2] TransitionsInTagHelperAttributes.cshtml) - Html - 42
+                            RazorIRToken - (204:8,23 [2] TransitionsInTagHelperAttributes.cshtml) - Html -  +
+                            RazorIRToken - (206:8,25 [1] TransitionsInTagHelperAttributes.cshtml) - Html -  
                         CSharpExpression - (207:8,26 [4] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - @
+                            HtmlContent - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - Html - @
                             RazorIRToken - (208:8,27 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
                     ExecuteTagHelpers - 
-                HtmlContent - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (219:9,0 [31] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
@@ -50,18 +61,22 @@ Document -
                         CSharpExpression - (241:9,22 [3] TransitionsInTagHelperAttributes.cshtml)
                             RazorIRToken - (241:9,22 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
                     ExecuteTagHelpers - 
-                HtmlContent - (250:9,31 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (250:9,31 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (250:9,31 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (252:10,0 [34] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (273:10,21 [7] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (274:10,22 [6] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - (
+                            HtmlContent - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - Html - (
                             RazorIRToken - (275:10,23 [4] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int
-                            HtmlContent - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - )
+                            HtmlContent - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - Html - )
                     ExecuteTagHelpers - 
-                HtmlContent - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
                 TagHelper - (288:11,0 [54] TransitionsInTagHelperAttributes.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
@@ -71,10 +86,17 @@ Document -
                             CSharpExpression - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml)
                                 RazorIRToken - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
                     SetTagHelperProperty - (321:11,33 [15] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (321:11,33 [4] TransitionsInTagHelperAttributes.cshtml) - 4 * 
+                        HtmlContent - (321:11,33 [4] TransitionsInTagHelperAttributes.cshtml)
+                            RazorIRToken - (321:11,33 [1] TransitionsInTagHelperAttributes.cshtml) - Html - 4
+                            RazorIRToken - (322:11,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html -  *
+                            RazorIRToken - (324:11,36 [1] TransitionsInTagHelperAttributes.cshtml) - Html -  
                         CSharpExpression - (325:11,37 [11] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (325:11,37 [2] TransitionsInTagHelperAttributes.cshtml) - @(
+                            HtmlContent - (325:11,37 [2] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (325:11,37 [1] TransitionsInTagHelperAttributes.cshtml) - Html - @
+                                RazorIRToken - (326:11,38 [1] TransitionsInTagHelperAttributes.cshtml) - Html - (
                             RazorIRToken - (327:11,39 [8] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int + 2
-                            HtmlContent - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - )
+                            HtmlContent - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml)
+                                RazorIRToken - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - Html - )
                     ExecuteTagHelpers - 
-                HtmlContent - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml) - \n
+                HtmlContent - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml)
+                    RazorIRToken - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.ir.txt
@@ -21,15 +21,28 @@ Document -
             CSharpStatement - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (16:0,16 [2] Usings.cshtml) - \n
-                HtmlContent - (51:1,33 [2] Usings.cshtml) - \n
-                HtmlContent - (66:2,13 [4] Usings.cshtml) - \n\n
-                HtmlContent - (90:4,20 [2] Usings.cshtml) - \n
-                HtmlContent - (120:5,28 [2] Usings.cshtml) - \n
-                HtmlContent - (164:6,42 [32] Usings.cshtml) - \n\n<p>Path's full type name is 
+                HtmlContent - (16:0,16 [2] Usings.cshtml)
+                    RazorIRToken - (16:0,16 [2] Usings.cshtml) - Html - \n
+                HtmlContent - (51:1,33 [2] Usings.cshtml)
+                    RazorIRToken - (51:1,33 [2] Usings.cshtml) - Html - \n
+                HtmlContent - (66:2,13 [4] Usings.cshtml)
+                    RazorIRToken - (66:2,13 [4] Usings.cshtml) - Html - \n\n
+                HtmlContent - (90:4,20 [2] Usings.cshtml)
+                    RazorIRToken - (90:4,20 [2] Usings.cshtml) - Html - \n
+                HtmlContent - (120:5,28 [2] Usings.cshtml)
+                    RazorIRToken - (120:5,28 [2] Usings.cshtml) - Html - \n
+                HtmlContent - (164:6,42 [32] Usings.cshtml)
+                    RazorIRToken - (164:6,42 [4] Usings.cshtml) - Html - \n\n
+                    RazorIRToken - (168:8,0 [3] Usings.cshtml) - Html - <p>
+                    RazorIRToken - (171:8,3 [25] Usings.cshtml) - Html - Path's full type name is 
                 CSharpExpression - (197:8,29 [21] Usings.cshtml)
                     RazorIRToken - (197:8,29 [21] Usings.cshtml) - CSharp - typeof(Path).FullName
-                HtmlContent - (218:8,50 [40] Usings.cshtml) - </p>\n<p>Foo's actual full type name is 
+                HtmlContent - (218:8,50 [40] Usings.cshtml)
+                    RazorIRToken - (218:8,50 [4] Usings.cshtml) - Html - </p>
+                    RazorIRToken - (222:8,54 [2] Usings.cshtml) - Html - \n
+                    RazorIRToken - (224:9,0 [3] Usings.cshtml) - Html - <p>
+                    RazorIRToken - (227:9,3 [31] Usings.cshtml) - Html - Foo's actual full type name is 
                 CSharpExpression - (259:9,35 [20] Usings.cshtml)
                     RazorIRToken - (259:9,35 [20] Usings.cshtml) - CSharp - typeof(Foo).FullName
-                HtmlContent - (279:9,55 [4] Usings.cshtml) - </p>
+                HtmlContent - (279:9,55 [4] Usings.cshtml)
+                    RazorIRToken - (279:9,55 [4] Usings.cshtml) - Html - </p>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_Runtime.ir.txt
@@ -10,11 +10,20 @@ Document -
         UsingStatement - (123:6,1 [43] Usings.cshtml) - static global::System.Text.Encoding
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Usings_Runtime -  - 
             RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (68:3,0 [2] Usings.cshtml) - \n
-                HtmlContent - (166:7,0 [30] Usings.cshtml) - \n<p>Path's full type name is 
+                HtmlContent - (68:3,0 [2] Usings.cshtml)
+                    RazorIRToken - (68:3,0 [2] Usings.cshtml) - Html - \n
+                HtmlContent - (166:7,0 [30] Usings.cshtml)
+                    RazorIRToken - (166:7,0 [2] Usings.cshtml) - Html - \n
+                    RazorIRToken - (168:8,0 [3] Usings.cshtml) - Html - <p>
+                    RazorIRToken - (171:8,3 [25] Usings.cshtml) - Html - Path's full type name is 
                 CSharpExpression - (197:8,29 [21] Usings.cshtml)
                     RazorIRToken - (197:8,29 [21] Usings.cshtml) - CSharp - typeof(Path).FullName
-                HtmlContent - (218:8,50 [40] Usings.cshtml) - </p>\n<p>Foo's actual full type name is 
+                HtmlContent - (218:8,50 [40] Usings.cshtml)
+                    RazorIRToken - (218:8,50 [4] Usings.cshtml) - Html - </p>
+                    RazorIRToken - (222:8,54 [2] Usings.cshtml) - Html - \n
+                    RazorIRToken - (224:9,0 [3] Usings.cshtml) - Html - <p>
+                    RazorIRToken - (227:9,3 [31] Usings.cshtml) - Html - Foo's actual full type name is 
                 CSharpExpression - (259:9,35 [20] Usings.cshtml)
                     RazorIRToken - (259:9,35 [20] Usings.cshtml) - CSharp - typeof(Foo).FullName
-                HtmlContent - (279:9,55 [4] Usings.cshtml) - </p>
+                HtmlContent - (279:9,55 [4] Usings.cshtml)
+                    RazorIRToken - (279:9,55 [4] Usings.cshtml) - Html - </p>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithConditionalAttribute.ir.txt
@@ -5,9 +5,20 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - Template -  - 
             RazorMethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [25] HtmlWithConditionalAttribute.cshtml) - <html>\n<body>\n    <span
+                HtmlContent - (0:0,0 [25] HtmlWithConditionalAttribute.cshtml)
+                    RazorIRToken - (0:0,0 [6] HtmlWithConditionalAttribute.cshtml) - Html - <html>
+                    RazorIRToken - (6:0,6 [2] HtmlWithConditionalAttribute.cshtml) - Html - \n
+                    RazorIRToken - (8:1,0 [6] HtmlWithConditionalAttribute.cshtml) - Html - <body>
+                    RazorIRToken - (14:1,6 [6] HtmlWithConditionalAttribute.cshtml) - Html - \n    
+                    RazorIRToken - (20:2,4 [5] HtmlWithConditionalAttribute.cshtml) - Html - <span
                 HtmlAttribute - (25:2,9 [13] HtmlWithConditionalAttribute.cshtml) -  val=" - "
                     CSharpAttributeValue - (31:2,15 [6] HtmlWithConditionalAttribute.cshtml) - 
                         CSharpExpression - (32:2,16 [5] HtmlWithConditionalAttribute.cshtml)
                             RazorIRToken - (32:2,16 [5] HtmlWithConditionalAttribute.cshtml) - CSharp - Hello
-                HtmlContent - (38:2,22 [22] HtmlWithConditionalAttribute.cshtml) -  />\n</body>\n</html>"
+                HtmlContent - (38:2,22 [22] HtmlWithConditionalAttribute.cshtml)
+                    RazorIRToken - (38:2,22 [3] HtmlWithConditionalAttribute.cshtml) - Html -  />
+                    RazorIRToken - (41:2,25 [2] HtmlWithConditionalAttribute.cshtml) - Html - \n
+                    RazorIRToken - (43:3,0 [7] HtmlWithConditionalAttribute.cshtml) - Html - </body>
+                    RazorIRToken - (50:3,7 [2] HtmlWithConditionalAttribute.cshtml) - Html - \n
+                    RazorIRToken - (52:4,0 [7] HtmlWithConditionalAttribute.cshtml) - Html - </html>
+                    RazorIRToken - (59:4,7 [1] HtmlWithConditionalAttribute.cshtml) - Html - "

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/HtmlAttributeIntegrationTest/HtmlWithDataDashAttribute.ir.txt
@@ -5,7 +5,20 @@ Document -
         UsingStatement -  - System.Threading.Tasks
         ClassDeclaration -  - public - Template -  - 
             RazorMethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (0:0,0 [36] HtmlWithDataDashAttribute.cshtml) - <html>\n<body>\n    <span data-val="
+                HtmlContent - (0:0,0 [36] HtmlWithDataDashAttribute.cshtml)
+                    RazorIRToken - (0:0,0 [6] HtmlWithDataDashAttribute.cshtml) - Html - <html>
+                    RazorIRToken - (6:0,6 [2] HtmlWithDataDashAttribute.cshtml) - Html - \n
+                    RazorIRToken - (8:1,0 [6] HtmlWithDataDashAttribute.cshtml) - Html - <body>
+                    RazorIRToken - (14:1,6 [6] HtmlWithDataDashAttribute.cshtml) - Html - \n    
+                    RazorIRToken - (20:2,4 [5] HtmlWithDataDashAttribute.cshtml) - Html - <span
+                    RazorIRToken - (25:2,9 [11] HtmlWithDataDashAttribute.cshtml) - Html -  data-val="
                 CSharpExpression - (37:2,21 [5] HtmlWithDataDashAttribute.cshtml)
                     RazorIRToken - (37:2,21 [5] HtmlWithDataDashAttribute.cshtml) - CSharp - Hello
-                HtmlContent - (42:2,26 [23] HtmlWithDataDashAttribute.cshtml) - " />\n</body>\n</html>"
+                HtmlContent - (42:2,26 [23] HtmlWithDataDashAttribute.cshtml)
+                    RazorIRToken - (42:2,26 [1] HtmlWithDataDashAttribute.cshtml) - Html - "
+                    RazorIRToken - (43:2,27 [3] HtmlWithDataDashAttribute.cshtml) - Html -  />
+                    RazorIRToken - (46:2,30 [2] HtmlWithDataDashAttribute.cshtml) - Html - \n
+                    RazorIRToken - (48:3,0 [7] HtmlWithDataDashAttribute.cshtml) - Html - </body>
+                    RazorIRToken - (55:3,7 [2] HtmlWithDataDashAttribute.cshtml) - Html - \n
+                    RazorIRToken - (57:4,0 [7] HtmlWithDataDashAttribute.cshtml) - Html - </html>
+                    RazorIRToken - (64:4,7 [1] HtmlWithDataDashAttribute.cshtml) - Html - "

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.ir.txt
@@ -11,7 +11,13 @@ Document -
             RazorMethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - BeginContext(31, 28, true);
-                HtmlContent - (31:1,0 [28] BasicTest.cshtml) - <span someattr>Hola</span>\n
+                HtmlContent - (31:1,0 [28] BasicTest.cshtml)
+                    RazorIRToken - (31:1,0 [5] BasicTest.cshtml) - Html - <span
+                    RazorIRToken - (36:1,5 [9] BasicTest.cshtml) - Html -  someattr
+                    RazorIRToken - (45:1,14 [1] BasicTest.cshtml) - Html - >
+                    RazorIRToken - (46:1,15 [4] BasicTest.cshtml) - Html - Hola
+                    RazorIRToken - (50:1,19 [7] BasicTest.cshtml) - Html - </span>
+                    RazorIRToken - (57:1,26 [2] BasicTest.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - EndContext();
                 CSharpStatement - 
@@ -22,14 +28,16 @@ Document -
                     RazorIRToken -  - CSharp - EndContext();
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - BeginContext(69, 2, true);
-                HtmlContent - (69:2,10 [2] BasicTest.cshtml) - \n
+                HtmlContent - (69:2,10 [2] BasicTest.cshtml)
+                    RazorIRToken - (69:2,10 [2] BasicTest.cshtml) - Html - \n
                 CSharpStatement - 
                     RazorIRToken -  - CSharp - EndContext();
                 TagHelper - (71:3,0 [87] BasicTest.cshtml)
                     InitializeTagHelperStructure -  - form - TagMode.StartTagAndEndTag
                         CSharpStatement - 
                             RazorIRToken -  - CSharp - BeginContext(91, 6, true);
-                        HtmlContent - (91:3,20 [6] BasicTest.cshtml) - \n    
+                        HtmlContent - (91:3,20 [6] BasicTest.cshtml)
+                            RazorIRToken - (91:3,20 [6] BasicTest.cshtml) - Html - \n    
                         CSharpStatement - 
                             RazorIRToken -  - CSharp - EndContext();
                         TagHelper - (97:4,4 [52] BasicTest.cshtml)
@@ -47,7 +55,8 @@ Document -
                                 RazorIRToken -  - CSharp - EndContext();
                         CSharpStatement - 
                             RazorIRToken -  - CSharp - BeginContext(149, 2, true);
-                        HtmlContent - (149:4,56 [2] BasicTest.cshtml) - \n
+                        HtmlContent - (149:4,56 [2] BasicTest.cshtml)
+                            RazorIRToken - (149:4,56 [2] BasicTest.cshtml) - Html - \n
                         CSharpStatement - 
                             RazorIRToken -  - CSharp - EndContext();
                     CreateTagHelper -  - FormTagHelper

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/TagHelpersIntegrationTest/NestedTagHelpers.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/TagHelpersIntegrationTest/NestedTagHelpers.ir.txt
@@ -11,21 +11,25 @@ Document -
             RazorMethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
                 TagHelper - (31:1,0 [20] NestedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (43:1,12 [4] NestedTagHelpers.cshtml) - Hola
+                        HtmlContent - (43:1,12 [4] NestedTagHelpers.cshtml)
+                            RazorIRToken - (43:1,12 [4] NestedTagHelpers.cshtml) - Html - Hola
                     CreateTagHelper -  - PTagHelper
                     AddTagHelperHtmlAttribute -  - someattr - HtmlAttributeValueStyle.Minimized
                     ExecuteTagHelpers - 
-                HtmlContent - (51:1,20 [2] NestedTagHelpers.cshtml) - \n
+                HtmlContent - (51:1,20 [2] NestedTagHelpers.cshtml)
+                    RazorIRToken - (51:1,20 [2] NestedTagHelpers.cshtml) - Html - \n
                 TagHelper - (53:2,0 [68] NestedTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - form - TagMode.StartTagAndEndTag
-                        HtmlContent - (73:2,20 [6] NestedTagHelpers.cshtml) - \n    
+                        HtmlContent - (73:2,20 [6] NestedTagHelpers.cshtml)
+                            RazorIRToken - (73:2,20 [6] NestedTagHelpers.cshtml) - Html - \n    
                         TagHelper - (79:3,4 [33] NestedTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - InputTagHelper
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - value - FooProp
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                             ExecuteTagHelpers - 
-                        HtmlContent - (112:3,37 [2] NestedTagHelpers.cshtml) - \n
+                        HtmlContent - (112:3,37 [2] NestedTagHelpers.cshtml)
+                            RazorIRToken - (112:3,37 [2] NestedTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - FormTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/TagHelpersIntegrationTest/SimpleTagHelpers.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/TagHelpersIntegrationTest/SimpleTagHelpers.ir.txt
@@ -8,11 +8,19 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1 - type - text - HtmlAttributeValueStyle.SingleQuotes
             DeclareTagHelperFields -  - InputTagHelper
             RazorMethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:1,0 [25] SimpleTagHelpers.cshtml) - <p>Hola</p>\n<form>\n    
+                HtmlContent - (31:1,0 [25] SimpleTagHelpers.cshtml)
+                    RazorIRToken - (31:1,0 [3] SimpleTagHelpers.cshtml) - Html - <p>
+                    RazorIRToken - (34:1,3 [4] SimpleTagHelpers.cshtml) - Html - Hola
+                    RazorIRToken - (38:1,7 [4] SimpleTagHelpers.cshtml) - Html - </p>
+                    RazorIRToken - (42:1,11 [2] SimpleTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (44:2,0 [6] SimpleTagHelpers.cshtml) - Html - <form>
+                    RazorIRToken - (50:2,6 [6] SimpleTagHelpers.cshtml) - Html - \n    
                 TagHelper - (56:3,4 [35] SimpleTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - InputTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     ExecuteTagHelpers - 
-                HtmlContent - (91:3,39 [9] SimpleTagHelpers.cshtml) - \n</form>
+                HtmlContent - (91:3,39 [9] SimpleTagHelpers.cshtml)
+                    RazorIRToken - (91:3,39 [2] SimpleTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (93:4,0 [7] SimpleTagHelpers.cshtml) - Html - </form>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/TagHelpersIntegrationTest/TagHelpersWithBoundAttributes.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/TagHelpersIntegrationTest/TagHelpersWithBoundAttributes.ir.txt
@@ -7,7 +7,9 @@ Document -
             DeclarePreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0 - type - text - HtmlAttributeValueStyle.SingleQuotes
             DeclareTagHelperFields -  - InputTagHelper
             RazorMethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
-                HtmlContent - (31:1,0 [12] TagHelpersWithBoundAttributes.cshtml) - <form>\n    
+                HtmlContent - (31:1,0 [12] TagHelpersWithBoundAttributes.cshtml)
+                    RazorIRToken - (31:1,0 [6] TagHelpersWithBoundAttributes.cshtml) - Html - <form>
+                    RazorIRToken - (37:1,6 [6] TagHelpersWithBoundAttributes.cshtml) - Html - \n    
                 TagHelper - (43:2,4 [34] TagHelpersWithBoundAttributes.cshtml)
                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                     CreateTagHelper -  - InputTagHelper
@@ -16,4 +18,6 @@ Document -
                             RazorIRToken - (57:2,18 [5] TagHelpersWithBoundAttributes.cshtml) - CSharp - Hello
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     ExecuteTagHelpers - 
-                HtmlContent - (77:2,38 [9] TagHelpersWithBoundAttributes.cshtml) - \n</form>
+                HtmlContent - (77:2,38 [9] TagHelpersWithBoundAttributes.cshtml)
+                    RazorIRToken - (77:2,38 [2] TagHelpersWithBoundAttributes.cshtml) - Html - \n
+                    RazorIRToken - (79:3,0 [7] TagHelpersWithBoundAttributes.cshtml) - Html - </form>


### PR DESCRIPTION
Issue - #1196 
@rynowak @NTaylorMullen 

**Perf Data:**
**Before:**
![image](https://cloud.githubusercontent.com/assets/1579269/24870881/a9b1f27a-1dcc-11e7-9096-8dc8ce4ed7bd.png)


**After:**
Generate separate `WriteLiteral` for each token (first and second commits of this PR) **Just FYI, we don't want this behavior**
![image](https://cloud.githubusercontent.com/assets/1579269/24854478/776aed0a-1d93-11e7-9e73-b0dfcffc7533.png)


Combine token contents using `StringBuilder` when generating code (third and fourth commits of this PR)

![image](https://cloud.githubusercontent.com/assets/1579269/24854501/8b40285e-1d93-11e7-8f40-926377d6acde.png)


