### PR TITLE
Adds a tracking system for Razor documents

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDocumentTracker.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDocumentTracker.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    public abstract class RazorDocumentTracker
+    {
+        public abstract event EventHandler ContextChanged;
+
+        public abstract bool IsSupportedDocument { get; }
+
+        public abstract ProjectId ProjectId { get; }
+
+        public abstract SourceTextContainer TextContainer { get; }
+
+        public abstract Workspace Workspace { get; }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor/RazorLanguage.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/RazorLanguage.cs
@@ -6,5 +6,7 @@ namespace Microsoft.CodeAnalysis.Razor
     public static class RazorLanguage
     {
         public const string Name = "Razor";
+
+        public const string ContentType = "RazorCSharp";
     }
 }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTextViewRazorDocumentTracker.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTextViewRazorDocumentTracker.cs
@@ -1,0 +1,267 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Projection;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    internal class DefaultTextViewRazorDocumentTracker : RazorDocumentTracker
+    {
+        private readonly DefaultTextViewRazorDocumentTrackerService _service;
+        private readonly ITextView _textView;
+
+        private DocumentId _documentId;
+        private ITextBuffer _razorBuffer;
+        private bool _isSupportedProject;
+        private ITextBuffer _cSharpBuffer;
+        private SourceTextContainer _textContainer;
+        private Workspace _workspace;
+        private WorkspaceRegistration _workspaceRegistration;
+
+        public override event EventHandler ContextChanged;
+
+        public DefaultTextViewRazorDocumentTracker(DefaultTextViewRazorDocumentTrackerService service, ITextView textView)
+        {
+            if (service == null)
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
+
+            if (textView == null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
+
+            _service = service;
+            _textView = textView;
+
+            Update();
+
+            _textView.Closed += TextView_Closed;
+
+            _textView.BufferGraph.GraphBufferContentTypeChanged += BufferGraph_GraphBufferContentTypeChanged;
+            _textView.BufferGraph.GraphBuffersChanged += BufferGraph_GraphBuffersChanged;
+        }
+
+        public override bool IsSupportedDocument => _isSupportedProject && _textContainer != null;
+
+        public override ProjectId ProjectId => _documentId?.ProjectId;
+
+        public override SourceTextContainer TextContainer => _textContainer;
+
+        public override Workspace Workspace => _workspace;
+
+        private bool Update()
+        {
+            // Update is called when the state of any of our surrounding systems changes. Here we want to examine the
+            // state of the world and then update properties as necessary.
+            //
+            // Fundamentally we have a Razor half of the world as as soon as the document is open - and then later 
+            // the C# half of the world will be initialized. This code is in general pretty tolerant of 
+            // unexpected /impossible states.
+            //
+            // We also want to successfully shut down when the buffer is renamed to something other .cshtml.
+
+            // If there's no Razor buffer, then there's really nothing to do. This isn't a Razor file.
+            var razorBuffer = _textView.BufferGraph.GetTextBuffers(IsRazorBuffer).FirstOrDefault();
+
+            // The source container is tied to the Razor buffer since that's what we want to watch for changes.
+            SourceTextContainer textContainer = null;
+            if (razorBuffer != null)
+            {
+                textContainer = razorBuffer.AsTextContainer();
+            }
+
+            bool isSupportedProject = false;
+            if (razorBuffer != null)
+            {
+                // The project can be null when the document is in the process of closing.
+                var project = _service.GetProject(razorBuffer);
+
+                if (project != null)
+                {
+                    isSupportedProject = _service.IsSupportedProject(project);
+                }
+            }
+
+            // The C# buffer is the other buffer in the graph that is C# (only if we already found a Razor buffer).
+            // We're not currently validating that it's a child of the Razor buffer even though we expect that.
+            ITextBuffer cSharpBuffer = null;
+            if (razorBuffer != null)
+            {
+                cSharpBuffer = _textView.BufferGraph.GetTextBuffers(IsCSharpBuffer).FirstOrDefault();
+            }
+
+            // Now if we have a C# buffer we want to watch for it be attached to a workspace.
+            SourceTextContainer cSharpTextContainer = null;
+            WorkspaceRegistration workspaceRegistration = null;
+            if (cSharpBuffer != null)
+            {
+                cSharpTextContainer = cSharpBuffer.AsTextContainer();
+                Debug.Assert(cSharpTextContainer != null);
+
+                workspaceRegistration = Workspace.GetWorkspaceRegistration(cSharpTextContainer);
+            }
+
+            // Now finally we can see if we have a workspace
+            Workspace workspace = null;
+            if (workspaceRegistration != null)
+            {
+                workspace = workspaceRegistration.Workspace;
+            }
+
+            // Now we know if the Roslyn state for this document has been initialized, let's look for a project.
+            DocumentId documentId = null;
+            if (cSharpTextContainer != null && workspace != null)
+            {
+                documentId = workspace.GetDocumentIdInCurrentContext(cSharpTextContainer);
+            }
+
+            // As a special case, we want to default to the VisualStudioWorkspace until we find out otherwise
+            // This lets us start working before a project gets initialized.
+            if (isSupportedProject && workspace == null)
+            {
+                workspace = _service.Workspace;
+            }
+            
+            var changed = false;
+            changed |= razorBuffer == _razorBuffer;
+            changed |= textContainer == _textContainer;
+            changed |= isSupportedProject == _isSupportedProject;
+            changed |= cSharpBuffer == _cSharpBuffer;
+            changed |= workspaceRegistration == _workspaceRegistration;
+            changed |= workspace == _workspace;
+            changed |= documentId == _documentId;
+
+            // Now if nothing has changed we're all done!
+            if (!changed)
+            {
+                return false;
+            }
+
+            // OK, so something did change, let's commit the changes.
+            //
+            // These are all of the straightforward ones.
+            _razorBuffer = razorBuffer;
+            _textContainer = textContainer;
+            _isSupportedProject = isSupportedProject;
+            _cSharpBuffer = cSharpBuffer;
+            _documentId = documentId;
+
+            // Now these ones we subscribe to events so it's a little tricky.
+            if (_workspaceRegistration != null)
+            {
+                _workspaceRegistration.WorkspaceChanged -= WorkspaceRegistration_WorkspaceChanged;
+            }
+            if (workspaceRegistration != null)
+            {
+                workspaceRegistration.WorkspaceChanged += WorkspaceRegistration_WorkspaceChanged;
+            }
+
+            if (_workspace != null)
+            {
+                _workspace.DocumentActiveContextChanged -= Workspace_DocumentActiveContextChanged;
+            }
+            if (workspace != null)
+            {
+                workspace.DocumentActiveContextChanged += Workspace_DocumentActiveContextChanged;
+            }
+
+            _workspaceRegistration = workspaceRegistration;
+            _workspace = workspace;
+
+            return true;
+        }
+
+        private static bool IsCSharpBuffer(ITextBuffer textBuffer)
+        {
+            return textBuffer.ContentType.IsOfType("CSharp");
+        }
+
+        private static bool IsRazorBuffer(ITextBuffer textBuffer)
+        {
+            return textBuffer.ContentType.IsOfType(RazorLanguage.ContentType);
+        }
+
+        private void BufferGraph_GraphBuffersChanged(object sender, GraphBuffersChangedEventArgs e)
+        {
+            if (Update())
+            {
+                OnContextChanged();
+            }
+        }
+
+        private void BufferGraph_GraphBufferContentTypeChanged(object sender, GraphBufferContentTypeChangedEventArgs e)
+        {
+            if (Update())
+            {
+                OnContextChanged();
+            }
+        }
+
+        private void WorkspaceRegistration_WorkspaceChanged(object sender, EventArgs e)
+        {
+            if (Update())
+            {
+                OnContextChanged();
+            }
+        }
+
+        private void Workspace_DocumentActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs e)
+        {
+            var textBuffer = e.SourceTextContainer.GetTextBuffer();
+            if (textBuffer != null && (textBuffer == _cSharpBuffer || textBuffer == _razorBuffer))
+            {
+                if (Update())
+                {
+                    OnContextChanged();
+                }
+            }
+        }
+
+        private void TextView_Closed(object sender, EventArgs e)
+        {
+            _textView.BufferGraph.GraphBufferContentTypeChanged -= BufferGraph_GraphBufferContentTypeChanged;
+            _textView.BufferGraph.GraphBuffersChanged -= BufferGraph_GraphBuffersChanged;
+
+            if (_workspaceRegistration != null)
+            {
+                _workspaceRegistration.WorkspaceChanged -= WorkspaceRegistration_WorkspaceChanged;
+            }
+
+            if (_workspace != null)
+            {
+                _workspace.DocumentActiveContextChanged -= Workspace_DocumentActiveContextChanged;
+            }
+
+            _textView.Closed -= TextView_Closed;
+
+            _razorBuffer = null;
+            _textContainer = null;
+            _isSupportedProject = false;
+            _cSharpBuffer = null;
+            _workspaceRegistration = null;
+            _workspace = null;
+            _documentId = null;
+
+            OnContextChanged();
+        }
+
+        private void OnContextChanged()
+        {
+            var handler = ContextChanged;
+            if (handler != null)
+            {
+                handler(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTextViewRazorDocumentTrackerService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTextViewRazorDocumentTrackerService.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [ContentType(RazorLanguage.ContentType)]
+    [TextViewRole(PredefinedTextViewRoles.Editable)]
+    //[Export(typeof(IWpfTextViewConnectionListener))] - we're not exporting this interface because we only want it to be hooked up
+    // in developer mode.
+    [Export(typeof(TextViewRazorDocumentTrackerService))]
+    internal class DefaultTextViewRazorDocumentTrackerService : TextViewRazorDocumentTrackerService, IWpfTextViewConnectionListener
+    {
+        private readonly ITextDocumentFactoryService _documentFactory;
+        private readonly IServiceProvider _services;
+        private readonly VisualStudioWorkspace _workspace;
+
+        private RunningDocumentTable _runningDocumentTable;
+        private IVsSolution _solution;
+
+        [ImportingConstructor]
+        public DefaultTextViewRazorDocumentTrackerService(
+            [Import(typeof(SVsServiceProvider))] IServiceProvider services,
+            ITextDocumentFactoryService documentFactory,
+            VisualStudioWorkspace workspace)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (documentFactory == null)
+            {
+                throw new ArgumentNullException(nameof(documentFactory));
+            }
+
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            _services = services;
+            _documentFactory = documentFactory;
+            _workspace = workspace;
+        }
+
+        // Lazy to avoid needing this in unit tests.
+        private RunningDocumentTable RunningDocumentTable
+        {
+            get
+            {
+                if (_runningDocumentTable == null)
+                {
+                    _runningDocumentTable = new RunningDocumentTable(_services);
+                }
+
+                return _runningDocumentTable;
+            }
+        }
+
+        // Lazy to avoid needing this in unit tests.
+        private IVsSolution Solution
+        {
+            get
+            {
+                if (_solution == null)
+                {
+                    _solution = (IVsSolution)_services.GetService(typeof(SVsSolution));
+                }
+
+                return _solution;
+            }
+        }
+
+        public VisualStudioWorkspace Workspace => _workspace;
+
+        public override RazorDocumentTracker CreateTracker(ITextView textView)
+        {
+            if (textView == null)
+            {
+                throw new ArgumentNullException(nameof(textView));
+            }
+
+            if (!textView.Properties.TryGetProperty<RazorDocumentTracker>(typeof(RazorDocumentTracker), out var tracker))
+            {
+                tracker = new DefaultTextViewRazorDocumentTracker(this, textView);
+                textView.Properties.AddProperty(typeof(RazorDocumentTracker), tracker);
+            }
+
+            return tracker;
+        }
+
+        public void SubjectBuffersConnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)
+        {
+            if (textView == null)
+            {
+                throw new ArgumentException(nameof(textView));
+            }
+
+            if (subjectBuffers == null)
+            {
+                throw new ArgumentNullException(nameof(subjectBuffers));
+            }
+
+            // This means a Razor buffer has been attached to this ITextView or the ITextView is just opening with Razor content.
+            //
+            // Call CreateTracker just for the side effect. The tracker will do all of the real work after it's initialized.
+            CreateTracker(textView);
+        }
+
+        public void SubjectBuffersDisconnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)
+        {
+            if (textView == null)
+            {
+                throw new ArgumentException(nameof(textView));
+            }
+
+            if (subjectBuffers == null)
+            {
+                throw new ArgumentNullException(nameof(subjectBuffers));
+            }
+
+            // This means a Razor buffer has be detached from this ITextView or the ITextView is closing.
+            //
+            // Do nothing, the tracker will update itself.
+        }
+
+        public virtual IVsHierarchy GetProject(ITextBuffer textBuffer)
+        {
+            if (textBuffer == null)
+            {
+                throw new ArgumentNullException(nameof(textBuffer));
+            }
+
+            // If there's no document we can't find the filename, or look for a matching hierarchy.
+            if (!_documentFactory.TryGetTextDocument(textBuffer, out var textDocument))
+            {
+                return null;
+            }
+
+            RunningDocumentTable.FindDocument(textDocument.FilePath, out var hierarchy, out uint itemId, out uint cookie);
+
+            // We don't currently try to look a Roslyn ProjectId at this point, we just want to know some
+            // basic things.
+            // See https://github.com/dotnet/roslyn/blob/4e3db2b7a0732d45a720e9ed00c00cd22ab67a14/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs#L47
+            // for a more complete implementation.
+            return hierarchy;
+        }
+
+        public virtual bool IsSupportedProject(IVsHierarchy project)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+            
+            return project.IsCapabilityMatch("DotNetCoreWeb");
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynDevVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="$(RoslynDevVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynDevVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="15.0.26201" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(RoslynDevVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient" Version="$(RoslynDevVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6070" />
@@ -38,6 +39,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="11.0.61030" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0" Version="12.0.30110" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="15.0.26201" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="15.0.26201" />
     <!-- We need to use this version of Json.Net to maintain consistency with Visual Studio. -->
     <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/TextViewRazorDocumentTrackerService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/TextViewRazorDocumentTrackerService.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public abstract class TextViewRazorDocumentTrackerService
+    {
+        public abstract RazorDocumentTracker CreateTracker(ITextView textView);
+    }
+}

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DefaultTextViewRazorDocumentTrackerServiceTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DefaultTextViewRazorDocumentTrackerServiceTest.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public class DefaultTextViewRazorDocumentTrackerServiceTest
+    {
+        [Fact]
+        public void CreateTracker_CreatesNewTracker_WhenDocumentNotTracked()
+        {
+            // Arrange
+            var service = CreateTrackerService();
+
+            var textView = CreateTextView();
+
+            // Act
+            var tracker = service.CreateTracker(textView);
+
+            // Assert
+            Assert.NotNull(tracker);
+            Assert.Same(tracker, textView.Properties.GetProperty(typeof(RazorDocumentTracker)));
+        }
+
+        [Fact]
+        public void CreateTracker_ReturnsExistingTracker_WhenDocumentIsAlreadyTracked()
+        {
+            // Arrange
+            var service = CreateTrackerService();
+
+            var textView = CreateTextView();
+
+            var expected = new DefaultTextViewRazorDocumentTracker(service, textView);
+            textView.Properties.AddProperty(typeof(RazorDocumentTracker), expected);
+
+            // Act
+            var tracker = service.CreateTracker(textView);
+
+            // Assert
+            Assert.NotNull(tracker);
+            Assert.Same(tracker, expected);
+        }
+
+        [Fact]
+        public void SubjectBuffersConnected_CreatesAndReturnsTracker()
+        {
+            // Arrange
+            var service = CreateTrackerService();
+
+            var textView = CreateTextView();
+
+            // Act
+            service.SubjectBuffersConnected(textView, ConnectionReason.BufferGraphChange, new Collection<ITextBuffer>());
+
+            // Assert
+            Assert.NotNull(textView.Properties.GetProperty(typeof(RazorDocumentTracker)));
+        }
+
+        private IWpfTextView CreateTextView()
+        {
+            var properties = new PropertyCollection();
+            var textView = Mock.Of<IWpfTextView>(t => t.Properties == properties);
+            return textView;
+        }
+
+        private DefaultTextViewRazorDocumentTrackerService CreateTrackerService()
+        {
+            var services = Mock.Of<IServiceProvider>();
+            var documentFactory = Mock.Of<ITextDocumentFactoryService>();
+            var workspace = Mock.Of<VisualStudioWorkspace>();
+            return new DefaultTextViewRazorDocumentTrackerService(services, documentFactory, workspace);
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynDevVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(DependencyModelVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>

--- a/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoViewModel.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoViewModel.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if RAZOR_EXTENSION_DEVELOPER_MODE
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.VisualStudio.RazorExtension.DocumentInfo
+{
+    public class RazorDocumentInfoViewModel : NotifyPropertyChanged
+    {
+        private readonly RazorDocumentTracker _documentTracker;
+
+        public RazorDocumentInfoViewModel(RazorDocumentTracker documentTracker)
+        {
+            if (documentTracker == null)
+            {
+                throw new ArgumentNullException(nameof(documentTracker));
+            }
+
+            _documentTracker = documentTracker;
+        }
+
+        public bool IsSupportedDocument => _documentTracker.IsSupportedDocument;
+
+        public Project Project
+        {
+            get
+            {
+                if (Workspace != null && ProjectId != null)
+                {
+                    return Workspace.CurrentSolution.GetProject(ProjectId);
+                }
+
+                return null;
+            }
+        }
+
+        public ProjectId ProjectId => _documentTracker.ProjectId;
+
+        public SourceTextContainer TextContainer => _documentTracker.TextContainer;
+
+        public Workspace Workspace => _documentTracker.Workspace;
+    }
+}
+
+#endif

--- a/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindow.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindow.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if RAZOR_EXTENSION_DEVELOPER_MODE
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.LanguageServices.Razor;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.RazorExtension.DocumentInfo
+{
+    [Guid("d8d83218-309c-4c8f-9c9f-38a6fead8dca")]
+    internal class RazorDocumentInfoWindow : ToolWindowPane
+    {
+        private IVsEditorAdaptersFactoryService _adapterFactory;
+        private TextViewRazorDocumentTrackerService _documentTrackerService;
+        private IVsTextManager _textManager;
+        private IVsRunningDocumentTable _rdt;
+        
+        private uint _cookie;
+        private ITextView _textView;
+        private RazorDocumentTracker _documentTracker;
+
+        public RazorDocumentInfoWindow() 
+            : base(null)
+        {
+            Caption = "Razor Document Info";
+
+            Content = new RazorDocumentInfoWindowControl();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            var component = (IComponentModel)GetService(typeof(SComponentModel));
+            _adapterFactory = component.GetService<IVsEditorAdaptersFactoryService>();
+            _documentTrackerService = component.GetService<TextViewRazorDocumentTrackerService>();
+            
+            _textManager = (IVsTextManager)GetService(typeof(SVsTextManager));
+            _rdt = (IVsRunningDocumentTable)GetService(typeof(SVsRunningDocumentTable));
+            
+            var hr = _rdt.AdviseRunningDocTableEvents(new RdtEvents(this), out uint _cookie);
+            ErrorHandler.ThrowOnFailure(hr);
+        }
+
+        protected override void OnClose()
+        {
+            _rdt.UnadviseRunningDocTableEvents(_cookie);
+            _cookie = 0u;
+
+            base.OnClose();
+        }
+
+        private void OnBeforeDocumentWindowShow(IVsWindowFrame frame)
+        {
+            var vsTextView = VsShellUtilities.GetTextView(frame);
+
+            var textView = _adapterFactory.GetWpfTextView(vsTextView);
+            if (textView != null && textView != _textView)
+            {
+                _textView = textView;
+
+                if (_documentTracker != null)
+                {
+                    _documentTracker.ContextChanged -= DocumentTracker_ContextChanged;
+                }
+
+                _documentTracker = _documentTrackerService.CreateTracker(textView);
+                _documentTracker.ContextChanged += DocumentTracker_ContextChanged;
+
+                ((FrameworkElement)Content).DataContext = new RazorDocumentInfoViewModel(_documentTracker);
+            }
+        }
+
+        private void OnAfterDocumentWindowHide(IVsWindowFrame frame)
+        {
+            var vsTextView = VsShellUtilities.GetTextView(frame);
+
+            var textView = _adapterFactory.GetWpfTextView(vsTextView);
+            if (textView == _textView)
+            {
+                ((FrameworkElement)Content).DataContext = null;
+                _documentTracker.ContextChanged -= DocumentTracker_ContextChanged;
+
+                _textView = null;
+                _documentTracker = null;
+            }
+        }
+
+        private void DocumentTracker_ContextChanged(object sender, EventArgs e)
+        {
+            ((FrameworkElement)Content).DataContext = new RazorDocumentInfoViewModel(_documentTracker);
+        }
+
+        private class RdtEvents : IVsRunningDocTableEvents
+        {
+            private readonly RazorDocumentInfoWindow _window;
+
+            public RdtEvents(RazorDocumentInfoWindow window)
+            {
+                _window = window;
+            }
+
+            public int OnAfterFirstDocumentLock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining) => VSConstants.S_OK;
+
+            public int OnBeforeLastDocumentUnlock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining) => VSConstants.S_OK;
+
+            public int OnAfterSave(uint docCookie) => VSConstants.S_OK;
+
+            public int OnAfterAttributeChange(uint docCookie, uint grfAttribs) => VSConstants.S_OK;
+
+            public int OnBeforeDocumentWindowShow(uint docCookie, int fFirstShow, IVsWindowFrame pFrame)
+            {
+                _window.OnBeforeDocumentWindowShow(pFrame);
+                return VSConstants.S_OK;
+            }
+
+            public int OnAfterDocumentWindowHide(uint docCookie, IVsWindowFrame pFrame)
+            {
+                _window.OnAfterDocumentWindowHide(pFrame);
+                return VSConstants.S_OK;
+            }
+        }
+    }
+}
+#endif

--- a/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindowCommand.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindowCommand.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if RAZOR_EXTENSION_DEVELOPER_MODE
+
+using System;
+using System.ComponentModel.Design;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.RazorExtension.DocumentInfo
+{
+    /// <summary>
+    /// Command handler
+    /// </summary>
+    internal sealed class RazorDocumentInfoWindowCommand
+    {
+        /// <summary>
+        /// Command ID.
+        /// </summary>
+        public const int CommandId = 0x101;
+
+        /// <summary>
+        /// Command menu group (command set GUID).
+        /// </summary>
+        public static readonly Guid CommandSet = new Guid("eaaf8ee4-d120-4a4d-8b58-b138b7f00b96");
+
+        /// <summary>
+        /// VS Package that provides this command, not null.
+        /// </summary>
+        private readonly Package package;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RazorDocumentInfoWindowCommand"/> class.
+        /// Adds our command handlers for menu (commands must exist in the command table file)
+        /// </summary>
+        /// <param name="package">Owner package, not null.</param>
+        private RazorDocumentInfoWindowCommand(Package package)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException("package");
+            }
+
+            this.package = package;
+
+            OleMenuCommandService commandService = this.ServiceProvider.GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
+            if (commandService != null)
+            {
+                var menuCommandID = new CommandID(CommandSet, CommandId);
+                var menuItem = new MenuCommand(this.ShowToolWindow, menuCommandID);
+                commandService.AddCommand(menuItem);
+            }
+        }
+
+        /// <summary>
+        /// Gets the instance of the command.
+        /// </summary>
+        public static RazorDocumentInfoWindowCommand Instance
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Gets the service provider from the owner package.
+        /// </summary>
+        private IServiceProvider ServiceProvider
+        {
+            get
+            {
+                return this.package;
+            }
+        }
+
+        /// <summary>
+        /// Initializes the singleton instance of the command.
+        /// </summary>
+        /// <param name="package">Owner package, not null.</param>
+        public static void Initialize(Package package)
+        {
+            Instance = new RazorDocumentInfoWindowCommand(package);
+        }
+
+        /// <summary>
+        /// Shows the tool window when the menu item is clicked.
+        /// </summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event args.</param>
+        private void ShowToolWindow(object sender, EventArgs e)
+        {
+            // Get the instance number 0 of this tool window. This window is single instance so this instance
+            // is actually the only one.
+            // The last flag is set to true so that if the tool window does not exists it will be created.
+            ToolWindowPane window = this.package.FindToolWindow(typeof(RazorDocumentInfoWindow), 0, true);
+            if ((null == window) || (null == window.Frame))
+            {
+                throw new NotSupportedException("Cannot create tool window");
+            }
+
+            IVsWindowFrame windowFrame = (IVsWindowFrame)window.Frame;
+            Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(windowFrame.Show());
+        }
+    }
+}
+
+#endif

