### PR TITLE
Rename the BoundAttributeDescriptor builder.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTagHelperPass.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTagHelperPass.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             foreach (var attribute in descriptor.BoundAttributes)
             {
                 writer.WriteAutoPropertyDeclaration(
-                    "public", attribute.TypeName, attribute.Metadata[ITagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]);
+                    "public", attribute.TypeName, attribute.Metadata[TagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]);
 
                 if (attribute.IndexerTypeName != null)
                 {
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
         private string[] GetMethodParameters(TagHelperDescriptor descriptor)
         {
             var propertyNames = descriptor.BoundAttributes.Select(
-                attribute => attribute.Metadata[ITagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]);
+                attribute => attribute.Metadata[TagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]);
             var joinedPropertyNames = string.Join(", ", propertyNames);
             var parametersString = $"new {{ { joinedPropertyNames } }}";
 

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeTagHelperWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeTagHelperWriter.cs
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             string attributeName,
             BoundAttributeDescriptor descriptor)
         {
-            var propertyAccessor = $"{tagHelperVariableName}.{descriptor.Metadata[ITagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]}";
+            var propertyAccessor = $"{tagHelperVariableName}.{descriptor.Metadata[TagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]}";
 
             if (isIndexerNameMatch)
             {

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/PreallocatedAttributeTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/PreallocatedAttributeTargetExtension.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             string attributeName,
             BoundAttributeDescriptor descriptor)
         {
-            var propertyAccessor = $"{tagHelperVariableName}.{descriptor.Metadata[ITagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]}";
+            var propertyAccessor = $"{tagHelperVariableName}.{descriptor.Metadata[TagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]}";
 
             if (isIndexerNameMatch)
             {

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeTagHelperWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeTagHelperWriter.cs
@@ -309,7 +309,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
         {
             var tagHelperVariableName = GetTagHelperVariableName(node.TagHelperTypeName);
             var tagHelperRenderingContext = context.TagHelperRenderingContext;
-            var propertyName = node.Descriptor.Metadata[ITagHelperBoundAttributeDescriptorBuilder.PropertyNameKey];
+            var propertyName = node.Descriptor.Metadata[TagHelperBoundAttributeDescriptorBuilder.PropertyNameKey];
 
             // Ensure that the property we're trying to set has initialized its dictionary bound properties.
             if (node.IsIndexerNameMatch &&
@@ -451,7 +451,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             string attributeName,
             BoundAttributeDescriptor descriptor)
         {
-            var propertyAccessor = $"{tagHelperVariableName}.{descriptor.Metadata[ITagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]}";
+            var propertyAccessor = $"{tagHelperVariableName}.{descriptor.Metadata[TagHelperBoundAttributeDescriptorBuilder.PropertyNameKey]}";
 
             if (isIndexerNameMatch)
             {

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIRLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIRLoweringPhase.cs
@@ -559,7 +559,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                             var associatedAttributeDescriptor = associatedDescriptor.BoundAttributes.First(
                                 attributeDescriptor => TagHelperMatchingConventions.CanSatisfyBoundAttribute(attribute.Name, attributeDescriptor));
                             var tagHelperTypeName = associatedDescriptor.Metadata[TagHelperDescriptorBuilder.TypeNameKey];
-                            var attributePropertyName = associatedAttributeDescriptor.Metadata[ITagHelperBoundAttributeDescriptorBuilder.PropertyNameKey];
+                            var attributePropertyName = associatedAttributeDescriptor.Metadata[TagHelperBoundAttributeDescriptorBuilder.PropertyNameKey];
 
                             var setTagHelperProperty = new SetTagHelperPropertyIRNode()
                             {

--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperBoundAttributeDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperBoundAttributeDescriptorBuilder.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public sealed class ITagHelperBoundAttributeDescriptorBuilder
+    public sealed class TagHelperBoundAttributeDescriptorBuilder
     {
         public static readonly string DescriptorKind = "ITagHelper";
         public static readonly string PropertyNameKey = "ITagHelper.PropertyName";
@@ -46,46 +46,46 @@ namespace Microsoft.AspNetCore.Razor.Language
         private readonly Dictionary<string, string> _metadata;
         private HashSet<RazorDiagnostic> _diagnostics;
 
-        private ITagHelperBoundAttributeDescriptorBuilder(string containingTypeName)
+        private TagHelperBoundAttributeDescriptorBuilder(string containingTypeName)
         {
             _containingTypeName = containingTypeName;
             _metadata = new Dictionary<string, string>();
         }
 
-        public static ITagHelperBoundAttributeDescriptorBuilder Create(string containingTypeName)
+        public static TagHelperBoundAttributeDescriptorBuilder Create(string containingTypeName)
         {
-            return new ITagHelperBoundAttributeDescriptorBuilder(containingTypeName);
+            return new TagHelperBoundAttributeDescriptorBuilder(containingTypeName);
         }
 
-        public ITagHelperBoundAttributeDescriptorBuilder Name(string name)
+        public TagHelperBoundAttributeDescriptorBuilder Name(string name)
         {
             _name = name;
 
             return this;
         }
 
-        public ITagHelperBoundAttributeDescriptorBuilder PropertyName(string propertyName)
+        public TagHelperBoundAttributeDescriptorBuilder PropertyName(string propertyName)
         {
             _propertyName = propertyName;
 
             return this;
         }
 
-        public ITagHelperBoundAttributeDescriptorBuilder TypeName(string typeName)
+        public TagHelperBoundAttributeDescriptorBuilder TypeName(string typeName)
         {
             _typeName = typeName;
 
             return this;
         }
 
-        public ITagHelperBoundAttributeDescriptorBuilder AsEnum()
+        public TagHelperBoundAttributeDescriptorBuilder AsEnum()
         {
             _isEnum = true;
 
             return this;
         }
 
-        public ITagHelperBoundAttributeDescriptorBuilder AsDictionary(string attributeNamePrefix, string valueTypeName)
+        public TagHelperBoundAttributeDescriptorBuilder AsDictionary(string attributeNamePrefix, string valueTypeName)
         {
             _indexerNamePrefix = attributeNamePrefix;
             _indexerValueTypeName = valueTypeName;
@@ -94,21 +94,21 @@ namespace Microsoft.AspNetCore.Razor.Language
             return this;
         }
 
-        public ITagHelperBoundAttributeDescriptorBuilder Documentation(string documentation)
+        public TagHelperBoundAttributeDescriptorBuilder Documentation(string documentation)
         {
             _documentation = documentation;
 
             return this;
         }
 
-        public ITagHelperBoundAttributeDescriptorBuilder AddMetadata(string key, string value)
+        public TagHelperBoundAttributeDescriptorBuilder AddMetadata(string key, string value)
         {
             _metadata[key] = value;
 
             return this;
         }
 
-        public ITagHelperBoundAttributeDescriptorBuilder AddDiagnostic(RazorDiagnostic diagnostic)
+        public TagHelperBoundAttributeDescriptorBuilder AddDiagnostic(RazorDiagnostic diagnostic)
         {
             EnsureDiagnostics();
             _diagnostics.Add(diagnostic);

--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorBuilder.cs
@@ -51,14 +51,14 @@ namespace Microsoft.AspNetCore.Razor.Language
             return this;
         }
 
-        public TagHelperDescriptorBuilder BindAttribute(Action<ITagHelperBoundAttributeDescriptorBuilder> configure)
+        public TagHelperDescriptorBuilder BindAttribute(Action<TagHelperBoundAttributeDescriptorBuilder> configure)
         {
             if (configure == null)
             {
                 throw new ArgumentNullException(nameof(configure));
             }
 
-            var builder = ITagHelperBoundAttributeDescriptorBuilder.Create(_typeName);
+            var builder = TagHelperBoundAttributeDescriptorBuilder.Create(_typeName);
 
             configure(builder);
 

--- a/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorFactory.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Razor
         }
 
         private void ConfigureBoundAttribute(
-            ITagHelperBoundAttributeDescriptorBuilder builder,
+            TagHelperBoundAttributeDescriptorBuilder builder,
             IPropertySymbol property,
             INamedTypeSymbol containingType)
         {
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Razor
         }
 
         private void ConfigureDictionaryBoundAttribute(
-            ITagHelperBoundAttributeDescriptorBuilder builder, 
+            TagHelperBoundAttributeDescriptorBuilder builder, 
             IPropertySymbol property, 
             INamedTypeSymbol containingType, 
             AttributeData attributeNameAttribute, 

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperDescriptorJsonConverter.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperDescriptorJsonConverter.cs
@@ -136,10 +136,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             }
         }
 
-        private void ReadBoundAttribute(ITagHelperBoundAttributeDescriptorBuilder builder, JObject attribute, JsonSerializer serializer)
+        private void ReadBoundAttribute(TagHelperBoundAttributeDescriptorBuilder builder, JObject attribute, JsonSerializer serializer)
         {
             var descriptorKind = attribute[nameof(BoundAttributeDescriptor.Kind)].Value<string>();
-            if (descriptorKind != ITagHelperBoundAttributeDescriptorBuilder.DescriptorKind)
+            if (descriptorKind != TagHelperBoundAttributeDescriptorBuilder.DescriptorKind)
             {
                 throw new NotSupportedException();
             }
@@ -182,7 +182,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 builder.AddMetadata(item.Key, item.Value);
             }
 
-            var propertyName = metadataValue[ITagHelperBoundAttributeDescriptorBuilder.PropertyNameKey];
+            var propertyName = metadataValue[TagHelperBoundAttributeDescriptorBuilder.PropertyNameKey];
             builder.PropertyName(propertyName);
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/InstrumentationPassIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/InstrumentationPassIntegrationTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.IntegrationTests
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("value")
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.IntegrationTests
             string tagName,
             string typeName,
             string assemblyName,
-            IEnumerable<Action<ITagHelperBoundAttributeDescriptorBuilder>> attributes = null)
+            IEnumerable<Action<TagHelperBoundAttributeDescriptorBuilder>> attributes = null)
         {
             var builder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/DesignTimeTagHelperWriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/DesignTimeTagHelperWriterTest.cs
@@ -67,7 +67,7 @@ private global::MyTagHelper __MyTagHelper = null;
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("bound")
@@ -110,7 +110,7 @@ __InputTagHelper.FooProp = ""value"";
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("bound")
@@ -156,7 +156,7 @@ __InputTagHelper.FooProp = 42;
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("bound")
@@ -244,7 +244,7 @@ __InputTagHelper.FooProp[""bound""] = 42;
             string tagName,
             string typeName,
             string assemblyName,
-            IEnumerable<Action<ITagHelperBoundAttributeDescriptorBuilder>> attributes = null)
+            IEnumerable<Action<TagHelperBoundAttributeDescriptorBuilder>> attributes = null)
         {
             var builder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/PreallocatedAttributeTargetExtensionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/PreallocatedAttributeTargetExtensionTest.cs
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
                 Writer = new CSharpCodeWriter()
             };
 
-            var descriptor = ITagHelperBoundAttributeDescriptorBuilder
+            var descriptor = TagHelperBoundAttributeDescriptorBuilder
                 .Create("FooTagHelper")
                 .Name("Foo")
                 .TypeName("System.String")
@@ -174,7 +174,7 @@ __tagHelperExecutionContext.AddTagHelperAttribute(_tagHelper1);
                 Writer = new CSharpCodeWriter()
             };
 
-            var descriptor = ITagHelperBoundAttributeDescriptorBuilder
+            var descriptor = TagHelperBoundAttributeDescriptorBuilder
                 .Create("FooTagHelper")
                 .Name("Foo")
                 .TypeName("System.Collections.Generic.Dictionary<System.String, System.String>")

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RuntimeTagHelperWriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RuntimeTagHelperWriterTest.cs
@@ -291,7 +291,7 @@ EndAddHtmlAttributeValues(__tagHelperExecutionContext);
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("bound")
@@ -339,7 +339,7 @@ __tagHelperExecutionContext.AddTagHelperAttribute(""bound"", __InputTagHelper.Fo
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("bound")
@@ -386,7 +386,7 @@ __tagHelperExecutionContext.AddTagHelperAttribute(""bound"", __InputTagHelper.Fo
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("bound")
@@ -478,7 +478,7 @@ __tagHelperExecutionContext.AddTagHelperAttribute(""foo-bound"", __InputTagHelpe
             string tagName,
             string typeName,
             string assemblyName,
-            IEnumerable<Action<ITagHelperBoundAttributeDescriptorBuilder>> attributes = null)
+            IEnumerable<Action<TagHelperBoundAttributeDescriptorBuilder>> attributes = null)
         {
             var builder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIRLoweringPhaseIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIRLoweringPhaseIntegrationTest.cs
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("bound")
@@ -463,7 +463,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             string tagName,
             string typeName,
             string assemblyName,
-            IEnumerable<Action<ITagHelperBoundAttributeDescriptorBuilder>> attributes = null)
+            IEnumerable<Action<TagHelperBoundAttributeDescriptorBuilder>> attributes = null)
         {
             var builder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -1458,7 +1458,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             string tagName,
             string typeName,
             string assemblyName,
-            IEnumerable<Action<ITagHelperBoundAttributeDescriptorBuilder>> attributes = null,
+            IEnumerable<Action<TagHelperBoundAttributeDescriptorBuilder>> attributes = null,
             IEnumerable<Action<TagMatchingRuleBuilder>> ruleBuilders = null)
         {
             var builder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/TagHelpersIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/TagHelpersIntegrationTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("bound")
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                     tagName: "input",
                     typeName: "InputTagHelper",
                     assemblyName: "TestAssembly",
-                    attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("value")
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             string tagName,
             string typeName,
             string assemblyName,
-            IEnumerable<Action<ITagHelperBoundAttributeDescriptorBuilder>> attributes = null)
+            IEnumerable<Action<TagHelperBoundAttributeDescriptorBuilder>> attributes = null)
         {
             var builder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/TestTagHelperDescriptors.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/TestTagHelperDescriptors.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "InputTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => builder
                                 .Name("value")
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "type", inputTypePropertyInfo),
                         },
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper2",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "type", inputTypePropertyInfo),
                         },
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "*",
                         typeName: "TestNamespace.CatchAllTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => builder
                                 .Name("catch-all")
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => builder
                                 .Name("value")
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "*",
                         typeName: "TestNamespace.CatchAllTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => builder
                                 .Name("[item]")
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "*",
                         typeName: "TestNamespace.CatchAllTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => builder
                                 .Name("catchall-bound-string")
