### PR TITLE
Introduce SourceChange in place of TextChange

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/AutoCompleteEditHandler.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/AutoCompleteEditHandler.cs
@@ -31,11 +31,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public string AutoCompleteString { get; set; }
 
-        protected override PartialParseResult CanAcceptChange(Span target, TextChange normalizedChange)
+        protected override PartialParseResult CanAcceptChange(Span target, SourceChange change)
         {
-            if (((AutoCompleteAtEndOfSpan && IsAtEndOfSpan(target, normalizedChange)) || IsAtEndOfFirstLine(target, normalizedChange)) &&
-                normalizedChange.IsInsert &&
-                ParserHelpers.IsNewLine(normalizedChange.NewText) &&
+            if (((AutoCompleteAtEndOfSpan && IsAtEndOfSpan(target, change)) || IsAtEndOfFirstLine(target, change)) &&
+                change.IsInsert &&
+                ParserHelpers.IsNewLine(change.NewText) &&
                 AutoCompleteString != null)
             {
                 return PartialParseResult.Rejected | PartialParseResult.AutoCompleteBlock;

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/BackgroundParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/BackgroundParser.cs
@@ -43,7 +43,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             _main.Cancel();
         }
 
+#pragma warning disable CS0612 // Type or member is obsolete
         public void QueueChange(TextChange change)
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             _main.QueueChange(change);
         }
@@ -67,37 +69,43 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        internal static bool TreesAreDifferent(RazorSyntaxTree leftTree, RazorSyntaxTree rightTree, IEnumerable<TextChange> changes)
-        {
-            return TreesAreDifferent(leftTree, rightTree, changes, CancellationToken.None);
-        }
-
+#pragma warning disable CS0612 // Type or member is obsolete
         internal static bool TreesAreDifferent(RazorSyntaxTree leftTree, RazorSyntaxTree rightTree, IEnumerable<TextChange> changes, CancellationToken cancelToken)
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             return TreesAreDifferent(leftTree.Root, rightTree.Root, changes, cancelToken);
         }
 
+#pragma warning disable CS0612 // Type or member is obsolete
         internal static bool TreesAreDifferent(Block leftTree, Block rightTree, IEnumerable<TextChange> changes)
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             return TreesAreDifferent(leftTree, rightTree, changes, CancellationToken.None);
         }
 
+#pragma warning disable CS0612 // Type or member is obsolete
         internal static bool TreesAreDifferent(Block leftTree, Block rightTree, IEnumerable<TextChange> changes, CancellationToken cancelToken)
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             // Apply all the pending changes to the original tree
             // PERF: If this becomes a bottleneck, we can probably do it the other way around,
             //  i.e. visit the tree and find applicable changes for each node.
-            foreach (TextChange change in changes)
+#pragma warning disable CS0612 // Type or member is obsolete
+            foreach (var change in changes)
+#pragma warning restore CS0612 // Type or member is obsolete
             {
                 cancelToken.ThrowIfCancellationRequested();
-                var changeOwner = leftTree.LocateOwner(change);
+
+                var sourceChange = change.AsSourceChange();
+                var changeOwner = leftTree.LocateOwner(sourceChange);
 
                 // Apply the change to the tree
                 if (changeOwner == null)
                 {
                     return true;
                 }
-                var result = changeOwner.EditHandler.ApplyChange(changeOwner, change, force: true);
+
+                var result = changeOwner.EditHandler.ApplyChange(changeOwner, sourceChange, force: true);
                 changeOwner.ReplaceWith(result.EditedSpan);
             }
 
@@ -150,7 +158,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
             private string _fileName;
             private readonly object _stateLock = new object();
+#pragma warning disable CS0612 // Type or member is obsolete
             private IList<TextChange> _changes = new List<TextChange>();
+#pragma warning restore CS0612 // Type or member is obsolete
 
             public MainThreadState(string fileName)
             {
@@ -189,7 +199,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 return new DisposableAction(() => Monitor.Exit(_stateLock));
             }
 
+#pragma warning disable CS0612 // Type or member is obsolete
             public void QueueChange(TextChange change)