--- a/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindowControl.xaml
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindowControl.xaml
@@ -1,0 +1,34 @@
+﻿<UserControl x:Class="Microsoft.VisualStudio.RazorExtension.DocumentInfo.RazorDocumentInfoWindowControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             Background="{DynamicResource VsBrush.Window}"
+             Foreground="{DynamicResource VsBrush.WindowText}"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="300"
+             Name="MyToolWindow">
+    <StackPanel HorizontalAlignment="Stretch">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" />
+                <ColumnDefinition Width="7*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <Label Grid.Column="0" Grid.Row="0" Content="Project"/>
+            <Label Grid.Column="1" Grid.Row="0" Content="{Binding Project.Name}"/>
+            <Label Grid.Column="0" Grid.Row="1" Content="Is Supported"/>
+            <Label Grid.Column="1" Grid.Row="1" Content="{Binding IsSupportedDocument}"/>
+            <Label Grid.Column="0" Grid.Row="2" Content="Text Container"/>
+            <Label Grid.Column="1" Grid.Row="2" Content="{Binding TextContainer}"/>
+            <Label Grid.Column="0" Grid.Row="3" Content="Workspace"/>
+            <Label Grid.Column="1" Grid.Row="3" Content="{Binding Workspace}"/>
+        </Grid>
+    </StackPanel>
+</UserControl>

