### PR TITLE
Rename TagHelperDescriptorProvider => TagHelperBinder.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinder.cs
@@ -4,23 +4,24 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 
-namespace Microsoft.AspNetCore.Razor.Language.Legacy
+namespace Microsoft.AspNetCore.Razor.Language
 {
     /// <summary>
-    /// Enables retrieval of <see cref="TagHelperDescriptor"/>'s.
+    /// Enables retrieval of <see cref="TagHelperBinding"/>'s.
     /// </summary>
-    internal class TagHelperDescriptorProvider
+    internal class TagHelperBinder
     {
         private IDictionary<string, HashSet<TagHelperDescriptor>> _registrations;
         private readonly string _tagHelperPrefix;
 
         /// <summary>
-        /// Instantiates a new instance of the <see cref="TagHelperDescriptorProvider"/>.
+        /// Instantiates a new instance of the <see cref="TagHelperBinder"/>.
         /// </summary>
         /// <param name="tagHelperPrefix">The tag helper prefix being used by the document.</param>
-        /// <param name="descriptors">The descriptors that the <see cref="TagHelperDescriptorProvider"/> will pull from.</param>
-        public TagHelperDescriptorProvider(string tagHelperPrefix, IEnumerable<TagHelperDescriptor> descriptors)
+        /// <param name="descriptors">The descriptors that the <see cref="TagHelperBinder"/> will pull from.</param>
+        public TagHelperBinder(string tagHelperPrefix, IEnumerable<TagHelperDescriptor> descriptors)
         {
             _tagHelperPrefix = tagHelperPrefix;
             _registrations = new Dictionary<string, HashSet<TagHelperDescriptor>>(StringComparer.OrdinalIgnoreCase);
@@ -33,16 +34,15 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         /// <summary>
-        /// Gets all tag helpers that match the given <paramref name="tagName"/>.
+        /// Gets all tag helpers that match the given HTML tag criteria.
         /// </summary>
         /// <param name="tagName">The name of the HTML tag to match. Providing a '*' tag name
         /// retrieves catch-all <see cref="TagHelperDescriptor"/>s (descriptors that target every tag).</param>
-        /// <param name="attributes">Attributes the HTML element must contain to match.</param>
+        /// <param name="attributes">Attributes on the HTML tag.</param>
         /// <param name="parentTagName">The parent tag name of the given <paramref name="tagName"/> tag.</param>
-        /// <returns><see cref="TagHelperDescriptor"/>s that apply to the given <paramref name="tagName"/>.
-        /// Will return an empty <see cref="Enumerable" /> if no <see cref="TagHelperDescriptor"/>s are
-        /// found.</returns>
-        public TagHelperBinding GetTagHelperBinding(
+        /// <returns><see cref="TagHelperDescriptor"/>s that apply to the given HTML tag criteria.
+        /// Will return <c>null</c> if no <see cref="TagHelperDescriptor"/>s are a match.</returns>
+        public TagHelperBinding GetBinding(
             string tagName,
             IEnumerable<KeyValuePair<string, string>> attributes,
             string parentTagName)

--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinderSyntaxTreePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinderSyntaxTreePass.cs
@@ -68,8 +68,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             }
             else
             { 
-                var descriptorProvider = new TagHelperDescriptorProvider(tagHelperPrefix, descriptors);
-                var rewriter = new TagHelperParseTreeRewriter(tagHelperPrefix, descriptorProvider);
+                var rewriter = new TagHelperParseTreeRewriter(tagHelperPrefix, descriptors);
                 root = rewriter.Rewrite(root, errorSink);
             }
 

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsService.cs
@@ -40,8 +40,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             }
 
             var prefix = documentContext.Prefix;
-            var provider = new TagHelperDescriptorProvider(prefix, descriptors);
-            var binding = provider.GetTagHelperBinding(tagName, attributes, parentTag);
+            var tagHelperBinder = new TagHelperBinder(prefix, descriptors);
+            var binding = tagHelperBinder.GetBinding(tagName, attributes, parentTag);
 
             return binding;
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
@@ -148,10 +148,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .TypeName(typeof(string).FullName))
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         public static TheoryData WithoutEndTagElementData
@@ -223,10 +222,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireTagStructure(TagStructure.WithoutEndTag))
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         public static TheoryData TagStructureCompatibilityData
@@ -328,10 +326,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireTagStructure(structure2))
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         public static TheoryData MalformedTagHelperAttributeBlockData
@@ -1212,13 +1209,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .TypeName(typeof(string).FullName))
                     .Build()
             };
