### PR TITLE
Prefix TagHelpers with tag helper prefix in completion list.

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionService.cs
@@ -45,6 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 StringComparer.OrdinalIgnoreCase);
 
             var catchAllDescriptors = new HashSet<TagHelperDescriptor>();
+            var prefix = completionContext.DocumentContext.Prefix ?? string.Empty;
             var possibleChildDescriptors = _tagHelperFactsService.GetTagHelpersGivenParent(completionContext.DocumentContext, completionContext.ContainingTagName);
             foreach (var possibleDescriptor in possibleChildDescriptors)
             {
@@ -76,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
                     if (addRuleCompletions)
                     {
-                        UpdateCompletions(rule.TagName, possibleDescriptor);
+                        UpdateCompletions(prefix + rule.TagName, possibleDescriptor);
                     }
                 }
             }
@@ -85,15 +86,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             // This way, any TagHelper added completions will also have catch-alls listed under their entries.
             foreach (var catchAllDescriptor in catchAllDescriptors)
             {
-                foreach (var completionTagNames in elementCompletions.Keys)
+                foreach (var completionTagName in elementCompletions.Keys)
                 {
-                    UpdateCompletions(completionTagNames, catchAllDescriptor);
+                    if (completionTagName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        UpdateCompletions(completionTagName, catchAllDescriptor);
+                    }
                 }
             }
 
             var result = ElementCompletionResult.Create(elementCompletions);
             return result;
-
 
             void UpdateCompletions(string tagName, TagHelperDescriptor possibleDescriptor)
             {


### PR DESCRIPTION
- We don't want tooling applying tag helper prefix to what we deem `TagHelper`s. Ultimately we should consume all the necessary data and do that work.
- Added two tests to validate that we're applying tag helper prefix to `TagHelper` element completions for catch-all's and non-catch-alls.

#1224