--- a/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindowControl.xaml.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindowControl.xaml.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if RAZOR_EXTENSION_DEVELOPER_MODE
+
+using System.Windows.Controls;
+
+namespace Microsoft.VisualStudio.RazorExtension.DocumentInfo
+{
+    public partial class RazorDocumentInfoWindowControl : UserControl
+    {
+        public RazorDocumentInfoWindowControl()
+        {
+            this.InitializeComponent();
+        }
+    }
+}
+
+#endif

--- a/tooling/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -63,6 +63,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="DocumentInfo\RazorDocumentInfoViewModel.cs" />
+    <Compile Include="DocumentInfo\RazorDocumentInfoWindow.cs" />
+    <Compile Include="DocumentInfo\RazorDocumentInfoWindowCommand.cs" />
+    <Compile Include="DocumentInfo\RazorDocumentInfoWindowControl.xaml.cs">
+      <DependentUpon>RazorDocumentInfoWindowControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="RazorInfo\AssemblyViewModel.cs" />
     <Compile Include="Behaviors\ItemSelectedBehavior.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -116,14 +122,29 @@
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.3.0-beta1-61624-03\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.EditorFeatures.2.3.0-beta1-61624-03\lib\net46\Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.2.3.0-beta1-61624-03\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.EditorFeatures, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.EditorFeatures.2.3.0-beta1-61624-03\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.EditorFeatures.Text, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.EditorFeatures.Text.2.3.0-beta1-61624-03\lib\net46\Microsoft.CodeAnalysis.EditorFeatures.Text.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Elfie, Version=0.10.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Elfie.0.10.6-rc2\lib\net46\Microsoft.CodeAnalysis.Elfie.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Features, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Features.2.3.0-beta1-61624-03\lib\netstandard1.3\Microsoft.CodeAnalysis.Features.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.2.3.0-beta1-61624-03\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.EditorFeatures.2.3.0-beta1-61624-03\lib\net46\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.2.3.0-beta1-61624-03\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
@@ -144,6 +165,10 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26201\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Editor, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Editor.15.0.26201\lib\net45\Microsoft.VisualStudio.Editor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Imaging, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -194,6 +219,18 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Text.Data.15.0.26201\lib\net45\Microsoft.VisualStudio.Text.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.Logic.15.0.26201\lib\net45\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.UI.15.0.26201\lib\net45\Microsoft.VisualStudio.Text.UI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.UI.Wpf.15.0.26201\lib\net45\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -328,6 +365,10 @@
     <Content Include="Resources\RazorInfoToolWindowCommand.png" />
     <Content Include="Resources\RazorPackage.ico" />
     <Page Include="RazorInfo\RazorInfoToolWindowControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="DocumentInfo\RazorDocumentInfoWindowControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/tooling/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -12,10 +11,10 @@ namespace Microsoft.VisualStudio.RazorExtension
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
     [Guid(RazorPackage.PackageGuidString)]