-            var providerContext = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(providerContext,
-                         documentContent,
-                         (MarkupBlock)expectedOutput,
-                         expectedErrors: Enumerable.Empty<RazorError>());
+            EvaluateData(
+                descriptors,
+                documentContent,
+                (MarkupBlock)expectedOutput,
+                expectedErrors: Enumerable.Empty<RazorError>());
         }
 
         public static IEnumerable<object[]> IncompleteHelperBlockData
@@ -2245,10 +2242,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .TypeName(typeof(string).FullName))
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
         }
 
         public static IEnumerable<object[]> ScriptBlockData
@@ -3935,10 +3931,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .TypeName(typeof(int).FullName))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             var errorSink = new ErrorSink();
             var parseResult = ParseDocument(documentContent);
             var document = parseResult.Root;
-            var parseTreeRewriter = new TagHelperParseTreeRewriter(null, provider: null);
+            var parseTreeRewriter = new TagHelperParseTreeRewriter(null, Enumerable.Empty<TagHelperDescriptor>());
 
             // Assert - Guard
             var rootBlock = Assert.IsType<Block>(document);
@@ -171,10 +171,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     .TagMatchingRule(rule => rule.RequireTagName("p"))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
         }
 
         public static TheoryData NestedVoidSelfClosingRequiredParentData
@@ -278,10 +277,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     .TagMatchingRule(rule => rule.RequireTagName("p"))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         public static TheoryData NestedRequiredParentData
@@ -354,10 +352,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     .TagMatchingRule(rule => rule.RequireTagName("p"))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         [Fact]
@@ -378,11 +375,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     .TagMatchingRule(rule => rule.RequireTagName("strong"))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider("th:", descriptors);
-
+            
             // Act & Assert
             EvaluateData(
-                descriptorProvider,
+                descriptors,
                 documentContent,
                 expectedOutput,
                 expectedErrors: Enumerable.Empty<RazorError>(),
@@ -687,10 +683,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     .AllowChildTag("br")
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, expectedOutput, expectedErrors);
+            EvaluateData(descriptors, documentContent, expectedOutput, expectedErrors);
         }
 
         [Fact]
@@ -727,10 +722,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     .AllowChildTag("br")
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, expectedOutput, expectedErrors);
+            EvaluateData(descriptors, documentContent, expectedOutput, expectedErrors);
         }
 
         [Fact]
@@ -764,10 +758,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireTagStructure(TagStructure.WithoutEndTag))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         [Fact]
@@ -801,10 +794,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireTagStructure(TagStructure.WithoutEndTag))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         public static TheoryData AllowedChildrenData
@@ -1042,10 +1034,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireTagStructure(TagStructure.WithoutEndTag))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
         }
 
         [Fact]
@@ -1066,7 +1057,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             var expectedOutput = new MarkupBlock(
                 new MarkupTagHelperBlock("p",
                     BlockFactory.MarkupTagBlock("</")));
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
             var expectedErrors = new[]
             {
                 new RazorError(
@@ -1078,7 +1068,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             };
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, expectedOutput, expectedErrors);
+            EvaluateData(descriptors, documentContent, expectedOutput, expectedErrors);
         }
 
         [Fact]
@@ -1099,7 +1089,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             var expectedOutput = new MarkupBlock(
                 new MarkupTagHelperBlock("th:p",
                     BlockFactory.MarkupTagBlock("</")));
-            var descriptorProvider = new TagHelperDescriptorProvider("th:", descriptors);
             var expectedErrors = new[]
             {
                 new RazorError(
@@ -1111,7 +1100,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             };
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, expectedOutput, expectedErrors, "th:");
+            EvaluateData(descriptors, documentContent, expectedOutput, expectedErrors, "th:");
         }
 
         [Fact]