@@ -246,7 +246,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => builder
                                 .Name("input-bound-required-string")
@@ -277,7 +277,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => builder
                                 .Name("bound")
@@ -308,7 +308,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "type", inputTypePropertyInfo),
                         },
@@ -320,7 +320,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper2",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "type", inputTypePropertyInfo),
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "checked", inputCheckedPropertyInfo),
@@ -353,7 +353,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper1",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => builder
                                 .Name("int-prefix-grabber")
@@ -378,7 +378,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper2",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => builder
                                 .Name("int-dictionary")
@@ -406,7 +406,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "MyTagHelper",
                         typeName: "TestNamespace.MyTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "BoundProperty", propertyInfo),
                         }),
@@ -432,7 +432,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "p",
                         typeName: "TestNamespace.PTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "age", pAgePropertyInfo),
                         },
@@ -444,7 +444,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "type", inputTypePropertyInfo),
                         },
@@ -456,7 +456,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                         tagName: "input",
                         typeName: "TestNamespace.InputTagHelper2",
                         assemblyName: "TestAssembly",
-                        attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                        attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                         {
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "type", inputTypePropertyInfo),
                             builder => BuildBoundAttributeDescriptorFromPropertyInfo(builder, "checked", checkedPropertyInfo),
@@ -469,7 +469,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             string tagName,
             string typeName,
             string assemblyName,
