### PR TITLE
[Design] Move a single class over to Workspaces.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ClassifiedSpan.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ClassifiedSpan.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.AspNetCore.Razor.Language;
 
-namespace Microsoft.VisualStudio.LanguageServices.Razor
+namespace Microsoft.CodeAnalysis.Razor
 {
     public struct ClassifiedSpan
     {

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorSyntaxFactsServiceFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorSyntaxFactsServiceFactory.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Razor;
 
-namespace Microsoft.VisualStudio.LanguageServices.Razor
+namespace Microsoft.CodeAnalysis.Razor
 {
     [ExportLanguageServiceFactory(typeof(RazorSyntaxFactsService), RazorLanguage.Name, ServiceLayer.Default)]
     internal class DefaultRazorSyntaxFactsServiceFactory : ILanguageServiceFactory

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSyntaxFactsService.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSyntaxFactsService.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.VisualStudio.Text;
 
-namespace Microsoft.VisualStudio.LanguageServices.Razor
+namespace Microsoft.CodeAnalysis.Razor
 {
     public abstract class RazorSyntaxFactsService : ILanguageService
     {
@@ -14,6 +14,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
         public abstract IReadOnlyList<TagHelperSpan> GetTagHelperSpans(RazorSyntaxTree syntaxTree);
 
-        public abstract int? GetDesiredIndentation(RazorSyntaxTree syntaxTree, ITextSnapshot syntaxTreeSnapshot, ITextSnapshotLine line, int indentSize, int tabSize);
+        public abstract int? GetDesiredIndentation(RazorSyntaxTree syntaxTree, int previousLineEndIndex, Func<int, string> getLineContent, int indentSize, int tabSize);
     }
 }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperSpan.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperSpan.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 
-namespace Microsoft.VisualStudio.LanguageServices.Razor
+namespace Microsoft.CodeAnalysis.Razor
 {
     public struct TagHelperSpan
     {

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorSyntaxFactsServiceExtensions.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorSyntaxFactsServiceExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    public static class RazorSyntaxFactsServiceExtensions
+    {
+        public static int? GetDesiredIndentation(
+            this RazorSyntaxFactsService service,
+            RazorSyntaxTree syntaxTree,
+            ITextSnapshot syntaxTreeSnapshot,
+            ITextSnapshotLine line,
+            int indentSize,
+            int tabSize)
+        {
+            // The tricky thing here is that line.Snapshot is very likely newer
+            var previousLine = line.Snapshot.GetLineFromLineNumber(line.LineNumber - 1);
+            var trackingPoint = line.Snapshot.CreateTrackingPoint(line.End, PointTrackingMode.Negative);
+            var previousLineEnd = trackingPoint.GetPosition(syntaxTreeSnapshot);
+
+            Func<int, string> getLineContentDelegate = (lineIndex) => line.Snapshot.GetLineFromLineNumber(lineIndex).GetText();
+
+            return service.GetDesiredIndentation(syntaxTree, previousLineEnd, getLineContentDelegate, indentSize, tabSize);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioRazorSyntaxFactsService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioRazorSyntaxFactsService.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor
+{
+    [Export(typeof(RazorSyntaxFactsService))]
+    internal class VisualStudioRazorSyntaxFactsService : DefaultRazorSyntaxFactsService
+    {
+    }
+}


### PR DESCRIPTION
- Had to modify the API a bit to massage the `TagHelperFactsService` into a state that didn't rely on VS.

@rynowak what do you think about this approach for supporting Roslyn's based services + VisualStudio's? I moved one of the more troublesome classes as an experiment.