### PR TITLE
Upgrade test framework versions and fix issues with tests

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -11,7 +11,7 @@
     <RoslynVersion>2.0.0</RoslynVersion>
     <RoslynDevVersion>2.3.0-beta1-61624-03</RoslynDevVersion>
     <StreamJsonRpcVersion>1.0.2-rc</StreamJsonRpcVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test.csproj
@@ -21,17 +21,15 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.Runtime\Microsoft.AspNetCore.Razor.Runtime.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor\Microsoft.CodeAnalysis.Razor.csproj" />
+  </ItemGroup>
 
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(DependencyModelVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ViewComponentTagHelperPassTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ViewComponentTagHelperPassTest.cs
@@ -122,7 +122,7 @@ public class __Generated__TagCloudViewComponentTagHelper : Microsoft.AspNetCore.
 ",
                 tokenNode.Content,
                 ignoreLineEndingDifferences: true);
-            Assert.Equal(tokenNode.Kind, RazorIRToken.TokenKind.CSharp);
+            Assert.Equal(RazorIRToken.TokenKind.CSharp, tokenNode.Kind);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ public class __Generated__TagCloudViewComponentTagHelper : Microsoft.AspNetCore.
 ",
                 tokenNode.Content,
                 ignoreLineEndingDifferences: true);
-            Assert.Equal(tokenNode.Kind, RazorIRToken.TokenKind.CSharp);
+            Assert.Equal(RazorIRToken.TokenKind.CSharp, tokenNode.Kind);
         }
 
         [Fact]
@@ -280,7 +280,7 @@ public class __Generated__TagCloudViewComponentTagHelper : Microsoft.AspNetCore.
 ",
                 tokenNode.Content,
                 ignoreLineEndingDifferences: true);
-            Assert.Equal(tokenNode.Kind, RazorIRToken.TokenKind.CSharp);
+            Assert.Equal(RazorIRToken.TokenKind.CSharp, tokenNode.Kind);
         }
 
         private RazorCodeDocument CreateDocument(string content)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultDirectiveIRPassTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultDirectiveIRPassTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 node => Assert.IsType<UsingStatementIRNode>(node),
                 node => Assert.IsType<ClassDeclarationIRNode>(node));
             var @class = (ClassDeclarationIRNode)@namespace.Children[2];
-            Assert.Equal(@class.BaseType, "Hello<World[]>");
+            Assert.Equal("Hello<World[]>", @class.BaseType);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CodeWriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CodeWriterTest.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Theory]
-        [MemberData("NewLines")]
+        [MemberData(nameof(NewLines))]
         public void CodeWriter_TracksPosition_WithWriteLine_WithNewLineInContent(string newLine)
         {
             // Arrange
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Theory]
-        [MemberData("NewLines")]
+        [MemberData(nameof(NewLines))]
         public void CodeWriter_TracksPosition_WithWrite_WithNewlineInContent(string newLine)
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlTagsTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlTagsTest.cs
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Theory]
-        [MemberData("VoidElementNames")]
+        [MemberData(nameof(VoidElementNames))]
         public void VoidElementFollowedByContent(string tagName)
         {
             ParseBlockTest("<" + tagName + ">foo",
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Theory]
-        [MemberData("VoidElementNames")]
+        [MemberData(nameof(VoidElementNames))]
         public void VoidElementFollowedByOtherTag(string tagName)
         {
             ParseBlockTest("<" + tagName + "><other>foo",
@@ -185,7 +185,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Theory]
-        [MemberData("VoidElementNames")]
+        [MemberData(nameof(VoidElementNames))]
         public void VoidElementFollowedByCloseTag(string tagName)
         {
             ParseBlockTest("<" + tagName + "> </" + tagName + ">foo",
@@ -196,7 +196,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Theory]
-        [MemberData("VoidElementNames")]
+        [MemberData(nameof(VoidElementNames))]
         public void IncompleteVoidElementEndTag(string tagName)
         {
             ParseBlockTest("<" + tagName + "></" + tagName,

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Microsoft.AspNetCore.Razor.Language.Test.csproj
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Microsoft.AspNetCore.Razor.Language.Test.csproj
@@ -1,16 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <Import Project="..\..\build\common.props" />
+
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
   </PropertyGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="TestFiles\**\*" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.Language\Microsoft.AspNetCore.Razor.Language.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
@@ -18,7 +25,5 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Microsoft.AspNetCore.Razor.Runtime.Test.csproj
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Microsoft.AspNetCore.Razor.Runtime.Test.csproj
@@ -1,15 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <Import Project="..\..\build\common.props" />
+
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\..\shared\Microsoft.AspNetCore.Razor.TagHelpers.Testing.Sources\**\*.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.Runtime\Microsoft.AspNetCore.Razor.Runtime.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.WebEncoders" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
@@ -17,7 +24,5 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
@@ -94,8 +94,8 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             await output.GetChildContentAsync();
 
             // Assert - 2
-            Assert.Equal(callCount, 0);
-            Assert.Equal(updatedCallCount, 1);
+            Assert.Equal(0, callCount);
+            Assert.Equal(1, updatedCallCount);
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             var context = executionContext.Context;
             var attribute = Assert.Single(context.AllAttributes);
             Assert.Equal(tagName, context.TagName);
-            Assert.Equal(attribute.Name, "Another attribute");
+            Assert.Equal("Another attribute", attribute.Name);
             Assert.Equal(updatedUniqueId, context.UniqueId);
             Assert.Same(updatedItems, context.Items);
         }

--- a/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
@@ -11,7 +11,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.Language\Microsoft.AspNetCore.Razor.Language.csproj" />
-    
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 

--- a/test/Microsoft.CodeAnalysis.Razor.Test/Microsoft.CodeAnalysis.Razor.Test.csproj
+++ b/test/Microsoft.CodeAnalysis.Razor.Test/Microsoft.CodeAnalysis.Razor.Test.csproj
@@ -35,8 +35,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <Import Project="..\..\build\common.props" />
+
   <PropertyGroup>
     <TargetFrameworks>net46</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
@@ -12,13 +14,16 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="TestFiles\**\*" />
     <None Include="xunit.runner.json" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor\Microsoft.CodeAnalysis.Razor.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
@@ -26,6 +31,9 @@
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.Language\Microsoft.AspNetCore.Razor.Language.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.Runtime\Microsoft.AspNetCore.Razor.Runtime.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor\Microsoft.AspNetCore.Razor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(RoslynDevVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynDevVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(DependencyModelVersion)" />
@@ -34,7 +42,5 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
+
 </Project>

--- a/test/RazorPageGenerator.Test/RazorPageGenerator.Test.csproj
+++ b/test/RazorPageGenerator.Test/RazorPageGenerator.Test.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <Import Project="..\..\build\common.props" />
+
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->
@@ -11,17 +13,19 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\RazorPageGenerator\RazorPageGenerator.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
+
   <ItemGroup>
     <None Include="TestFiles\Views\TestFile.js" />
     <None Include="TestFiles\Views\TestView.cshtml" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
More xunit 2.3 goodness.

Update test framework versions and fixed all the issues that xunit.analyzers didn't like.