### PR TITLE
Add incomplete directive integration tests.

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -24,6 +24,21 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.IntegrationTests
 
         #region Runtime
         [Fact]
+        public void IncompleteDirectives_Runtime()
+        {
+            // Arrange
+            var engine = CreateDesignTimeEngine();
+            var document = CreateCodeDocument();
+
+            // Act
+            engine.Process(document);
+
+            // Assert
+            AssertIRMatchesBaseline(document.GetIRDocument());
+            AssertCSharpDocumentMatchesBaseline(document.GetCSharpDocument());
+        }
+
+        [Fact]
         public void InheritsViewModel_Runtime()
         {
             // Arrange
@@ -235,6 +250,20 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.IntegrationTests
         #endregion
 
         #region DesignTime
+        [Fact]
+        public void IncompleteDirectives_DesignTime()
+        {
+            // Arrange
+            var engine = CreateDesignTimeEngine();
+            var document = CreateCodeDocument();
+
+            // Act
+            engine.Process(document);
+
+            // Assert
+            AssertIRMatchesBaseline(document.GetIRDocument());
+            AssertCSharpDocumentMatchesBaseline(document.GetCSharpDocument());
+        }
 
         [Fact]
         public void InheritsViewModel_DesignTime()

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml
@@ -1,0 +1,15 @@
+﻿@* These test files validate that end-to-end, incomplete directives don't throw. *@
+
+@page
+@page 
+@page "
+
+@model
+@model 
+
+@inject
+@inject 
+@inject TypeName
+
+@namespace
+@namespace 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -1,0 +1,41 @@
+namespace 
+{
+    #line hidden
+    using TModel = global::System.Object;
+    using System;
+    using System.Threading.Tasks;
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
+    {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        ((System.Action)(() => {
+TypeName __typeHelper = null;
+        }
+        ))();
+        }
+        #pragma warning restore 219
+        private static System.Object __o = null;
+        #pragma warning disable 1998
+        public async override global::System.Threading.Tasks.Task ExecuteAsync()
+        {
+        }
+        #pragma warning restore 1998
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.ViewFeatures.IModelExpressionProvider ModelExpressionProvider { get; private set; }
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.IUrlHelper Url { get; private set; }
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.IViewComponentHelper Component { get; private set; }
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml> Html { get; private set; }
+        public global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml> ViewData => (global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml>)PageContext?.ViewData;
+        public TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml Model => ViewData.Model;
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -1,0 +1,55 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - 
+        UsingStatement -  - TModel = global::System.Object
+        UsingStatement - (1:0,1 [12] ) - System
+        UsingStatement -  - System.Threading.Tasks
+        UsingStatement - (16:1,1 [17] ) - System.Linq
+        UsingStatement - (36:2,1 [32] ) - System.Collections.Generic
+        UsingStatement - (71:3,1 [30] ) - Microsoft.AspNetCore.Mvc
+        UsingStatement - (104:4,1 [40] ) - Microsoft.AspNetCore.Mvc.Rendering
+        UsingStatement - (147:5,1 [43] ) - Microsoft.AspNetCore.Mvc.ViewFeatures
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml - global::Microsoft.AspNetCore.Mvc.RazorPages.Page - 
+            DesignTimeDirective - 
+                DirectiveToken - (200:6,8 [62] ) - global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<TModel>
+                DirectiveToken - (263:6,71 [4] ) - Html
+                DirectiveToken - (277:7,8 [54] ) - global::Microsoft.AspNetCore.Mvc.Rendering.IJsonHelper
+                DirectiveToken - (332:7,63 [4] ) - Json
+                DirectiveToken - (346:8,8 [53] ) - global::Microsoft.AspNetCore.Mvc.IViewComponentHelper
+                DirectiveToken - (400:8,62 [9] ) - Component
+                DirectiveToken - (419:9,8 [43] ) - global::Microsoft.AspNetCore.Mvc.IUrlHelper
+                DirectiveToken - (463:9,52 [3] ) - Url
+                DirectiveToken - (476:10,8 [70] ) - global::Microsoft.AspNetCore.Mvc.ViewFeatures.IModelExpressionProvider
+                DirectiveToken - (547:10,79 [23] ) - ModelExpressionProvider
+                DirectiveToken - (586:11,14 [96] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper, Microsoft.AspNetCore.Mvc.Razor
+                DirectiveToken - (698:12,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor
+                DirectiveToken - (801:13,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
+                DirectiveToken - (159:11,8 [8] IncompleteDirectives.cshtml) - TypeName
+            CSharpStatement - 
+                RazorIRToken -  - CSharp - private static System.Object __o = null;
+            RazorMethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
+                    RazorIRToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
+                HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (149:10,8 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (149:10,8 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (167:11,16 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (167:11,16 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (181:13,10 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (181:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
+            InjectDirective - 
+            InjectDirective - 
+            InjectDirective - 
+            InjectDirective - 
+            InjectDirective - 
+            CSharpStatement - 
+                RazorIRToken -  - CSharp - public global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml> ViewData => (global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml>)PageContext?.ViewData;
+            CSharpStatement - 
+                RazorIRToken -  - CSharp - public TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml Model => ViewData.Model;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
@@ -1,0 +1,41 @@
+namespace 
+{
+    #line hidden
+    using TModel = global::System.Object;
+    using System;
+    using System.Threading.Tasks;
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
+    {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        ((System.Action)(() => {
+TypeName __typeHelper = null;
+        }
+        ))();
+        }
+        #pragma warning restore 219
+        private static System.Object __o = null;
+        #pragma warning disable 1998
+        public async override global::System.Threading.Tasks.Task ExecuteAsync()
+        {
+        }
+        #pragma warning restore 1998
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.ViewFeatures.IModelExpressionProvider ModelExpressionProvider { get; private set; }
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.IUrlHelper Url { get; private set; }
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.IViewComponentHelper Component { get; private set; }
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.Rendering.IJsonHelper Json { get; private set; }
+        [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+        public global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml> Html { get; private set; }
+        public global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml> ViewData => (global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml>)PageContext?.ViewData;
+        public TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml Model => ViewData.Model;
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -1,0 +1,55 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - 
+        UsingStatement -  - TModel = global::System.Object
+        UsingStatement - (1:0,1 [12] ) - System
+        UsingStatement -  - System.Threading.Tasks
+        UsingStatement - (16:1,1 [17] ) - System.Linq
+        UsingStatement - (36:2,1 [32] ) - System.Collections.Generic
+        UsingStatement - (71:3,1 [30] ) - Microsoft.AspNetCore.Mvc
+        UsingStatement - (104:4,1 [40] ) - Microsoft.AspNetCore.Mvc.Rendering
+        UsingStatement - (147:5,1 [43] ) - Microsoft.AspNetCore.Mvc.ViewFeatures
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml - global::Microsoft.AspNetCore.Mvc.RazorPages.Page - 
+            DesignTimeDirective - 
+                DirectiveToken - (200:6,8 [62] ) - global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<TModel>
+                DirectiveToken - (263:6,71 [4] ) - Html
+                DirectiveToken - (277:7,8 [54] ) - global::Microsoft.AspNetCore.Mvc.Rendering.IJsonHelper
+                DirectiveToken - (332:7,63 [4] ) - Json
+                DirectiveToken - (346:8,8 [53] ) - global::Microsoft.AspNetCore.Mvc.IViewComponentHelper
+                DirectiveToken - (400:8,62 [9] ) - Component
+                DirectiveToken - (419:9,8 [43] ) - global::Microsoft.AspNetCore.Mvc.IUrlHelper
+                DirectiveToken - (463:9,52 [3] ) - Url
+                DirectiveToken - (476:10,8 [70] ) - global::Microsoft.AspNetCore.Mvc.ViewFeatures.IModelExpressionProvider
+                DirectiveToken - (547:10,79 [23] ) - ModelExpressionProvider
+                DirectiveToken - (586:11,14 [96] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper, Microsoft.AspNetCore.Mvc.Razor
+                DirectiveToken - (698:12,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor
+                DirectiveToken - (801:13,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
+                DirectiveToken - (159:11,8 [8] IncompleteDirectives.cshtml) - TypeName
+            CSharpStatement - 
+                RazorIRToken -  - CSharp - private static System.Object __o = null;
+            RazorMethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
+                    RazorIRToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
+                HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (149:10,8 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (149:10,8 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (167:11,16 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (167:11,16 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (181:13,10 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (181:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
+            InjectDirective - 
+            InjectDirective - 
+            InjectDirective - 
+            InjectDirective - 
+            InjectDirective - 
+            CSharpStatement - 
+                RazorIRToken -  - CSharp - public global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml> ViewData => (global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml>)PageContext?.ViewData;
+            CSharpStatement - 
+                RazorIRToken -  - CSharp - public TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml Model => ViewData.Model;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -10,6 +10,21 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
     {
         #region Runtime
         [Fact]
+        public void IncompleteDirectives_Runtime()
+        {
+            // Arrange
+            var engine = RazorEngine.Create(builder => builder.Features.Add(new ApiSetsIRTestAdapter()));
+            var document = CreateCodeDocument();
+
+            // Act
+            engine.Process(document);
+
+            // Assert
+            AssertIRMatchesBaseline(document.GetIRDocument());
+            AssertCSharpDocumentMatchesBaseline(document.GetCSharpDocument());
+        }
+
+        [Fact]
         public void CSharp7_Runtime()
         {
             // Arrange
@@ -793,6 +808,21 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
         #endregion
 
         #region DesignTime
+        [Fact]
+        public void IncompleteDirectives_DesignTime()
+        {
+            // Arrange
+            var engine = RazorEngine.CreateDesignTime(builder => builder.Features.Add(new ApiSetsIRTestAdapter()));
+            var document = CreateCodeDocument();
+
+            // Act
+            engine.Process(document);
+
+            // Assert
+            AssertIRMatchesBaseline(document.GetIRDocument());
+            AssertDesignTimeDocumentMatchBaseline(document);
+        }
+
         [Fact]
         public void CSharp7_DesignTime()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml
@@ -1,0 +1,25 @@
+﻿@* These test files validate that end-to-end, incomplete directives don't throw. *@
+
+@addTagHelper
+@addTagHelper 
+@addTagHelper "
+
+@removeTagHelper
+@removeTagHelper 
+@removeTagHelper "
+
+@tagHelperPrefix
+@tagHelperPrefix 
+@tagHelperPrefix "
+
+@inherits
+@inherits 
+
+@functions
+@functions 
+
+@section
+@section 
+
+@section {
+@functions {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -1,0 +1,61 @@
+namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
+{
+    #line hidden
+    using System;
+    using System.Threading.Tasks;
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_DesignTime
+    {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        ((System.Action)(() => {
+global::System.Object __typeHelper = "";
+        }
+        ))();
+        ((System.Action)(() => {
+global::System.Object __typeHelper = "";
+        }
+        ))();
+        ((System.Action)(() => {
+global::System.Object __typeHelper = ";
+        }
+        ))();
+        ((System.Action)(() => {
+global::System.Object __typeHelper = "";
+        }
+        ))();
+        ((System.Action)(() => {
+global::System.Object __typeHelper = "";
+        }
+        ))();
+        ((System.Action)(() => {
+global::System.Object __typeHelper = ";
+        }
+        ))();
+        ((System.Action)(() => {
+global::System.Object __typeHelper = "";
+        }
+        ))();
+        ((System.Action)(() => {
+global::System.Object __typeHelper = "";
+        }
+        ))();
+        ((System.Action)(() => {
+global::System.Object __typeHelper = ";
+        }
+        ))();
+        }
+        #pragma warning restore 219
+        private static System.Object __o = null;
+        #pragma warning disable 1998
+        public async System.Threading.Tasks.Task ExecuteAsync()
+        {
+            DefineSection("", async (__razor_section_writer) => {
+            });
+            DefineSection("", async (__razor_section_writer) => {
+            });
+            DefineSection("", async (__razor_section_writer) => {
+            });
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -1,0 +1,61 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_DesignTime -  - 
+            DesignTimeDirective - 
+                DirectiveToken - (100:2,13 [0] IncompleteDirectives.cshtml) - 
+                DirectiveToken - (116:3,14 [0] IncompleteDirectives.cshtml) - 
+                DirectiveToken - (132:4,14 [1] IncompleteDirectives.cshtml) - "
+                DirectiveToken - (153:6,16 [0] IncompleteDirectives.cshtml) - 
+                DirectiveToken - (172:7,17 [0] IncompleteDirectives.cshtml) - 
+                DirectiveToken - (191:8,17 [1] IncompleteDirectives.cshtml) - "
+                DirectiveToken - (212:10,16 [0] IncompleteDirectives.cshtml) - 
+                DirectiveToken - (231:11,17 [0] IncompleteDirectives.cshtml) - 
+                DirectiveToken - (250:12,17 [1] IncompleteDirectives.cshtml) - "
+            CSharpStatement - 
+                RazorIRToken -  - CSharp - private static System.Object __o = null;
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (100:2,13 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (100:2,13 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (116:3,14 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (116:3,14 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (133:4,15 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (133:4,15 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (153:6,16 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (153:6,16 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (172:7,17 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (172:7,17 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (192:8,18 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (192:8,18 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (212:10,16 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (212:10,16 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (231:11,17 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (231:11,17 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (251:12,18 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (251:12,18 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (264:14,9 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (264:14,9 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (276:15,10 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (276:15,10 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - DefineSection("", async (__razor_section_writer) => {
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - });
+                HtmlContent - (315:20,8 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (315:20,8 [2] IncompleteDirectives.cshtml) - Html - \n
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - DefineSection("", async (__razor_section_writer) => {
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - });
+                HtmlContent - (326:21,9 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (326:21,9 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - DefineSection("", async (__razor_section_writer) => {
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - });
+                HtmlContent - (339:23,9 [3] IncompleteDirectives.cshtml)
+                    RazorIRToken - (339:23,9 [3] IncompleteDirectives.cshtml) - Html - {\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,0 +1,45 @@
+Source Location: (100:2,13 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (429:10,38 [0] )
+||
+
+Source Location: (116:3,14 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (531:14,38 [0] )
+||
+
+Source Location: (132:4,14 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+|"|
+Generated Location: (632:18,37 [1] )
+|"|
+
+Source Location: (153:6,16 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (734:22,38 [0] )
+||
+
+Source Location: (172:7,17 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (836:26,38 [0] )
+||
+
+Source Location: (191:8,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+|"|
+Generated Location: (937:30,37 [1] )
+|"|
+
+Source Location: (212:10,16 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (1039:34,38 [0] )
+||
+
+Source Location: (231:11,17 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (1141:38,38 [0] )
+||
+
+Source Location: (250:12,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+|"|
+Generated Location: (1242:42,37 [1] )
+|"|
+

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
@@ -1,0 +1,30 @@
+#pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "df5d66431db818236f9c26c6dd920838c22ddb82"
+namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
+{
+    #line hidden
+    using System;
+    using System.Threading.Tasks;
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_Runtime
+    {
+        #pragma warning disable 1998
+        public async System.Threading.Tasks.Task ExecuteAsync()
+        {
+            WriteLiteral("\r\n\r\n");
+            WriteLiteral("\r\n");
+            WriteLiteral("\r\n");
+            WriteLiteral("\r\n");
+            WriteLiteral("\r\n");
+            WriteLiteral("\r\n\r\n");
+            DefineSection("", async () => {
+            });
+            WriteLiteral("\r\n");
+            DefineSection("", async () => {
+            });
+            WriteLiteral("\r\n\r\n");
+            DefineSection("", async () => {
+            });
+            WriteLiteral("{\r\n");
+        }
+        #pragma warning restore 1998
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -1,0 +1,37 @@
+Document - 
+    Checksum - 
+    NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
+        UsingStatement -  - System
+        UsingStatement -  - System.Threading.Tasks
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_Runtime -  - 
+            RazorMethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
+                HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                HtmlContent - (135:5,0 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (135:5,0 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (194:9,0 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (194:9,0 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (253:13,0 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (253:13,0 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (264:14,9 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (264:14,9 [2] IncompleteDirectives.cshtml) - Html - \n
+                HtmlContent - (276:15,10 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (276:15,10 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - DefineSection("", async () => {
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - });
+                HtmlContent - (315:20,8 [2] IncompleteDirectives.cshtml)
+                    RazorIRToken - (315:20,8 [2] IncompleteDirectives.cshtml) - Html - \n
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - DefineSection("", async () => {
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - });
+                HtmlContent - (326:21,9 [4] IncompleteDirectives.cshtml)
+                    RazorIRToken - (326:21,9 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - DefineSection("", async () => {
+                CSharpStatement - 
+                    RazorIRToken -  - CSharp - });
+                HtmlContent - (339:23,9 [3] IncompleteDirectives.cshtml)
+                    RazorIRToken - (339:23,9 [3] IncompleteDirectives.cshtml) - Html - {\n


### PR DESCRIPTION
- These tests validate that our extensible directives do not have code that explodes when an incomplete directive is encountered. This is typically the case when a user is in the midst of typing a directive at design time.
- Added an extensions test and a language test.

#1271