-            IEnumerable<Action<ITagHelperBoundAttributeDescriptorBuilder>> attributes = null,
+            IEnumerable<Action<TagHelperBoundAttributeDescriptorBuilder>> attributes = null,
             IEnumerable<Action<TagMatchingRuleBuilder>> ruleBuilders = null)
         {
             var builder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);
@@ -503,7 +503,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
         }
 
         private static void BuildBoundAttributeDescriptorFromPropertyInfo(
-            ITagHelperBoundAttributeDescriptorBuilder builder,
+            TagHelperBoundAttributeDescriptorBuilder builder,
             string name,
             PropertyInfo propertyInfo)
         {

--- a/test/Microsoft.CodeAnalysis.Razor.Test/DefaultTagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Test/DefaultTagHelperDescriptorFactoryTest.cs
@@ -570,7 +570,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                             tagName: "inherited-editor-browsable",
                             typeName: typeof(InheritedEditorBrowsableTagHelper).FullName,
                             assemblyName: AssemblyName,
-                            attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                            attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                             {
                                 builder => builder
                                     .Name("property")
@@ -586,7 +586,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                             tagName: "editor-browsable",
                             typeName: typeof(EditorBrowsableTagHelper).FullName,
                             assemblyName: AssemblyName,
-                            attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                            attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                             {
                                 builder => builder
                                     .Name("property")
@@ -609,7 +609,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                             tagName: "hidden-property-editor-browsable",
                             typeName: typeof(HiddenPropertyEditorBrowsableTagHelper).FullName,
                             assemblyName: AssemblyName,
-                            attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                            attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                             {
                                 builder => builder
                                     .Name("property")
@@ -624,7 +624,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                             tagName: "overridden-editor-browsable",
                             typeName: typeof(OverriddenEditorBrowsableTagHelper).FullName,
                             assemblyName: AssemblyName,
-                            attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                            attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                             {
                                 builder => builder
                                     .Name("property")
@@ -639,7 +639,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                             tagName: "multi-property-editor-browsable",
                             typeName: typeof(MultiPropertyEditorBrowsableTagHelper).FullName,
                             assemblyName: AssemblyName,
-                            attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                            attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                             {
                                 builder => builder
                                     .Name("property2")
@@ -654,7 +654,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                             tagName: "multi-property-editor-browsable",
                             typeName: typeof(MultiPropertyEditorBrowsableTagHelper).FullName,
                             assemblyName: AssemblyName,
-                            attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                            attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                             {
                                 builder => builder
                                     .Name("property")
@@ -681,7 +681,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                             tagName: "overridden-property-editor-browsable",
                             typeName: typeof(OverriddenPropertyEditorBrowsableTagHelper).FullName,
                             assemblyName: AssemblyName,
-                            attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                            attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                             {
                                 builder => builder
                                     .Name("property2")
@@ -700,7 +700,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                             tagName: "default-editor-browsable",
                             typeName: typeof(DefaultEditorBrowsableTagHelper).FullName,
                             assemblyName: AssemblyName,
-                            attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                            attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                             {
                                 builder => builder
                                     .Name("property")
@@ -981,7 +981,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                     "overridden-attribute",
                     typeof(OverriddenAttributeTagHelper).FullName,
                     AssemblyName,
-                    new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("SomethingElse")
@@ -1015,7 +1015,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                     "inherited-overridden-attribute",
                     typeof(InheritedOverriddenAttributeTagHelper).FullName,
                     AssemblyName,
-                    new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("valid-attribute1")
@@ -1049,7 +1049,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                     "inherited-not-overridden-attribute",
                     typeof(InheritedNotOverriddenAttributeTagHelper).FullName,
                     AssemblyName,
-                    new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("SomethingElse")
@@ -1078,7 +1078,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 "inherited-single-attribute",
                 typeof(InheritedSingleAttributeTagHelper).FullName,
                 AssemblyName,
-                new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                 {
                     builder => builder
                         .Name("int-attribute")
@@ -1104,7 +1104,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 "single-attribute",
                 typeof(SingleAttributeTagHelper).FullName,
                 AssemblyName,
-                new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                 {
                     builder => builder
                         .Name("int-attribute")
@@ -1131,7 +1131,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 "missing-accessor",
                 typeof(MissingAccessorTagHelper).FullName,
                 AssemblyName,
-                new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                 {
                     builder => builder
                         .Name("valid-attribute")
@@ -1158,7 +1158,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 "non-public-accessor",
                 typeof(NonPublicAccessorTagHelper).FullName,
                 AssemblyName,
-                new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                 {
                     builder => builder
                         .Name("valid-attribute")
@@ -1183,7 +1183,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                 "not-bound-attribute",
                 typeof(NotBoundAttributeTagHelper).FullName,
                 AssemblyName,
-                new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                 {
                     builder => builder
                         .Name("bound-property")
@@ -1209,7 +1209,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                     string.Empty,
                     typeof(MultiTagTagHelper).FullName,
                     AssemblyName,
-                    new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("valid-attribute")
@@ -1240,7 +1240,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                     "inherited-multi-tag",
                     typeof(InheritedMultiTagTagHelper).FullName,
                     AssemblyName,
-                    new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                    new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                     {
                         builder => builder
                             .Name("valid-attribute")
@@ -1382,7 +1382,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(InvalidBoundAttribute),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(InvalidBoundAttribute).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(InvalidBoundAttribute).FullName)
                                 .Name("data-something")
                                 .PropertyName(nameof(InvalidBoundAttribute.DataSomething))
                                 .TypeName(typeof(string).FullName)
@@ -1398,7 +1398,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(InvalidBoundAttributeWithValid),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(InvalidBoundAttributeWithValid).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(InvalidBoundAttributeWithValid).FullName)
                                 .Name("data-something")
                                 .PropertyName(nameof(InvalidBoundAttributeWithValid.DataSomething))
                                 .TypeName(typeof(string).FullName)
@@ -1408,7 +1408,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                                         nameof(InvalidBoundAttributeWithValid.DataSomething),
                                         "data-something"))
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(InvalidBoundAttributeWithValid).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(InvalidBoundAttributeWithValid).FullName)
                                 .Name("int-attribute")
                                 .PropertyName(nameof(InvalidBoundAttributeWithValid.IntAttribute))
                                 .TypeName(typeof(int).FullName)
@@ -1419,7 +1419,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(OverriddenInvalidBoundAttributeWithValid),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(OverriddenInvalidBoundAttributeWithValid).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(OverriddenInvalidBoundAttributeWithValid).FullName)
                                 .Name("valid-something")
                                 .PropertyName(nameof(OverriddenInvalidBoundAttributeWithValid.DataSomething))
                                 .TypeName(typeof(string).FullName)
@@ -1430,7 +1430,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(OverriddenValidBoundAttributeWithInvalid),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(OverriddenValidBoundAttributeWithInvalid).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(OverriddenValidBoundAttributeWithInvalid).FullName)
                                 .Name("data-something")
                                 .PropertyName(nameof(OverriddenValidBoundAttributeWithInvalid.ValidSomething))
                                 .TypeName(typeof(string).FullName)
@@ -1446,7 +1446,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(OverriddenValidBoundAttributeWithInvalidUpperCase),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(OverriddenValidBoundAttributeWithInvalidUpperCase).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(OverriddenValidBoundAttributeWithInvalidUpperCase).FullName)
                                 .Name("DATA-SOMETHING")
                                 .PropertyName(nameof(OverriddenValidBoundAttributeWithInvalidUpperCase.ValidSomething))
                                 .TypeName(typeof(string).FullName)
@@ -1762,7 +1762,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(DefaultValidHtmlAttributePrefix),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(DefaultValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(DefaultValidHtmlAttributePrefix).FullName)
                                 .Name("dictionary-property")
                                 .PropertyName(nameof(DefaultValidHtmlAttributePrefix.DictionaryProperty))
                                 .TypeName($"{dictionaryNamespace}<System.String, System.String>")
@@ -1775,7 +1775,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(SingleValidHtmlAttributePrefix),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(SingleValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(SingleValidHtmlAttributePrefix).FullName)
                                 .Name("valid-name")
                                 .PropertyName(nameof(SingleValidHtmlAttributePrefix.DictionaryProperty))
                                 .TypeName($"{dictionaryNamespace}<System.String, System.String>")
@@ -1788,47 +1788,47 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(MultipleValidHtmlAttributePrefix),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
                                 .Name("valid-name1")
                                 .PropertyName(nameof(MultipleValidHtmlAttributePrefix.DictionaryProperty))
                                 .TypeName($"{typeof(Dictionary<,>).Namespace}.Dictionary<System.String, System.Object>")
                                 .AsDictionary("valid-prefix1-", typeof(object).FullName)
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
                                 .Name("valid-name2")
                                 .PropertyName(nameof(MultipleValidHtmlAttributePrefix.DictionarySubclassProperty))
                                 .TypeName(typeof(DictionarySubclass).FullName)
                                 .AsDictionary("valid-prefix2-", typeof(string).FullName)
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
                                 .Name("valid-name3")
                                 .PropertyName(nameof(MultipleValidHtmlAttributePrefix.DictionaryWithoutParameterlessConstructorProperty))
                                 .TypeName(typeof(DictionaryWithoutParameterlessConstructor).FullName)
                                 .AsDictionary("valid-prefix3-", typeof(string).FullName)
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
                                 .Name("valid-name4")
                                 .PropertyName(nameof(MultipleValidHtmlAttributePrefix.GenericDictionarySubclassProperty))
                                 .TypeName(typeof(GenericDictionarySubclass<object>).Namespace + ".GenericDictionarySubclass<System.Object>")
                                 .AsDictionary("valid-prefix4-", typeof(object).FullName)
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
                                 .Name("valid-name5")
                                 .PropertyName(nameof(MultipleValidHtmlAttributePrefix.SortedDictionaryProperty))
                                 .TypeName(typeof(SortedDictionary<string, int>).Namespace + ".SortedDictionary<System.String, System.Int32>")
                                 .AsDictionary("valid-prefix5-", typeof(int).FullName)
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
                                 .Name("valid-name6")
                                 .PropertyName(nameof(MultipleValidHtmlAttributePrefix.StringProperty))
                                 .TypeName(typeof(string).FullName)
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
                                 .PropertyName(nameof(MultipleValidHtmlAttributePrefix.GetOnlyDictionaryProperty))
                                 .TypeName($"{dictionaryNamespace}<System.String, System.Int32>")
                                 .AsDictionary("get-only-dictionary-property-", typeof(int).FullName)
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleValidHtmlAttributePrefix).FullName)
                                 .PropertyName(nameof(MultipleValidHtmlAttributePrefix.GetOnlyDictionaryPropertyWithAttributePrefix))
                                 .TypeName($"{dictionaryNamespace}<System.String, System.String>")
                                 .AsDictionary("valid-prefix6", typeof(string).FullName)
@@ -1840,7 +1840,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(SingleInvalidHtmlAttributePrefix),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(SingleInvalidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(SingleInvalidHtmlAttributePrefix).FullName)
                                 .Name("valid-name")
                                 .PropertyName(nameof(SingleInvalidHtmlAttributePrefix.StringProperty))
                                 .TypeName(typeof(string).FullName)
@@ -1860,12 +1860,12 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                         typeof(MultipleInvalidHtmlAttributePrefix),
                         new[]
                         {
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
                                 .Name("valid-name1")
                                 .PropertyName(nameof(MultipleInvalidHtmlAttributePrefix.LongProperty))
                                 .TypeName(typeof(long).FullName)
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
                                 .Name("valid-name2")
                                 .PropertyName(nameof(MultipleInvalidHtmlAttributePrefix.DictionaryOfIntProperty))
                                 .TypeName($"{typeof(Dictionary<,>).Namespace}.Dictionary<System.Int32, System.String>")
@@ -1875,7 +1875,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                                         typeof(MultipleInvalidHtmlAttributePrefix).FullName,
                                         nameof(MultipleInvalidHtmlAttributePrefix.DictionaryOfIntProperty)))
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
                                 .Name("valid-name3")
                                 .PropertyName(nameof(MultipleInvalidHtmlAttributePrefix.ReadOnlyDictionaryProperty))
                                 .TypeName($"{typeof(IReadOnlyDictionary<,>).Namespace}.IReadOnlyDictionary<System.String, System.Object>")
@@ -1884,7 +1884,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                                         typeof(MultipleInvalidHtmlAttributePrefix).FullName,
                                         nameof(MultipleInvalidHtmlAttributePrefix.ReadOnlyDictionaryProperty)))
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
                                 .Name("valid-name4")
                                 .PropertyName(nameof(MultipleInvalidHtmlAttributePrefix.IntProperty))
                                 .TypeName(typeof(int).FullName)
@@ -1893,7 +1893,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                                         typeof(MultipleInvalidHtmlAttributePrefix).FullName,
                                         nameof(MultipleInvalidHtmlAttributePrefix.IntProperty)))
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
                                 .Name("valid-name5")
                                 .PropertyName(nameof(MultipleInvalidHtmlAttributePrefix.DictionaryOfIntSubclassProperty))
                                 .TypeName(typeof(DictionaryOfIntSubclass).FullName)