+#pragma warning restore CS0612 // Type or member is obsolete
             {
                 EnsureOnThread();
                 lock (_stateLock)
@@ -216,7 +228,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     _currentParcelCancelSource = new CancellationTokenSource();
 
                     var changes = _changes;
+#pragma warning disable CS0612 // Type or member is obsolete
                     _changes = new List<TextChange>();
+#pragma warning restore CS0612 // Type or member is obsolete
                     return new WorkParcel(changes, _currentParcelCancelSource.Token);
                 }
             }
@@ -274,7 +288,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             private RazorTemplateEngine _templateEngine;
             private string _fileName;
             private RazorSyntaxTree _currentSyntaxTree;
+#pragma warning disable CS0612 // Type or member is obsolete
             private IList<TextChange> _previouslyDiscarded = new List<TextChange>();
+#pragma warning restore CS0612 // Type or member is obsolete
 
             public BackgroundThread(MainThreadState main, RazorTemplateEngine templateEngine, string fileName)
             {
@@ -321,7 +337,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                     if (!linkedCancel.IsCancellationRequested)
                                     {
                                         // Collect ALL changes
+#pragma warning disable CS0612 // Type or member is obsolete
                                         List<TextChange> allChanges;
+#pragma warning restore CS0612 // Type or member is obsolete
 
                                         if (_previouslyDiscarded != null)
                                         {
@@ -411,14 +429,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         private class WorkParcel
         {
+#pragma warning disable CS0612 // Type or member is obsolete
             public WorkParcel(IList<TextChange> changes, CancellationToken cancelToken)
+#pragma warning restore CS0612 // Type or member is obsolete
             {
                 Changes = changes;
                 CancelToken = cancelToken;
             }
 
             public CancellationToken CancelToken { get; private set; }
+#pragma warning disable CS0612 // Type or member is obsolete
             public IList<TextChange> Changes { get; private set; }
+#pragma warning restore CS0612 // Type or member is obsolete
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/Block.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/Block.cs
@@ -102,9 +102,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return current as Span;
         }
 
-        public virtual Span LocateOwner(TextChange change) => LocateOwner(change, Children);
+        public virtual Span LocateOwner(SourceChange change) => LocateOwner(change, Children);
 
-        protected static Span LocateOwner(TextChange change, IEnumerable<SyntaxTreeNode> elements)
+        protected static Span LocateOwner(SourceChange change, IEnumerable<SyntaxTreeNode> elements)
         {
             // Ask each child recursively
             Span owner = null;
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 }
                 else
                 {
-                    if (change.OldPosition < span.Start.AbsoluteIndex)
+                    if (change.Span.AbsoluteIndex < span.Start.AbsoluteIndex)
                     {
                         // Early escape for cases where changes overlap multiple spans
                         // In those cases, the span will return false, and we don't want to search the whole tree
@@ -134,6 +134,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
             return owner;
         }
+
         public override string ToString()
         {
             return string.Format(

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/DocumentParseCompleteEventArgs.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/DocumentParseCompleteEventArgs.cs
@@ -20,9 +20,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         /// </summary>
         public RazorCodeDocument GeneratorResults { get; set; }
 
+
         /// <summary>
         /// The TextChange which triggered the re-parse
         /// </summary>
+#pragma warning disable CS0612 // Type or member is obsolete
         public TextChange SourceChange { get; set; }
+#pragma warning restore CS0612 // Type or member is obsolete
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/RazorEditorParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/RazorEditorParser.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 
+#pragma warning disable CS0618 // TextChange is Obsolete
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     /// <summary>
@@ -118,6 +118,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return null;
         }
 
+        // Type or member is obsolete
         /// <summary>
         /// Determines if a change will cause a structural change to the document and if not, applies it to the
         /// existing tree. If a structural change would occur, automatically starts a reparse.
@@ -128,7 +129,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         /// </remarks>
         /// <param name="change">The change to apply to the parse tree.</param>
         /// <returns>A <see cref="PartialParseResult"/> value indicating the result of the incremental parse.</returns>
+#pragma warning disable CS0612
         public virtual PartialParseResult CheckForStructureChanges(TextChange change)
+#pragma warning restore CS0612 // Type or member is obsolete
         {
             var result = PartialParseResult.Rejected;
 
@@ -171,14 +174,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
+#pragma warning disable CS0612 // Type or member is obsolete
         private PartialParseResult TryPartialParse(TextChange change)
+#pragma warning restore CS0612 // Type or member is obsolete
         {
+            var sourceChange = change.AsSourceChange();
+
             var result = PartialParseResult.Rejected;
 
             // Try the last change owner
-            if (_lastChangeOwner != null && _lastChangeOwner.EditHandler.OwnsChange(_lastChangeOwner, change))
+            if (_lastChangeOwner != null && _lastChangeOwner.EditHandler.OwnsChange(_lastChangeOwner, sourceChange))
             {
-                var editResult = _lastChangeOwner.EditHandler.ApplyChange(_lastChangeOwner, change);
+                var editResult = _lastChangeOwner.EditHandler.ApplyChange(_lastChangeOwner, sourceChange);
                 result = editResult.Result;
                 if ((editResult.Result & PartialParseResult.Rejected) != PartialParseResult.Rejected)
                 {
@@ -189,7 +196,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
 
             // Locate the span responsible for this change
-            _lastChangeOwner = CurrentSyntaxTree.Root.LocateOwner(change);
+            _lastChangeOwner = CurrentSyntaxTree.Root.LocateOwner(sourceChange);
 
             if (LastResultProvisional)
             {
@@ -198,7 +205,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
             else if (_lastChangeOwner != null)
             {
-                var editResult = _lastChangeOwner.EditHandler.ApplyChange(_lastChangeOwner, change);
+                var editResult = _lastChangeOwner.EditHandler.ApplyChange(_lastChangeOwner, sourceChange);
                 result = editResult.Result;
                 if ((editResult.Result & PartialParseResult.Rejected) != PartialParseResult.Rejected)
                 {
@@ -258,3 +265,4 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlock.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlock.cs
@@ -120,9 +120,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        public override Span LocateOwner(TextChange change)
+        public override Span LocateOwner(SourceChange change)
         {
-            var oldPosition = change.OldPosition;
+            var oldPosition = change.Span.AbsoluteIndex;
             if (oldPosition < Start.AbsoluteIndex)
             {
                 // Change occurs prior to the TagHelper.

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TextChange.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TextChange.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
+    [Obsolete] // Superseded by SourceChange
     public struct TextChange
     {
         private string _newText;
@@ -127,6 +128,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             get { return OldLength > 0 && NewLength > 0; }
         }
 
+        public SourceChange AsSourceChange()
+        {
+            var normalized = Normalize();
+            return new SourceChange(
+                new SourceSpan(
+                    filePath: null,
+                    absoluteIndex: normalized.OldPosition,
+                    lineIndex: -1,
+                    characterIndex: -1,
+                    length: normalized.OldLength), 
+                normalized.NewText);
+        }
+
         public override bool Equals(object obj)
         {
             if (!(obj is TextChange))
@@ -154,15 +168,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             hashCodeCombiner.Add(NewBuffer);
 
             return hashCodeCombiner;
-        }
-
-        public string ApplyChange(string content, int changeOffset)
-        {
-            var changeRelativePosition = OldPosition - changeOffset;
-
-            Debug.Assert(changeRelativePosition >= 0);
-            return content.Remove(changeRelativePosition, OldLength)
-                .Insert(changeRelativePosition, NewText);
         }
 
         public override string ToString()

--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -374,6 +374,20 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static string FormatInvalidTargetedTagNameNullOrWhitespace()
             => GetString("InvalidTargetedTagNameNullOrWhitespace");
 
+        /// <summary>
+        /// The node '{0}' is not the owner of change '{1}'.
+        /// </summary>
+        internal static string InvalidOperation_SpanIsNotChangeOwner
+        {
+            get => GetString("InvalidOperation_SpanIsNotChangeOwner");
+        }
+
+        /// <summary>
+        /// The node '{0}' is not the owner of change '{1}'.
+        /// </summary>
+        internal static string FormatInvalidOperation_SpanIsNotChangeOwner(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("InvalidOperation_SpanIsNotChangeOwner"), p0, p1);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -195,4 +195,7 @@
   <data name="InvalidTargetedTagNameNullOrWhitespace" xml:space="preserve">
     <value>Targeted tag name cannot be null or whitespace.</value>
   </data>
+  <data name="InvalidOperation_SpanIsNotChangeOwner" xml:space="preserve">
+    <value>The node '{0}' is not the owner of change '{1}'.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Razor.Language/SourceChange.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/SourceChange.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public sealed class SourceChange : IEquatable<SourceChange>
+    {
+        public SourceChange(int absoluteIndex, int length, string newText)
+        {
+            if (absoluteIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(absoluteIndex));
+            }
+
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (newText == null)
+            {
+                throw new ArgumentNullException(nameof(newText));
+            }
+
+            Span = new SourceSpan(absoluteIndex, length);
+            NewText = newText;
+        }
+
+        public SourceChange(SourceSpan span, string newText)
+        {
+            if (newText == null)
+            {
+                throw new ArgumentNullException(nameof(newText));
+            }
+
+            Span = span;
+            NewText = newText;
+        }
+
+        public bool IsDelete => Span.Length > 0 && NewText.Length == 0;
+
+        public bool IsInsert => Span.Length == 0 && NewText.Length > 0;
+
+        public bool IsReplace => Span.Length > 0 && NewText.Length > 0;
+
+        public SourceSpan Span { get; }
+
+        public string NewText { get; }
+
+        internal string GetEditedContent(Span span)
+        {
+            if (span == null)
+            {
+                throw new ArgumentNullException(nameof(span));
+            }
+
+            var offset = GetOffset(span);
+            return GetEditedContent(span.Content, offset);
+        }
+
+        internal string GetEditedContent(string text, int offset)
+        {
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            return text.Remove(offset, Span.Length).Insert(offset, NewText);
+        }
+
+        internal int GetOffset(Span span)
+        {
+            if (span == null)
+            {
+                throw new ArgumentNullException(nameof(span));
+            }
+
+            var start = Span.AbsoluteIndex;
+            var end = Span.AbsoluteIndex + Span.Length;
+
+            if (start < span.Start.AbsoluteIndex ||
+                start > span.Start.AbsoluteIndex + span.Length ||
+                end < span.Start.AbsoluteIndex || 
+                end > span.Start.AbsoluteIndex + span.Length)
+            {
+                throw new InvalidOperationException(Resources.FormatInvalidOperation_SpanIsNotChangeOwner(span, this));
+            }
+
+            return start - span.Start.AbsoluteIndex;
+        }
+
+        internal string GetOriginalText(Span span)
+        {
+            if (span == null)
+            {
+                throw new ArgumentNullException(nameof(span));
+            }
+
+            if (span.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var offset = GetOffset(span);
+            return span.Content.Substring(offset, Span.Length);
+        }
+
+        public bool Equals(SourceChange other)
+        {
+            return
+                other != null &&
+                Span.Equals(other.Span) &&
+                string.Equals(NewText, other.NewText, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as SourceChange);
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCodeCombiner();
+            hash.Add(Span);
+            hash.Add(NewText, StringComparer.Ordinal);
+            return hash;
+        }
+
+        public override string ToString()
+        {
+            return Span.ToString() + " : " + NewText;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/SourceSpan.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/SourceSpan.cs
@@ -9,6 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public struct SourceSpan : IEquatable<SourceSpan>
     {
+        public SourceSpan(int absoluteIndex, int length)
+            : this(null, absoluteIndex, -1, -1, length)
+        {
+        }
+
         public SourceSpan(SourceLocation location, int contentLength)
             : this(location.FilePath, location.AbsoluteIndex, location.LineIndex, location.CharacterIndex, contentLength)
         {

--- a/src/Microsoft.CodeAnalysis.Razor/TextChangeExtensions.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/TextChangeExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    internal static class TextChangeExtensions
+    {
+        public static SourceChange AsSourceChange(this TextChange textChange)
+        {
+            if (textChange == null)
+            {
+                throw new ArgumentNullException(nameof(textChange));
+            }
+
+            return new SourceChange(textChange.Span.AsSourceSpan(), textChange.NewText);
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor/TextSpanExtensions.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/TextSpanExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    internal static class TextSpanExtensions
+    {
+        public static SourceSpan AsSourceSpan(this TextSpan textSpan)
+        {
+            return new SourceSpan(filePath: null, absoluteIndex: textSpan.Start, lineIndex: -1, characterIndex: -1, length: textSpan.Length);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/RazorEditorParserTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/RazorEditorParserTest.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#pragma warning disable CS0612 // Type or member is obsolete
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     public class RazorEditorParserTest
@@ -1448,3 +1449,4 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
     }
 }
+#pragma warning restore CS0612 // Type or member is obsolete

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TextChangeTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TextChangeTest.cs
@@ -5,6 +5,7 @@ using System;
 using Moq;
 using Xunit;
 
+#pragma warning disable CS0612 // Type or member is obsolete
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     public class TextChangeTest
@@ -225,51 +226,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void ApplyChangeWithInsertedTextReturnsNewContentWithChangeApplied()
-        {
-            // Arrange
-            var newBuffer = new StringTextBuffer("test");
-            var oldBuffer = new StringTextBuffer("");
-            var textChange = new TextChange(0, 0, oldBuffer, 3, newBuffer);
-
-            // Act
-            var text = textChange.ApplyChange("abcd", 0);
-
-            // Assert
-            Assert.Equal("tesabcd", text);
-        }
-
-        [Fact]
-        public void ApplyChangeWithRemovedTextReturnsNewContentWithChangeApplied()
-        {
-            // Arrange
-            var newBuffer = new StringTextBuffer("abcdefg");
-            var oldBuffer = new StringTextBuffer("");
-            var textChange = new TextChange(1, 1, oldBuffer, 0, newBuffer);
-
-            // Act
-            var text = textChange.ApplyChange("abcdefg", 1);
-
-            // Assert
-            Assert.Equal("bcdefg", text);
-        }
-
-        [Fact]
-        public void ApplyChangeWithReplacedTextReturnsNewContentWithChangeApplied()
-        {
-            // Arrange
-            var newBuffer = new StringTextBuffer("abcdefg");
-            var oldBuffer = new StringTextBuffer("");
-            var textChange = new TextChange(1, 1, oldBuffer, 2, newBuffer);
-
-            // Act
-            var text = textChange.ApplyChange("abcdefg", 1);
-
-            // Assert
-            Assert.Equal("bcbcdefg", text);
-        }
-
-        [Fact]
         public void NormalizeFixesUpIntelliSenseStyleReplacements()
         {
             // Arrange
@@ -315,3 +271,4 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
     }
 }
+#pragma warning restore CS0612 // Type or member is obsolete

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/SourceChangeTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/SourceChangeTest.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class SourceChangeTest
+    {
+        [Fact]
+        public void SourceChange_ConstructorSetsDefaults_WhenNotProvided()
+        {
+            // Arrange & Act
+            var change = new SourceChange(15, 7, "Hello");
+
+            // Assert
+            Assert.Equal(15, change.Span.AbsoluteIndex);
+            Assert.Equal(-1, change.Span.CharacterIndex);
+            Assert.Null(change.Span.FilePath);
+            Assert.Equal(7, change.Span.Length);
+            Assert.Equal(-1, change.Span.LineIndex);
+            Assert.Equal("Hello", change.NewText);
+        }
+
+        [Fact]
+        public void IsDelete_IsTrue_WhenOldLengthIsPositive_AndNewLengthIsZero()
+        {
+            // Arrange & Act
+            var change = new SourceChange(3, 5, string.Empty);
+
+            // Assert
+            Assert.True(change.IsDelete);
+        }
+
+        [Fact]
+        public void IsInsert_IsTrue_WhenOldLengthIsZero_AndNewLengthIsPositive()
+        {
+            // Arrange & Act
+            var change = new SourceChange(3, 0, "Hello");
+
+            // Assert
+            Assert.True(change.IsInsert);
+        }
+
+        [Fact]
+        public void IsReplace_IsTrue_WhenOldLengthIsPositive_AndNewLengthIsPositive()
+        {
+            // Arrange & Act
+            var change = new SourceChange(3, 5, "Hello");
+
+            // Assert
+            Assert.True(change.IsReplace);
+        }
+
+        [Fact]
+        public void GetEditedContent_ForDelete_ReturnsNewContent()
+        {
+            // Arrange
+            var text = "Hello, World";
+
+            var change = new SourceChange(2, 2, string.Empty);
+
+            // Act
+            var result = change.GetEditedContent(text, 1);
+
+            // Act
+            Assert.Equal("Hlo, World", result);
+        }
+
+        [Fact]
+        public void GetEditedContent_ForInsert_ReturnsNewContent()
+        {
+            // Arrange
+            var text = "Hello, World";
+
+            var change = new SourceChange(2, 0, "heyo");
+
+            // Act
+            var result = change.GetEditedContent(text, 1);
+
+            // Act
+            Assert.Equal("Hheyoello, World", result);
+        }
+
+        [Fact]
+        public void GetEditedContent_ForReplace_ReturnsNewContent()
+        {
+            // Arrange
+            var text = "Hello, World";
+
+            var change = new SourceChange(2, 2, "heyo");
+
+            // Act
+            var result = change.GetEditedContent(text, 1);
+
+            // Act
+            Assert.Equal("Hheyolo, World", result);
+        }
+
+        [Fact]
+        public void GetEditedContent_Span_ReturnsNewContent()
+        {
+            // Arrange
+            var builder = new SpanBuilder(new SourceLocation(0, 0, 0));
+            builder.Accept(new RawTextSymbol(new SourceLocation(0, 0, 0), "Hello, "));
+            builder.Accept(new RawTextSymbol(new SourceLocation(7, 0, 7), "World"));
+
+            var span = new Span(builder);
+
+            var change = new SourceChange(2, 2, "heyo");
+
+            // Act
+            var result = change.GetEditedContent(span);
+
+            // Act
+            Assert.Equal("Heheyoo, World", result);
+        }
+
+        [Fact]
+        public void GetOffSet_SpanIsOwner_ReturnsOffset()
+        {
+            // Arrange
+            var builder = new SpanBuilder(new SourceLocation(13, 0, 0));
+            builder.Accept(new RawTextSymbol(new SourceLocation(13, 0, 13), "Hello, "));
+            builder.Accept(new RawTextSymbol(new SourceLocation(20, 0, 20), "World"));
+
+            var span = new Span(builder);
+
+            var change = new SourceChange(15, 2, "heyo");
+
+            // Act
+            var result = change.GetOffset(span);
+
+            // Act
+            Assert.Equal(2, result);
+        }
+
+        [Theory]
+        [InlineData(12, 2)]
+        [InlineData(12, 14)]
+        [InlineData(13, 13)]
+        [InlineData(13, 13)]
+        [InlineData(20, 1)]
+        [InlineData(21, 0)]
+        public void GetOffSet_SpanIsNotOwnerOfChange_ThrowsException(int absoluteIndex, int length)
+        {
+            // Arrange
+            var builder = new SpanBuilder(new SourceLocation(13, 0, 0));
+            builder.Accept(new RawTextSymbol(new SourceLocation(13, 0, 13), "Hello, "));
+            builder.Accept(new RawTextSymbol(new SourceLocation(20, 0, 20), "World"));
+
+            var span = new Span(builder);
+
+            var change = new SourceChange(12, 2, "heyo");
+
+            var expected = $"The node '{span}' is not the owner of change '{change}'.";
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => { change.GetOffset(span); });
+            Assert.Equal(expected, exception.Message);
+        }
+
+        [Fact]
+        public void GetOrigninalText_SpanIsOwner_ReturnsContent()
+        {
+            // Arrange
+            var builder = new SpanBuilder(new SourceLocation(13, 0, 0));
+            builder.Accept(new RawTextSymbol(new SourceLocation(13, 0, 13), "Hello, "));
+            builder.Accept(new RawTextSymbol(new SourceLocation(20, 0, 20), "World"));
+
+            var span = new Span(builder);
+
+            var change = new SourceChange(15, 2, "heyo");
+
+            // Act
+            var result = change.GetOriginalText(span);
+
+            // Act
+            Assert.Equal("ll", result);
+        }
+
+        [Fact]
+        public void GetOrigninalText_SpanIsOwner_ReturnsContent_ZeroLengthSpan()
+        {
+            // Arrange
+            var builder = new SpanBuilder(new SourceLocation(13, 0, 0));
+            builder.Accept(new RawTextSymbol(new SourceLocation(13, 0, 13), "Hello, "));
+            builder.Accept(new RawTextSymbol(new SourceLocation(20, 0, 20), "World"));
+
+            var span = new Span(builder);
+
+            var change = new SourceChange(15, 0, "heyo");
+
+            // Act
+            var result = change.GetOriginalText(span);
+
+            // Act
+            Assert.Equal(string.Empty, result);
+        }
+    }
+}


### PR DESCRIPTION
This is the first step on the journey to replacing RazorEditorParser. We
can't just get rid of this because VS is using it today.