### PR TITLE
Change `GetImports` to allow querying of information on non-existent files.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/RazorTemplateEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorTemplateEngine.cs
@@ -182,12 +182,6 @@ namespace Microsoft.AspNetCore.Razor.Language
             {
                 throw new ArgumentNullException(nameof(projectItem));
             }
-
-            if (!projectItem.Exists)
-            {
-                throw new InvalidOperationException(Resources.FormatRazorTemplateEngine_ItemCouldNotBeFound(projectItem.Path));
-            }
-
             var result = new List<RazorSourceDocument>();
 
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorTemplateEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorTemplateEngineTest.cs
@@ -12,6 +12,53 @@ namespace Microsoft.AspNetCore.Razor.Language
     public class RazorTemplateEngineTest
     {
         [Fact]
+        public void GetImports_CanQueryInformationOnNonExistentFileWithoutImports()
+        {
+            // Arrange
+            var project = new TestRazorProject();
+            var razorEngine = RazorEngine.Create();
+            var templateEngine = new RazorTemplateEngine(razorEngine, project)
+            {
+                Options =
+                {
+                    ImportsFileName = "MyImport.cshtml"
+                }
+            };
+            var projectItemToQuery = project.GetItem("/Views/Home/Index.cshtml");
+
+            // Act
+            var imports = templateEngine.GetImports(projectItemToQuery);
+
+            // Assert
+            Assert.Empty(imports);
+        }
+
+        [Fact]
+        public void GetImports_CanQueryInformationOnNonExistentFileWithImports()
+        {
+            // Arrange
+            var path = "/Views/Home/MyImport.cshtml";
+            var projectItem = new TestRazorProjectItem(path);
+            var project = new TestRazorProject(new[] { projectItem });
+            var razorEngine = RazorEngine.Create();
+            var templateEngine = new RazorTemplateEngine(razorEngine, project)
+            {
+                Options =
+                {
+                    ImportsFileName = "MyImport.cshtml"
+                }
+            };
+            var projectItemToQuery = project.GetItem("/Views/Home/Index.cshtml");
+
+            // Act
+            var imports = templateEngine.GetImports(projectItemToQuery);
+
+            // Assert
+            var import = Assert.Single(imports);
+            Assert.Equal(projectItem.Path, import.FileName);
+        }
+
+        [Fact]
         public void GenerateCode_ThrowsIfItemCannotBeFound()
         {
             // Arrange


### PR DESCRIPTION
- Added tests to validate imports can still be found on non-existent files.
- End-to-end verified this test fix by quick-swapping the Razor.Language binary in VS.

#1267 