### PR TITLE
Limit memory allocation when translating 'RazorIRToken' of type HTMLRazorIR to C# code.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RedirectedRuntimeBasicWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RedirectedRuntimeBasicWriter.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             linePragmaScope?.Dispose();
         }
 
-        protected override void WriteHtmlContentStartMethodInvocation(CSharpRenderingContext context, string methodName)
+        protected override void WriteHtmlContentStartMethodInvocation(CSharpRenderingContext context)
         {
             context.Writer
                 .WriteStartMethodInvocation(WriteHtmlContentMethod)

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RedirectedRuntimeBasicWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RedirectedRuntimeBasicWriter.cs
@@ -62,46 +62,12 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             linePragmaScope?.Dispose();
         }
 
-        public override void WriteHtmlContent(CSharpRenderingContext context, HtmlContentIRNode node)
+        protected override void WriteHtmlContentStartMethodInvocation(CSharpRenderingContext context, string methodName)
         {
-            const int MaxStringLiteralLength = 1024;
-
-            var builder = new StringBuilder();
-            for (var i = 0; i < node.Children.Count; i++)
-            {
-                if (node.Children[i] is RazorIRToken token && token.IsHtml)
-                {
-                    builder.Append(token.Content);
-                }
-            }
-
-            var content = builder.ToString();
-
-            var charactersConsumed = 0;
-
-            // Render the string in pieces to avoid Roslyn OOM exceptions at compile time: https://github.com/aspnet/External/issues/54
-            while (charactersConsumed < content.Length)
-            {
-                string textToRender;
-                if (content.Length <= MaxStringLiteralLength)
-                {
-                    textToRender = content;
-                }
-                else
-                {
-                    var charactersToSubstring = Math.Min(MaxStringLiteralLength, content.Length - charactersConsumed);
-                    textToRender = content.Substring(charactersConsumed, charactersToSubstring);
-                }
-
-                context.Writer
-                    .WriteStartMethodInvocation(WriteHtmlContentMethod)
-                    .Write(_textWriter)
-                    .WriteParameterSeparator()
-                    .WriteStringLiteral(textToRender)
-                    .WriteEndMethodInvocation();
-
-                    charactersConsumed += textToRender.Length;
-            }
+            context.Writer
+                .WriteStartMethodInvocation(WriteHtmlContentMethod)
+                .Write(_textWriter)
+                .WriteParameterSeparator();
         }
 
         public override void WriteHtmlAttribute(CSharpRenderingContext context, HtmlAttributeIRNode node)

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeBasicWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeBasicWriter.cs
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
                     {
                         if (!insideWrite)
                         {
-                            WriteHtmlContentStartMethodInvocation(context, WriteHtmlContentMethod);
+                            WriteHtmlContentStartMethodInvocation(context);
                             stringLiteralWriter = context.Writer.BuildStringLiteralWriter();
                             insideWrite = true;
                         }
@@ -286,9 +286,9 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             }
         }
 
-        protected virtual void WriteHtmlContentStartMethodInvocation(CSharpRenderingContext context, string methodName)
+        protected virtual void WriteHtmlContentStartMethodInvocation(CSharpRenderingContext context)
         {
-            context.Writer.WriteStartMethodInvocation(methodName);
+            context.Writer.WriteStartMethodInvocation(WriteHtmlContentMethod);
         }
 
         protected virtual void WriteHtmlContentEndMethodInvocation(CSharpRenderingContext context)

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeWriter.cs
@@ -191,11 +191,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return this;
         }
 
