### PR TITLE
Ensure output hint descriptors don't schema check.

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionService.cs
@@ -62,11 +62,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                     {
                         addRuleCompletions = true;
                     }
-                    else if (outputHint != null && elementCompletions.ContainsKey(outputHint))
+                    else if (outputHint != null)
                     {
-                        // If the possible descriptors final output tag already exists in our list of completions, we should add every representation
-                        // of that descriptor to the possible element completions.
-                        addRuleCompletions = true;
+                        // If the current descriptor has an output hint we need to make sure it shows up only when its output hint would normally show up.
+                        // Example: We have a MyTableTagHelper that has an output hint of "table" and a MyTrTagHelper that has an output hint of "tr".
+                        // If we try typing in a situation like this: <body > | </body>
+                        // We'd expect to only get "my-table" as a completion because the "body" tag doesn't allow "tr" tags.
+                        addRuleCompletions = elementCompletions.ContainsKey(outputHint);
                     }
                     else if (!completionContext.InHTMLSchema(rule.TagName))
                     {


### PR DESCRIPTION
- Prior to this if you had a `TagHelper` whos output hint was not in the final form of the completions we'd fall through into a schema check which resulted in a completion being added when it shouldn't. Example: `TagHelper` for `my-tr` that has an output hint of `tr` would end up getting added to the completion list under `body` because `my-tr` was not in the schema and would then be treated like the `environment` `TagHelper` (a new element).
- Added a test to validate that `TagHelper`s with output hints are cross referenced vs. existing completions and do not fall through to a schema check.

#1225