-    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     [ProvideMenuResource("Menus.ctmenu", 1)]
 #if RAZOR_EXTENSION_DEVELOPER_MODE
     [ProvideToolWindow(typeof(Microsoft.VisualStudio.RazorExtension.RazorInfo.RazorInfoToolWindow))]
+    [ProvideToolWindow(typeof(Microsoft.VisualStudio.RazorExtension.DocumentInfo.RazorDocumentInfoWindow))]
 #endif
     public sealed class RazorPackage : Package
     {
@@ -41,6 +40,7 @@ namespace Microsoft.VisualStudio.RazorExtension
 
 #if RAZOR_EXTENSION_DEVELOPER_MODE
             RazorInfo.RazorInfoToolWindowCommand.Initialize(this);
+            DocumentInfo.RazorDocumentInfoWindowCommand.Initialize(this);
 #endif
         }
     }

--- a/tooling/Microsoft.VisualStudio.RazorExtension/RazorPackage.vsct
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/RazorPackage.vsct
@@ -2,24 +2,31 @@
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
-  <Extern href="stdidcmd.h"/>
+  <Extern href="stdidcmd.h" />
 
   <!--This header contains the command ids for the menus provided by the shell. -->
-  <Extern href="vsshlids.h"/>
+  <Extern href="vsshlids.h" />
 
   <Commands package="guidRazorPackage">
     <Buttons>
