### PR TITLE
Enable TagHelper directives to handle malformed text.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinderSyntaxTreePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinderSyntaxTreePass.cs
@@ -345,7 +345,8 @@ namespace Microsoft.AspNetCore.Razor.Language
                 TagHelperDirectiveType directiveType)
             {
                 directiveText = directiveText.Trim();
-                if (directiveText.StartsWith("\"", StringComparison.Ordinal) &&
+                if (directiveText.Length >= 2 &&
+                    directiveText.StartsWith("\"", StringComparison.Ordinal) &&
                     directiveText.EndsWith("\"", StringComparison.Ordinal))
                 {
                     directiveText = directiveText.Substring(1, directiveText.Length - 2);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TagHelperBinderSyntaxTreePassTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TagHelperBinderSyntaxTreePassTest.cs
@@ -14,6 +14,132 @@ namespace Microsoft.AspNetCore.Razor.Language
     public class TagHelperBinderSyntaxTreePassTest
     {
         [Fact]
+        public void Execute_CanHandleSingleLengthAddTagHelperDirective()
+        {
+            // Arrange
+            var engine = RazorEngine.Create(builder =>
+            {
+                builder.AddTagHelpers(new TagHelperDescriptor[0]);
+            });
+
+            var pass = new TagHelperBinderSyntaxTreePass()
+            {
+                Engine = engine,
+            };
+            var expectedDiagnostics = new[]
+            {
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.ParseError_Unterminated_String_Literal,
+                        new SourceLocation(16, 1, 14),
+                        length: 1)),
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        Resources.FormatInvalidTagHelperLookupText("\""),
+                        new SourceLocation(16, 1, 14),
+                        length: 1))
+            };
+                
+
+            var content =
+            @"
+@addTagHelper """;
+            var sourceDocument = TestRazorSourceDocument.Create(content, fileName: null);
+            var codeDocument = RazorCodeDocument.Create(sourceDocument);
+            var originalTree = RazorSyntaxTree.Parse(sourceDocument);
+
+            // Act
+            var rewrittenTree = pass.Execute(codeDocument, originalTree);
+
+            // Assert
+            Assert.Equal(expectedDiagnostics, rewrittenTree.Diagnostics);
+        }
+
+        [Fact]
+        public void Execute_CanHandleSingleLengthRemoveTagHelperDirective()
+        {
+            // Arrange
+            var engine = RazorEngine.Create(builder =>
+            {
+                builder.AddTagHelpers(new TagHelperDescriptor[0]);
+            });
+
+            var pass = new TagHelperBinderSyntaxTreePass()
+            {
+                Engine = engine,
+            };
+            var expectedDiagnostics = new[]
+            {
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.ParseError_Unterminated_String_Literal,
+                        new SourceLocation(19, 1, 17),
+                        length: 1)),
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        Resources.FormatInvalidTagHelperLookupText("\""),
+                        new SourceLocation(19, 1, 17),
+                        length: 1))
+            };
+
+
+            var content =
+            @"
+@removeTagHelper """;
+            var sourceDocument = TestRazorSourceDocument.Create(content, fileName: null);
+            var codeDocument = RazorCodeDocument.Create(sourceDocument);
+            var originalTree = RazorSyntaxTree.Parse(sourceDocument);
+
+            // Act
+            var rewrittenTree = pass.Execute(codeDocument, originalTree);
+
+            // Assert
+            Assert.Equal(expectedDiagnostics, rewrittenTree.Diagnostics);
+        }
+
+        [Fact]
+        public void Execute_CanHandleSingleLengthTagHelperPrefix()
+        {
+            // Arrange
+            var engine = RazorEngine.Create(builder =>
+            {
+                builder.AddTagHelpers(new TagHelperDescriptor[0]);
+            });
+
+            var pass = new TagHelperBinderSyntaxTreePass()
+            {
+                Engine = engine,
+            };
+            var expectedDiagnostics = new[]
+            {
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.ParseError_Unterminated_String_Literal,
+                        new SourceLocation(19, 1, 17),
+                        length: 1)),
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        Resources.FormatInvalidTagHelperPrefixValue("tagHelperPrefix", "\"", "\""),
+                        new SourceLocation(19, 1, 17),
+                        length: 1))
+            };
+
+
+            var content =
+            @"
+@tagHelperPrefix """;
+            var sourceDocument = TestRazorSourceDocument.Create(content, fileName: null);
+            var codeDocument = RazorCodeDocument.Create(sourceDocument);
+            var originalTree = RazorSyntaxTree.Parse(sourceDocument);
+
+            // Act
+            var rewrittenTree = pass.Execute(codeDocument, originalTree);
+
+            // Assert
+            Assert.Equal(expectedDiagnostics, rewrittenTree.Diagnostics);
+        }
+
+        [Fact]
         public void Execute_RewritesTagHelpers()
         {
             // Arrange


### PR DESCRIPTION
- Prior to this change we'd try to substring a TagHelper directive with length 1 but our substring call would be for -1 (explosions).
- Added tests to validate that `@tagHelperPrefix`, `@removeTagHelper` and `@addTagHelper` all behave properly when they have malformed quotes.

#1242