### PR TITLE
Add AttributeCompletion API.

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/AttributeCompletionContext.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/AttributeCompletionContext.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public class AttributeCompletionContext
+    {
+        public AttributeCompletionContext(
+            TagHelperDocumentContext documentContext,
+            IEnumerable<string> existingCompletions,
+            string currentTagName,
+            IEnumerable<KeyValuePair<string, string>> attributes,
+            string currentParentTagName,
+            Func<string, bool> inHTMLSchema)
+        {
+            if (documentContext == null)
+            {
+                throw new ArgumentNullException(nameof(documentContext));
+            }
+
+            if (existingCompletions == null)
+            {
+                throw new ArgumentNullException(nameof(existingCompletions));
+            }
+
+            if (currentTagName == null)
+            {
+                throw new ArgumentNullException(nameof(currentTagName));
+            }
+
+            if (attributes == null)
+            {
+                throw new ArgumentNullException(nameof(attributes));
+            }
+
+            if (inHTMLSchema == null)
+            {
+                throw new ArgumentNullException(nameof(inHTMLSchema));
+            }
+
+            DocumentContext = documentContext;
+            ExistingCompletions = existingCompletions;
+            CurrentTagName = currentTagName;
+            Attributes = attributes;
+            CurrentParentTagName = currentParentTagName;
+            InHTMLSchema = inHTMLSchema;
+        }
+
+        public TagHelperDocumentContext DocumentContext { get; }
+
+        public IEnumerable<string> ExistingCompletions { get; }
+
+        public string CurrentTagName { get; }
+
+        public IEnumerable<KeyValuePair<string, string>> Attributes { get; }
+
+        public string CurrentParentTagName { get; }
+
+        public Func<string, bool> InHTMLSchema { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/AttributeCompletionResult.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/AttributeCompletionResult.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public abstract class AttributeCompletionResult
+    {
+        private AttributeCompletionResult()
+        {
+        }
+
+        public abstract IReadOnlyDictionary<string, IEnumerable<BoundAttributeDescriptor>> Completions { get; }
+
+        internal static AttributeCompletionResult Create(Dictionary<string, HashSet<BoundAttributeDescriptor>> completions)
+        {
+            var readonlyCompletions = completions.ToDictionary(
+                key => key.Key,
+                value => (IEnumerable<BoundAttributeDescriptor>)value.Value,
+                completions.Comparer);
+            var result = new DefaultAttributeCompletionResult(readonlyCompletions);
+
+            return result;
+        }
+
+        private class DefaultAttributeCompletionResult : AttributeCompletionResult
+        {
+            private readonly IReadOnlyDictionary<string, IEnumerable<BoundAttributeDescriptor>> _completions;
+
+            public DefaultAttributeCompletionResult(IReadOnlyDictionary<string, IEnumerable<BoundAttributeDescriptor>> completions)
+            {
+                _completions = completions;
+            }
+
+            public override IReadOnlyDictionary<string, IEnumerable<BoundAttributeDescriptor>> Completions => _completions;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperCompletionService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperCompletionService.cs
@@ -5,6 +5,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     public abstract class TagHelperCompletionService
     {
+        public abstract AttributeCompletionResult GetAttributeCompletions(AttributeCompletionContext completionContext);
+
         public abstract ElementCompletionResult GetElementCompletions(ElementCompletionContext completionContext);
     }
 }


### PR DESCRIPTION
- Added a `GetAttributeCompletions` API that's consistent with current Razor's editor expectations.
- Added unit tests to validate all code paths of the new `GetAttributeCompletions` method.

#1120