@@ -1129,10 +1118,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireTagStructure(TagStructure.WithoutEndTag))
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         [Fact]
@@ -1161,10 +1149,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireTagStructure(TagStructure.WithoutEndTag))
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, expectedOutput, expectedErrors: new[] { expectedError });
+            EvaluateData(descriptors, documentContent, expectedOutput, expectedErrors: new[] { expectedError });
         }
 
         [Fact]
@@ -1200,10 +1187,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireTagStructure(TagStructure.NormalOrSelfClosing))
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, expectedOutput, expectedErrors: new[] { expectedError });
+            EvaluateData(descriptors, documentContent, expectedOutput, expectedErrors: new[] { expectedError });
         }
 
         public static TheoryData RequiredAttributeData
@@ -1630,10 +1616,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireAttribute(attribute => attribute.Name("catchAll")))
                     .Build()
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         public static TheoryData NestedRequiredAttributeData
@@ -1884,10 +1869,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireAttribute(attribute => attribute.Name("catchAll")))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, expectedErrors: new RazorError[0]);
         }
 
         public static TheoryData MalformedRequiredAttributeData
@@ -2100,10 +2084,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .RequireAttribute(attribute => attribute.Name("class")))
                     .Build(),
             };
-            var descriptorProvider = new TagHelperDescriptorProvider(null, descriptors);
 
             // Act & Assert
-            EvaluateData(descriptorProvider, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
+            EvaluateData(descriptors, documentContent, (MarkupBlock)expectedOutput, (RazorError[])expectedErrors);
         }
 
         public static TheoryData PrefixedTagHelperBoundData
