### PR TITLE
Add Roslyn language service factories for our exported types.

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultRazorSyntaxFactsServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultRazorSyntaxFactsServiceFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [ExportLanguageServiceFactory(typeof(RazorSyntaxFactsService), RazorLanguage.Name, ServiceLayer.Default)]
+    internal class DefaultRazorSyntaxFactsServiceFactory : ILanguageServiceFactory
+    {
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            return new DefaultRazorSyntaxFactsService();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultRazorTemplateEngineFactoryServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultRazorTemplateEngineFactoryServiceFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [ExportLanguageServiceFactory(typeof(RazorTemplateEngineFactoryService), RazorLanguage.Name, ServiceLayer.Default)]
+    internal class DefaultRazorTemplateEngineFactoryServiceFactory : ILanguageServiceFactory
+    {
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            return new DefaultRazorTemplateEngineFactoryService();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionServiceFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [ExportLanguageServiceFactory(typeof(TagHelperCompletionService), RazorLanguage.Name, ServiceLayer.Default)]
+    internal class DefaultTagHelperCompletionServiceFactory : ILanguageServiceFactory
+    {
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            var tagHelperFactsService = languageServices.GetRequiredService<TagHelperFactsService>();
+            return new DefaultTagHelperCompletionService(tagHelperFactsService);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsServiceFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [ExportLanguageServiceFactory(typeof(TagHelperFactsService), RazorLanguage.Name, ServiceLayer.Default)]
+    internal class DefaultTagHelperFactsServiceFactory : ILanguageServiceFactory
+    {
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            return new DefaultTagHelperFactsService();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperResolverFactory.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperResolverFactory.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [ExportLanguageServiceFactory(typeof(ITagHelperResolver), RazorLanguage.Name, ServiceLayer.Default)]
+    internal class DefaultTagHelperResolverFactory : ILanguageServiceFactory
+    {
+        private readonly VisualStudioWorkspace _workspace;
+        private readonly SVsServiceProvider _services;
+
+        [ImportingConstructor]
+        public DefaultTagHelperResolverFactory(VisualStudioWorkspace workspace, SVsServiceProvider services)
+        {
+            _workspace = workspace;
+            _services = services;
+        }
+
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            return new DefaultTagHelperResolver()
+            {
+                Workspace = _workspace,
+                Services = _services,
+            };
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/ITagHelperResolver.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/ITagHelperResolver.cs
@@ -4,11 +4,12 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
-    public interface ITagHelperResolver
+    public interface ITagHelperResolver : ILanguageService
     {
         Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project, IEnumerable<string> assemblyNameFilters);
     }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorSyntaxFactsService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorSyntaxFactsService.cs
@@ -3,11 +3,12 @@
 
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
-    public abstract class RazorSyntaxFactsService
+    public abstract class RazorSyntaxFactsService : ILanguageService
     {
         public abstract IReadOnlyList<ClassifiedSpan> GetClassifiedSpans(RazorSyntaxTree syntaxTree);
 

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorTemplateEngineFactoryService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorTemplateEngineFactoryService.cs
@@ -3,10 +3,11 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
-    public abstract class RazorTemplateEngineFactoryService
+    public abstract class RazorTemplateEngineFactoryService : ILanguageService
     {
         public abstract RazorTemplateEngine Create(string projectPath, Action<IRazorEngineBuilder> configure);
     }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperCompletionService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperCompletionService.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Host;
+
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
-    public abstract class TagHelperCompletionService
+    public abstract class TagHelperCompletionService : ILanguageService
     {
         public abstract AttributeCompletionResult GetAttributeCompletions(AttributeCompletionContext completionContext);
 

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperFactsService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperFactsService.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
-using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
-    public abstract class TagHelperFactsService
+    public abstract class TagHelperFactsService : ILanguageService
     {
         public abstract TagHelperBinding GetTagHelperBinding(TagHelperDocumentContext documentContext, string tagName, IEnumerable<KeyValuePair<string, string>> attributes, string parentTag);
 


### PR DESCRIPTION
- Verified this all worked via our Razor extension:
![image](https://cloud.githubusercontent.com/assets/2008729/25967996/d13b1c14-3644-11e7-90fe-96ba556e39ea.png)

Wasn't going to check in the extension changes due to their lack of usefulness but if you feel different let me know.

#1260 