@@ -1903,7 +1903,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                                         typeof(MultipleInvalidHtmlAttributePrefix).FullName,
                                         nameof(MultipleInvalidHtmlAttributePrefix.DictionaryOfIntSubclassProperty)))
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
                                 .PropertyName(nameof(MultipleInvalidHtmlAttributePrefix.GetOnlyDictionaryAttributePrefix))
                                 .TypeName($"{dictionaryNamespace}<System.Int32, System.String>")
                                 .AsDictionary("valid-prefix6", typeof(string).FullName)
@@ -1912,7 +1912,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
                                         typeof(MultipleInvalidHtmlAttributePrefix).FullName,
                                         nameof(MultipleInvalidHtmlAttributePrefix.GetOnlyDictionaryAttributePrefix)))
                                 .Build(),
-                            ITagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
+                            TagHelperBoundAttributeDescriptorBuilder.Create(typeof(MultipleInvalidHtmlAttributePrefix).FullName)
                                 .PropertyName(nameof(MultipleInvalidHtmlAttributePrefix.GetOnlyDictionaryPropertyWithAttributeName))
                                 .TypeName($"{dictionaryNamespace}<System.String, System.Object>")
                                 .AsDictionary("invalid-name7-", typeof(object).FullName)
@@ -2291,7 +2291,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             string tagName,
             string typeName,
             string assemblyName,
