### PR TITLE
Remove assembly name filter from THD API.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperResolver.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultTagHelperResolver.cs
@@ -16,12 +16,12 @@ namespace Microsoft.CodeAnalysis.Razor
 
         public bool DesignTime { get; }
 
-        public override TagHelperResolutionResult GetTagHelpers(Compilation compilation, IEnumerable<string> assemblyNameFilters)
+        public override TagHelperResolutionResult GetTagHelpers(Compilation compilation)
         {
             var descriptors = new List<TagHelperDescriptor>();
 
-            VisitTagHelpers(compilation, assemblyNameFilters, descriptors);
-            VisitViewComponents(compilation, assemblyNameFilters, descriptors);
+            VisitTagHelpers(compilation, descriptors);
+            VisitViewComponents(compilation, descriptors);
 
             var diagnostics = new List<RazorDiagnostic>();
             var resolutionResult = new TagHelperResolutionResult(descriptors, diagnostics);
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Razor
             return resolutionResult;
         }
 
-        private void VisitTagHelpers(Compilation compilation, IEnumerable<string> assemblyNameFilters, List<TagHelperDescriptor> results)
+        private void VisitTagHelpers(Compilation compilation, List<TagHelperDescriptor> results)
         {
             var types = new List<INamedTypeSymbol>();
             var visitor = TagHelperTypeVisitor.Create(compilation, types);
@@ -40,19 +40,16 @@ namespace Microsoft.CodeAnalysis.Razor
 
             foreach (var type in types)
             {
-                if (assemblyNameFilters == null || assemblyNameFilters.Contains(type.ContainingAssembly.Identity.Name))
-                {
-                    var descriptor = factory.CreateDescriptor(type);
+                var descriptor = factory.CreateDescriptor(type);
 
-                    if (descriptor != null)
-                    {
-                        results.Add(descriptor);
-                    }
+                if (descriptor != null)
+                {
+                    results.Add(descriptor);
                 }
             }
         }
 
-        private void VisitViewComponents(Compilation compilation, IEnumerable<string> assemblyNameFilters, List<TagHelperDescriptor> results)
+        private void VisitViewComponents(Compilation compilation, List<TagHelperDescriptor> results)
         {
             var types = new List<INamedTypeSymbol>();
             var visitor = ViewComponentTypeVisitor.Create(compilation, types);
@@ -62,12 +59,9 @@ namespace Microsoft.CodeAnalysis.Razor
             var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
             foreach (var type in types)
             {
-                if (assemblyNameFilters == null || assemblyNameFilters.Contains(type.ContainingAssembly.Identity.Name))
-                {
-                    var descriptor = factory.CreateDescriptor(type);
+                var descriptor = factory.CreateDescriptor(type);
 
-                    results.Add(descriptor);
-                }
+                results.Add(descriptor);
             }
         }
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
@@ -10,15 +10,14 @@ namespace Microsoft.CodeAnalysis.Razor
 {
     internal abstract class TagHelperResolver : ILanguageService
     {
-        public abstract TagHelperResolutionResult GetTagHelpers(Compilation compilation, IEnumerable<string> assemblyNameFilters);
+        public abstract TagHelperResolutionResult GetTagHelpers(Compilation compilation);
 
         public virtual async Task<TagHelperResolutionResult> GetTagHelpersAsync(
             Project project,
-            IEnumerable<string> assemblyNameFilters,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-            return GetTagHelpers(compilation, assemblyNameFilters);
+            return GetTagHelpers(compilation);
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Remote.Razor/RazorLanguageService.cs
+++ b/src/Microsoft.CodeAnalysis.Remote.Razor/RazorLanguageService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             Rpc.JsonSerializer.Converters.Add(new RazorDiagnosticJsonConverter());
         }
 
-        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(Guid projectIdBytes, string projectDebugName, IEnumerable<string> assemblyNameFilters, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(Guid projectIdBytes, string projectDebugName, CancellationToken cancellationToken = default(CancellationToken))
         {
             var projectId = ProjectId.CreateFromSerialized(projectIdBytes, projectDebugName);
 
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             var project = solution.GetProject(projectId);
 
             var resolver = new DefaultTagHelperResolver(designTime: true);
-            var result = await resolver.GetTagHelpersAsync(project, assemblyNameFilters, cancellationToken).ConfigureAwait(false);
+            var result = await resolver.GetTagHelpersAsync(project, cancellationToken).ConfigureAwait(false);
 
             return result;
         }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperResolver.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperResolver.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
         [Import]
         public SVsServiceProvider Services { get; set; }
 
-        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project, IEnumerable<string> assemblyNameFilters)
+        public async Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project)
         {
             try
             {
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                         {
                             var jsonObject = await session.InvokeAsync<JObject>(
                                 "GetTagHelpersAsync",
-                                new object[] { project.Id.Id, "Foo", assemblyNameFilters, }).ConfigureAwait(false);
+                                new object[] { project.Id.Id, "Foo", }).ConfigureAwait(false);
 
                             result = GetTagHelperResolutionResult(jsonObject);
 
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
                 // The OOP host is turned off, so let's do this in process.
                 var resolver = new CodeAnalysis.Razor.DefaultTagHelperResolver(designTime: true);
-                result = await resolver.GetTagHelpersAsync(project, assemblyNameFilters, CancellationToken.None).ConfigureAwait(false);
+                result = await resolver.GetTagHelpersAsync(project, CancellationToken.None).ConfigureAwait(false);
                 return result;
             }
             catch (Exception exception)

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/ITagHelperResolver.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/ITagHelperResolver.cs
@@ -10,6 +10,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     public interface ITagHelperResolver
     {
-        Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project, IEnumerable<string> assemblyNameFilters);
+        Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project);
     }
 }

--- a/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/RazorInfoViewModel.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/RazorInfoViewModel.cs
@@ -175,10 +175,7 @@ namespace Microsoft.VisualStudio.RazorExtension.RazorInfo
                     .Select(reference => reference.Display)
                     .Select(filter => Path.GetFileNameWithoutExtension(filter));
                 var projectFilters = project.AllProjectReferences.Select(filter => solution.GetProject(filter.ProjectId).AssemblyName);
-                var tagHelperAssemblyFilters = assemblyFilters
-                    .Concat(projectFilters)
-                    .Concat(new[] { project.AssemblyName });
-                var resolutionResult = await _tagHelperResolver.GetTagHelpersAsync(project, tagHelperAssemblyFilters);
+                var resolutionResult = await _tagHelperResolver.GetTagHelpersAsync(project);
 
                 var files = GetCshtmlDocuments(project);
 


### PR DESCRIPTION
- This parameter was always passed `null` by tooling in the past.

#1279