-      <Button guid="guidRazorPackageCmdSet" id="RazorInfoToolWindowCommandId" priority="0x0100" type="Button">
-        <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
+      <Button guid="guidRazorPackageCmdSet" id="cmdidRazorInfoToolWindow" priority="0x0100" type="Button">
+        <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1" />
         <Icon guid="guidImages" id="bmpPic1" />
         <Strings>
           <ButtonText>Razor Diagnostics</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidRazorPackageCmdSet" id="cmdidRazorDocumentInfoWindow" priority="0x0100" type="Button">
+        <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1" />
+        <Icon guid="guidImages" id="bmpPic1" />
+        <Strings>
+          <ButtonText>Razor Document Info</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
 
     <Bitmaps>
-      <Bitmap guid="guidImages" href="Resources\RazorInfoToolWindowCommand.png" usedList="bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows, bmpPicStrikethrough"/>
+      <Bitmap guid="guidImages" href="Resources\RazorInfoToolWindowCommand.png" usedList="bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows, bmpPicStrikethrough" />
     </Bitmaps>
   </Commands>
 
@@ -27,10 +34,11 @@
     <GuidSymbol name="guidRazorPackage" value="{13b72f58-279e-49e0-a56d-296be02f0805}" />
 
     <GuidSymbol name="guidRazorPackageCmdSet" value="{eaaf8ee4-d120-4a4d-8b58-b138b7f00b96}">
