### PR TITLE
Add CompilerGeneratedAttribute to gen'd code.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DefaultDocumentWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DefaultDocumentWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
@@ -96,6 +97,12 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
 
             public override void VisitClass(ClassDeclarationIRNode node)
             {
+                // Mark generated classes with compiler generated attributes so IDEs don't show generaetd classes when unnecessary.
+                Context.Writer
+                    .Write("[global::")
+                    .Write(typeof(CompilerGeneratedAttribute).FullName)
+                    .WriteLine("()]");
+
                 Context.Writer
                     .Write(node.AccessModifier)
                     .Write(" class ")

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Basic_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_Runtime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Basic_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InjectWithModel_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<MyModel>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_Runtime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InjectWithModel_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<MyModel>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InjectWithSemicolon_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<MyModel>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_Runtime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InjectWithSemicolon_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<MyModel>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
@@ -14,6 +14,7 @@ using MyNamespace;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Inject_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_Runtime.codegen.cs
@@ -14,6 +14,7 @@ using MyNamespace;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Inject_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ModelExpressionTagHelper_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ModelExpressionTagHelper_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
         #line hidden

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Model_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<System.Collections.IEnumerable>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_Runtime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Model_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<System.Collections.IEnumerable>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MultipleModels_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<System.Collections.IEnumerable>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.codegen.cs
@@ -9,6 +9,7 @@ namespace Test.Namespace
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class PageWithNamespace_Page : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_Runtime.codegen.cs
@@ -9,6 +9,7 @@ namespace Test.Namespace
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class PageWithNamespace_Page : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPagesWithoutModel_cshtml : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPagesWithoutModel_cshtml : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("text-danger"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPages_cshtml : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorPages_cshtml : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("text-danger"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.codegen.cs
@@ -9,6 +9,7 @@ namespace Test.Namespace
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ViewWithNamespace_View : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_Runtime.codegen.cs
@@ -9,6 +9,7 @@ namespace Test.Namespace
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ViewWithNamespace_View : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest__ViewImports_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_Runtime.codegen.cs
@@ -9,6 +9,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest__ViewImports_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_AddTagHelperDirective_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective.cshtml)
 |"*, TestAssembly"|
-Generated Location: (429:10,37 [17] )
+Generated Location: (505:11,37 [17] )
 |"*, TestAssembly"|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_AttributeTargetingTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (437:10,38 [15] )
+Generated Location: (513:11,38 [15] )
 |*, TestAssembly|
 
 Source Location: (187:5,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (1681:29,42 [4] )
+Generated Location: (1757:30,42 [4] )
 |true|
 
 Source Location: (233:6,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (2334:39,42 [4] )
+Generated Location: (2410:40,42 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_AttributeTargetingTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("catchAll", new global::Microsoft.AspNetCore.Html.HtmlString("hi"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Await_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.mappings.txt
@@ -1,81 +1,81 @@
 Source Location: (192:9,39 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo()|
-Generated Location: (675:16,39 [11] )
+Generated Location: (751:17,39 [11] )
 |await Foo()|
 
 Source Location: (247:10,38 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo()|
-Generated Location: (840:21,38 [11] )
+Generated Location: (916:22,38 [11] )
 |await Foo()|
 
 Source Location: (304:11,39 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | await Foo(); |
-Generated Location: (1006:26,39 [14] )
+Generated Location: (1082:27,39 [14] )
 | await Foo(); |
 
 Source Location: (371:12,46 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | |
-Generated Location: (1111:30,58 [1] )
+Generated Location: (1187:31,58 [1] )
 | |
 
 Source Location: (376:12,51 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo()|
-Generated Location: (1247:32,51 [11] )
+Generated Location: (1323:33,51 [11] )
 |await Foo()|
 
 Source Location: (391:12,66 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | |
-Generated Location: (1370:36,78 [1] )
+Generated Location: (1446:37,78 [1] )
 | |
 
 Source Location: (448:13,49 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await|
-Generated Location: (1504:38,49 [5] )
+Generated Location: (1580:39,49 [5] )
 |await|
 
 Source Location: (578:18,42 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo(1, 2)|
-Generated Location: (1667:43,42 [15] )
+Generated Location: (1743:44,42 [15] )
 |await Foo(1, 2)|
 
 Source Location: (650:19,51 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo.Bar(1, 2)|
-Generated Location: (1849:48,51 [19] )
+Generated Location: (1925:49,51 [19] )
 |await Foo.Bar(1, 2)|
 
 Source Location: (716:20,41 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo("bob", true)|
-Generated Location: (2025:53,41 [22] )
+Generated Location: (2101:54,41 [22] )
 |await Foo("bob", true)|
 
 Source Location: (787:21,42 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | await Foo(something, hello: "world"); |
-Generated Location: (2205:58,42 [39] )
+Generated Location: (2281:59,42 [39] )
 | await Foo(something, hello: "world"); |
 
 Source Location: (884:22,51 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | await Foo.Bar(1, 2) |
-Generated Location: (2410:63,51 [21] )
+Generated Location: (2486:64,51 [21] )
 | await Foo.Bar(1, 2) |
 
 Source Location: (961:23,49 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | |
-Generated Location: (2525:67,61 [1] )
+Generated Location: (2601:68,61 [1] )
 | |
 
 Source Location: (966:23,54 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo(boolValue: false)|
-Generated Location: (2664:69,54 [27] )
+Generated Location: (2740:70,54 [27] )
 |await Foo(boolValue: false)|
 
 Source Location: (997:23,85 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | |
-Generated Location: (2822:73,97 [1] )
+Generated Location: (2898:74,97 [1] )
 | |
 
 Source Location: (1057:24,52 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await ("wrrronggg")|
-Generated Location: (2959:75,52 [19] )
+Generated Location: (3035:76,52 [19] )
 |await ("wrrronggg")|
 
 Source Location: (12:0,12 [76] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
@@ -85,7 +85,7 @@ Source Location: (12:0,12 [76] TestFiles/IntegrationTests/CodeGenerationIntegrat
         return "Bar";
     }
 |
-Generated Location: (3154:82,12 [76] )
+Generated Location: (3230:83,12 [76] )
 |
     public async Task<string> Foo()
     {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Await_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.codegen.cs
@@ -18,6 +18,7 @@ using System.Text;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicImports_DesignTime : Hello
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.codegen.cs
@@ -19,6 +19,7 @@ using System.Text;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicImports_Runtime : Hello
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (423:10,37 [17] )
+Generated Location: (499:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (220:5,38 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1386:26,38 [23] )
+Generated Location: (1462:27,38 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (303:6,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |true|
-Generated Location: (2084:37,42 [4] )
+Generated Location: (2160:38,42 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_Prefixed_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (17:0,17 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |"THS"|
-Generated Location: (432:10,37 [5] )
+Generated Location: (508:11,37 [5] )
 |"THS"|
 
 Source Location: (38:1,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |"*, TestAssembly"|
-Generated Location: (537:14,37 [17] )
+Generated Location: (613:15,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (226:7,43 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |true|
-Generated Location: (1571:31,43 [4] )
+Generated Location: (1647:32,43 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_Prefixed_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_RemoveTagHelper_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "text", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data", new global::Microsoft.AspNetCore.Html.HtmlString("-delay1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Blocks_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (2:0,2 [18] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |
     int i = 1;
 |
-Generated Location: (639:16,2 [18] )
+Generated Location: (715:17,2 [18] )
 |
     int i = 1;
 |
@@ -10,20 +10,20 @@ Generated Location: (639:16,2 [18] )
 Source Location: (26:4,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |while(i <= 10) {
     |
-Generated Location: (771:22,1 [22] )
+Generated Location: (847:23,1 [22] )
 |while(i <= 10) {
     |
 
 Source Location: (69:5,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |i|
-Generated Location: (933:28,25 [1] )
+Generated Location: (1009:29,25 [1] )
 |i|
 
 Source Location: (75:5,31 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
     i += 1;
 }|
-Generated Location: (1081:33,31 [16] )
+Generated Location: (1157:34,31 [16] )
 |
     i += 1;
 }|
@@ -31,14 +31,14 @@ Generated Location: (1081:33,31 [16] )
 Source Location: (96:9,1 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |if(i == 11) {
     |
-Generated Location: (1214:40,1 [19] )
+Generated Location: (1290:41,1 [19] )
 |if(i == 11) {
     |
 
 Source Location: (140:10,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
 }|
-Generated Location: (1378:46,29 [3] )
+Generated Location: (1454:47,29 [3] )
 |
 }|
 
@@ -46,7 +46,7 @@ Source Location: (148:13,1 [35] TestFiles/IntegrationTests/CodeGenerationIntegra
 |switch(i) {
     case 11:
         |
-Generated Location: (1498:52,1 [35] )
+Generated Location: (1574:53,1 [35] )
 |switch(i) {
     case 11:
         |
@@ -56,7 +56,7 @@ Source Location: (219:15,44 [40] TestFiles/IntegrationTests/CodeGenerationIntegr
         break;
     default:
         |
-Generated Location: (1693:59,44 [40] )
+Generated Location: (1769:60,44 [40] )
 |
         break;
     default:
@@ -66,7 +66,7 @@ Source Location: (288:18,37 [19] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
         break;
 }|
-Generated Location: (1886:67,37 [19] )
+Generated Location: (1962:68,37 [19] )
 |
         break;
 }|
@@ -74,26 +74,26 @@ Generated Location: (1886:67,37 [19] )
 Source Location: (312:22,1 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |for(int j = 1; j <= 10; j += 2) {
     |
-Generated Location: (2022:74,1 [39] )
+Generated Location: (2098:75,1 [39] )
 |for(int j = 1; j <= 10; j += 2) {
     |
 
 Source Location: (378:23,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |j|
-Generated Location: (2208:80,31 [1] )
+Generated Location: (2284:81,31 [1] )
 |j|
 
 Source Location: (384:23,37 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
 }|
-Generated Location: (2363:85,37 [3] )
+Generated Location: (2439:86,37 [3] )
 |
 }|
 
 Source Location: (392:26,1 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |try {
     |
-Generated Location: (2483:91,1 [11] )
+Generated Location: (2559:92,1 [11] )
 |try {
     |
 
@@ -101,39 +101,39 @@ Source Location: (438:27,39 [31] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
 } catch(Exception ex) {
     |
-Generated Location: (2649:97,39 [31] )
+Generated Location: (2725:98,39 [31] )
 |
 } catch(Exception ex) {
     |
 
 Source Location: (500:29,35 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |ex.Message|
-Generated Location: (2831:104,35 [10] )
+Generated Location: (2907:105,35 [10] )
 |ex.Message|
 
 Source Location: (515:29,50 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
 }|
-Generated Location: (3008:109,50 [3] )
+Generated Location: (3084:110,50 [3] )
 |
 }|
 
 Source Location: (535:32,13 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |i|
-Generated Location: (3140:115,13 [1] )
+Generated Location: (3216:116,13 [1] )
 |i|
 
 Source Location: (545:34,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |lock(new object()) {
     |
-Generated Location: (3259:120,1 [26] )
+Generated Location: (3335:121,1 [26] )
 |lock(new object()) {
     |
 
 Source Location: (618:35,51 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
 }|
-Generated Location: (3452:126,51 [3] )
+Generated Location: (3528:127,51 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Blocks_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlockAtEOF_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (2:0,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF.cshtml)
 ||
-Generated Location: (577:15,14 [0] )
+Generated Location: (653:16,14 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlockAtEOF_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlockWithTextElement_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.mappings.txt
@@ -1,26 +1,26 @@
 Source Location: (2:0,2 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml)
 |
     var a = 1; |
-Generated Location: (675:16,2 [17] )
+Generated Location: (751:17,2 [17] )
 |
     var a = 1; |
 
 Source Location: (35:1,31 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml)
 | 		
     var b = 1;			|
-Generated Location: (856:22,31 [22] )
+Generated Location: (932:23,31 [22] )
 | 		
     var b = 1;			|
 
 Source Location: (69:2,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml)
 |a+b|
-Generated Location: (1049:28,38 [3] )
+Generated Location: (1125:29,38 [3] )
 |a+b|
 
 Source Location: (80:2,40 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml)
 |
 |
-Generated Location: (1147:32,61 [2] )
+Generated Location: (1223:33,61 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlockWithTextElement_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlock_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.mappings.txt
@@ -4,7 +4,7 @@ Source Location: (2:0,2 [115] TestFiles/IntegrationTests/CodeGenerationIntegrati
         Output.Write("<p>Hello from C#, #" + i.ToString() + "</p>");
     }
 |
-Generated Location: (645:16,2 [115] )
+Generated Location: (721:17,2 [115] )
 |
     for(int i = 1; i <= 10; i++) {
         Output.Write("<p>Hello from C#, #" + i.ToString() + "</p>");

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlock_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ComplexTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (425:10,37 [17] )
+Generated Location: (501:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (36:2,1 [52] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
@@ -9,7 +9,7 @@ Source Location: (36:2,1 [52] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var checkbox = "checkbox";
 
     |
-Generated Location: (1050:23,1 [52] )
+Generated Location: (1126:24,1 [52] )
 |if (true)
 {
     var checkbox = "checkbox";
@@ -20,7 +20,7 @@ Source Location: (224:9,13 [43] TestFiles/IntegrationTests/CodeGenerationIntegra
 |if (false)
             {
                 |
-Generated Location: (1242:32,13 [43] )
+Generated Location: (1318:33,13 [43] )
 |if (false)
             {
                 |
@@ -31,7 +31,7 @@ Source Location: (350:11,99 [66] TestFiles/IntegrationTests/CodeGenerationIntegr
             else
             {
                 |
-Generated Location: (1962:44,99 [66] )
+Generated Location: (2038:45,99 [66] )
 |
             }
             else
@@ -40,224 +40,224 @@ Generated Location: (1962:44,99 [66] )
 
 Source Location: (446:15,46 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checkbox|
-Generated Location: (2409:55,46 [8] )
+Generated Location: (2485:56,46 [8] )
 |checkbox|
 
 Source Location: (463:15,63 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true|
-Generated Location: (2762:62,63 [4] )
+Generated Location: (2838:63,63 [4] )
 |true|
 
 Source Location: (474:15,74 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (2981:67,86 [18] )
+Generated Location: (3057:68,86 [18] )
 |
                 |
 
 Source Location: (507:16,31 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true ? "checkbox" : "anything"|
-Generated Location: (3334:72,31 [30] )
+Generated Location: (3410:73,31 [30] )
 |true ? "checkbox" : "anything"|
 
 Source Location: (542:16,66 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (3630:78,78 [18] )
+Generated Location: (3706:79,78 [18] )
 |
                 |
 
 Source Location: (574:17,30 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if(true) { |
-Generated Location: (3982:83,30 [11] )
+Generated Location: (4058:84,30 [11] )
 |if(true) { |
 
 Source Location: (606:17,62 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | } else { |
-Generated Location: (4182:88,62 [10] )
+Generated Location: (4258:89,62 [10] )
 | } else { |
 
 Source Location: (637:17,93 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | }|
-Generated Location: (4412:93,93 [2] )
+Generated Location: (4488:94,93 [2] )
 | }|
 
 Source Location: (641:17,97 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
             }|
-Generated Location: (4792:100,97 [15] )
+Generated Location: (4868:101,97 [15] )
 |
             }|
 
 Source Location: (163:7,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (5060:107,32 [12] )
+Generated Location: (5136:108,32 [12] )
 |DateTime.Now|
 
 Source Location: (783:21,14 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | var @object = false;|
-Generated Location: (5214:112,14 [21] )
+Generated Location: (5290:113,14 [21] )
 | var @object = false;|
 
 Source Location: (836:22,29 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (5612:119,42 [1] )
+Generated Location: (5688:120,42 [1] )
 |(|
 
 Source Location: (837:22,30 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@object|
-Generated Location: (5613:119,43 [7] )
+Generated Location: (5689:120,43 [7] )
 |@object|
 
 Source Location: (844:22,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (5620:119,50 [1] )
+Generated Location: (5696:120,50 [1] )
 |)|
 
 Source Location: (711:20,39 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (5882:125,38 [23] )
+Generated Location: (5958:126,38 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (734:20,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | -|
-Generated Location: (5905:125,61 [2] )
+Generated Location: (5981:126,61 [2] )
 | -|
 
 Source Location: (736:20,64 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 1970|
-Generated Location: (5907:125,63 [5] )
+Generated Location: (5983:126,63 [5] )
 | 1970|
 
 Source Location: (976:25,61 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (6308:132,60 [1] )
+Generated Location: (6384:133,60 [1] )
 |(|
 
 Source Location: (977:25,62 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (6309:132,61 [30] )
+Generated Location: (6385:133,61 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1007:25,92 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (6339:132,91 [1] )
+Generated Location: (6415:133,91 [1] )
 |)|
 
 Source Location: (879:24,16 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |-1970|
-Generated Location: (6596:138,33 [5] )
+Generated Location: (6672:139,33 [5] )
 |-1970|
 
 Source Location: (884:24,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | +|
-Generated Location: (6601:138,38 [2] )
+Generated Location: (6677:139,38 [2] )
 | +|
 
 Source Location: (886:24,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | |
-Generated Location: (6603:138,40 [1] )
+Generated Location: (6679:139,40 [1] )
 | |
 
 Source Location: (887:24,24 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (6604:138,41 [1] )
+Generated Location: (6680:139,41 [1] )
 |@|
 
 Source Location: (888:24,25 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (6605:138,42 [23] )
+Generated Location: (6681:139,42 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (1106:28,28 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (7006:145,42 [30] )
+Generated Location: (7082:146,42 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1044:27,16 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year - 1970|
-Generated Location: (7292:151,33 [30] )
+Generated Location: (7368:152,33 [30] )
 |DateTimeOffset.Now.Year - 1970|
 
 Source Location: (1234:31,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (7700:158,42 [3] )
+Generated Location: (7776:159,42 [3] )
 |   |
 
 Source Location: (1237:31,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (7703:158,45 [1] )
+Generated Location: (7779:159,45 [1] )
 |@|
 
 Source Location: (1238:31,32 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (7704:158,46 [1] )
+Generated Location: (7780:159,46 [1] )
 |(|
 
 Source Location: (1239:31,33 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |  DateTimeOffset.Now.Year  |
-Generated Location: (7705:158,47 [27] )
+Generated Location: (7781:159,47 [27] )
 |  DateTimeOffset.Now.Year  |
 
 Source Location: (1266:31,60 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (7732:158,74 [1] )
+Generated Location: (7808:159,74 [1] )
 |)|
 
 Source Location: (1267:31,61 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | >|
-Generated Location: (7733:158,75 [2] )
+Generated Location: (7809:159,75 [2] )
 | >|
 
 Source Location: (1269:31,63 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 2014|
-Generated Location: (7735:158,77 [5] )
+Generated Location: (7811:159,77 [5] )
 | 2014|
 
 Source Location: (1274:31,68 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (7740:158,82 [3] )
+Generated Location: (7816:159,82 [3] )
 |   |
 
 Source Location: (1171:30,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (7999:164,33 [1] )
+Generated Location: (8075:165,33 [1] )
 |(|
 
 Source Location: (1172:30,18 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"My age is this long.".Length|
-Generated Location: (8000:164,34 [29] )
+Generated Location: (8076:165,34 [29] )
 |"My age is this long.".Length|
 
 Source Location: (1201:30,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (8029:164,63 [1] )
+Generated Location: (8105:165,63 [1] )
 |)|
 
 Source Location: (1306:33,9 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |someMethod(|
-Generated Location: (8167:169,9 [11] )
+Generated Location: (8243:170,9 [11] )
 |someMethod(|
 
 Source Location: (1361:33,64 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checked|
-Generated Location: (8620:173,63 [7] )
+Generated Location: (8696:174,63 [7] )
 |checked|
 
 Source Location: (1326:33,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |123|
-Generated Location: (8875:179,33 [3] )
+Generated Location: (8951:180,33 [3] )
 |123|
 
 Source Location: (1375:33,78 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (8916:184,1 [1] )
+Generated Location: (8992:185,1 [1] )
 |)|
 
 Source Location: (1388:34,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
 }|
-Generated Location: (9055:189,10 [3] )
+Generated Location: (9131:190,10 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ComplexTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "text", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ConditionalAttributes_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (2:0,2 [48] TestFiles/IntegrationTests/CodeGenerationIntegratio
     var ch = true;
     var cls = "bar";
     |
-Generated Location: (669:16,2 [48] )
+Generated Location: (745:17,2 [48] )
 |
     var ch = true;
     var cls = "bar";
@@ -12,127 +12,127 @@ Generated Location: (669:16,2 [48] )
 Source Location: (66:3,20 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (782:23,32 [6] )
+Generated Location: (858:24,32 [6] )
 |
     |
 
 Source Location: (83:4,15 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (902:26,15 [3] )
+Generated Location: (978:27,15 [3] )
 |cls|
 
 Source Location: (90:4,22 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (973:30,34 [6] )
+Generated Location: (1049:31,34 [6] )
 |
     |
 
 Source Location: (111:5,19 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (1097:33,19 [3] )
+Generated Location: (1173:34,19 [3] )
 |cls|
 
 Source Location: (118:5,26 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (1172:37,38 [6] )
+Generated Location: (1248:38,38 [6] )
 |
     |
 
 Source Location: (135:6,15 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (1292:40,15 [3] )
+Generated Location: (1368:41,15 [3] )
 |cls|
 
 Source Location: (146:6,26 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (1367:44,38 [6] )
+Generated Location: (1443:45,38 [6] )
 |
     |
 
 Source Location: (185:7,37 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |ch|
-Generated Location: (1509:47,37 [2] )
+Generated Location: (1585:48,37 [2] )
 |ch|
 
 Source Location: (191:7,43 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (1600:51,55 [6] )
+Generated Location: (1676:52,55 [6] )
 |
     |
 
 Source Location: (234:8,41 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |ch|
-Generated Location: (1746:54,41 [2] )
+Generated Location: (1822:55,41 [2] )
 |ch|
 
 Source Location: (240:8,47 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (1841:58,59 [6] )
+Generated Location: (1917:59,59 [6] )
 |
     |
 
 Source Location: (257:9,15 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |if(cls != null) { |
-Generated Location: (1962:61,15 [18] )
+Generated Location: (2038:62,15 [18] )
 |if(cls != null) { |
 
 Source Location: (276:9,34 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (2145:66,34 [3] )
+Generated Location: (2221:67,34 [3] )
 |cls|
 
 Source Location: (279:9,37 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 | }|
-Generated Location: (2317:71,37 [2] )
+Generated Location: (2393:72,37 [2] )
 | }|
 
 Source Location: (285:9,43 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (2407:75,55 [6] )
+Generated Location: (2483:76,55 [6] )
 |
     |
 
 Source Location: (309:10,22 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (2449:77,34 [6] )
+Generated Location: (2525:78,34 [6] )
 |
     |
 
 Source Location: (329:11,18 [44] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |Url.Content("~/Scripts/jquery-1.6.2.min.js")|
-Generated Location: (2573:80,18 [44] )
+Generated Location: (2649:81,18 [44] )
 |Url.Content("~/Scripts/jquery-1.6.2.min.js")|
 
 Source Location: (407:11,96 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (2759:84,108 [6] )
+Generated Location: (2835:85,108 [6] )
 |
     |
 
 Source Location: (427:12,18 [60] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")|
-Generated Location: (2883:87,18 [60] )
+Generated Location: (2959:88,18 [60] )
 |Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")|
 
 Source Location: (521:12,112 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (3101:91,124 [6] )
+Generated Location: (3177:92,124 [6] )
 |
     |
 
 Source Location: (638:13,115 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
 |
-Generated Location: (3236:93,127 [2] )
+Generated Location: (3312:94,127 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ConditionalAttributes_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CssSelectorTagHelperAttributes_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("href", new global::Microsoft.AspNetCore.Html.HtmlString("~/"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DesignTime_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
@@ -1,49 +1,49 @@
 Source Location: (173:11,9 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Footer|
-Generated Location: (403:10,22 [6] )
+Generated Location: (479:11,22 [6] )
 |Footer|
 
 Source Location: (20:1,13 [36] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |for(int i = 1; i <= 10; i++) {
     |
-Generated Location: (756:20,13 [36] )
+Generated Location: (832:21,13 [36] )
 |for(int i = 1; i <= 10; i++) {
     |
 
 Source Location: (74:2,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |i|
-Generated Location: (933:26,22 [1] )
+Generated Location: (1009:27,22 [1] )
 |i|
 
 Source Location: (79:2,27 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |
             }|
-Generated Location: (1081:31,27 [15] )
+Generated Location: (1157:32,27 [15] )
 |
             }|
 
 Source Location: (113:7,2 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(Bar.Baz)|
-Generated Location: (1221:37,6 [12] )
+Generated Location: (1297:38,6 [12] )
 |Foo(Bar.Baz)|
 
 Source Location: (129:8,1 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(|
-Generated Location: (1359:42,6 [4] )
+Generated Location: (1435:43,6 [4] )
 |Foo(|
 
 Source Location: (142:8,14 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |baz|
-Generated Location: (1556:44,14 [3] )
+Generated Location: (1632:45,14 [3] )
 |baz|
 
 Source Location: (153:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |)|
-Generated Location: (1597:49,1 [1] )
+Generated Location: (1673:50,1 [1] )
 |)|
 
 Source Location: (204:13,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |bar|
-Generated Location: (1798:55,6 [3] )
+Generated Location: (1874:56,6 [3] )
 |bar|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DuplicateAttributeTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (436:10,37 [17] )
+Generated Location: (512:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (146:4,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (1829:31,42 [4] )
+Generated Location: (1905:32,42 [4] )
 |true|
 
 Source Location: (222:5,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (2371:40,42 [4] )
+Generated Location: (2447:41,42 [4] )
 |true|
 
 Source Location: (43:2,8 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |3|
-Generated Location: (2641:46,33 [1] )
+Generated Location: (2717:47,33 [1] )
 |3|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DuplicateAttributeTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "button", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DynamicAttributeTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,155 +1,155 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (434:10,37 [17] )
+Generated Location: (510:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (59:2,24 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1014:22,24 [12] )
+Generated Location: (1090:23,24 [12] )
 |DateTime.Now|
 
 Source Location: (96:4,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (1282:28,17 [12] )
+Generated Location: (1358:29,17 [12] )
 |if (true) { |
 
 Source Location: (109:4,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (1459:33,30 [12] )
+Generated Location: (1535:34,30 [12] )
 |string.Empty|
 
 Source Location: (121:4,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (1649:38,42 [10] )
+Generated Location: (1725:39,42 [10] )
 | } else { |
 
 Source Location: (132:4,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (1847:43,53 [5] )
+Generated Location: (1923:44,53 [5] )
 |false|
 
 Source Location: (137:4,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (2046:48,58 [2] )
+Generated Location: (2122:49,58 [2] )
 | }|
 
 Source Location: (176:6,22 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (2308:54,22 [12] )
+Generated Location: (2384:55,22 [12] )
 |DateTime.Now|
 
 Source Location: (214:6,60 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (2582:60,60 [12] )
+Generated Location: (2658:61,60 [12] )
 |DateTime.Now|
 
 Source Location: (256:8,15 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (2848:66,15 [13] )
+Generated Location: (2924:67,15 [13] )
 |long.MinValue|
 
 Source Location: (271:8,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (3027:71,30 [12] )
+Generated Location: (3103:72,30 [12] )
 |if (true) { |
 
 Source Location: (284:8,43 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (3217:76,43 [12] )
+Generated Location: (3293:77,43 [12] )
 |string.Empty|
 
 Source Location: (296:8,55 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (3420:81,55 [10] )
+Generated Location: (3496:82,55 [10] )
 | } else { |
 
 Source Location: (307:8,66 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (3631:86,66 [5] )
+Generated Location: (3707:87,66 [5] )
 |false|
 
 Source Location: (312:8,71 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (3843:91,71 [2] )
+Generated Location: (3919:92,71 [2] )
 | }|
 
 Source Location: (316:8,75 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (4055:96,75 [12] )
+Generated Location: (4131:97,75 [12] )
 |int.MaxValue|
 
 Source Location: (348:9,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (4287:102,17 [13] )
+Generated Location: (4363:103,17 [13] )
 |long.MinValue|
 
 Source Location: (363:9,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (4469:107,32 [12] )
+Generated Location: (4545:108,32 [12] )
 |if (true) { |
 
 Source Location: (376:9,45 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (4662:112,45 [12] )
+Generated Location: (4738:113,45 [12] )
 |string.Empty|
 
 Source Location: (388:9,57 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (4868:117,57 [10] )
+Generated Location: (4944:118,57 [10] )
 | } else { |
 
 Source Location: (399:9,68 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (5082:122,68 [5] )
+Generated Location: (5158:123,68 [5] )
 |false|
 
 Source Location: (404:9,73 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (5297:127,73 [2] )
+Generated Location: (5373:128,73 [2] )
 | }|
 
 Source Location: (408:9,77 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (5512:132,77 [12] )
+Generated Location: (5588:133,77 [12] )
 |int.MaxValue|
 
 Source Location: (445:11,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (5781:138,17 [13] )
+Generated Location: (5857:139,17 [13] )
 |long.MinValue|
 
 Source Location: (460:11,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (5963:143,32 [12] )
+Generated Location: (6039:144,32 [12] )
 |DateTime.Now|
 
 Source Location: (492:11,64 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (6176:148,64 [12] )
+Generated Location: (6252:149,64 [12] )
 |int.MaxValue|
 
 Source Location: (529:13,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (6445:154,17 [12] )
+Generated Location: (6521:155,17 [12] )
 |if (true) { |
 
 Source Location: (542:13,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (6623:159,30 [12] )
+Generated Location: (6699:160,30 [12] )
 |string.Empty|
 
 Source Location: (554:13,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (6814:164,42 [10] )
+Generated Location: (6890:165,42 [10] )
 | } else { |
 
 Source Location: (565:13,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (7013:169,53 [5] )
+Generated Location: (7089:170,53 [5] )
 |false|
 
 Source Location: (570:13,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (7213:174,58 [2] )
+Generated Location: (7289:175,58 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DynamicAttributeTagHelpers_Runtime
     {
         #line hidden

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyAttributeTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (433:10,38 [15] )
+Generated Location: (509:11,38 [15] )
 |*, TestAssembly|
 
 Source Location: (66:3,26 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (1457:27,42 [0] )
+Generated Location: (1533:28,42 [0] )
 ||
 
 Source Location: (126:5,30 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (1985:36,42 [0] )
+Generated Location: (2061:37,42 [0] )
 ||
 
 Source Location: (92:4,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (2247:42,33 [0] )
+Generated Location: (2323:43,33 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyAttributeTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyCodeBlock_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (20:2,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock.cshtml)
 ||
-Generated Location: (577:15,14 [0] )
+Generated Location: (653:16,14 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyCodeBlock_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyExplicitExpression_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (20:2,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression.cshtml)
 ||
-Generated Location: (677:16,6 [0] )
+Generated Location: (753:17,6 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyExplicitExpression_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyImplicitExpressionInCode_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
 |
     |
-Generated Location: (592:15,14 [6] )
+Generated Location: (668:16,14 [6] )
 |
     |
 
 Source Location: (9:1,5 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
 ||
-Generated Location: (711:18,6 [0] )
+Generated Location: (787:19,6 [0] )
 ||
 
 Source Location: (9:1,5 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
 |
 |
-Generated Location: (762:22,17 [2] )
+Generated Location: (838:23,17 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyImplicitExpressionInCode_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyImplicitExpression_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (19:2,1 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression.cshtml)
 ||
-Generated Location: (677:16,6 [0] )
+Generated Location: (753:17,6 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyImplicitExpression_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EnumTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
@@ -1,49 +1,49 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (422:10,37 [17] )
+Generated Location: (498:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (37:2,2 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |
     var enumValue = MyEnum.MyValue;
 |
-Generated Location: (964:22,2 [39] )
+Generated Location: (1040:23,2 [39] )
 |
     var enumValue = MyEnum.MyValue;
 |
 
 Source Location: (96:6,15 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MyValue|
-Generated Location: (1375:30,39 [14] )
+Generated Location: (1451:31,39 [14] )
 |MyEnum.MyValue|
 
 Source Location: (131:7,15 [20] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MySecondValue|
-Generated Location: (1740:37,15 [20] )
+Generated Location: (1816:38,15 [20] )
 |MyEnum.MySecondValue|
 
 Source Location: (171:8,14 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (2228:44,132 [7] )
+Generated Location: (2304:45,132 [7] )
 |MyValue|
 
 Source Location: (198:9,14 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MySecondValue|
-Generated Location: (2704:51,132 [13] )
+Generated Location: (2780:52,132 [13] )
 |MySecondValue|
 
 Source Location: (224:9,40 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (2980:56,138 [7] )
+Generated Location: (3056:57,138 [7] )
 |MyValue|
 
 Source Location: (251:10,15 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (3363:63,39 [9] )
+Generated Location: (3439:64,39 [9] )
 |enumValue|
 
 Source Location: (274:10,38 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (3542:68,45 [9] )
+Generated Location: (3618:69,45 [9] )
 |enumValue|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EnumTagHelpers_Runtime
     {
         #line hidden

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EscapedTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (426:10,38 [15] )
+Generated Location: (502:11,38 [15] )
 |*, TestAssembly|
 
 Source Location: (106:3,29 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (993:22,29 [12] )
+Generated Location: (1069:23,29 [12] )
 |DateTime.Now|
 
 Source Location: (204:5,51 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1391:29,51 [12] )
+Generated Location: (1467:30,51 [12] )
 |DateTime.Now|
 
 Source Location: (227:5,74 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |true|
-Generated Location: (1758:36,74 [4] )
+Generated Location: (1834:37,74 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EscapedTagHelpers_Runtime
     {
         #line hidden

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpressionAtEOF_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (20:2,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF.cshtml)
 ||
-Generated Location: (677:16,6 [0] )
+Generated Location: (753:17,6 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpressionAtEOF_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpressionWithMarkup_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup.cshtml)
 ||
-Generated Location: (786:18,1 [0] )
+Generated Location: (862:19,1 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpressionWithMarkup_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpression_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (10:0,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression.cshtml)
 |1+1|
-Generated Location: (671:16,10 [3] )
+Generated Location: (747:17,10 [3] )
 |1+1|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpression_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExpressionsInCode_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (2:0,2 [51] TestFiles/IntegrationTests/CodeGenerationIntegratio
     object foo = null;
     string bar = "Foo";
 |
-Generated Location: (661:16,2 [51] )
+Generated Location: (737:17,2 [51] )
 |
     object foo = null;
     string bar = "Foo";
@@ -12,20 +12,20 @@ Generated Location: (661:16,2 [51] )
 Source Location: (59:5,1 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |if(foo != null) {
     |
-Generated Location: (837:23,1 [23] )
+Generated Location: (913:24,1 [23] )
 |if(foo != null) {
     |
 
 Source Location: (83:6,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |foo|
-Generated Location: (992:29,6 [3] )
+Generated Location: (1068:30,6 [3] )
 |foo|
 
 Source Location: (86:6,8 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |
 } else {
     |
-Generated Location: (1130:34,8 [16] )
+Generated Location: (1206:35,8 [16] )
 |
 } else {
     |
@@ -33,26 +33,26 @@ Generated Location: (1130:34,8 [16] )
 Source Location: (121:8,23 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |
 }|
-Generated Location: (1295:41,23 [3] )
+Generated Location: (1371:42,23 [3] )
 |
 }|
 
 Source Location: (134:12,1 [38] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |if(!String.IsNullOrEmpty(bar)) {
     |
-Generated Location: (1426:47,1 [38] )
+Generated Location: (1502:48,1 [38] )
 |if(!String.IsNullOrEmpty(bar)) {
     |
 
 Source Location: (174:13,6 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |bar.Replace("F", "B")|
-Generated Location: (1597:53,6 [21] )
+Generated Location: (1673:54,6 [21] )
 |bar.Replace("F", "B")|
 
 Source Location: (196:13,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |
 }|
-Generated Location: (1774:58,28 [3] )
+Generated Location: (1850:59,28 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExpressionsInCode_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_FunctionsBlockMinimal_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.mappings.txt
@@ -4,7 +4,7 @@ string foo(string input) {
 	return input + "!";
 }
 |
-Generated Location: (731:18,15 [55] )
+Generated Location: (807:19,15 [55] )
 |
 string foo(string input) {
 	return input + "!";

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_FunctionsBlockMinimal_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_FunctionsBlock_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (167:11,25 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock.cshtml)
 |RandomInt()|
-Generated Location: (679:16,25 [11] )
+Generated Location: (755:17,25 [11] )
 |RandomInt()|
 
 Source Location: (12:0,12 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock.cshtml)
 |
 
 |
-Generated Location: (793:22,20 [4] )
+Generated Location: (869:23,20 [4] )
 |
 
 |
@@ -19,7 +19,7 @@ Source Location: (33:4,12 [104] TestFiles/IntegrationTests/CodeGenerationIntegra
         return _rand.Next();
     }
 |
-Generated Location: (901:26,12 [104] )
+Generated Location: (977:27,12 [104] )
 |
     Random _rand = new Random();
     private int RandomInt() {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_FunctionsBlock_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HiddenSpansInCode_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.mappings.txt
@@ -1,14 +1,14 @@
 Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode.cshtml)
 |
     |
-Generated Location: (580:15,14 [6] )
+Generated Location: (656:16,14 [6] )
 |
     |
 
 Source Location: (9:1,5 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode.cshtml)
 |@Da
 |
-Generated Location: (686:18,5 [5] )
+Generated Location: (762:19,5 [5] )
 |@Da
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HiddenSpansInCode_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HtmlCommentWithQuote_Double_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HtmlCommentWithQuote_Double_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HtmlCommentWithQuote_Single_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HtmlCommentWithQuote_Single_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ImplicitExpressionAtEOF_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (19:2,1 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF.cshtml)
 ||
-Generated Location: (677:16,6 [0] )
+Generated Location: (753:17,6 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ImplicitExpressionAtEOF_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ImplicitExpression_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (1:0,1 [36] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression.cshtml)
 |for(int i = 1; i <= 10; i++) {
     |
-Generated Location: (662:16,1 [36] )
+Generated Location: (738:17,1 [36] )
 |for(int i = 1; i <= 10; i++) {
     |
 
 Source Location: (55:1,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression.cshtml)
 |i|
-Generated Location: (847:22,22 [1] )
+Generated Location: (923:23,22 [1] )
 |i|
 
 Source Location: (60:1,27 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression.cshtml)
 |
 }|
-Generated Location: (1003:27,27 [3] )
+Generated Location: (1079:28,27 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ImplicitExpression_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteTagHelper_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (427:10,37 [17] )
+Generated Location: (503:11,37 [17] )
 |"*, TestAssembly"|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteTagHelper_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Inherits_DesignTime : foo.bar<baz<biz>>.boz
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (20:2,10 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
 |foo.bar<baz<biz>>.boz|
-Generated Location: (403:10,0 [21] )
+Generated Location: (479:11,0 [21] )
 |foo.bar<baz<biz>>.boz|
 
 Source Location: (1:0,1 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
 |foo()|
-Generated Location: (775:20,6 [5] )
+Generated Location: (851:21,6 [5] )
 |foo()|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Inherits_Runtime : foo.bar<baz<biz>>.boz
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InlineBlocks_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (9:0,9 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |Link|
-Generated Location: (405:10,22 [4] )
+Generated Location: (481:11,22 [4] )
 |Link|
 
 Source Location: (44:1,14 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |if(link != null) { |
-Generated Location: (847:22,14 [19] )
+Generated Location: (923:23,14 [19] )
 |if(link != null) { |
 
 Source Location: (64:1,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |link|
-Generated Location: (1021:27,34 [4] )
+Generated Location: (1097:28,34 [4] )
 |link|
 
 Source Location: (68:1,38 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | } else { |
-Generated Location: (1185:32,38 [10] )
+Generated Location: (1261:33,38 [10] )
 | } else { |
 
 Source Location: (92:1,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | }|
-Generated Location: (1378:37,62 [2] )
+Generated Location: (1454:38,62 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InlineBlocks_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Instrumented_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (2:0,2 [32] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |
     int i = 1;
     var foo = |
-Generated Location: (651:16,2 [32] )
+Generated Location: (727:17,2 [32] )
 |
     int i = 1;
     var foo = |
@@ -10,39 +10,39 @@ Generated Location: (651:16,2 [32] )
 Source Location: (45:2,25 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |;
     |
-Generated Location: (964:26,25 [7] )
+Generated Location: (1040:27,25 [7] )
 |;
     |
 
 Source Location: (68:4,0 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |    |
-Generated Location: (1004:31,0 [4] )
+Generated Location: (1080:32,0 [4] )
 |    |
 
 Source Location: (91:4,23 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 |
-Generated Location: (1057:32,35 [2] )
+Generated Location: (1133:33,35 [2] )
 |
 |
 
 Source Location: (99:7,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |while(i <= 10) {
     |
-Generated Location: (1150:35,1 [22] )
+Generated Location: (1226:36,1 [22] )
 |while(i <= 10) {
     |
 
 Source Location: (142:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |i|
-Generated Location: (1318:41,25 [1] )
+Generated Location: (1394:42,25 [1] )
 |i|
 
 Source Location: (148:8,31 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
     i += 1;
 }|
-Generated Location: (1472:46,31 [16] )
+Generated Location: (1548:47,31 [16] )
 |
     i += 1;
 }|
@@ -50,14 +50,14 @@ Generated Location: (1472:46,31 [16] )
 Source Location: (169:12,1 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |if(i == 11) {
     |
-Generated Location: (1611:53,1 [19] )
+Generated Location: (1687:54,1 [19] )
 |if(i == 11) {
     |
 
 Source Location: (213:13,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (1781:59,29 [3] )
+Generated Location: (1857:60,29 [3] )
 |
 }|
 
@@ -65,7 +65,7 @@ Source Location: (221:16,1 [35] TestFiles/IntegrationTests/CodeGenerationIntegra
 |switch(i) {
     case 11:
         |
-Generated Location: (1907:65,1 [35] )
+Generated Location: (1983:66,1 [35] )
 |switch(i) {
     case 11:
         |
@@ -75,7 +75,7 @@ Source Location: (292:18,44 [40] TestFiles/IntegrationTests/CodeGenerationIntegr
         break;
     default:
         |
-Generated Location: (2108:72,44 [40] )
+Generated Location: (2184:73,44 [40] )
 |
         break;
     default:
@@ -85,7 +85,7 @@ Source Location: (361:21,37 [19] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
         break;
 }|
-Generated Location: (2307:80,37 [19] )
+Generated Location: (2383:81,37 [19] )
 |
         break;
 }|
@@ -93,26 +93,26 @@ Generated Location: (2307:80,37 [19] )
 Source Location: (385:25,1 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |for(int j = 1; j <= 10; j += 2) {
     |
-Generated Location: (2449:87,1 [39] )
+Generated Location: (2525:88,1 [39] )
 |for(int j = 1; j <= 10; j += 2) {
     |
 
 Source Location: (451:26,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |j|
-Generated Location: (2641:93,31 [1] )
+Generated Location: (2717:94,31 [1] )
 |j|
 
 Source Location: (457:26,37 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (2802:98,37 [3] )
+Generated Location: (2878:99,37 [3] )
 |
 }|
 
 Source Location: (465:29,1 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |try {
     |
-Generated Location: (2928:104,1 [11] )
+Generated Location: (3004:105,1 [11] )
 |try {
     |
 
@@ -120,34 +120,34 @@ Source Location: (511:30,39 [31] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
 } catch(Exception ex) {
     |
-Generated Location: (3100:110,39 [31] )
+Generated Location: (3176:111,39 [31] )
 |
 } catch(Exception ex) {
     |
 
 Source Location: (573:32,35 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |ex.Message|
-Generated Location: (3288:117,35 [10] )
+Generated Location: (3364:118,35 [10] )
 |ex.Message|
 
 Source Location: (588:32,50 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (3471:122,50 [3] )
+Generated Location: (3547:123,50 [3] )
 |
 }|
 
 Source Location: (596:35,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |lock(new object()) {
     |
-Generated Location: (3597:128,1 [26] )
+Generated Location: (3673:129,1 [26] )
 |lock(new object()) {
     |
 
 Source Location: (669:36,51 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (3796:134,51 [3] )
+Generated Location: (3872:135,51 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Instrumented_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MarkupInCodeBlock_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.mappings.txt
@@ -2,21 +2,21 @@ Source Location: (2:0,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |
     for(int i = 1; i <= 10; i++) {
         |
-Generated Location: (661:16,2 [46] )
+Generated Location: (737:17,2 [46] )
 |
     for(int i = 1; i <= 10; i++) {
         |
 
 Source Location: (69:2,29 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock.cshtml)
 |i.ToString()|
-Generated Location: (862:23,29 [12] )
+Generated Location: (938:24,29 [12] )
 |i.ToString()|
 
 Source Location: (86:2,46 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock.cshtml)
 |
     }
 |
-Generated Location: (1047:28,46 [9] )
+Generated Location: (1123:29,46 [9] )
 |
     }
 |

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MarkupInCodeBlock_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MinimizedTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (427:10,37 [17] )
+Generated Location: (503:11,37 [17] )
 |"*, TestAssembly"|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MinimizedTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("btn"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedCSharp_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.mappings.txt
@@ -1,7 +1,7 @@
 Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |
     |
-Generated Location: (575:15,14 [6] )
+Generated Location: (651:16,14 [6] )
 |
     |
 
@@ -9,27 +9,27 @@ Source Location: (9:1,5 [53] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |foreach (var result in (dynamic)Url)
     {
         |
-Generated Location: (676:18,5 [53] )
+Generated Location: (752:19,5 [53] )
 |foreach (var result in (dynamic)Url)
     {
         |
 
 Source Location: (82:4,13 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |result.SomeValue|
-Generated Location: (863:25,13 [16] )
+Generated Location: (939:26,13 [16] )
 |result.SomeValue|
 
 Source Location: (115:5,14 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |
     }|
-Generated Location: (1015:30,14 [7] )
+Generated Location: (1091:31,14 [7] )
 |
     }|
 
 Source Location: (122:6,5 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |
 |
-Generated Location: (1072:35,17 [2] )
+Generated Location: (1148:36,17 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedCSharp_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedCodeBlocks_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.mappings.txt
@@ -1,21 +1,21 @@
 Source Location: (1:0,1 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks.cshtml)
 |if(foo) {
     |
-Generated Location: (658:16,1 [15] )
+Generated Location: (734:17,1 [15] )
 |if(foo) {
     |
 
 Source Location: (17:1,5 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks.cshtml)
 |if(bar) {
     }|
-Generated Location: (803:22,5 [16] )
+Generated Location: (879:23,5 [16] )
 |if(bar) {
     }|
 
 Source Location: (33:2,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks.cshtml)
 |
 }|
-Generated Location: (949:28,5 [3] )
+Generated Location: (1025:29,5 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedCodeBlocks_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedScriptTagTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
@@ -1,29 +1,29 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (433:10,37 [17] )
+Generated Location: (509:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (195:5,13 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |for(var i = 0; i < 5; i++) {
                 |
-Generated Location: (1078:23,13 [46] )
+Generated Location: (1154:24,13 [46] )
 |for(var i = 0; i < 5; i++) {
                 |
 
 Source Location: (339:7,50 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1516:31,50 [23] )
+Generated Location: (1592:32,50 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (389:7,100 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |true|
-Generated Location: (1922:38,100 [4] )
+Generated Location: (1998:39,100 [4] )
 |true|
 
 Source Location: (422:8,25 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |
             }|
-Generated Location: (2086:43,25 [15] )
+Generated Location: (2162:44,25 [15] )
 |
             }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedScriptTagTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "text", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (425:10,38 [15] )
+Generated Location: (501:11,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", "Hello", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NoLinePragmas_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (2:0,2 [18] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |
     int i = 1;
 |
-Generated Location: (653:16,2 [18] )
+Generated Location: (729:17,2 [18] )
 |
     int i = 1;
 |
@@ -10,20 +10,20 @@ Generated Location: (653:16,2 [18] )
 Source Location: (26:4,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |while(i <= 10) {
     |
-Generated Location: (792:22,1 [22] )
+Generated Location: (868:23,1 [22] )
 |while(i <= 10) {
     |
 
 Source Location: (69:5,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |i|
-Generated Location: (961:28,25 [1] )
+Generated Location: (1037:29,25 [1] )
 |i|
 
 Source Location: (75:5,31 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |
     i += 1;
 }|
-Generated Location: (1116:33,31 [16] )
+Generated Location: (1192:34,31 [16] )
 |
     i += 1;
 }|
@@ -31,14 +31,14 @@ Generated Location: (1116:33,31 [16] )
 Source Location: (96:9,1 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |if(i == 11) {
     |
-Generated Location: (1256:40,1 [19] )
+Generated Location: (1332:41,1 [19] )
 |if(i == 11) {
     |
 
 Source Location: (140:10,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |
 }|
-Generated Location: (1427:46,29 [3] )
+Generated Location: (1503:47,29 [3] )
 |
 }|
 
@@ -46,7 +46,7 @@ Source Location: (148:13,1 [35] TestFiles/IntegrationTests/CodeGenerationIntegra
 |switch(i) {
     case 11:
         |
-Generated Location: (1554:52,1 [35] )
+Generated Location: (1630:53,1 [35] )
 |switch(i) {
     case 11:
         |
@@ -56,7 +56,7 @@ Source Location: (219:15,44 [40] TestFiles/IntegrationTests/CodeGenerationIntegr
         break;
     default:
         |
-Generated Location: (1756:59,44 [40] )
+Generated Location: (1832:60,44 [40] )
 |
         break;
     default:
@@ -66,7 +66,7 @@ Source Location: (288:18,37 [19] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
         break;
 }|
-Generated Location: (1956:67,37 [19] )
+Generated Location: (2032:68,37 [19] )
 |
         break;
 }|
@@ -74,26 +74,26 @@ Generated Location: (1956:67,37 [19] )
 Source Location: (312:22,1 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |for(int j = 1; j <= 10; j += 2) {
     |
-Generated Location: (2099:74,1 [39] )
+Generated Location: (2175:75,1 [39] )
 |for(int j = 1; j <= 10; j += 2) {
     |
 
 Source Location: (378:23,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |j|
-Generated Location: (2292:80,31 [1] )
+Generated Location: (2368:81,31 [1] )
 |j|
 
 Source Location: (384:23,37 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |
 }|
-Generated Location: (2454:85,37 [3] )
+Generated Location: (2530:86,37 [3] )
 |
 }|
 
 Source Location: (392:26,1 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |try {
     |
-Generated Location: (2581:91,1 [11] )
+Generated Location: (2657:92,1 [11] )
 |try {
     |
 
@@ -101,14 +101,14 @@ Source Location: (438:27,39 [31] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
 } catch(Exception ex) {
     |
-Generated Location: (2754:97,39 [31] )
+Generated Location: (2830:98,39 [31] )
 |
 } catch(Exception ex) {
     |
 
 Source Location: (500:29,35 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |ex.Message|
-Generated Location: (2943:104,35 [10] )
+Generated Location: (3019:105,35 [10] )
 |ex.Message|
 
 Source Location: (515:29,50 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
@@ -116,7 +116,7 @@ Source Location: (515:29,50 [7] TestFiles/IntegrationTests/CodeGenerationIntegra
 }
 
 |
-Generated Location: (3127:109,50 [7] )
+Generated Location: (3203:110,50 [7] )
 |
 }
 
@@ -124,25 +124,25 @@ Generated Location: (3127:109,50 [7] )
 
 Source Location: (556:32,34 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 ||
-Generated Location: (3211:115,46 [0] )
+Generated Location: (3287:116,46 [0] )
 ||
 
 Source Location: (571:33,13 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |i|
-Generated Location: (3316:117,13 [1] )
+Generated Location: (3392:118,13 [1] )
 |i|
 
 Source Location: (581:35,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |lock(new object()) {
     |
-Generated Location: (3442:122,1 [26] )
+Generated Location: (3518:123,1 [26] )
 |lock(new object()) {
     |
 
 Source Location: (654:36,51 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |
 }|
-Generated Location: (3642:128,51 [3] )
+Generated Location: (3718:129,51 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NoLinePragmas_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NullConditionalExpressions_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.mappings.txt
@@ -1,75 +1,75 @@
 Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
     |
-Generated Location: (589:15,14 [6] )
+Generated Location: (665:16,14 [6] )
 |
     |
 
 Source Location: (9:1,5 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Data|
-Generated Location: (705:18,6 [13] )
+Generated Location: (781:19,6 [13] )
 |ViewBag?.Data|
 
 Source Location: (22:1,18 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
     |
-Generated Location: (782:22,30 [6] )
+Generated Location: (858:23,30 [6] )
 |
     |
 
 Source Location: (29:2,5 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.IntIndexer?[0]|
-Generated Location: (898:25,6 [22] )
+Generated Location: (974:26,6 [22] )
 |ViewBag.IntIndexer?[0]|
 
 Source Location: (51:2,27 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
     |
-Generated Location: (993:29,39 [6] )
+Generated Location: (1069:30,39 [6] )
 |
     |
 
 Source Location: (58:3,5 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.StrIndexer?["key"]|
-Generated Location: (1109:32,6 [26] )
+Generated Location: (1185:33,6 [26] )
 |ViewBag.StrIndexer?["key"]|
 
 Source Location: (84:3,31 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
     |
-Generated Location: (1212:36,43 [6] )
+Generated Location: (1288:37,43 [6] )
 |
     |
 
 Source Location: (91:4,5 [41] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
-Generated Location: (1328:39,6 [41] )
+Generated Location: (1404:40,6 [41] )
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
 
 Source Location: (132:4,46 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
 |
-Generated Location: (1461:43,58 [2] )
+Generated Location: (1537:44,58 [2] )
 |
 |
 
 Source Location: (140:7,1 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Data|
-Generated Location: (1573:46,6 [13] )
+Generated Location: (1649:47,6 [13] )
 |ViewBag?.Data|
 
 Source Location: (156:8,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.IntIndexer?[0]|
-Generated Location: (1728:51,6 [22] )
+Generated Location: (1804:52,6 [22] )
 |ViewBag.IntIndexer?[0]|
 
 Source Location: (181:9,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.StrIndexer?["key"]|
-Generated Location: (1893:56,6 [26] )
+Generated Location: (1969:57,6 [26] )
 |ViewBag.StrIndexer?["key"]|
 
 Source Location: (210:10,1 [41] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
-Generated Location: (2062:61,6 [41] )
+Generated Location: (2138:62,6 [41] )
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NullConditionalExpressions_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_OpenedIf_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (17:2,1 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf.cshtml)
 |if (true) { 
 |
-Generated Location: (642:16,1 [14] )
+Generated Location: (718:17,1 [14] )
 |if (true) { 
 |
 
 Source Location: (38:3,7 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf.cshtml)
 |
 |
-Generated Location: (706:20,19 [2] )
+Generated Location: (782:21,19 [2] )
 |
 |
 
 Source Location: (47:4,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf.cshtml)
 ||
-Generated Location: (729:22,19 [0] )
+Generated Location: (805:23,19 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_OpenedIf_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ParserError_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.mappings.txt
@@ -4,7 +4,7 @@ Source Location: (2:0,2 [31] TestFiles/IntegrationTests/CodeGenerationIntegratio
 int i =10;
 int j =20;
 }|
-Generated Location: (649:16,2 [31] )
+Generated Location: (725:17,2 [31] )
 |
 /*
 int i =10;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ParserError_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_PrefixedAttributeTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (435:10,37 [17] )
+Generated Location: (511:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (37:2,2 [242] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
@@ -15,7 +15,7 @@ Source Location: (37:2,2 [242] TestFiles/IntegrationTests/CodeGenerationIntegrat
         { "name", "value" },
     };
 |
-Generated Location: (988:22,2 [242] )
+Generated Location: (1064:23,2 [242] )
 |
     var literate = "or illiterate";
     var intDictionary = new Dictionary<string, int>
@@ -30,51 +30,51 @@ Generated Location: (988:22,2 [242] )
 
 Source Location: (370:15,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (1631:38,56 [13] )
+Generated Location: (1707:39,56 [13] )
 |intDictionary|
 
 Source Location: (404:15,77 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |stringDictionary|
-Generated Location: (1983:44,77 [16] )
+Generated Location: (2059:45,77 [16] )
 |stringDictionary|
 
 Source Location: (468:16,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (2533:52,56 [13] )
+Generated Location: (2609:53,56 [13] )
 |intDictionary|
 
 Source Location: (502:16,77 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (2885:58,77 [2] )
+Generated Location: (2961:59,77 [2] )
 |37|
 
 Source Location: (526:16,101 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (3270:64,101 [2] )
+Generated Location: (3346:65,101 [2] )
 |42|
 
 Source Location: (590:18,31 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (3791:72,46 [2] )
+Generated Location: (3867:73,46 [2] )
 |42|
 
 Source Location: (611:18,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (4120:78,64 [2] )
+Generated Location: (4196:79,64 [2] )
 |37|
 
 Source Location: (634:18,75 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |98|
-Generated Location: (4475:84,75 [2] )
+Generated Location: (4551:85,75 [2] )
 |98|
 
 Source Location: (783:20,42 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |literate|
-Generated Location: (5257:94,42 [8] )
+Generated Location: (5333:95,42 [8] )
 |literate|
 
 Source Location: (826:21,29 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (5921:103,65 [2] )
+Generated Location: (5997:104,65 [2] )
 |37|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_PrefixedAttributeTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorComments_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.mappings.txt
@@ -1,14 +1,14 @@
 Source Location: (81:3,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |
     |
-Generated Location: (576:15,14 [6] )
+Generated Location: (652:16,14 [6] )
 |
     |
 
 Source Location: (122:4,39 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |
     Exception foo = |
-Generated Location: (712:18,39 [22] )
+Generated Location: (788:19,39 [22] )
 |
     Exception foo = |
 
@@ -18,7 +18,7 @@ Source Location: (173:5,49 [58] TestFiles/IntegrationTests/CodeGenerationIntegra
         throw foo;
     }
 |
-Generated Location: (905:24,49 [58] )
+Generated Location: (981:25,49 [58] )
 | null;
     if(foo != null) {
         throw foo;
@@ -27,21 +27,21 @@ Generated Location: (905:24,49 [58] )
 
 Source Location: (238:11,2 [24] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 | var bar = "@* bar *@"; |
-Generated Location: (1086:32,2 [24] )
+Generated Location: (1162:33,2 [24] )
 | var bar = "@* bar *@"; |
 
 Source Location: (310:12,45 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |bar|
-Generated Location: (1278:37,45 [3] )
+Generated Location: (1354:38,45 [3] )
 |bar|
 
 Source Location: (323:14,2 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |a|
-Generated Location: (1411:42,6 [1] )
+Generated Location: (1487:43,6 [1] )
 |a|
 
 Source Location: (328:14,7 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |b|
-Generated Location: (1412:42,7 [1] )
+Generated Location: (1488:43,7 [1] )
 |b|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorComments_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RemoveTagHelperDirective_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (17:0,17 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective.cshtml)
 |*, TestAssembly|
-Generated Location: (433:10,38 [15] )
+Generated Location: (509:11,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Sections_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -1,44 +1,44 @@
 Source Location: (89:6,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section2|
-Generated Location: (401:10,22 [8] )
+Generated Location: (477:11,22 [8] )
 |Section2|
 
 Source Location: (172:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (501:14,22 [8] )
+Generated Location: (577:15,22 [8] )
 |Section1|
 
 Source Location: (235:14,9 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |NestedDelegates|
-Generated Location: (601:18,22 [15] )
+Generated Location: (677:19,22 [15] )
 |NestedDelegates|
 
 Source Location: (2:0,2 [44] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |
     Layout = "_SectionTestLayout.cshtml"
 |
-Generated Location: (950:28,2 [44] )
+Generated Location: (1026:29,2 [44] )
 |
     Layout = "_SectionTestLayout.cshtml"
 |
 
 Source Location: (123:7,22 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |thing|
-Generated Location: (1206:35,22 [5] )
+Generated Location: (1282:36,22 [5] )
 |thing|
 
 Source Location: (260:15,6 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | Func<dynamic, object> f = |
-Generated Location: (1527:44,6 [27] )
+Generated Location: (1603:45,6 [27] )
 | Func<dynamic, object> f = |
 
 Source Location: (295:15,41 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |item|
-Generated Location: (1818:50,41 [4] )
+Generated Location: (1894:51,41 [4] )
 |item|
 
 Source Location: (306:15,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |; |
-Generated Location: (2023:57,52 [2] )
+Generated Location: (2099:58,52 [2] )
 |; |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Sections_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SimpleTagHelpers_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (425:10,38 [15] )
+Generated Location: (501:11,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SimpleTagHelpers_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", "Hello", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SimpleUnspacedIf_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (1:0,1 [15] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |if (true)
 {
 	|
-Generated Location: (658:16,1 [15] )
+Generated Location: (734:17,1 [15] )
 |if (true)
 {
 	|
@@ -10,7 +10,7 @@ Generated Location: (658:16,1 [15] )
 Source Location: (27:2,12 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf.cshtml)
 |
 }|
-Generated Location: (813:23,15 [3] )
+Generated Location: (889:24,15 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SimpleUnspacedIf_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelperWithNewlineBeforeAttributes_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (450:10,37 [17] )
+Generated Location: (526:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (67:3,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml)
 |1337|
-Generated Location: (1039:22,33 [4] )
+Generated Location: (1115:23,33 [4] )
 |1337|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelperWithNewlineBeforeAttributes_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelper_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (423:10,37 [17] )
+Generated Location: (499:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (63:2,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml)
 |1337|
-Generated Location: (985:22,33 [4] )
+Generated Location: (1061:23,33 [4] )
 |1337|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SingleTagHelper_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_StringLiterals_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (2022:85,9 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml)
 |WriteLiteralsToInHere|
-Generated Location: (407:10,22 [21] )
+Generated Location: (483:11,22 [21] )
 |WriteLiteralsToInHere|
 
 Source Location: (5701:205,9 [25] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml)
 |WriteLiteralsToInHereAlso|
-Generated Location: (520:14,22 [25] )
+Generated Location: (596:15,22 [25] )
 |WriteLiteralsToInHereAlso|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_StringLiterals_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SymbolBoundAttributes_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |*, TestAssembly|
-Generated Location: (430:10,38 [15] )
+Generated Location: (506:11,38 [15] )
 |*, TestAssembly|
 
 Source Location: (302:11,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1039:22,46 [5] )
+Generated Location: (1115:23,46 [5] )
 |items|
 
 Source Location: (351:12,20 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1332:28,47 [5] )
+Generated Location: (1408:29,47 [5] )
 |items|
 
 Source Location: (405:13,23 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (1621:34,43 [13] )
+Generated Location: (1697:35,43 [13] )
 |doSomething()|
 
 Source Location: (487:14,24 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (1918:40,43 [13] )
+Generated Location: (1994:41,43 [13] )
 |doSomething()|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SymbolBoundAttributes_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("[item]", new global::Microsoft.AspNetCore.Html.HtmlString("items"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersInSection_Runtime
     {
         #line hidden

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithBoundAttributes_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml)
 |*, TestAssembly|
-Generated Location: (438:10,38 [15] )
+Generated Location: (514:11,38 [15] )
 |*, TestAssembly|
 
 Source Location: (57:2,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml)
 |Hello|
-Generated Location: (958:22,18 [5] )
+Generated Location: (1034:23,18 [5] )
 |Hello|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithBoundAttributes_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithPrefix_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |*, TestAssembly|
-Generated Location: (429:10,38 [15] )
+Generated Location: (505:11,38 [15] )
 |*, TestAssembly|
 
 Source Location: (48:1,17 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |cool:|
-Generated Location: (546:14,38 [5] )
+Generated Location: (622:15,38 [5] )
 |cool:|
 
 Source Location: (86:3,23 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |Hello|
-Generated Location: (1052:26,23 [5] )
+Generated Location: (1128:27,23 [5] )
 |Hello|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithPrefix_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithTemplate_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |"*, TestAssembly"|
-Generated Location: (430:10,37 [17] )
+Generated Location: (506:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (333:12,6 [66] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
@@ -8,7 +8,7 @@ Source Location: (333:12,6 [66] TestFiles/IntegrationTests/CodeGenerationIntegra
         RenderTemplate(
             "Template: ",
             |
-Generated Location: (919:22,6 [66] )
+Generated Location: (995:23,6 [66] )
 |
         RenderTemplate(
             "Template: ",
@@ -16,13 +16,13 @@ Generated Location: (919:22,6 [66] )
 
 Source Location: (427:15,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |item|
-Generated Location: (1262:31,40 [4] )
+Generated Location: (1338:32,40 [4] )
 |item|
 
 Source Location: (482:15,95 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |);
     |
-Generated Location: (1678:40,95 [8] )
+Generated Location: (1754:41,95 [8] )
 |);
     |
 
@@ -35,7 +35,7 @@ Source Location: (47:2,12 [268] TestFiles/IntegrationTests/CodeGenerationIntegra
         helperResult.WriteTo(Output, HtmlEncoder);
     }
 |
-Generated Location: (1949:49,12 [268] )
+Generated Location: (2025:50,12 [268] )
 |
     public void RenderTemplate(string title, Func<string, HelperResult> template)
     {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithTemplate_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("checkbox"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithWeirdlySpacedAttributes_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (445:10,37 [17] )
+Generated Location: (521:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (74:5,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1337|
-Generated Location: (1217:24,33 [4] )
+Generated Location: (1293:25,33 [4] )
 |1337|
 
 Source Location: (99:6,19 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |true|
-Generated Location: (1387:29,19 [4] )
+Generated Location: (1463:30,19 [4] )
 |true|
 
 Source Location: (186:10,11 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1234|
-Generated Location: (2023:39,33 [4] )
+Generated Location: (2099:40,33 [4] )
 |1234|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersWithWeirdlySpacedAttributes_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Templates_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.mappings.txt
@@ -1,118 +1,118 @@
 Source Location: (284:10,2 [34] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |
     Func<dynamic, object> foo = |
-Generated Location: (646:16,2 [34] )
+Generated Location: (722:17,2 [34] )
 |
     Func<dynamic, object> foo = |
 
 Source Location: (337:11,51 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (955:23,51 [4] )
+Generated Location: (1031:24,51 [4] )
 |item|
 
 Source Location: (349:11,63 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |;
     |
-Generated Location: (1172:30,63 [7] )
+Generated Location: (1248:31,63 [7] )
 |;
     |
 
 Source Location: (357:12,5 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |foo("")|
-Generated Location: (1304:36,6 [7] )
+Generated Location: (1380:37,6 [7] )
 |foo("")|
 
 Source Location: (364:12,12 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |
 |
-Generated Location: (1369:40,24 [2] )
+Generated Location: (1445:41,24 [2] )
 |
 |
 
 Source Location: (379:16,2 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10, |
-Generated Location: (1465:43,6 [11] )
+Generated Location: (1541:44,6 [11] )
 |Repeat(10, |
 
 Source Location: (402:16,25 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (1680:45,25 [4] )
+Generated Location: (1756:46,25 [4] )
 |item|
 
 Source Location: (411:16,34 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (1722:50,1 [1] )
+Generated Location: (1798:51,1 [1] )
 |)|
 
 Source Location: (430:20,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (1849:55,6 [16] )
+Generated Location: (1925:56,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (463:21,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2065:58,21 [4] )
+Generated Location: (2141:59,21 [4] )
 |item|
 
 Source Location: (484:22,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2107:63,1 [1] )
+Generated Location: (2183:64,1 [1] )
 |)|
 
 Source Location: (501:26,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (2234:68,6 [16] )
+Generated Location: (2310:69,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (535:27,22 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2451:71,22 [4] )
+Generated Location: (2527:72,22 [4] )
 |item|
 
 Source Location: (557:28,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2493:76,1 [1] )
+Generated Location: (2569:77,1 [1] )
 |)|
 
 Source Location: (574:32,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (2620:81,6 [16] )
+Generated Location: (2696:82,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (609:33,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2838:84,23 [4] )
+Generated Location: (2914:85,23 [4] )
 |item|
 
 Source Location: (631:34,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2880:89,1 [1] )
+Generated Location: (2956:90,1 [1] )
 |)|
 
 Source Location: (655:39,5 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10, |
-Generated Location: (3007:94,6 [11] )
+Generated Location: (3083:95,6 [11] )
 |Repeat(10, |
 
 Source Location: (688:40,15 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (3212:96,15 [4] )
+Generated Location: (3288:97,15 [4] )
 |item|
 
 Source Location: (704:41,10 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |var parent = item;|
-Generated Location: (3346:101,10 [18] )
+Generated Location: (3422:102,10 [18] )
 |var parent = item;|
 
 Source Location: (863:46,9 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (3401:106,1 [1] )
+Generated Location: (3477:107,1 [1] )
 |)|
 
 Source Location: (12:0,12 [265] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
@@ -125,7 +125,7 @@ Source Location: (12:0,12 [265] TestFiles/IntegrationTests/CodeGenerationIntegra
         });
     }
 |
-Generated Location: (3582:113,12 [265] )
+Generated Location: (3658:114,12 [265] )
 |
     public HelperResult Repeat(int times, Func<int, object> template) {
         return new HelperResult((writer) => {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Templates_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TransitionsInTagHelperAttributes_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (440:10,37 [17] )
+Generated Location: (516:11,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (35:1,2 [59] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
@@ -8,7 +8,7 @@ Source Location: (35:1,2 [59] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var @class = "container-fluid";
     var @int = 1;
 |
-Generated Location: (893:21,2 [59] )
+Generated Location: (969:22,2 [59] )
 | 
     var @class = "container-fluid";
     var @int = 1;
@@ -16,101 +16,101 @@ Generated Location: (893:21,2 [59] )
 
 Source Location: (122:6,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |1337|
-Generated Location: (1219:29,33 [4] )
+Generated Location: (1295:30,33 [4] )
 |1337|
 
 Source Location: (157:7,12 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (1472:35,12 [6] )
+Generated Location: (1548:36,12 [6] )
 |@class|
 
 Source Location: (171:7,26 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42|
-Generated Location: (1653:40,33 [2] )
+Generated Location: (1729:41,33 [2] )
 |42|
 
 Source Location: (202:8,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42|
-Generated Location: (1925:46,33 [2] )
+Generated Location: (2001:47,33 [2] )
 |42|
 
 Source Location: (204:8,23 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | +|
-Generated Location: (1927:46,35 [2] )
+Generated Location: (2003:47,35 [2] )
 | +|
 
 Source Location: (206:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | |
-Generated Location: (1929:46,37 [1] )
+Generated Location: (2005:47,37 [1] )
 | |
 
 Source Location: (207:8,26 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
-Generated Location: (1930:46,38 [1] )
+Generated Location: (2006:47,38 [1] )
 |@|
 
 Source Location: (208:8,27 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (1931:46,39 [3] )
+Generated Location: (2007:47,39 [3] )
 |int|
 
 Source Location: (241:9,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (2205:52,33 [3] )
+Generated Location: (2281:53,33 [3] )
 |int|
 
 Source Location: (274:10,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |(|
-Generated Location: (2479:58,33 [1] )
+Generated Location: (2555:59,33 [1] )
 |(|
 
 Source Location: (275:10,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int|
-Generated Location: (2480:58,34 [4] )
+Generated Location: (2556:59,34 [4] )
 |@int|
 
 Source Location: (279:10,27 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (2484:58,38 [1] )
+Generated Location: (2560:59,38 [1] )
 |)|
 
 Source Location: (307:11,19 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (2742:64,19 [6] )
+Generated Location: (2818:65,19 [6] )
 |@class|
 
 Source Location: (321:11,33 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |4|
-Generated Location: (2924:69,33 [1] )
+Generated Location: (3000:70,33 [1] )
 |4|
 
 Source Location: (322:11,34 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | *|
-Generated Location: (2925:69,34 [2] )
+Generated Location: (3001:70,34 [2] )
 | *|
 
 Source Location: (324:11,36 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | |
-Generated Location: (2927:69,36 [1] )
+Generated Location: (3003:70,36 [1] )
 | |
 
 Source Location: (325:11,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
-Generated Location: (2928:69,37 [1] )
+Generated Location: (3004:70,37 [1] )
 |@|
 
 Source Location: (326:11,38 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |(|
-Generated Location: (2929:69,38 [1] )
+Generated Location: (3005:70,38 [1] )
 |(|
 
 Source Location: (327:11,39 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int + 2|
-Generated Location: (2930:69,39 [8] )
+Generated Location: (3006:70,39 [8] )
 |@int + 2|
 
 Source Location: (335:11,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (2938:69,47 [1] )
+Generated Location: (3014:70,47 [1] )
 |)|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TransitionsInTagHelperAttributes_Runtime
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("test"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_UnfinishedExpressionInCode_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (2:0,2 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml)
 |
 |
-Generated Location: (589:15,14 [2] )
+Generated Location: (665:16,14 [2] )
 |
 |
 
 Source Location: (5:1,1 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml)
 |DateTime.|
-Generated Location: (701:18,6 [9] )
+Generated Location: (777:19,6 [9] )
 |DateTime.|
 
 Source Location: (14:1,10 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml)
 |
 |
-Generated Location: (766:22,22 [2] )
+Generated Location: (842:23,22 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_Runtime.codegen.cs
@@ -4,6 +4,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_UnfinishedExpressionInCode_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.codegen.cs
@@ -32,6 +32,7 @@ using static global::System.Text.Encoding;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Usings_DesignTime
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.mappings.txt
@@ -30,11 +30,11 @@ Generated Location: (897:30,0 [41] )
 
 Source Location: (197:8,29 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
 |typeof(Path).FullName|
-Generated Location: (1489:45,29 [21] )
+Generated Location: (1565:46,29 [21] )
 |typeof(Path).FullName|
 
 Source Location: (259:9,35 [20] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
 |typeof(Foo).FullName|
-Generated Location: (1662:50,35 [20] )
+Generated Location: (1738:51,35 [20] )
 |typeof(Foo).FullName|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_Runtime.codegen.cs
@@ -33,6 +33,7 @@ using static global::System.Text.Encoding;
 
 #line default
 #line hidden
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Usings_Runtime
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.codegen.cs
@@ -3,6 +3,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class TestFiles_IntegrationTests_ExtensibleDirectiveTest_NamespaceToken
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (8:0,8 [20] TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.cshtml)
 |System.Globalization|
-Generated Location: (412:10,44 [20] )
+Generated Location: (488:11,44 [20] )
 |System.Globalization|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
@@ -4,6 +4,7 @@ namespace Razor
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Template
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", "Hello", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithBaseType.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithBaseType.codegen.cs
@@ -4,6 +4,7 @@ namespace Razor
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Template : MyBaseType
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithConfigureClass.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithConfigureClass.codegen.cs
@@ -4,6 +4,7 @@ namespace Razor
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     protected internal class MyClass : CustomBaseType, global::System.IDisposable
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithDefaults.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithDefaults.codegen.cs
@@ -4,6 +4,7 @@ namespace Razor
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Template
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithSetNamespace.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithSetNamespace.codegen.cs
@@ -4,6 +4,7 @@ namespace MyApp.Razor.Views
     #line hidden
     using System;
     using System.Threading.Tasks;
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Template
     {
         #pragma warning disable 1998


### PR DESCRIPTION
- This will stop Visual Studio and other IDEs from manifesting code generated classes when they don't need to be.
- Re-generated test file baselines.

#1237