@@ -2252,12 +2235,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             object expectedOutput,
             object availableDescriptors)
         {
-            // Arrange
-            var descriptorProvider = new TagHelperDescriptorProvider("th:", (IEnumerable<TagHelperDescriptor>)availableDescriptors);
-
             // Act & Assert
             EvaluateData(
-                descriptorProvider,
+                (IEnumerable<TagHelperDescriptor>)availableDescriptors,
                 documentContent,
                 (MarkupBlock)expectedOutput,
                 expectedErrors: Enumerable.Empty<RazorError>(),

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperRewritingTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperRewritingTestBase.cs
@@ -26,12 +26,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             IEnumerable<RazorError> errors,
             params string[] tagNames)
         {
-            var providerContext = BuildProviderContext(tagNames);
+            var descriptors = BuildDescriptors(tagNames);
 
-            EvaluateData(providerContext, documentContent, expectedOutput, errors);
+            EvaluateData(descriptors, documentContent, expectedOutput, errors);
         }
 
-        internal TagHelperDescriptorProvider BuildProviderContext(params string[] tagNames)
+        internal IEnumerable<TagHelperDescriptor> BuildDescriptors(params string[] tagNames)
         {
             var descriptors = new List<TagHelperDescriptor>();
 
@@ -43,11 +43,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 descriptors.Add(descriptor);
             }
 
-            return new TagHelperDescriptorProvider(null, descriptors);
+            return descriptors;
         }
 
         internal void EvaluateData(
-            TagHelperDescriptorProvider provider,
+            IEnumerable<TagHelperDescriptor> descriptors,
             string documentContent,
             MarkupBlock expectedOutput,
             IEnumerable<RazorError> expectedErrors,
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             var syntaxTree = ParseDocument(documentContent);
             var errorSink = new ErrorSink();
-            var parseTreeRewriter = new TagHelperParseTreeRewriter(tagHelperPrefix, provider);
+            var parseTreeRewriter = new TagHelperParseTreeRewriter(tagHelperPrefix, descriptors);
             var actualTree = parseTreeRewriter.Rewrite(syntaxTree.Root, errorSink);
 
             var allErrors = syntaxTree.Diagnostics.Concat(errorSink.Errors.Select(error => RazorDiagnostic.Create(error)));

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TagHelperBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TagHelperBinderTest.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Razor.Language.Legacy
+namespace Microsoft.AspNetCore.Razor.Language
 {
-    public class TagHelperDescriptorProviderTest
+    public class TagHelperBinderTest
     {
         public static TheoryData RequiredParentData
         {
@@ -67,17 +67,17 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         [Theory]
         [MemberData(nameof(RequiredParentData))]
-        public void GetTagHelperBinding_ReturnsBindingResultWithDescriptorsParentTags(
+        public void GetBinding_ReturnsBindingResultWithDescriptorsParentTags(
             string tagName,
             string parentTagName,
             object availableDescriptors,
             object expectedDescriptors)
         {
             // Arrange
-            var provider = new TagHelperDescriptorProvider(null, (IEnumerable<TagHelperDescriptor>)availableDescriptors);
+            var tagHelperBinder = new TagHelperBinder(null, (IEnumerable<TagHelperDescriptor>)availableDescriptors);
 
             // Act
-            var bindingResult = provider.GetTagHelperBinding(
+            var bindingResult = tagHelperBinder.GetBinding(
                 tagName,
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: parentTagName);
@@ -233,34 +233,34 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         [Theory]
         [MemberData(nameof(RequiredAttributeData))]
-        public void GetTagHelperBinding_ReturnsBindingResultDescriptorsWithRequiredAttributes(
+        public void GetBinding_ReturnsBindingResultDescriptorsWithRequiredAttributes(
             string tagName,
             IEnumerable<KeyValuePair<string, string>> providedAttributes,
             object availableDescriptors,
             object expectedDescriptors)
         {
             // Arrange
-            var provider = new TagHelperDescriptorProvider(null, (IEnumerable<TagHelperDescriptor>)availableDescriptors);
+            var tagHelperBinder = new TagHelperBinder(null, (IEnumerable<TagHelperDescriptor>)availableDescriptors);
 
             // Act
-            var bindingResult = provider.GetTagHelperBinding(tagName, providedAttributes, parentTagName: "p");
+            var bindingResult = tagHelperBinder.GetBinding(tagName, providedAttributes, parentTagName: "p");
 
             // Assert
             Assert.Equal((IEnumerable<TagHelperDescriptor>)expectedDescriptors, bindingResult?.Descriptors, TagHelperDescriptorComparer.CaseSensitive);
         }
 
         [Fact]
-        public void GetTagHelperBinding_ReturnsNullBindingResultPrefixAsTagName()
+        public void GetBinding_ReturnsNullBindingResultPrefixAsTagName()
         {
             // Arrange
             var catchAllDescriptor = TagHelperDescriptorBuilder.Create("foo1", "SomeAssembly")
                 .TagMatchingRule(rule => rule.RequireTagName(TagHelperMatchingConventions.ElementCatchAllName))
                 .Build();
             var descriptors = new[] { catchAllDescriptor };
-            var provider = new TagHelperDescriptorProvider("th", descriptors);
+            var tagHelperBinder = new TagHelperBinder("th", descriptors);
 
             // Act
-            var bindingResult = provider.GetTagHelperBinding(
+            var bindingResult = tagHelperBinder.GetBinding(
                 tagName: "th",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
@@ -270,21 +270,21 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void GetTagHelperBinding_ReturnsBindingResultCatchAllDescriptorsForPrefixedTags()
+        public void GetBinding_ReturnsBindingResultCatchAllDescriptorsForPrefixedTags()
         {
             // Arrange
             var catchAllDescriptor = TagHelperDescriptorBuilder.Create("foo1", "SomeAssembly")
                 .TagMatchingRule(rule => rule.RequireTagName(TagHelperMatchingConventions.ElementCatchAllName))
                 .Build();
             var descriptors = new[] { catchAllDescriptor };
-            var provider = new TagHelperDescriptorProvider("th:", descriptors);
+            var tagHelperBinder = new TagHelperBinder("th:", descriptors);
 
             // Act
-            var bindingResultDiv = provider.GetTagHelperBinding(
+            var bindingResultDiv = tagHelperBinder.GetBinding(
                 tagName: "th:div",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
-            var bindingResultSpan = provider.GetTagHelperBinding(
+            var bindingResultSpan = tagHelperBinder.GetBinding(
                 tagName: "th:span",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
@@ -297,17 +297,17 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void GetTagHelperBinding_ReturnsBindingResultDescriptorsForPrefixedTags()
+        public void GetBinding_ReturnsBindingResultDescriptorsForPrefixedTags()
         {
             // Arrange
             var divDescriptor = TagHelperDescriptorBuilder.Create("foo1", "SomeAssembly")
                 .TagMatchingRule(rule => rule.RequireTagName("div"))
                 .Build();
             var descriptors = new[] { divDescriptor };
-            var provider = new TagHelperDescriptorProvider("th:", descriptors);
+            var tagHelperBinder = new TagHelperBinder("th:", descriptors);
 
             // Act
-            var bindingResult = provider.GetTagHelperBinding(
+            var bindingResult = tagHelperBinder.GetBinding(
                 tagName: "th:div",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
@@ -320,17 +320,17 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         [Theory]
         [InlineData("*")]
         [InlineData("div")]
-        public void GetTagHelperBinding_ReturnsNullForUnprefixedTags(string tagName)
+        public void GetBinding_ReturnsNullForUnprefixedTags(string tagName)
         {
             // Arrange
             var divDescriptor = TagHelperDescriptorBuilder.Create("foo1", "SomeAssembly")
                 .TagMatchingRule(rule => rule.RequireTagName(tagName))
                 .Build();
             var descriptors = new[] { divDescriptor };
-            var provider = new TagHelperDescriptorProvider("th:", descriptors);
+            var tagHelperBinder = new TagHelperBinder("th:", descriptors);
 
             // Act
-            var bindingResult = provider.GetTagHelperBinding(
+            var bindingResult = tagHelperBinder.GetBinding(
                 tagName: "div",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
@@ -350,10 +350,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 .TagMatchingRule(rule => rule.RequireTagName("span"))
                 .Build();
             var descriptors = new TagHelperDescriptor[] { divDescriptor, spanDescriptor };
-            var provider = new TagHelperDescriptorProvider(null, descriptors);
+            var tagHelperBinder = new TagHelperBinder(null, descriptors);
 
             // Act
-            var tagHelperBinding = provider.GetTagHelperBinding(
+            var tagHelperBinding = tagHelperBinder.GetBinding(
                 tagName: "foo",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
@@ -376,14 +376,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 .TagMatchingRule(rule => rule.RequireTagName(TagHelperMatchingConventions.ElementCatchAllName))
                 .Build();
             var descriptors = new TagHelperDescriptor[] { divDescriptor, spanDescriptor, catchAllDescriptor };
-            var provider = new TagHelperDescriptorProvider(null, descriptors);
+            var tagHelperBinder = new TagHelperBinder(null, descriptors);
 
             // Act
-            var divBinding = provider.GetTagHelperBinding(
+            var divBinding = tagHelperBinder.GetBinding(
                 tagName: "div",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
-            var spanBinding = provider.GetTagHelperBinding(
+            var spanBinding = tagHelperBinder.GetBinding(
                 tagName: "span",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
@@ -408,10 +408,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 .TagMatchingRule(rule => rule.RequireTagName("div"))
                 .Build(); 
             var descriptors = new TagHelperDescriptor[] { divDescriptor, divDescriptor };
-            var provider = new TagHelperDescriptorProvider(null, descriptors);
+            var tagHelperBinder = new TagHelperBinder(null, descriptors);
 
             // Act
-            var bindingResult = provider.GetTagHelperBinding(
+            var bindingResult = tagHelperBinder.GetBinding(
                 tagName: "div",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
@@ -422,7 +422,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void GetTagHelperBinding_DescriptorWithMultipleRules_CorrectlySelectsMatchingRules()
+        public void GetBinding_DescriptorWithMultipleRules_CorrectlySelectsMatchingRules()
         {
             // Arrange
             var multiRuleDescriptor = TagHelperDescriptorBuilder.Create("foo", "SomeAssembly")
@@ -435,10 +435,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     .RequireTagName("span"))
                 .Build();
             var descriptors = new TagHelperDescriptor[] { multiRuleDescriptor };
-            var provider = new TagHelperDescriptorProvider(null, descriptors);
+            var tagHelperBinder = new TagHelperBinder(null, descriptors);
 
             // Act
-            var binding = provider.GetTagHelperBinding(
+            var binding = tagHelperBinder.GetBinding(
                 tagName: "div",
                 attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");


### PR DESCRIPTION
- Moved the type out of the Legacy namespace.
- Renamed the types method to `GetBinding` since `TagHelper` is now inferred.
- Updated test names to reflect new method/class name.
- Updated product code variables to reflect new naming (provider => binder).

#1289