-      <IDSymbol name="RazorInfoToolWindowCommandId" value="0x0100" />
+      <IDSymbol name="cmdidRazorInfoToolWindow" value="0x0100" />
+      <IDSymbol name="cmdidRazorDocumentInfoWindow" value="0x101"  />
     </GuidSymbol>
 
-    <GuidSymbol name="guidImages" value="{9dfcb7a0-bfd4-4081-845e-a67a274f7cba}" >
+    <GuidSymbol name="guidImages" value="{9dfcb7a0-bfd4-4081-845e-a67a274f7cba}">
       <IDSymbol name="bmpPic1" value="1" />
       <IDSymbol name="bmpPic2" value="2" />
       <IDSymbol name="bmpPicSearch" value="3" />
@@ -38,5 +46,6 @@
       <IDSymbol name="bmpPicArrows" value="5" />
       <IDSymbol name="bmpPicStrikethrough" value="6" />
     </GuidSymbol>
+
   </Symbols>
 </CommandTable>

--- a/tooling/Microsoft.VisualStudio.RazorExtension/packages.config
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/packages.config
@@ -6,13 +6,17 @@
   <package id="Microsoft.CodeAnalysis.Common" version="2.3.0-beta1-61624-03" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.3.0-beta1-61624-03" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.3.0-beta1-61624-03" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" version="2.3.0-beta1-61624-03" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="2.3.0-beta1-61624-03" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Elfie" version="0.10.6-rc2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Features" version="2.3.0-beta1-61624-03" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.3.0-beta1-61624-03" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.3.0-beta1-61624-03" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.3.0-beta1-61624-03" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Editor" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Imaging" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.LanguageServices" version="2.3.0-beta1-61624-03" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net46" />
@@ -25,6 +29,9 @@
   <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Text.Data" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.Logic" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.UI" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Threading" version="15.0.240" targetFramework="net46" />


### PR DESCRIPTION
This is a MEF service that can actively or passively track open ITextViews
and give us information about the Razor initialization state and eventing
when it changes.

The purpose of this is to act as a bridge between the VS mef world and the
roslyn world.

For now this doesn't do any passive tracking of Razor documents, it's only
on demand. That means it will only be initialized and used right now when
you are using the Razor developer tools. This is just to reduce our risk,
it's not ideal to ship code in VS that's doing something without anyone
looking at the result.