### PR TITLE
Update TModel code generation.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelDirective.cs
@@ -75,9 +75,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
                 if (_designTime)
                 {
-                    // Alias the TModel token to a known type ('object' if the model type is unknown).
+                    // Alias the TModel token to a known type.
                     // This allows design time compilation to succeed for Razor files where the token isn't replaced.
-                    var typeName = modelType == "dynamic" ? $"global::{typeof(object).FullName}" : modelType;
+                    var typeName = $"global::{typeof(object).FullName}";
                     var usingNode = new UsingStatementIRNode()
                     {
                         Content = $"TModel = {typeName}"

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelDirectiveTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelDirectiveTest.cs
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
             var @namespace = FindNamespaceNode(irDocument);
             var usingNode = Assert.IsType<UsingStatementIRNode>(@namespace.Children[0]);
-            Assert.Equal($"TModel = SomeType", usingNode.Content);
+            Assert.Equal($"TModel = global::System.Object", usingNode.Content);
         }
 
         private RazorCodeDocument CreateDocument(string content)

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
@@ -1,7 +1,7 @@
 namespace AspNetCore
 {
     #line hidden
-    using TModel = MyModel;
+    using TModel = global::System.Object;
     using System;
     using System.Threading.Tasks;
     using System.Linq;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.ir.txt
@@ -1,7 +1,7 @@
 Document - 
     Checksum - 
     NamespaceDeclaration -  - AspNetCore
-        UsingStatement -  - TModel = MyModel
+        UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement -  - System.Threading.Tasks
         UsingStatement - (16:1,1 [17] ) - System.Linq

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
@@ -1,7 +1,7 @@
 namespace AspNetCore
 {
     #line hidden
-    using TModel = MyModel;
+    using TModel = global::System.Object;
     using System;
     using System.Threading.Tasks;
     using System.Linq;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.ir.txt
@@ -1,7 +1,7 @@
 Document - 
     Checksum - 
     NamespaceDeclaration -  - AspNetCore
-        UsingStatement -  - TModel = MyModel
+        UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement -  - System.Threading.Tasks
         UsingStatement - (16:1,1 [17] ) - System.Linq

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -1,7 +1,7 @@
 namespace AspNetCore
 {
     #line hidden
-    using TModel = DateTime;
+    using TModel = global::System.Object;
     using System;
     using System.Threading.Tasks;
     using System.Linq;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.ir.txt
@@ -1,7 +1,7 @@
 Document - 
     Checksum - 
     NamespaceDeclaration -  - AspNetCore
-        UsingStatement -  - TModel = DateTime
+        UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement -  - System.Threading.Tasks
         UsingStatement - (16:1,1 [17] ) - System.Linq

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
@@ -1,7 +1,7 @@
 namespace AspNetCore
 {
     #line hidden
-    using TModel = System.Collections.IEnumerable;
+    using TModel = global::System.Object;
     using System;
     using System.Threading.Tasks;
     using System.Linq;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.ir.txt
@@ -1,7 +1,7 @@
 Document - 
     Checksum - 
     NamespaceDeclaration -  - AspNetCore
-        UsingStatement -  - TModel = System.Collections.IEnumerable
+        UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement -  - System.Threading.Tasks
         UsingStatement - (16:1,1 [17] ) - System.Linq

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -1,7 +1,7 @@
 namespace AspNetCore
 {
     #line hidden
-    using TModel = System.Collections.IEnumerable;
+    using TModel = global::System.Object;
     using System;
     using System.Threading.Tasks;
     using System.Linq;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.ir.txt
@@ -1,7 +1,7 @@
 Document - 
     Checksum - 
     NamespaceDeclaration -  - AspNetCore
-        UsingStatement -  - TModel = System.Collections.IEnumerable
+        UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement -  - System.Threading.Tasks
         UsingStatement - (16:1,1 [17] ) - System.Linq

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.codegen.cs
@@ -1,7 +1,7 @@
 namespace Test.Namespace
 {
     #line hidden
-    using TModel = PageWithNamespace_Page;
+    using TModel = global::System.Object;
     using System;
     using System.Threading.Tasks;
     using System.Linq;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.ir.txt
@@ -1,7 +1,7 @@
 Document - 
     Checksum - 
     NamespaceDeclaration -  - Test.Namespace
-        UsingStatement -  - TModel = PageWithNamespace_Page
+        UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement -  - System.Threading.Tasks
         UsingStatement - (16:1,1 [17] ) - System.Linq

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
@@ -1,7 +1,7 @@
 namespace AspNetCore
 {
     #line hidden
-    using TModel = TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPagesWithoutModel_cshtml;
+    using TModel = global::System.Object;
     using System;
     using System.Threading.Tasks;
     using System.Linq;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.ir.txt
@@ -1,7 +1,7 @@
 Document - 
     Checksum - 
     NamespaceDeclaration -  - AspNetCore
-        UsingStatement -  - TModel = TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPagesWithoutModel_cshtml
+        UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement -  - System.Threading.Tasks
         UsingStatement - (16:1,1 [17] ) - System.Linq

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -1,7 +1,7 @@
 namespace AspNetCore
 {
     #line hidden
-    using TModel = NewModel;
+    using TModel = global::System.Object;
     using System;
     using System.Threading.Tasks;
     using System.Linq;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.ir.txt
@@ -1,7 +1,7 @@
 Document - 
     Checksum - 
     NamespaceDeclaration -  - AspNetCore
-        UsingStatement -  - TModel = NewModel
+        UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement -  - System.Threading.Tasks
         UsingStatement - (16:1,1 [17] ) - System.Linq


### PR DESCRIPTION
- Prior to this TModel would be set to a potentially non-fully qualified name. This would cause errors in default MVC templates.
- Regenerated test files to reflect new TModel.
- Updated unit test to reflect new behavior.

#1222