-        public StringLiteralWriter BuildStringLiteralWriter()
-        {
-            return new StringLiteralWriter(this);
-        }
-
         public CSharpCodeWriter WriteLineHiddenDirective()
         {
             return WriteLine("#line hidden");
@@ -654,47 +649,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
             public void Dispose()
             {
-            }
-        }
-
-        public struct StringLiteralWriter : IDisposable
-        {
-            private readonly CSharpCodeWriter _writer;
-
-            internal StringLiteralWriter(CSharpCodeWriter writer)
-            {
-                _writer = writer;
-                _writer.Write("@\"");
-            }
-
-            public void Write(string literalPart)
-            {
-                Write(literalPart, 0, literalPart.Length);
-            }
-
-            public void Write(string literalPart, int startIndex, int length)
-            {
-                // We need to find the index of each '"' (double-quote) to escape it.
-                var start = startIndex;
-                int end;
-                while ((end = literalPart.IndexOf('\"', start, length - (start - startIndex))) > -1)
-                {
-                    _writer.Write(literalPart, start, end - start);
-
-                    _writer.Write("\"\"");
-
-                    start = end + 1;
-                }
-
-                Debug.Assert(end == -1); // We've hit all of the double-quotes.
-
-                // Write the remainder after the last double-quote.
-                _writer.Write(literalPart, start, startIndex + length - start);
-            }
-
-            public void Dispose()
-            {
-                _writer.Write("\"");
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_Runtime.codegen.cs
@@ -15,7 +15,7 @@ namespace AspNetCore
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             BeginContext(0, 4, true);
-            WriteLiteral("<div");
+            WriteLiteral(@"<div");
             EndContext();
             BeginWriteAttribute("class", " class=\"", 4, "\"", 17, 1);
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml"
@@ -25,7 +25,9 @@ WriteAttributeValue("", 12, logo, 12, 5, false);
 #line hidden
             EndWriteAttribute();
             BeginContext(18, 24, true);
-            WriteLiteral(">\r\n    Hello world\r\n    ");
+            WriteLiteral(@">
+    Hello world
+    ");
             EndContext();
             BeginContext(43, 21, false);
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml"
@@ -35,7 +37,8 @@ Write(Html.Input("SomeKey"));
 #line hidden
             EndContext();
             BeginContext(64, 8, true);
-            WriteLiteral("\r\n</div>");
+            WriteLiteral(@"
+</div>");
             EndContext();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.codegen.cs
@@ -15,7 +15,10 @@ namespace AspNetCore
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             BeginContext(6, 49, true);
-            WriteLiteral("\"foo\r\n\r\n<h1>About Us</h1>\r\n<p>We are awesome.</p>");
+            WriteLiteral(@"""foo
+
+<h1>About Us</h1>
+<p>We are awesome.</p>");
             EndContext();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
@@ -34,10 +34,12 @@ namespace AspNetCore
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             BeginContext(17, 2, true);
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             EndContext();
             BeginContext(143, 2, true);
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
@@ -60,7 +62,8 @@ __Microsoft_AspNetCore_Mvc_Razor_Extensions_InputTestTagHelper.For = ModelExpres
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             EndContext();
             BeginContext(169, 2, true);
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input-test", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
@@ -83,7 +86,8 @@ __Microsoft_AspNetCore_Mvc_Razor_Extensions_InputTestTagHelper.For = ModelExpres
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             EndContext();
             BeginContext(198, 2, true);
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             EndContext();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_Runtime.codegen.cs
@@ -15,7 +15,8 @@ namespace Test.Namespace
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             BeginContext(34, 20, true);
-            WriteLiteral("<h1>Hi There!</h1>\r\n");
+            WriteLiteral(@"<h1>Hi There!</h1>
+");
             EndContext();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
@@ -43,13 +43,18 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             BeginContext(7, 2, true);
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             EndContext();
             BeginContext(86, 2, true);
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             EndContext();
             BeginContext(386, 75, true);
-            WriteLiteral("\r\n<h1>New Customer</h1>\r\n<form method=\"post\" class=\"form-horizontal\">\r\n    ");
+            WriteLiteral(@"
+<h1>New Customer</h1>
+<form method=""post"" class=""form-horizontal"">
+    ");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
@@ -67,11 +72,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             EndContext();
             BeginContext(492, 6, true);
-            WriteLiteral("\r\n    ");
+            WriteLiteral(@"
+    ");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 BeginContext(522, 48, true);
-                WriteLiteral("\r\n        <label class=\"col-md-2 control-label\">");
+                WriteLiteral(@"
+        <label class=""col-md-2 control-label"">");
                 EndContext();
                 BeginContext(571, 4, false);
 #line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml"
@@ -81,11 +88,15 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 #line hidden
                 EndContext();
                 BeginContext(575, 18, true);
-                WriteLiteral("</label>\r\n        ");
+                WriteLiteral(@"</label>
+        ");
                 EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                     BeginContext(616, 101, true);
-                    WriteLiteral("\r\n            <input class=\"form-control\" />\r\n            <span class=\"text-danger\"></span>\r\n        ");
+                    WriteLiteral(@"
+            <input class=""form-control"" />
+            <span class=""text-danger""></span>
+        ");
                     EndContext();
                 }
                 );
@@ -102,7 +113,8 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 EndContext();
                 BeginContext(723, 6, true);
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 EndContext();
             }
             );
@@ -119,15 +131,19 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             EndContext();
             BeginContext(735, 6, true);
-            WriteLiteral("\r\n    ");
+            WriteLiteral(@"
+    ");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 BeginContext(765, 10, true);
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
                 EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                     BeginContext(814, 83, true);
-                    WriteLiteral("\r\n            <button type=\"submit\" class=\"btn btn-primary\">Save</button>\r\n        ");
+                    WriteLiteral(@"
+            <button type=""submit"" class=""btn btn-primary"">Save</button>
+        ");
                     EndContext();
                 }
                 );
@@ -144,7 +160,8 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 EndContext();
                 BeginContext(903, 6, true);
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 EndContext();
             }
             );
@@ -161,7 +178,9 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             EndContext();
             BeginContext(915, 11, true);
-            WriteLiteral("\r\n</form>\r\n");
+            WriteLiteral(@"
+</form>
+");
             EndContext();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
@@ -43,13 +43,18 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             BeginContext(7, 2, true);
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             EndContext();
             BeginContext(103, 2, true);
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             EndContext();
             BeginContext(480, 76, true);
-            WriteLiteral("\r\n<h1>New Customer</h1>\r\n<form method=\"post\" class=\"form-horizontal\" >\r\n    ");
+            WriteLiteral(@"
+<h1>New Customer</h1>
+<form method=""post"" class=""form-horizontal"" >
+    ");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
@@ -67,11 +72,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             EndContext();
             BeginContext(587, 6, true);
-            WriteLiteral("\r\n    ");
+            WriteLiteral(@"
+    ");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 BeginContext(617, 48, true);
-                WriteLiteral("\r\n        <label class=\"col-md-2 control-label\">");
+                WriteLiteral(@"
+        <label class=""col-md-2 control-label"">");
                 EndContext();
                 BeginContext(666, 4, false);
 #line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"
@@ -81,11 +88,15 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 #line hidden
                 EndContext();
                 BeginContext(670, 18, true);
-                WriteLiteral("</label>\r\n        ");
+                WriteLiteral(@"</label>
+        ");
                 EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                     BeginContext(711, 101, true);
-                    WriteLiteral("\r\n            <input class=\"form-control\" />\r\n            <span class=\"text-danger\"></span>\r\n        ");
+                    WriteLiteral(@"
+            <input class=""form-control"" />
+            <span class=""text-danger""></span>
+        ");
                     EndContext();
                 }
                 );
@@ -102,7 +113,8 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 EndContext();
                 BeginContext(818, 6, true);
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 EndContext();
             }
             );
@@ -119,15 +131,19 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             EndContext();
             BeginContext(830, 6, true);
-            WriteLiteral("\r\n    ");
+            WriteLiteral(@"
+    ");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 BeginContext(860, 10, true);
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
                 EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                     BeginContext(909, 83, true);
-                    WriteLiteral("\r\n            <button type=\"submit\" class=\"btn btn-primary\">Save</button>\r\n        ");
+                    WriteLiteral(@"
+            <button type=""submit"" class=""btn btn-primary"">Save</button>
+        ");
                     EndContext();
                 }
                 );
@@ -144,7 +160,8 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 EndContext();
                 BeginContext(998, 6, true);
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 EndContext();
             }
             );
@@ -161,7 +178,9 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             EndContext();
             BeginContext(1010, 11, true);
-            WriteLiteral("\r\n</form>\r\n");
+            WriteLiteral(@"
+</form>
+");
             EndContext();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_Runtime.codegen.cs
@@ -15,7 +15,8 @@ namespace Test.Namespace
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             BeginContext(27, 20, true);
-            WriteLiteral("<h1>Hi There!</h1>\r\n");
+            WriteLiteral(@"<h1>Hi There!</h1>
+");
             EndContext();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RedirectedRuntimeBasicWriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RedirectedRuntimeBasicWriterTest.cs
@@ -207,7 +207,7 @@ Test(test_writer, i++);
             // Assert
             var csharp = context.Writer.Builder.ToString();
             Assert.Equal(
-@"WriteLiteralTo(test_writer, ""SomeContent"");
+@"WriteLiteralTo(test_writer, @""SomeContent"");
 ",
                 csharp,
                 ignoreLineEndingDifferences: true);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RuntimeBasicWriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RuntimeBasicWriterTest.cs
@@ -454,7 +454,7 @@ if (true) { }
             // Assert
             var csharp = context.Writer.Builder.ToString();
             Assert.Equal(
-@"WriteLiteral(""SomeContent"");
+@"WriteLiteral(@""SomeContent"");
 ",
                 csharp,
                 ignoreLineEndingDifferences: true);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.codegen.cs
@@ -34,11 +34,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n    <p>");
+                WriteLiteral(@"
+    <p>");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("strong", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                    WriteLiteral("Hello");
+                    WriteLiteral(@"Hello");
                 }
                 );
                 __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
@@ -51,7 +53,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("<strong>World</strong></p>\r\n    <input checked=\"true\" />\r\n    ");
+                WriteLiteral(@"<strong>World</strong></p>
+    <input checked=""true"" />
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -76,7 +80,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -104,7 +109,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_Runtime.codegen.cs
@@ -9,83 +9,102 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<section>\r\n    <h1>Basic Asynchronous Expression Test</h1>\r\n    <p>Basic Asynchronous Expression: ");
+            WriteLiteral(@"
+<section>
+    <h1>Basic Asynchronous Expression Test</h1>
+    <p>Basic Asynchronous Expression: ");
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                  Write(await Foo());
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Basic Asynchronous Template: ");
+            WriteLiteral(@"</p>
+    <p>Basic Asynchronous Template: ");
 #line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                 Write(await Foo());
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Basic Asynchronous Statement: ");
+            WriteLiteral(@"</p>
+    <p>Basic Asynchronous Statement: ");
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                         await Foo(); 
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Basic Asynchronous Statement Nested: ");
-            WriteLiteral(" <b>");
+            WriteLiteral(@"</p>
+    <p>Basic Asynchronous Statement Nested: ");
+            WriteLiteral(@" <b>");
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                              Write(await Foo());
 
 #line default
 #line hidden
-            WriteLiteral("</b> ");
-            WriteLiteral("</p>\r\n    <p>Basic Incomplete Asynchronous Statement: ");
+            WriteLiteral(@"</b> ");
+            WriteLiteral(@"</p>
+    <p>Basic Incomplete Asynchronous Statement: ");
 #line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                            Write(await);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n</section>\r\n\r\n<section>\r\n    <h1>Advanced Asynchronous Expression Test</h1>\r\n    <p>Advanced Asynchronous Expression: ");
+            WriteLiteral(@"</p>
+</section>
+
+<section>
+    <h1>Advanced Asynchronous Expression Test</h1>
+    <p>Advanced Asynchronous Expression: ");
 #line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                     Write(await Foo(1, 2));
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Advanced Asynchronous Expression Extended: ");
+            WriteLiteral(@"</p>
+    <p>Advanced Asynchronous Expression Extended: ");
 #line 20 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                              Write(await Foo.Bar(1, 2));
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Advanced Asynchronous Template: ");
+            WriteLiteral(@"</p>
+    <p>Advanced Asynchronous Template: ");
 #line 21 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                    Write(await Foo("bob", true));
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Advanced Asynchronous Statement: ");
+            WriteLiteral(@"</p>
+    <p>Advanced Asynchronous Statement: ");
 #line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                            await Foo(something, hello: "world"); 
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Advanced Asynchronous Statement Extended: ");
+            WriteLiteral(@"</p>
+    <p>Advanced Asynchronous Statement Extended: ");
 #line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                                     await Foo.Bar(1, 2) 
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n    <p>Advanced Asynchronous Statement Nested: ");
-            WriteLiteral(" <b>");
+            WriteLiteral(@"</p>
+    <p>Advanced Asynchronous Statement Nested: ");
+            WriteLiteral(@" <b>");
 #line 24 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                                 Write(await Foo(boolValue: false));
 
 #line default
 #line hidden
-            WriteLiteral("</b> ");
-            WriteLiteral("</p>\r\n    <p>Advanced Incomplete Asynchronous Statement: ");
+            WriteLiteral(@"</b> ");
+            WriteLiteral(@"</p>
+    <p>Advanced Incomplete Asynchronous Statement: ");
 #line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"
                                               Write(await ("wrrronggg"));
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n</section>");
+            WriteLiteral(@"</p>
+</section>");
         }
         #pragma warning restore 1998
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.codegen.cs
@@ -24,7 +24,8 @@ using System.Text;
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<p>Hi there!</p>\r\n");
+            WriteLiteral(@"<p>Hi there!</p>
+");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
@@ -32,9 +32,14 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<THSdiv class=\"randomNonTagHelperAttribute\">\r\n    ");
+            WriteLiteral(@"
+<THSdiv class=""randomNonTagHelperAttribute"">
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n        <p></p>\r\n        <input type=\"text\">\r\n        ");
+                WriteLiteral(@"
+        <p></p>
+        <input type=""text"">
+        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
                 }
                 );
@@ -59,7 +64,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -72,7 +78,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n</THSdiv>");
+            WriteLiteral(@"
+</THSdiv>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.codegen.cs
@@ -33,9 +33,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
+            WriteLiteral(@"
+<div class=""randomNonTagHelperAttribute"">
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 }
                 );
@@ -48,7 +51,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -67,7 +71,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -92,7 +97,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -105,7 +111,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n</div>");
+            WriteLiteral(@"
+</div>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.codegen.cs
@@ -35,9 +35,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<div data-animation=\"fade\" class=\"randomNonTagHelperAttribute\">\r\n    ");
+            WriteLiteral(@"
+<div data-animation=""fade"" class=""randomNonTagHelperAttribute"">
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 }
                 );
@@ -51,7 +54,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
                 }
                 );
@@ -60,13 +64,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 BeginWriteTagHelperAttribute();
-                WriteLiteral("2000 + ");
+                WriteLiteral(@"2000 + ");
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml"
                                 Write(ViewBag.DefaultInterval);
 
 #line default
 #line hidden
-                WriteLiteral(" + 1");
+                WriteLiteral(@" + 1");
                 __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
                 __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper.Type = (string)__tagHelperAttribute_1.Value;
@@ -80,7 +84,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -105,7 +110,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -119,7 +125,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n</div>");
+            WriteLiteral(@"
+</div>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_Runtime.codegen.cs
@@ -15,113 +15,129 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
  while(i <= 10) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Hello from C#, #");
+            WriteLiteral(@"    <p>Hello from C#, #");
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
                    Write(i);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
     i += 1;
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
  if(i == 11) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>We wrote 10 lines!</p>\r\n");
+            WriteLiteral(@"    <p>We wrote 10 lines!</p>
+");
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
  switch(i) {
     case 11:
 
 #line default
 #line hidden
-            WriteLiteral("        <p>No really, we wrote 10 lines!</p>\r\n");
+            WriteLiteral(@"        <p>No really, we wrote 10 lines!</p>
+");
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
         break;
     default:
 
 #line default
 #line hidden
-            WriteLiteral("        <p>Actually, we didn\'t...</p>\r\n");
+            WriteLiteral(@"        <p>Actually, we didn't...</p>
+");
 #line 20 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
         break;
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
  for(int j = 1; j <= 10; j += 2) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Hello again from C#, #");
+            WriteLiteral(@"    <p>Hello again from C#, #");
 #line 24 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
                          Write(j);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 27 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
  try {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>That time, we wrote 5 lines!</p>\r\n");
+            WriteLiteral(@"    <p>That time, we wrote 5 lines!</p>
+");
 #line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
 } catch(Exception ex) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Oh no! An error occurred: ");
+            WriteLiteral(@"    <p>Oh no! An error occurred: ");
 #line 30 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
                              Write(ex.Message);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 31 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n<p>i is now ");
+            WriteLiteral(@"
+<p>i is now ");
 #line 33 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
        Write(i);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n\r\n");
+            WriteLiteral(@"</p>
+
+");
 #line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
  lock(new object()) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>This block is locked, for your security!</p>\r\n");
+            WriteLiteral(@"    <p>This block is locked, for your security!</p>
+");
 #line 37 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml"
 }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7_Runtime.codegen.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<body>\r\n");
+            WriteLiteral(@"<body>
+");
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7.cshtml"
       
         var nameLookup = new Dictionary<string, (string FirstName, string LastName, object Extra)>()
@@ -32,7 +33,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7.cshtml"
      if (nameLookup.TryGetValue("John Doe", out var entry))
     {
@@ -44,20 +46,28 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("    <p>\r\n        Here\'s a very unique number: ");
+            WriteLiteral(@"    <p>
+        Here's a very unique number: ");
 #line 24 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7.cshtml"
                                  Write(1.618_033_988_749_894_848_204_586_834_365_638_117_720_309_179M);
 
 #line default
 #line hidden
-            WriteLiteral("\r\n    </p>\r\n\r\n    <div>\r\n        ");
+            WriteLiteral(@"
+    </p>
+
+    <div>
+        ");
 #line 28 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7.cshtml"
     Write((First: "John", Last: "Doe").First);
 
 #line default
 #line hidden
-            WriteLiteral(" ");
-            WriteLiteral("\r\n    </div>\r\n\r\n");
+            WriteLiteral(@" ");
+            WriteLiteral(@"
+    </div>
+
+");
 #line 31 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7.cshtml"
      switch (entry.Extra)
     {
@@ -74,7 +84,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("</body>");
+            WriteLiteral(@"</body>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_Runtime.codegen.cs
@@ -15,14 +15,14 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("foo");
+            WriteLiteral(@"foo");
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml"
                                 		
     var b = 1;
 
 #line default
 #line hidden
-            WriteLiteral("bar ");
+            WriteLiteral(@"bar ");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml"
                                 Write(a+b);
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
@@ -38,7 +38,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
  if (true)
 {
@@ -47,18 +48,21 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("    <div class=\"randomNonTagHelperAttribute\">\r\n        ");
+            WriteLiteral(@"    <div class=""randomNonTagHelperAttribute"">
+        ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n            <h1>Set Time:</h1>\r\n");
+                WriteLiteral(@"
+            <h1>Set Time:</h1>
+");
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
              if (false)
             {
 
 #line default
 #line hidden
-                WriteLiteral("                ");
+                WriteLiteral(@"                ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                    WriteLiteral("New Time: ");
+                    WriteLiteral(@"New Time: ");
                     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                     }
                     );
@@ -90,7 +94,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
             }
             else
@@ -98,9 +103,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-                WriteLiteral("                ");
+                WriteLiteral(@"                ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                    WriteLiteral("Current Time: ");
+                    WriteLiteral(@"Current Time: ");
                     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                     }
                     );
@@ -142,7 +147,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n                ");
+                WriteLiteral(@"
+                ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -167,7 +173,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n                ");
+                WriteLiteral(@"
+                ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
                 }
                 );
@@ -181,13 +188,13 @@ __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
 #line hidden
-                WriteLiteral("checkbox");
+                WriteLiteral(@"checkbox");
 #line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                } else {
 
 #line default
 #line hidden
-                WriteLiteral("anything");
+                WriteLiteral(@"anything");
 #line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                                               }
 
@@ -204,13 +211,14 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
 #line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
             }
 
 #line default
 #line hidden
-                WriteLiteral("        ");
+                WriteLiteral(@"        ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -231,15 +239,17 @@ AddHtmlAttributeValue(" ", 161, DateTime.Now, 162, 13, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n        ");
+            WriteLiteral(@"
+        ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
 #line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                var @object = false;
 
 #line default
 #line hidden
-                WriteLiteral("            ");
+                WriteLiteral(@"            ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
                 }
                 );
@@ -260,7 +270,8 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -280,9 +291,11 @@ __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n        ");
+            WriteLiteral(@"
+        ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n            ");
+                WriteLiteral(@"
+            ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -305,7 +318,8 @@ __TestNamespace_InputTagHelper2.Checked = (DateTimeOffset.Now.Year > 2014);
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -323,9 +337,11 @@ __TestNamespace_PTagHelper.Age = -1970 + @DateTimeOffset.Now.Year;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n        ");
+            WriteLiteral(@"
+        ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n            ");
+                WriteLiteral(@"
+            ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
                 }
                 );
@@ -346,7 +362,8 @@ __TestNamespace_InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -364,9 +381,11 @@ __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n        ");
+            WriteLiteral(@"
+        ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n            ");
+                WriteLiteral(@"
+            ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -387,7 +406,8 @@ __TestNamespace_InputTagHelper2.Checked =    @(  DateTimeOffset.Now.Year  ) > 20
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -405,7 +425,8 @@ __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n        ");
+            WriteLiteral(@"
+        ");
 #line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
    Write(someMethod(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
@@ -452,7 +473,9 @@ __TestNamespace_PTagHelper.Age = 123;
 
 #line default
 #line hidden
-            WriteLiteral("\r\n    </div>\r\n");
+            WriteLiteral(@"
+    </div>
+");
 #line 36 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_Runtime.codegen.cs
@@ -16,7 +16,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("    <a href=\"Foo\" />\r\n    <p");
+            WriteLiteral(@"    <a href=""Foo"" />
+    <p");
             BeginWriteAttribute("class", " class=\"", 74, "\"", 86, 1);
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
 WriteAttributeValue("", 82, cls, 82, 4, false);
@@ -24,7 +25,8 @@ WriteAttributeValue("", 82, cls, 82, 4, false);
 #line default
 #line hidden
             EndWriteAttribute();
-            WriteLiteral(" />\r\n    <p");
+            WriteLiteral(@" />
+    <p");
             BeginWriteAttribute("class", " class=\"", 98, "\"", 114, 2);
             WriteAttributeValue("", 106, "foo", 106, 3, true);
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
@@ -33,7 +35,8 @@ WriteAttributeValue(" ", 109, cls, 110, 4, false);
 #line default
 #line hidden
             EndWriteAttribute();
-            WriteLiteral(" />\r\n    <p");
+            WriteLiteral(@" />
+    <p");
             BeginWriteAttribute("class", " class=\"", 126, "\"", 142, 2);
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
 WriteAttributeValue("", 134, cls, 134, 4, false);
@@ -42,7 +45,8 @@ WriteAttributeValue("", 134, cls, 134, 4, false);
 #line hidden
             WriteAttributeValue(" ", 138, "foo", 139, 4, true);
             EndWriteAttribute();
-            WriteLiteral(" />\r\n    <input type=\"checkbox\"");
+            WriteLiteral(@" />
+    <input type=""checkbox""");
             BeginWriteAttribute("checked", " checked=\"", 174, "\"", 187, 1);
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
 WriteAttributeValue("", 184, ch, 184, 3, false);
@@ -50,7 +54,8 @@ WriteAttributeValue("", 184, ch, 184, 3, false);
 #line default
 #line hidden
             EndWriteAttribute();
-            WriteLiteral(" />\r\n    <input type=\"checkbox\"");
+            WriteLiteral(@" />
+    <input type=""checkbox""");
             BeginWriteAttribute("checked", " checked=\"", 219, "\"", 236, 2);
             WriteAttributeValue("", 229, "foo", 229, 3, true);
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
@@ -59,7 +64,8 @@ WriteAttributeValue(" ", 232, ch, 233, 3, false);
 #line default
 #line hidden
             EndWriteAttribute();
-            WriteLiteral(" />\r\n    <p");
+            WriteLiteral(@" />
+    <p");
             BeginWriteAttribute("class", " class=\"", 248, "\"", 281, 1);
             WriteAttributeValue("", 256, new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_attribute_value_writer) => {
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
@@ -80,7 +86,9 @@ WriteTo(__razor_attribute_value_writer, cls);
             }
             ), 256, 25, false);
             EndWriteAttribute();
-            WriteLiteral(" />\r\n    <a href=\"~/Foo\" />\r\n    <script");
+            WriteLiteral(@" />
+    <a href=""~/Foo"" />
+    <script");
             BeginWriteAttribute("src", " src=\"", 322, "\"", 373, 1);
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
 WriteAttributeValue("", 328, Url.Content("~/Scripts/jquery-1.6.2.min.js"), 328, 45, false);
@@ -88,7 +96,8 @@ WriteAttributeValue("", 328, Url.Content("~/Scripts/jquery-1.6.2.min.js"), 328, 
 #line default
 #line hidden
             EndWriteAttribute();
-            WriteLiteral(" type=\"text/javascript\"></script>\r\n    <script");
+            WriteLiteral(@" type=""text/javascript""></script>
+    <script");
             BeginWriteAttribute("src", " src=\"", 420, "\"", 487, 1);
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml"
 WriteAttributeValue("", 426, Url.Content("~/Scripts/modernizr-2.0.6-development-only.js"), 426, 61, false);
@@ -96,7 +105,9 @@ WriteAttributeValue("", 426, Url.Content("~/Scripts/modernizr-2.0.6-development-
 #line default
 #line hidden
             EndWriteAttribute();
-            WriteLiteral(" type=\"text/javascript\"></script>\r\n    <script src=\"http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.16/jquery-ui.min.js\" type=\"text/javascript\"></script>\r\n");
+            WriteLiteral(@" type=""text/javascript""></script>
+    <script src=""http://ajax.aspnetcdn.com/ajax/jquery.ui/1.8.16/jquery-ui.min.js"" type=""text/javascript""></script>
+");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.codegen.cs
@@ -42,9 +42,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("2 TagHelpers.");
+                WriteLiteral(@"2 TagHelpers.");
             }
             );
             __TestNamespace_ATagHelper = CreateTagHelper<global::TestNamespace.ATagHelper>();
@@ -59,9 +60,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("1 TagHelper.");
+                WriteLiteral(@"1 TagHelper.");
             }
             );
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
@@ -74,9 +76,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("2 TagHelpers");
+                WriteLiteral(@"2 TagHelpers");
             }
             );
             __TestNamespace_ATagHelperMultipleSelectors = CreateTagHelper<global::TestNamespace.ATagHelperMultipleSelectors>();
@@ -91,9 +94,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("2 TagHelpers");
+                WriteLiteral(@"2 TagHelpers");
             }
             );
             __TestNamespace_ATagHelperMultipleSelectors = CreateTagHelper<global::TestNamespace.ATagHelperMultipleSelectors>();
@@ -116,9 +120,11 @@ AddHtmlAttributeValue("", 155, false, 155, 6, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n<a href=\' ~/\'>0 TagHelpers.</a>\r\n");
+            WriteLiteral(@"
+<a href=' ~/'>0 TagHelpers.</a>
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("1 TagHelper");
+                WriteLiteral(@"1 TagHelper");
             }
             );
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
@@ -138,9 +144,10 @@ AddHtmlAttributeValue("", 236, false, 236, 6, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("1 TagHelper");
+                WriteLiteral(@"1 TagHelper");
             }
             );
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
@@ -153,9 +160,10 @@ AddHtmlAttributeValue("", 236, false, 236, 6, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("a", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("1 TagHelper");
+                WriteLiteral(@"1 TagHelper");
             }
             );
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
@@ -175,7 +183,8 @@ AddHtmlAttributeValue(" ", 331, false, 332, 6, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -197,7 +206,8 @@ AddHtmlAttributeValue(" ", 331, false, 332, 6, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -215,7 +225,8 @@ AddHtmlAttributeValue(" ", 331, false, 332, 6, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.codegen.cs
@@ -39,9 +39,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -61,7 +63,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -88,7 +91,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -117,7 +121,8 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.codegen.cs
@@ -30,7 +30,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.codegen.cs
@@ -28,7 +28,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -49,7 +50,9 @@ AddHtmlAttributeValue(" ", 57, DateTime.Now, 58, 13, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -93,20 +96,22 @@ WriteTo(__razor_attribute_value_writer, string.Empty);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
             BeginWriteTagHelperAttribute();
-            WriteLiteral("prefix ");
+            WriteLiteral(@"prefix ");
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml"
          WriteLiteral(DateTime.Now);
 
 #line default
 #line hidden
-            WriteLiteral(" suffix");
+            WriteLiteral(@" suffix");
             __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
             __TestNamespace_InputTagHelper.Bound = __tagHelperStringValueBuffer;
             __tagHelperExecutionContext.AddTagHelperAttribute("bound", __TestNamespace_InputTagHelper.Bound, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
@@ -126,7 +131,9 @@ AddHtmlAttributeValue(" ", 212, DateTime.Now, 213, 13, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -138,7 +145,7 @@ AddHtmlAttributeValue(" ", 212, DateTime.Now, 213, 13, false);
 
 #line default
 #line hidden
-            WriteLiteral(" ");
+            WriteLiteral(@" ");
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml"
                               if (true) { 
 
@@ -164,7 +171,7 @@ AddHtmlAttributeValue(" ", 212, DateTime.Now, 213, 13, false);
 
 #line default
 #line hidden
-            WriteLiteral(" ");
+            WriteLiteral(@" ");
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml"
                                                               WriteLiteral(int.MaxValue);
 
@@ -220,7 +227,9 @@ AddHtmlAttributeValue(" ", 406, int.MaxValue, 407, 13, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -252,7 +261,9 @@ AddHtmlAttributeValue(" ", 490, int.MaxValue, 491, 13, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
@@ -32,7 +32,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<div>\r\n    ");
+            WriteLiteral(@"
+<div>
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -58,9 +60,11 @@ __TestNamespace_InputTagHelper2.Checked = ;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n    ");
+            WriteLiteral(@"
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -86,7 +90,8 @@ __TestNamespace_InputTagHelper2.Checked = ;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -104,7 +109,8 @@ __TestNamespace_PTagHelper.Age = ;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n</div>");
+            WriteLiteral(@"
+</div>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_Runtime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("This is markup\r\n\r\n");
+            WriteLiteral(@"This is markup
+
+");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_Runtime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("This is markup\r\n\r\n");
+            WriteLiteral(@"This is markup
+
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression.cshtml"
 Write();
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_Runtime.codegen.cs
@@ -9,13 +9,15 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("This is markup\r\n\r\n");
+            WriteLiteral(@"This is markup
+
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression.cshtml"
 Write();
 
 #line default
 #line hidden
-            WriteLiteral("!");
+            WriteLiteral(@"!");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.codegen.cs
@@ -29,14 +29,16 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml"
   
     var enumValue = MyEnum.MyValue;
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -57,7 +59,8 @@ __TestNamespace_InputTagHelper.Value = MyEnum.MyValue;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -79,7 +82,8 @@ AddHtmlAttributeValue("", 130, MyEnum.MySecondValue, 130, 21, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -100,7 +104,8 @@ __TestNamespace_InputTagHelper.Value = global::Microsoft.AspNetCore.Razor.Langua
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -127,7 +132,8 @@ __TestNamespace_CatchAllTagHelper.CatchAll = global::Microsoft.AspNetCore.Razor.
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -154,7 +160,8 @@ __TestNamespace_CatchAllTagHelper.CatchAll = enumValue;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
@@ -29,18 +29,22 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<");
-            WriteLiteral("div class=\"randomNonTagHelperAttribute\">\r\n    <");
-            WriteLiteral("p class=\"Hello World\" ");
+            WriteLiteral(@"
+<");
+            WriteLiteral(@"div class=""randomNonTagHelperAttribute"">
+    <");
+            WriteLiteral(@"p class=""Hello World"" ");
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml"
                        Write(DateTime.Now);
 
 #line default
 #line hidden
-            WriteLiteral(">\r\n        <");
-            WriteLiteral("input type=\"text\" />\r\n        <");
-            WriteLiteral("em>Not a TagHelper: </");
-            WriteLiteral("em> ");
+            WriteLiteral(@">
+        <");
+            WriteLiteral(@"input type=""text"" />
+        <");
+            WriteLiteral(@"em>Not a TagHelper: </");
+            WriteLiteral(@"em> ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -71,9 +75,11 @@ __TestNamespace_InputTagHelper2.Checked = true;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n    </");
-            WriteLiteral("p>\r\n</");
-            WriteLiteral("div>");
+            WriteLiteral(@"
+    </");
+            WriteLiteral(@"p>
+</");
+            WriteLiteral(@"div>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_Runtime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("This is markup\r\n\r\n");
+            WriteLiteral(@"This is markup
+
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF.cshtml"
 Write();
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_Runtime.codegen.cs
@@ -9,10 +9,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<div>");
+            WriteLiteral(@"<div>");
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup.cshtml"
   Write(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-    WriteLiteralTo(__razor_template_writer, "</div>");
+    WriteLiteralTo(__razor_template_writer, @"</div>");
 }
 ));
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_Runtime.codegen.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("1 + 1 = ");
+            WriteLiteral(@"1 + 1 = ");
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression.cshtml"
     Write(1+1);
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_Runtime.codegen.cs
@@ -16,7 +16,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml"
  if(foo != null) {
     
@@ -34,13 +35,16 @@ Write(foo);
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Foo is Null!</p>\r\n");
+            WriteLiteral(@"    <p>Foo is Null!</p>
+");
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml"
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n<p>\r\n");
+            WriteLiteral(@"
+<p>
+");
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml"
  if(!String.IsNullOrEmpty(bar)) {
     
@@ -58,7 +62,7 @@ Write(bar.Replace("F", "B"));
 
 #line default
 #line hidden
-            WriteLiteral("</p>");
+            WriteLiteral(@"</p>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_Runtime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
         }
         #pragma warning restore 1998
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_Runtime.codegen.cs
@@ -9,8 +9,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
-            WriteLiteral("\r\nHere\'s a random number: ");
+            WriteLiteral(@"
+");
+            WriteLiteral(@"
+Here's a random number: ");
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock.cshtml"
                    Write(RandomInt());
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_Runtime.codegen.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<!-- \" -->\r\n<img src=\"~/images/submit.png\" />");
+            WriteLiteral(@"<!-- "" -->
+<img src=""~/images/submit.png"" />");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_Runtime.codegen.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<!-- \' -->\r\n<img src=\"~/images/submit.png\" />");
+            WriteLiteral(@"<!-- ' -->
+<img src=""~/images/submit.png"" />");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_Runtime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("This is markup\r\n\r\n");
+            WriteLiteral(@"This is markup
+
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF.cshtml"
 Write();
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_Runtime.codegen.cs
@@ -14,13 +14,14 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("    <p>This is item #");
+            WriteLiteral(@"    <p>This is item #");
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression.cshtml"
                 Write(i);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression.cshtml"
 }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
@@ -9,21 +9,33 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n\r\n");
-            WriteLiteral("\r\n");
-            WriteLiteral("\r\n");
-            WriteLiteral("\r\n");
-            WriteLiteral("\r\n");
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
+            WriteLiteral(@"
+");
+            WriteLiteral(@"
+");
+            WriteLiteral(@"
+");
+            WriteLiteral(@"
+");
+            WriteLiteral(@"
+
+");
             DefineSection("", async () => {
             });
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             DefineSection("", async () => {
             });
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
             DefineSection("", async () => {
             });
-            WriteLiteral("{\r\n");
+            WriteLiteral(@"{
+");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.codegen.cs
@@ -29,7 +29,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.codegen.cs
@@ -14,7 +14,9 @@ Write(foo());
 
 #line default
 #line hidden
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.codegen.cs
@@ -11,7 +11,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         {
             DefineSection("Link", async () => {
             });
-            WriteLiteral("(string link) {\r\n    <a");
+            WriteLiteral(@"(string link) {
+    <a");
             BeginWriteAttribute("href", " href=\"", 36, "\"", 93, 1);
             WriteAttributeValue("", 43, new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_attribute_value_writer) => {
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml"
@@ -29,7 +30,7 @@ WriteTo(__razor_attribute_value_writer, link);
 
 #line default
 #line hidden
-                WriteLiteralTo(__razor_attribute_value_writer, "#");
+                WriteLiteralTo(__razor_attribute_value_writer, @"#");
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml"
                                                                }
 
@@ -38,7 +39,8 @@ WriteTo(__razor_attribute_value_writer, link);
             }
             ), 43, 50, false);
             EndWriteAttribute();
-            WriteLiteral(" />\r\n}");
+            WriteLiteral(@" />
+}");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.codegen.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 #line default
 #line hidden
             item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-                WriteLiteralTo(__razor_template_writer, "<p>Bar</p>");
+                WriteLiteralTo(__razor_template_writer, @"<p>Bar</p>");
             }
             )
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
@@ -25,109 +25,125 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("    ");
-            WriteLiteral("Hello, World\r\n    <p>Hello, World</p>\r\n");
-            WriteLiteral("\r\n");
+            WriteLiteral(@"    ");
+            WriteLiteral(@"Hello, World
+    <p>Hello, World</p>
+");
+            WriteLiteral(@"
+");
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
  while(i <= 10) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Hello from C#, #");
+            WriteLiteral(@"    <p>Hello from C#, #");
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
                    Write(i);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
     i += 1;
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
  if(i == 11) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>We wrote 10 lines!</p>\r\n");
+            WriteLiteral(@"    <p>We wrote 10 lines!</p>
+");
 #line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
  switch(i) {
     case 11:
 
 #line default
 #line hidden
-            WriteLiteral("        <p>No really, we wrote 10 lines!</p>\r\n");
+            WriteLiteral(@"        <p>No really, we wrote 10 lines!</p>
+");
 #line 20 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
         break;
     default:
 
 #line default
 #line hidden
-            WriteLiteral("        <p>Actually, we didn\'t...</p>\r\n");
+            WriteLiteral(@"        <p>Actually, we didn't...</p>
+");
 #line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
         break;
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 26 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
  for(int j = 1; j <= 10; j += 2) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Hello again from C#, #");
+            WriteLiteral(@"    <p>Hello again from C#, #");
 #line 27 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
                          Write(j);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 28 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 30 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
  try {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>That time, we wrote 5 lines!</p>\r\n");
+            WriteLiteral(@"    <p>That time, we wrote 5 lines!</p>
+");
 #line 32 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
 } catch(Exception ex) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Oh no! An error occurred: ");
+            WriteLiteral(@"    <p>Oh no! An error occurred: ");
 #line 33 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
                              Write(ex.Message);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 36 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
  lock(new object()) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>This block is locked, for your security!</p>\r\n");
+            WriteLiteral(@"    <p>This block is locked, for your security!</p>
+");
 #line 38 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"
 }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_Runtime.codegen.cs
@@ -15,13 +15,14 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("        <p>Hello from C#, #");
+            WriteLiteral(@"        <p>Hello from C#, #");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock.cshtml"
                        Write(i.ToString());
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock.cshtml"
     }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.codegen.cs
@@ -36,9 +36,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n    <input nottaghelper />\r\n    ");
+                WriteLiteral(@"
+    <input nottaghelper />
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -55,7 +58,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -79,7 +83,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -105,7 +110,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -128,7 +134,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
             }
             );
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_Runtime.codegen.cs
@@ -15,13 +15,16 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("        <div>\r\n            ");
+            WriteLiteral(@"        <div>
+            ");
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml"
        Write(result.SomeValue);
 
 #line default
 #line hidden
-            WriteLiteral(".\r\n        </div>\r\n");
+            WriteLiteral(@".
+        </div>
+");
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml"
     }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.codegen.cs
@@ -33,15 +33,20 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<script type=\"text/html\">\r\n    <div data-animation=\"fade\" class=\"randomNonTagHelperAttribute\">\r\n        ");
+            WriteLiteral(@"
+<script type=""text/html"">
+    <div data-animation=""fade"" class=""randomNonTagHelperAttribute"">
+        ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml"
              for(var i = 0; i < 5; i++) {
 
 #line default
 #line hidden
-                WriteLiteral("                <script id=\"nestedScriptTag\" type=\"text/html\">\r\n                    ");
+                WriteLiteral(@"                <script id=""nestedScriptTag"" type=""text/html"">
+                    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagOnly, "test", async() => {
                 }
                 );
@@ -50,13 +55,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 BeginWriteTagHelperAttribute();
-                WriteLiteral("2000 + ");
+                WriteLiteral(@"2000 + ");
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml"
                                             Write(ViewBag.DefaultInterval);
 
 #line default
 #line hidden
-                WriteLiteral(" + 1");
+                WriteLiteral(@" + 1");
                 __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
                 __tagHelperExecutionContext.AddHtmlAttribute("data-interval", Html.Raw(__tagHelperStringValueBuffer), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __TestNamespace_InputTagHelper.Type = (string)__tagHelperAttribute_0.Value;
@@ -76,13 +81,18 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n                </script>\r\n");
+                WriteLiteral(@"
+                </script>
+");
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml"
             }
 
 #line default
 #line hidden
-                WriteLiteral("            <script type=\"text/javascript\">\r\n                var tag = \'<input checked=\"true\">\';\r\n            </script>\r\n        ");
+                WriteLiteral(@"            <script type=""text/javascript"">
+                var tag = '<input checked=""true"">';
+            </script>
+        ");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -96,7 +106,9 @@ __TestNamespace_InputTagHelper2.Checked = true;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n    </div>\r\n</script>");
+            WriteLiteral(@"
+    </div>
+</script>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.codegen.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("span", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("Hola");
+                WriteLiteral(@"Hola");
             }
             );
             __SpanTagHelper = CreateTagHelper<global::SpanTagHelper>();
@@ -49,9 +49,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
                 );
@@ -67,7 +69,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
             }
             );
             __DivTagHelper = CreateTagHelper<global::DivTagHelper>();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_Runtime.codegen.cs
@@ -15,114 +15,129 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
  while(i <= 10) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Hello from C#, #");
+            WriteLiteral(@"    <p>Hello from C#, #");
 #line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
                    Write(i);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
     i += 1;
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
  if(i == 11) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>We wrote 10 lines!</p>\r\n");
+            WriteLiteral(@"    <p>We wrote 10 lines!</p>
+");
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
  switch(i) {
     case 11:
 
 #line default
 #line hidden
-            WriteLiteral("        <p>No really, we wrote 10 lines!</p>\r\n");
+            WriteLiteral(@"        <p>No really, we wrote 10 lines!</p>
+");
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
         break;
     default:
 
 #line default
 #line hidden
-            WriteLiteral("        <p>Actually, we didn\'t...</p>\r\n");
+            WriteLiteral(@"        <p>Actually, we didn't...</p>
+");
 #line 20 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
         break;
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
  for(int j = 1; j <= 10; j += 2) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Hello again from C#, #");
+            WriteLiteral(@"    <p>Hello again from C#, #");
 #line 24 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
                          Write(j);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
 }
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 27 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
  try {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>That time, we wrote 5 lines!</p>\r\n");
+            WriteLiteral(@"    <p>That time, we wrote 5 lines!</p>
+");
 #line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
 } catch(Exception ex) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>Oh no! An error occurred: ");
+            WriteLiteral(@"    <p>Oh no! An error occurred: ");
 #line 30 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
                              Write(ex.Message);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n");
+            WriteLiteral(@"</p>
+");
 #line 31 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
 }
 
 
 #line default
 #line hidden
-            WriteLiteral("<p>i is now ");
+            WriteLiteral(@"<p>i is now ");
 #line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
        Write(i);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n\r\n");
+            WriteLiteral(@"</p>
+
+");
 #line 36 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
  lock(new object()) {
 
 #line default
 #line hidden
-            WriteLiteral("    <p>This block is locked, for your security!</p>\r\n");
+            WriteLiteral(@"    <p>This block is locked, for your security!</p>
+");
 #line 38 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml"
 }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_Runtime.codegen.cs
@@ -29,25 +29,29 @@ Write(ViewBag?.Method(Value?[23]?.More)?["key"]);
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml"
 Write(ViewBag?.Data);
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml"
 Write(ViewBag.IntIndexer?[0]);
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml"
 Write(ViewBag.StrIndexer?["key"]);
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml"
 Write(ViewBag?.Method(Value?[23]?.More)?["key"]);
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_Runtime.codegen.cs
@@ -9,13 +9,16 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<html>\r\n<body>\r\n");
+            WriteLiteral(@"<html>
+<body>
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf.cshtml"
  if (true) { 
 
 #line default
 #line hidden
-            WriteLiteral("</body>\r\n</html>");
+            WriteLiteral(@"</body>
+</html>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.codegen.cs
@@ -36,7 +36,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml"
   
     var literate = "or illiterate";
@@ -51,7 +52,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("\r\n<div class=\"randomNonTagHelperAttribute\">\r\n    ");
+            WriteLiteral(@"
+<div class=""randomNonTagHelperAttribute"">
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -81,7 +84,8 @@ __TestNamespace_InputTagHelper1.StringDictionaryProperty = stringDictionary;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n    ");
+            WriteLiteral(@"
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -122,7 +126,8 @@ __TestNamespace_InputTagHelper1.IntProperty = 42;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n    ");
+            WriteLiteral(@"
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -170,13 +175,13 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"] = 98;
                 throw new InvalidOperationException(InvalidTagHelperIndexerAssignment("string-prefix-cumin", "TestNamespace.InputTagHelper1", "StringDictionaryProperty"));
             }
             BeginWriteTagHelperAttribute();
-            WriteLiteral("literate ");
+            WriteLiteral(@"literate ");
 #line 21 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml"
                              WriteLiteral(literate);
 
 #line default
 #line hidden
-            WriteLiteral("?");
+            WriteLiteral(@"?");
             __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
             __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"] = __tagHelperStringValueBuffer;
             __tagHelperExecutionContext.AddTagHelperAttribute("string-prefix-cumin", __TestNamespace_InputTagHelper1.StringDictionaryProperty["cumin"], global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
@@ -188,7 +193,8 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["pepper"] = 98;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n    ");
+            WriteLiteral(@"
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -218,7 +224,8 @@ __TestNamespace_InputTagHelper1.IntDictionaryProperty["value"] = 37;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n</div>");
+            WriteLiteral(@"
+</div>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_Runtime.codegen.cs
@@ -9,8 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<p>This should ");
-            WriteLiteral(" be shown</p>\r\n\r\n");
+            WriteLiteral(@"
+<p>This should ");
+            WriteLiteral(@" be shown</p>
+
+");
 #line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml"
                                        
     Exception foo = 
@@ -25,25 +28,29 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml"
    var bar = "@* bar *@"; 
 
 #line default
 #line hidden
-            WriteLiteral("<p>But this should show the comment syntax: ");
+            WriteLiteral(@"<p>But this should show the comment syntax: ");
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml"
                                        Write(bar);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n\r\n");
+            WriteLiteral(@"</p>
+
+");
 #line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml"
 Write(ab);
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
@@ -15,9 +15,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("\r\n<div>This is in the Body>\r\n\r\n");
+            WriteLiteral(@"
+<div>This is in the Body>
+
+");
             DefineSection("Section2", async () => {
-            WriteLiteral("\r\n    <div");
+            WriteLiteral(@"
+    <div");
             BeginWriteAttribute("class", " class=\"", 109, "\"", 128, 2);
             WriteAttributeValue("", 117, "some", 117, 4, true);
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
@@ -26,28 +30,34 @@ WriteAttributeValue(" ", 121, thing, 122, 6, false);
 #line default
 #line hidden
             EndWriteAttribute();
-            WriteLiteral(">This is in Section 2</div>\r\n");
+            WriteLiteral(@">This is in Section 2</div>
+");
             });
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             DefineSection("Section1", async () => {
-            WriteLiteral("\r\n    <div>This is in Section 1</div>\r\n");
+            WriteLiteral(@"
+    <div>This is in Section 1</div>
+");
             });
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             DefineSection("NestedDelegates", async () => {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
        Func<dynamic, object> f = 
 
 #line default
 #line hidden
             item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-                WriteLiteralTo(__razor_template_writer, "<span>");
+                WriteLiteralTo(__razor_template_writer, @"<span>");
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
         WriteTo(__razor_template_writer, item);
 
 #line default
 #line hidden
-                WriteLiteralTo(__razor_template_writer, "</span>");
+                WriteLiteralTo(__razor_template_writer, @"</span>");
             }
             )
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.codegen.cs
@@ -30,7 +30,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<p>Hola</p>\r\n<form>\r\n    ");
+            WriteLiteral(@"<p>Hola</p>
+<form>
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -46,7 +48,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n</form>");
+            WriteLiteral(@"
+</form>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_Runtime.codegen.cs
@@ -15,7 +15,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("\t<div></div>\r\n");
+            WriteLiteral(@"	<div></div>
+");
 #line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf.cshtml"
 }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.codegen.cs
@@ -29,9 +29,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("Body of Tag");
+                WriteLiteral(@"Body of Tag");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.codegen.cs
@@ -29,9 +29,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("Body of Tag");
+                WriteLiteral(@"Body of Tag");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_Runtime.codegen.cs
@@ -220,7 +220,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 <p>This is line 41</p>
 <p>This is line 42</p>
 <p>This is line 43</p>hi!");
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             DefineSection("WriteLiteralsToInHereAlso", async () => {
             WriteLiteral(@"
     <p>This is line 1 nested</p>
@@ -255,7 +256,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     <p>30</p>
 ");
             });
-            WriteLiteral("!");
+            WriteLiteral(@"!");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.codegen.cs
@@ -36,7 +36,17 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n<ul [item]=\"items\"></ul>\r\n<ul [(item)]=\"items\"></ul>\r\n<button (click)=\"doSomething()\">Click Me</button>\r\n<button (^click)=\"doSomething()\">Click Me</button>\r\n<template *something=\"value\">\r\n</template>\r\n<div #local></div>\r\n<div #local=\"value\"></div>\r\n\r\n");
+            WriteLiteral(@"
+<ul [item]=""items""></ul>
+<ul [(item)]=""items""></ul>
+<button (click)=""doSomething()"">Click Me</button>
+<button (^click)=""doSomething()"">Click Me</button>
+<template *something=""value"">
+</template>
+<div #local></div>
+<div #local=""value""></div>
+
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("ul", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );
@@ -59,7 +69,8 @@ __TestNamespace_CatchAllTagHelper.ListItems = items;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("ul", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );
@@ -82,9 +93,10 @@ __TestNamespace_CatchAllTagHelper.ArrayItems = items;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("button", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("Click Me");
+                WriteLiteral(@"Click Me");
             }
             );
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
@@ -106,9 +118,10 @@ __TestNamespace_CatchAllTagHelper.Event1 = doSomething();
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("button", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("Click Me");
+                WriteLiteral(@"Click Me");
             }
             );
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
@@ -130,9 +143,11 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("template", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
             }
             );
             __TestNamespace_CatchAllTagHelper = CreateTagHelper<global::TestNamespace.CatchAllTagHelper>();
@@ -150,7 +165,8 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );
@@ -169,7 +185,8 @@ __TestNamespace_CatchAllTagHelper.Event2 = doSomething();
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.codegen.cs
@@ -29,20 +29,26 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml"
   
     var code = "some code";
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             DefineSection("MySection", async () => {
-            WriteLiteral("\r\n    <div>\r\n        ");
+            WriteLiteral(@"
+    <div>
+        ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("mytaghelper", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n            In None ContentBehavior.\r\n            ");
+                WriteLiteral(@"
+            In None ContentBehavior.
+            ");
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("nestedtaghelper", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                    WriteLiteral("Some buffered values with ");
+                    WriteLiteral(@"Some buffered values with ");
 #line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml"
                                                   Write(code);
 
@@ -59,13 +65,14 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 }
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
-                WriteLiteral("\r\n        ");
+                WriteLiteral(@"
+        ");
             }
             );
             __TestNamespace_MyTagHelper = CreateTagHelper<global::TestNamespace.MyTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_MyTagHelper);
             BeginWriteTagHelperAttribute();
-            WriteLiteral("Current Time: ");
+            WriteLiteral(@"Current Time: ");
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection.cshtml"
                                       WriteLiteral(DateTime.Now);
 
@@ -90,7 +97,9 @@ AddHtmlAttributeValue(" ", 201, DateTime.Now, 202, 13, false);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n    </div>\r\n");
+            WriteLiteral(@"
+    </div>
+");
             });
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.codegen.cs
@@ -29,7 +29,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<form>\r\n    ");
+            WriteLiteral(@"<form>
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -52,7 +53,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n</form>");
+            WriteLiteral(@"
+</form>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
@@ -29,7 +29,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<form>\r\n    ");
+            WriteLiteral(@"<form>
+    ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -52,7 +53,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n</form>");
+            WriteLiteral(@"
+</form>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
@@ -32,10 +32,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
 #line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
       
         RenderTemplate(
@@ -46,13 +49,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 #line hidden
                 item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
                     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                        WriteLiteral("<h3>");
+                        WriteLiteral(@"<h3>");
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
                                   Write(item);
 
 #line default
 #line hidden
-                        WriteLiteral("</h3>");
+                        WriteLiteral(@"</h3>");
                         __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                         }
                         );
@@ -98,7 +101,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
         }
         #pragma warning restore 1998
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.codegen.cs
@@ -36,9 +36,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("Body of Tag");
+                WriteLiteral(@"Body of Tag");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -65,7 +66,9 @@ __TestNamespace_PTagHelper.Age = 1337;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );
@@ -85,7 +88,9 @@ __TestNamespace_PTagHelper.Age = 1337;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );
@@ -105,7 +110,9 @@ __TestNamespace_PTagHelper.Age = 1234;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n\r\n");
+            WriteLiteral(@"
+
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
             }
             );

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.codegen.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
   
     Func<dynamic, object> foo = 
@@ -17,13 +18,13 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 #line default
 #line hidden
             item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-                WriteLiteralTo(__razor_template_writer, "This works ");
+                WriteLiteralTo(__razor_template_writer, @"This works ");
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
                   WriteTo(__razor_template_writer, item);
 
 #line default
 #line hidden
-                WriteLiteralTo(__razor_template_writer, "!");
+                WriteLiteralTo(__razor_template_writer, @"!");
             }
             )
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
@@ -37,7 +38,8 @@ Write(foo(""));
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
    
     Func<dynamic, object> bar = 
@@ -45,7 +47,7 @@ Write(foo(""));
 #line default
 #line hidden
             item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-                WriteLiteralTo(__razor_template_writer, "<p");
+                WriteLiteralTo(__razor_template_writer, @"<p");
                 BeginWriteAttributeTo(__razor_template_writer, "class", " class=\"", 411, "\"", 424, 1);
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 WriteAttributeValueTo(__razor_template_writer, "", 419, item, 419, 5, false);
@@ -53,7 +55,7 @@ WriteAttributeValueTo(__razor_template_writer, "", 419, item, 419, 5, false);
 #line default
 #line hidden
                 EndWriteAttributeTo(__razor_template_writer);
-                WriteLiteralTo(__razor_template_writer, ">Hello</p>");
+                WriteLiteralTo(__razor_template_writer, @">Hello</p>");
             }
             )
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
@@ -67,92 +69,120 @@ Write(bar("myclass"));
 
 #line default
 #line hidden
-            WriteLiteral("\r\n<ul>\r\n");
+            WriteLiteral(@"
+<ul>
+");
 #line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 Write(Repeat(10, item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-    WriteLiteralTo(__razor_template_writer, "<li>Item #");
+    WriteLiteralTo(__razor_template_writer, @"<li>Item #");
 #line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 WriteTo(__razor_template_writer, item);
 
 #line default
 #line hidden
-    WriteLiteralTo(__razor_template_writer, "</li>");
+    WriteLiteralTo(__razor_template_writer, @"</li>");
 }
 )));
 
 #line default
 #line hidden
-            WriteLiteral("\r\n</ul>\r\n\r\n<p>\r\n");
+            WriteLiteral(@"
+</ul>
+
+<p>
+");
 #line 26 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 Write(Repeat(10,
     item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-    WriteLiteralTo(__razor_template_writer, " This is line#");
+    WriteLiteralTo(__razor_template_writer, @" This is line#");
 #line 27 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 WriteTo(__razor_template_writer, item);
 
 #line default
 #line hidden
-    WriteLiteralTo(__razor_template_writer, " of markup<br/>\r\n");
+    WriteLiteralTo(__razor_template_writer, @" of markup<br/>
+");
 }
 )));
 
 #line default
 #line hidden
-            WriteLiteral("\r\n</p>\r\n\r\n<p>\r\n");
+            WriteLiteral(@"
+</p>
+
+<p>
+");
 #line 32 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 Write(Repeat(10,
     item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-    WriteLiteralTo(__razor_template_writer, ": This is line#");
+    WriteLiteralTo(__razor_template_writer, @": This is line#");
 #line 33 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 WriteTo(__razor_template_writer, item);
 
 #line default
 #line hidden
-    WriteLiteralTo(__razor_template_writer, " of markup<br />\r\n");
+    WriteLiteralTo(__razor_template_writer, @" of markup<br />
+");
 }
 )));
 
 #line default
 #line hidden
-            WriteLiteral("\r\n</p>\r\n\r\n<p>\r\n");
+            WriteLiteral(@"
+</p>
+
+<p>
+");
 #line 38 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 Write(Repeat(10,
     item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-    WriteLiteralTo(__razor_template_writer, ":: This is line#");
+    WriteLiteralTo(__razor_template_writer, @":: This is line#");
 #line 39 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 WriteTo(__razor_template_writer, item);
 
 #line default
 #line hidden
-    WriteLiteralTo(__razor_template_writer, " of markup<br />\r\n");
+    WriteLiteralTo(__razor_template_writer, @" of markup<br />
+");
 }
 )));
 
 #line default
 #line hidden
-            WriteLiteral("\r\n</p>\r\n\r\n\r\n<ul>\r\n    ");
+            WriteLiteral(@"
+</p>
+
+
+<ul>
+    ");
 #line 45 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 Write(Repeat(10, item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
-    WriteLiteralTo(__razor_template_writer, "<li>\r\n        Item #");
+    WriteLiteralTo(__razor_template_writer, @"<li>
+        Item #");
 #line 46 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 WriteTo(__razor_template_writer, item);
 
 #line default
 #line hidden
-    WriteLiteralTo(__razor_template_writer, "\r\n");
+    WriteLiteralTo(__razor_template_writer, @"
+");
 #line 47 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
           var parent = item;
 
 #line default
 #line hidden
-    WriteLiteralTo(__razor_template_writer, "        <ul>\r\n            <li>Child Items... ?</li>\r\n");
-    WriteLiteralTo(__razor_template_writer, "        </ul>\r\n    </li>");
+    WriteLiteralTo(__razor_template_writer, @"        <ul>
+            <li>Child Items... ?</li>
+");
+    WriteLiteralTo(__razor_template_writer, @"        </ul>
+    </li>");
 }
 )));
 
 #line default
 #line hidden
-            WriteLiteral("\r\n</ul> ");
+            WriteLiteral(@"
+</ul> ");
         }
         #pragma warning restore 1998
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.codegen.cs
@@ -36,9 +36,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
-                WriteLiteral("Body of Tag");
+                WriteLiteral(@"Body of Tag");
             }
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
@@ -61,7 +62,8 @@ __TestNamespace_PTagHelper.Age = 1337;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );
@@ -87,7 +89,8 @@ __TestNamespace_PTagHelper.Age = 42;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );
@@ -107,7 +110,8 @@ __TestNamespace_PTagHelper.Age = 42 + @int;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );
@@ -127,7 +131,8 @@ __TestNamespace_PTagHelper.Age = int;
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );
@@ -147,7 +152,8 @@ __TestNamespace_PTagHelper.Age = (@int);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
             }
             );
@@ -174,7 +180,8 @@ __TestNamespace_PTagHelper.Age = 4 * @(@int + 2);
             }
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_Runtime.codegen.cs
@@ -38,20 +38,23 @@ using static global::System.Text.Encoding;
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("\r\n");
-            WriteLiteral("\r\n<p>Path\'s full type name is ");
+            WriteLiteral(@"
+");
+            WriteLiteral(@"
+<p>Path's full type name is ");
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml"
                        Write(typeof(Path).FullName);
 
 #line default
 #line hidden
-            WriteLiteral("</p>\r\n<p>Foo\'s actual full type name is ");
+            WriteLiteral(@"</p>
+<p>Foo's actual full type name is ");
 #line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml"
                              Write(typeof(Foo).FullName);
 
 #line default
 #line hidden
-            WriteLiteral("</p>");
+            WriteLiteral(@"</p>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
@@ -33,7 +33,8 @@ namespace Razor
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
             BeginContext(31, 28, true);
-            WriteLiteral("<span someattr>Hola</span>\r\n");
+            WriteLiteral(@"<span someattr>Hola</span>
+");
             EndContext();
             BeginContext(61, 7, false);
 #line 3 "TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.cshtml"
@@ -43,11 +44,13 @@ Write("Hello");
 #line hidden
             EndContext();
             BeginContext(69, 2, true);
-            WriteLiteral("\r\n");
+            WriteLiteral(@"
+");
             EndContext();
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("form", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 BeginContext(91, 6, true);
-                WriteLiteral("\r\n    ");
+                WriteLiteral(@"
+    ");
                 EndContext();
                 __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {
                 }
@@ -73,7 +76,8 @@ __InputTagHelper.BarProp = DateTime.Now;
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 EndContext();
                 BeginContext(149, 2, true);
-                WriteLiteral("\r\n");
+                WriteLiteral(@"
+");
                 EndContext();
             }
             );

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
@@ -94,16 +94,19 @@ __InputTagHelper.BarProp = DateTime.Now;
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             EndContext();
             BeginContext(158, 31, true);
-            WriteLiteral("\r\n\r\n<span>Here is some content ");
+            WriteLiteral(@"
+
+<span>Here is some content ");
             EndContext();
             BeginContext(207, 9, true);
-            WriteLiteral("</span>\r\n");
+            WriteLiteral(@"</span>
+");
             EndContext();
             BeginContext(217, 29, false);
 #line 9 "TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.cshtml"
 Write(Foo(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
     BeginContext(222, 24, true);
-    WriteLiteralTo(__razor_template_writer, "<span>Hello world</span>");
+    WriteLiteralTo(__razor_template_writer, @"<span>Hello world</span>");
     EndContext();
 }
 )));

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithBaseType.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithBaseType.codegen.cs
@@ -9,7 +9,7 @@ namespace Razor
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<h1>Hello world!</h1>");
+            WriteLiteral(@"<h1>Hello world!</h1>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithConfigureClass.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithConfigureClass.codegen.cs
@@ -9,7 +9,7 @@ namespace Razor
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<h1>Hello world!</h1>");
+            WriteLiteral(@"<h1>Hello world!</h1>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithDefaults.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithDefaults.codegen.cs
@@ -9,7 +9,7 @@ namespace Razor
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<h1>Hello world!</h1>");
+            WriteLiteral(@"<h1>Hello world!</h1>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithSetNamespace.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/RazorTemplateEngineIntegrationTest/GenerateCodeWithSetNamespace.codegen.cs
@@ -9,7 +9,7 @@ namespace MyApp.Razor.Views
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("<h1>Hello world!</h1>");
+            WriteLiteral(@"<h1>Hello world!</h1>");
         }
         #pragma warning restore 1998
     }

--- a/test/RazorPageGenerator.Test/TestFiles/Views/TestView.Designer.expected.cs
+++ b/test/RazorPageGenerator.Test/TestFiles/Views/TestView.Designer.expected.cs
@@ -8,13 +8,15 @@ namespace Microsoft.AspNetCore.TestGenerated
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
-            WriteLiteral("The time is ");
+            WriteLiteral(@"The time is ");
 #line 1 "TestView.cshtml"
        Write(DateTime.UtcNow);
 
 #line default
 #line hidden
-            WriteLiteral("\r\nwindow.alert(\"Hello world\");\r\nFooter goes here.");
+            WriteLiteral(@"
+window.alert(""Hello world"");
+Footer goes here.");
         }
         #pragma warning restore 1998
     }


### PR DESCRIPTION
Necessary because some files may have large HTML parts.