-            IEnumerable<Action<ITagHelperBoundAttributeDescriptorBuilder>> attributes = null,
+            IEnumerable<Action<TagHelperBoundAttributeDescriptorBuilder>> attributes = null,
             IEnumerable<Action<TagMatchingRuleBuilder>> ruleBuilders = null)
         {
             var builder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/TagHelperDescriptorSerializationTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/TagHelperDescriptorSerializationTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 tagName: "tag-name",
                 typeName: "type name",
                 assemblyName: "assembly name",
-                attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                 {
                     builder => builder
                         .Name("test-attribute")
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 tagName: "tag-name",
                 typeName: "type name",
                 assemblyName: "assembly name",
-                attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                 {
                     builder => builder
                         .Name("test-attribute")
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 tagName: "tag-name",
                 typeName: "type name",
                 assemblyName: "assembly name",
-                attributes: new Action<ITagHelperBoundAttributeDescriptorBuilder>[]
+                attributes: new Action<TagHelperBoundAttributeDescriptorBuilder>[]
                 {
                     builder => builder
                         .Name("test-attribute")
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             string tagName,
             string typeName,
             string assemblyName,
-            IEnumerable<Action<ITagHelperBoundAttributeDescriptorBuilder>> attributes = null,
+            IEnumerable<Action<TagHelperBoundAttributeDescriptorBuilder>> attributes = null,
             IEnumerable<Action<TagMatchingRuleBuilder>> ruleBuilders = null,
             Action<TagHelperDescriptorBuilder> configureAction = null)
         {


### PR DESCRIPTION
- ITagHelperBoundAttributeDescriptor => TagHelperBoundAttributeDescriptorBuilder

#1306 

@ajaybhargavb @rynowak do we even want to PR these changes or just get them in? Thought I'd do a dry run to ask.