### PR TITLE
Reduce catch all element completion usage.

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionService.cs
@@ -194,8 +194,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             {
                 foreach (var completionTagName in elementCompletions.Keys)
                 {
-                    if (completionTagName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    if (elementCompletions[completionTagName].Count > 0 || 
+                        !string.IsNullOrEmpty(prefix) && completionTagName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                     {
+                        // The current completion either has other TagHelper's associated with it or is prefixed with a non-empty
+                        // TagHelper prefix.
                         UpdateCompletions(completionTagName, catchAllDescriptor);
                     }
                 }


### PR DESCRIPTION
- This makes it so if you have catch all `TagHelperDescriptor`s their completions don't apply to every existing completion. Instead, they now only apply to already TagHelperified completions and existing completions that are prefixed with a non-empty TagHelperPrefix.
- Updated existing test to have new expectations.
- Added new test to validate non-empty tag helper prefix case.

#1230 

/cc @alexgav This changes the expectations on how catch-all TagHelpers work.