### PR TITLE
Set the chunk generator of non-string tag helper attributes to ExpressionChunkGenerator

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelExpressionPass.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelExpressionPass.cs
@@ -38,12 +38,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                         Content = "ModelExpressionProvider.CreateModelExpression(ViewData, __model => ",
                     });
 
-                    if (node.Children.Count == 1 && node.Children[0] is HtmlContentIRNode original)
+                    if (node.Children.Count == 1 && node.Children[0] is RazorIRToken token && token.IsCSharp)
                     {
                         // A 'simple' expression will look like __model => __model.Foo
-                        //
-                        // Note that the fact we're looking for HTML here is based on a bug.
-                        // https://github.com/aspnet/Razor/issues/963
 
                         builder.Add(new RazorIRToken()
                         {
@@ -51,13 +48,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                             Content = "__model."
                         });
 
-                        var content = GetContent(original);
-                        builder.Add(new RazorIRToken()
-                        {
-                            Kind = RazorIRToken.TokenKind.CSharp,
-                            Content = content,
-                            Source = original.Source,
-                        });
+                        builder.Add(token);
                     }
                     else
                     {
@@ -76,19 +67,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
                                 continue;
                             }
-
-                            // Note that the fact we're looking for HTML here is based on a bug.
-                            // https://github.com/aspnet/Razor/issues/963
-                            if (node.Children[i] is HtmlContentIRNode html)
-                            {
-                                var content = GetContent(html);
-                                builder.Add(new RazorIRToken()
-                                {
-                                    Kind = RazorIRToken.TokenKind.CSharp,
-                                    Content = content,
-                                    Source = html.Source,
-                                });
-                            }
                         }
                     }
 
@@ -103,20 +81,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                     node.Children.Add(expression);
                     expression.Parent = node;
                 }
-            }
-
-            private string GetContent(HtmlContentIRNode node)
-            {
-                var builder = new StringBuilder();
-                for (var i = 0; i < node.Children.Count; i++)
-                {
-                    if (node.Children[i] is RazorIRToken token && token.IsHtml)
-                    {
-                        builder.Append(token.Content);
-                    }
-                }
-
-                return builder.ToString();
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeTagHelperWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeTagHelperWriter.cs
@@ -100,7 +100,8 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
                     var assignmentPrefixLength = propertyValueAccessor.Length + " = ".Length;
                     if (node.Descriptor.IsEnum &&
                         node.Children.Count == 1 &&
-                        node.Children.First() is HtmlContentIRNode)
+                        node.Children.First() is RazorIRToken token &&
+                        token.IsCSharp)
                     {
                         assignmentPrefixLength += $"global::{node.Descriptor.TypeName}.".Length;
 

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeTagHelperWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeTagHelperWriter.cs
@@ -380,7 +380,8 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
 
                     if (node.Descriptor.IsEnum &&
                         node.Children.Count == 1 &&
-                        node.Children.First() is HtmlContentIRNode)
+                        node.Children.First() is RazorIRToken token &&
+                        token.IsCSharp)
                     {
                         context.Writer
                             .Write("global::")

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelExpressionPassTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelExpressionPassTest.cs
@@ -49,8 +49,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             var tagHelper = FindTagHelperNode(irDocument);
             var setProperty = tagHelper.Children.OfType<SetTagHelperPropertyIRNode>().Single();
 
-            var html = Assert.IsType<HtmlContentIRNode>(Assert.Single(setProperty.Children));
-            var token = Assert.IsType<RazorIRToken>(Assert.Single(html.Children));
+            var token = Assert.IsType<RazorIRToken>(Assert.Single(setProperty.Children));
+            Assert.True(token.IsCSharp);
             Assert.Equal("17", token.Content);
         }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/TestTagHelperDescriptors.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/TestTagHelperDescriptors.cs
@@ -37,6 +37,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                                 .Name("bound")
                                 .PropertyName("BoundProp")
                                 .TypeName("System.String"),
+                            builder => builder
+                                .Name("age")
+                                .PropertyName("AgeProp")
+                                .TypeName("System.Int32"),
                         })
                 };
             }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
@@ -26,7 +26,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 attributes: new List<TagHelperAttributeNode>
                                 {
                                     new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
-                                    new TagHelperAttributeNode("[item]", factory.CodeMarkup("items"), HtmlAttributeValueStyle.SingleQuotes)
+                                    new TagHelperAttributeNode(
+                                        "[item]",
+                                        factory.CodeMarkup("items").With(new ExpressionChunkGenerator()),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                     {
@@ -36,7 +39,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 attributes: new List<TagHelperAttributeNode>
                                 {
                                     new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
-                                    new TagHelperAttributeNode("[(item)]", factory.CodeMarkup("items"), HtmlAttributeValueStyle.SingleQuotes)
+                                    new TagHelperAttributeNode(
+                                        "[(item)]",
+                                        factory.CodeMarkup("items").With(new ExpressionChunkGenerator()),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 }))
                     },
                     {
@@ -48,7 +54,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                     new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
                                     new TagHelperAttributeNode(
                                         "(click)",
-                                        factory.CodeMarkup("doSomething()"),
+                                        factory.CodeMarkup("doSomething()").With(new ExpressionChunkGenerator()),
                                         HtmlAttributeValueStyle.SingleQuotes)
                                 },
                                 children: factory.Markup("Click Me")))
@@ -62,7 +68,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                     new TagHelperAttributeNode("bound", null, HtmlAttributeValueStyle.Minimized),
                                     new TagHelperAttributeNode(
                                         "(^click)",
-                                        factory.CodeMarkup("doSomething()"),
+                                        factory.CodeMarkup("doSomething()").With(new ExpressionChunkGenerator()),
                                         HtmlAttributeValueStyle.SingleQuotes)
                                 },
                                 children: factory.Markup("Click Me")))
@@ -961,7 +967,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12"))
+                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12").With(new ExpressionChunkGenerator()))
                                 }))
                     },
                     {
@@ -973,7 +979,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 {
                                     new TagHelperAttributeNode(
                                         "birthday",
-                                        factory.CodeMarkup("DateTime.Now"))
+                                        factory.CodeMarkup("DateTime.Now").With(new ExpressionChunkGenerator()))
                                 }))
                     },
                     {
@@ -1005,9 +1011,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                         "age",
                                         new MarkupBlock(
                                             new MarkupBlock(
-                                                factory.CodeMarkup(" "),
+                                                factory.CodeMarkup(" ").With(new ExpressionChunkGenerator()),
                                                 new ExpressionBlock(
-                                                    factory.CSharpCodeMarkup("@"),
+                                                    factory.CSharpCodeMarkup("@").With(new ExpressionChunkGenerator()),
                                                     factory
                                                         .CSharpCodeMarkup("DateTime.Now.Year")
                                                         .With(new ExpressionChunkGenerator())))))
@@ -1045,39 +1051,38 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                     new TagHelperAttributeNode(
                                         "age",
                                         new MarkupBlock(
-                                            factory.CodeMarkup("1"),
-                                            factory.CodeMarkup(" +"),
+                                            factory.CodeMarkup("1").With(new ExpressionChunkGenerator()),
+                                            factory.CodeMarkup(" +").With(new ExpressionChunkGenerator()),
                                             new MarkupBlock(
-                                                factory.CodeMarkup(" "),
+                                                factory.CodeMarkup(" ").With(new ExpressionChunkGenerator()),
                                                 new ExpressionBlock(
-                                                    factory.CSharpCodeMarkup("@"),
+                                                    factory.CSharpCodeMarkup("@").With(new ExpressionChunkGenerator()),
                                                     factory.CSharpCodeMarkup("value")
                                                         .With(new ExpressionChunkGenerator()))),
-                                            factory.CodeMarkup(" +"),
-                                            factory.CodeMarkup(" 2"))),
+                                            factory.CodeMarkup(" +").With(new ExpressionChunkGenerator()),
+                                            factory.CodeMarkup(" 2").With(new ExpressionChunkGenerator()))),
                                     new TagHelperAttributeNode(
                                         "birthday",
                                         new MarkupBlock(
-                                            factory.CodeMarkup("(bool)"),
+                                            factory.CodeMarkup("(bool)").With(new ExpressionChunkGenerator()),
                                             new MarkupBlock(
                                                 new ExpressionBlock(
-                                                    factory.CSharpCodeMarkup("@"),
+                                                    factory.CSharpCodeMarkup("@").With(new ExpressionChunkGenerator()),
                                                     factory
                                                         .CSharpCodeMarkup("Bag[\"val\"]")
                                                         .With(new ExpressionChunkGenerator()))),
-                                            factory.CodeMarkup(" ?"),
+                                            factory.CodeMarkup(" ?").With(new ExpressionChunkGenerator()),
                                             new MarkupBlock(
-                                                factory.CodeMarkup(" @")
+                                                factory.CodeMarkup(" @").With(new ExpressionChunkGenerator())
                                                     .As(SpanKind.Code),
-                                                factory.CodeMarkup("@")
-                                                    .As(SpanKind.Code)
-                                                    .With(SpanChunkGenerator.Null)),
-                                            factory.CodeMarkup("DateTime"),
-                                            factory.CodeMarkup(" :"),
+                                                factory.CodeMarkup("@").With(SpanChunkGenerator.Null)
+                                                    .As(SpanKind.Code)),
+                                            factory.CodeMarkup("DateTime").With(new ExpressionChunkGenerator()),
+                                            factory.CodeMarkup(" :").With(new ExpressionChunkGenerator()),
                                             new MarkupBlock(
-                                                factory.CodeMarkup(" "),
+                                                factory.CodeMarkup(" ").With(new ExpressionChunkGenerator()),
                                                 new ExpressionBlock(
-                                                    factory.CSharpCodeMarkup("@"),
+                                                    factory.CSharpCodeMarkup("@").With(new ExpressionChunkGenerator()),
                                                     factory
                                                         .CSharpCodeMarkup("DateTime.Now")
                                                         .With(new ExpressionChunkGenerator())))),
@@ -1091,10 +1096,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12")),
+                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12").With(new ExpressionChunkGenerator())),
                                     new TagHelperAttributeNode(
                                         "birthday",
-                                        factory.CodeMarkup("DateTime.Now")),
+                                        factory.CodeMarkup("DateTime.Now").With(new ExpressionChunkGenerator())),
                                     new TagHelperAttributeNode(
                                         "name",
                                         new MarkupBlock(factory.Markup("Time:"), dateTimeNow))
@@ -1107,10 +1112,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12")),
+                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12").With(new ExpressionChunkGenerator())),
                                     new TagHelperAttributeNode(
                                         "birthday",
-                                        factory.CodeMarkup("DateTime.Now")),
+                                        factory.CodeMarkup("DateTime.Now").With(new ExpressionChunkGenerator())),
                                     new TagHelperAttributeNode(
                                         "name",
                                         new MarkupBlock(
@@ -1130,10 +1135,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12")),
+                                    new TagHelperAttributeNode("age", factory.CodeMarkup("12").With(new ExpressionChunkGenerator())),
                                     new TagHelperAttributeNode(
                                         "birthday",
-                                        factory.CodeMarkup("DateTime.Now")),
+                                        factory.CodeMarkup("DateTime.Now").With(new ExpressionChunkGenerator())),
                                     new TagHelperAttributeNode(
                                         "name",
                                         new MarkupBlock(
@@ -1156,22 +1161,21 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                         "age",
                                         new MarkupBlock(
                                             new MarkupBlock(
-                                                factory.CodeMarkup("@"),
-                                                factory.CodeMarkup("@")
-                                                    .With(SpanChunkGenerator.Null)),
+                                                factory.CodeMarkup("@").With(new ExpressionChunkGenerator()),
+                                                factory.CodeMarkup("@").With(SpanChunkGenerator.Null)),
                                             new MarkupBlock(
                                                 factory.EmptyHtml()
-                                                    .AsCodeMarkup()
+                                                    .AsCodeMarkup().With(new ExpressionChunkGenerator())
                                                     .As(SpanKind.Code),
                                                 new ExpressionBlock(
-                                                    factory.CSharpCodeMarkup("@"),
-                                                    factory.CSharpCodeMarkup("("),
+                                                    factory.CSharpCodeMarkup("@").With(new ExpressionChunkGenerator()),
+                                                    factory.CSharpCodeMarkup("(").With(new ExpressionChunkGenerator()),
                                                     factory.CSharpCodeMarkup("11+1")
                                                         .With(new ExpressionChunkGenerator()),
-                                                    factory.CSharpCodeMarkup(")"))))),
+                                                    factory.CSharpCodeMarkup(")").With(new ExpressionChunkGenerator()))))),
                                     new TagHelperAttributeNode(
                                         "birthday",
-                                        factory.CodeMarkup("DateTime.Now")),
+                                        factory.CodeMarkup("DateTime.Now").With(new ExpressionChunkGenerator())),
                                     new TagHelperAttributeNode(
                                         "name",
                                         new MarkupBlock(factory.Markup("Time:"), dateTimeNow))
@@ -1954,7 +1958,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("    true"), HtmlAttributeValueStyle.SingleQuotes)
+                                    new TagHelperAttributeNode(
+                                        "bound",
+                                        factory.CodeMarkup("    true").With(new ExpressionChunkGenerator()),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new RazorError[0]
                     },
@@ -1966,7 +1973,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("    "), HtmlAttributeValueStyle.SingleQuotes)
+                                    new TagHelperAttributeNode(
+                                        "bound",
+                                        factory.CodeMarkup("    ").With(new ExpressionChunkGenerator()),
+                                        HtmlAttributeValueStyle.SingleQuotes)
                                 })),
                         new[]
                         {
@@ -2004,8 +2014,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("bound", factory.CodeMarkup(" "), HtmlAttributeValueStyle.SingleQuotes),
-                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("  "))
+                                    new TagHelperAttributeNode(
+                                        "bound",
+                                        factory.CodeMarkup(" ").With(new ExpressionChunkGenerator()),
+                                        HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode(
+                                        "bound",
+                                        factory.CodeMarkup("  "))
                                 })),
                         new[]
                         {
@@ -2025,7 +2040,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("true"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode(
+                                        "bound",
+                                        factory.CodeMarkup("true").With(new ExpressionChunkGenerator()),
+                                        HtmlAttributeValueStyle.SingleQuotes),
                                     new TagHelperAttributeNode(
                                         "bound",
                                         factory.CodeMarkup(string.Empty).With(SpanChunkGenerator.Null),
@@ -2088,7 +2106,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("bound", factory.CodeMarkup("true"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode(
+                                        "bound",
+                                        factory.CodeMarkup("true").With(new ExpressionChunkGenerator()),
+                                        HtmlAttributeValueStyle.SingleQuotes),
                                     new TagHelperAttributeNode("name", factory.Markup("john"), HtmlAttributeValueStyle.SingleQuotes),
                                     new TagHelperAttributeNode(
                                         "bound",
@@ -2177,12 +2198,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                             "bound",
                                             new MarkupBlock(
                                                 new MarkupBlock(
-                                                factory.CodeMarkup("    "),
+                                                factory.CodeMarkup("    ").With(new ExpressionChunkGenerator()),
                                                 new ExpressionBlock(
-                                                    factory.CSharpCodeMarkup("@"),
+                                                    factory.CSharpCodeMarkup("@").With(new ExpressionChunkGenerator()),
                                                     factory.CSharpCodeMarkup("true")
                                                         .With(new ExpressionChunkGenerator()))),
-                                                factory.CodeMarkup("  ")),
+                                                factory.CodeMarkup("  ").With(new ExpressionChunkGenerator())),
                                             HtmlAttributeValueStyle.SingleQuotes)
                                     }
                                 })),
@@ -2201,14 +2222,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                             "bound",
                                             new MarkupBlock(
                                                 new MarkupBlock(
-                                                factory.CodeMarkup("    "),
+                                                factory.CodeMarkup("    ").With(new ExpressionChunkGenerator()),
                                                 new ExpressionBlock(
-                                                    factory.CSharpCodeMarkup("@"),
-                                                    factory.CSharpCodeMarkup("("),
+                                                    factory.CSharpCodeMarkup("@").With(new ExpressionChunkGenerator()),
+                                                    factory.CSharpCodeMarkup("(").With(new ExpressionChunkGenerator()),
                                                     factory.CSharpCodeMarkup("true")
                                                         .With(new ExpressionChunkGenerator()),
-                                                    factory.CSharpCodeMarkup(")"))),
-                                                factory.CodeMarkup("  ")),
+                                                    factory.CSharpCodeMarkup(")").With(new ExpressionChunkGenerator()))),
+                                                factory.CodeMarkup("  ").With(new ExpressionChunkGenerator())),
                                             HtmlAttributeValueStyle.SingleQuotes)
                                     }
                                 })),
@@ -3125,7 +3146,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 TagMode.SelfClosing,
                                 attributes: new List<TagHelperAttributeNode>
                                 {
-                                    new TagHelperAttributeNode("int-prefix-value", factory.CodeMarkup("3"), HtmlAttributeValueStyle.SingleQuotes),
+                                    new TagHelperAttributeNode(
+                                        "int-prefix-value",
+                                        factory.CodeMarkup("3").With(new ExpressionChunkGenerator()),
+                                        HtmlAttributeValueStyle.SingleQuotes),
                                 })),
                         new RazorError[0]
                     },

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.ir.txt
@@ -45,8 +45,7 @@ Document -
                                 HtmlContent - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml)
                                     RazorIRToken - (168:5,17 [8] AttributeTargetingTagHelpers.cshtml) - Html - checkbox
                             SetTagHelperProperty - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml)
-                                    RazorIRToken - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - CSharp - true
                             ExecuteTagHelpers - 
                         HtmlContent - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml)
                             RazorIRToken - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
@@ -62,8 +61,7 @@ Document -
                                 HtmlContent - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml)
                                     RazorIRToken - (214:6,17 [8] AttributeTargetingTagHelpers.cshtml) - Html - checkbox
                             SetTagHelperProperty - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml)
-                                    RazorIRToken - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - CSharp - true
                             AddTagHelperHtmlAttribute -  - catchAll - HtmlAttributeValueStyle.DoubleQuotes
                                 HtmlContent - (249:6,52 [2] AttributeTargetingTagHelpers.cshtml)
                                     RazorIRToken - (249:6,52 [2] AttributeTargetingTagHelpers.cshtml) - Html - hi

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.ir.txt
@@ -38,8 +38,7 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetTagHelperProperty - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml)
-                                    RazorIRToken - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (187:5,36 [4] AttributeTargetingTagHelpers.cshtml) - CSharp - true
                             ExecuteTagHelpers - 
                         HtmlContent - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml)
                             RazorIRToken - (195:5,44 [6] AttributeTargetingTagHelpers.cshtml) - Html - \n    
@@ -51,8 +50,7 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetTagHelperProperty - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml)
-                                    RazorIRToken - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (233:6,36 [4] AttributeTargetingTagHelpers.cshtml) - CSharp - true
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                             ExecuteTagHelpers - 
                         HtmlContent - (255:6,58 [2] AttributeTargetingTagHelpers.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.ir.txt
@@ -61,8 +61,7 @@ Document -
                                 HtmlContent - (284:6,21 [8] BasicTagHelpers.cshtml)
                                     RazorIRToken - (284:6,21 [8] BasicTagHelpers.cshtml) - Html - checkbox
                             SetTagHelperProperty - (303:6,40 [4] BasicTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (303:6,40 [4] BasicTagHelpers.cshtml)
-                                    RazorIRToken - (303:6,40 [4] BasicTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (303:6,40 [4] BasicTagHelpers.cshtml) - CSharp - true
                             ExecuteTagHelpers - 
                         HtmlContent - (310:6,47 [6] BasicTagHelpers.cshtml)
                             RazorIRToken - (310:6,47 [6] BasicTagHelpers.cshtml) - Html - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.ir.txt
@@ -39,8 +39,7 @@ Document -
                                 HtmlContent - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml)
                                     RazorIRToken - (207:7,24 [8] BasicTagHelpers_Prefixed.cshtml) - Html - checkbox
                             SetTagHelperProperty - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml)
-                                    RazorIRToken - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - Html - true
+                                RazorIRToken - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - CSharp - true
                             ExecuteTagHelpers - 
                         HtmlContent - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml)
                             RazorIRToken - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml) - Html - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.ir.txt
@@ -30,8 +30,7 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetTagHelperProperty - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml)
-                                    RazorIRToken - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - Html - true
+                                RazorIRToken - (226:7,43 [4] BasicTagHelpers_Prefixed.cshtml) - CSharp - true
                             ExecuteTagHelpers - 
                         HtmlContent - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml)
                             RazorIRToken - (232:7,49 [6] BasicTagHelpers_Prefixed.cshtml) - Html - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.ir.txt
@@ -39,8 +39,7 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_1 - type - Type
                             SetTagHelperProperty - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml)
-                                    RazorIRToken - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - true
+                                RazorIRToken - (234:7,40 [4] BasicTagHelpers_RemoveTagHelper.cshtml) - CSharp - true
                             ExecuteTagHelpers - 
                         HtmlContent - (241:7,47 [6] BasicTagHelpers_RemoveTagHelper.cshtml)
                             RazorIRToken - (241:7,47 [6] BasicTagHelpers_RemoveTagHelper.cshtml) - Html - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.ir.txt
@@ -52,8 +52,7 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_2 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_2 - type - Type
                             SetTagHelperProperty - (303:6,40 [4] BasicTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (303:6,40 [4] BasicTagHelpers.cshtml)
-                                    RazorIRToken - (303:6,40 [4] BasicTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (303:6,40 [4] BasicTagHelpers.cshtml) - CSharp - true
                             ExecuteTagHelpers - 
                         HtmlContent - (310:6,47 [6] BasicTagHelpers.cshtml)
                             RazorIRToken - (310:6,47 [6] BasicTagHelpers.cshtml) - Html - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml
@@ -5,6 +5,7 @@
     var checkbox = "checkbox";
 
     <div class="randomNonTagHelperAttribute">
+        <p age="@@@(1+2)" class="@@string"></p>
         <p time="Current Time: @DateTime.Now">
             <h1>Set Time:</h1>
             @if (false)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
@@ -27,7 +27,13 @@ global::System.Object __typeHelper = "*, TestAssembly";
 
 #line default
 #line hidden
-#line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+            __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+__TestNamespace_PTagHelper.Age = @@(1+2);
+
+#line default
+#line hidden
+#line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
              if (false)
             {
                 
@@ -39,7 +45,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
             __TestNamespace_InputTagHelper.Type = "text";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
-#line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                                                    
             }
             else
@@ -50,14 +56,14 @@ global::System.Object __typeHelper = "*, TestAssembly";
 #line hidden
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
-#line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                         __o = checkbox;
 
 #line default
 #line hidden
             __TestNamespace_InputTagHelper.Type = string.Empty;
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
-#line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                      __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
@@ -67,7 +73,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
                 
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
-#line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                          __o = true ? "checkbox" : "anything";
 
 #line default
@@ -78,103 +84,103 @@ global::System.Object __typeHelper = "*, TestAssembly";
                 
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
-#line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                               if(true) { 
 
 #line default
 #line hidden
-#line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                } else { 
 
 #line default
 #line hidden
-#line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                                               }
 
 #line default
 #line hidden
             __TestNamespace_InputTagHelper.Type = string.Empty;
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
-#line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                                                  
             }
 
 #line default
 #line hidden
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
-#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                           __o = DateTime.Now;
 
 #line default
 #line hidden
-#line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                var @object = false;
 
 #line default
 #line hidden
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
-#line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 24 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = (@object);
 
 #line default
 #line hidden
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
-#line 21 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
      __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
 
 #line default
 #line hidden
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
-#line 26 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 27 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                   __TestNamespace_InputTagHelper2.Checked = (DateTimeOffset.Now.Year > 2014);
 
 #line default
 #line hidden
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
-#line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 26 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = -1970 + @DateTimeOffset.Now.Year;
 
 #line default
 #line hidden
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
-#line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 30 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
 
 #line default
 #line hidden
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
-#line 28 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
 
 #line default
 #line hidden
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
-#line 32 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 33 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked =    @(  DateTimeOffset.Now.Year  ) > 2014   ;
 
 #line default
 #line hidden
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
-#line 31 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 32 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
 
 #line default
 #line hidden
-#line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
    __o = someMethod(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
     __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
     __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
-#line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                      __TestNamespace_InputTagHelper2.Checked = checked;
 
 #line default
 #line hidden
     __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
-#line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = 123;
 
 #line default
@@ -184,7 +190,7 @@ __TestNamespace_PTagHelper.Age = 123;
 
 #line default
 #line hidden
-#line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 36 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
           
 }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
@@ -17,273 +17,275 @@ Document -
                     RazorIRToken - (92:6,8 [36] ComplexTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
                     RazorIRToken - (128:6,44 [1] ComplexTagHelpers.cshtml) - Html - >
                     RazorIRToken - (129:6,45 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (139:7,8 [531] ComplexTagHelpers.cshtml)
+                TagHelper - (139:7,8 [39] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (177:7,46 [46] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (177:7,46 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                            RazorIRToken - (191:8,12 [4] ComplexTagHelpers.cshtml) - Html - <h1>
-                            RazorIRToken - (195:8,16 [9] ComplexTagHelpers.cshtml) - Html - Set Time:
-                            RazorIRToken - (204:8,25 [5] ComplexTagHelpers.cshtml) - Html - </h1>
-                            RazorIRToken - (209:8,30 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                        CSharpStatement - (224:9,13 [43] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (224:9,13 [43] ComplexTagHelpers.cshtml) - CSharp - if (false)\n            {\n                
-                        TagHelper - (267:11,16 [83] ComplexTagHelpers.cshtml)
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (147:7,16 [8] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        RazorIRToken - (147:7,16 [1] ComplexTagHelpers.cshtml) - CSharp - @
+                        RazorIRToken - (149:7,18 [0] ComplexTagHelpers.cshtml) - CSharp - 
+                        CSharpExpression - (149:7,18 [6] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (149:7,18 [1] ComplexTagHelpers.cshtml) - CSharp - @
+                            RazorIRToken - (150:7,19 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                            RazorIRToken - (151:7,20 [3] ComplexTagHelpers.cshtml) - CSharp - 1+2
+                            RazorIRToken - (154:7,23 [1] ComplexTagHelpers.cshtml) - CSharp - )
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (164:7,33 [1] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (164:7,33 [1] ComplexTagHelpers.cshtml) - Html - @
+                        HtmlContent - (166:7,35 [6] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (166:7,35 [6] ComplexTagHelpers.cshtml) - Html - string
+                    ExecuteTagHelpers - 
+                HtmlContent - (178:7,47 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (178:7,47 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (188:8,8 [531] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (226:8,46 [46] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (226:8,46 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                            RazorIRToken - (240:9,12 [4] ComplexTagHelpers.cshtml) - Html - <h1>
+                            RazorIRToken - (244:9,16 [9] ComplexTagHelpers.cshtml) - Html - Set Time:
+                            RazorIRToken - (253:9,25 [5] ComplexTagHelpers.cshtml) - Html - </h1>
+                            RazorIRToken - (258:9,30 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                        CSharpStatement - (273:10,13 [43] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (273:10,13 [43] ComplexTagHelpers.cshtml) - CSharp - if (false)\n            {\n                
+                        TagHelper - (316:12,16 [83] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                HtmlContent - (270:11,19 [10] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (270:11,19 [10] ComplexTagHelpers.cshtml) - Html - New Time: 
-                                TagHelper - (280:11,29 [66] ComplexTagHelpers.cshtml)
+                                HtmlContent - (319:12,19 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (319:12,19 [10] ComplexTagHelpers.cshtml) - Html - New Time: 
+                                TagHelper - (329:12,29 [66] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
                                     CreateTagHelper -  - TestNamespace.InputTagHelper2
-                                    SetTagHelperProperty - (293:11,42 [4] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (293:11,42 [4] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (293:11,42 [4] ComplexTagHelpers.cshtml) - Html - text
-                                    SetTagHelperProperty - (293:11,42 [4] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (293:11,42 [4] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (293:11,42 [4] ComplexTagHelpers.cshtml) - Html - text
+                                    SetTagHelperProperty - (342:12,42 [4] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        HtmlContent - (342:12,42 [4] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (342:12,42 [4] ComplexTagHelpers.cshtml) - Html - text
+                                    SetTagHelperProperty - (342:12,42 [4] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        HtmlContent - (342:12,42 [4] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (342:12,42 [4] ComplexTagHelpers.cshtml) - Html - text
                                     AddTagHelperHtmlAttribute -  - value - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (306:11,55 [0] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (306:11,55 [0] ComplexTagHelpers.cshtml) - Html - 
+                                        HtmlContent - (355:12,55 [0] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (355:12,55 [0] ComplexTagHelpers.cshtml) - Html - 
                                     AddTagHelperHtmlAttribute -  - placeholder - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (321:11,70 [22] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (321:11,70 [22] ComplexTagHelpers.cshtml) - Html - Enter in a new time...
+                                        HtmlContent - (370:12,70 [22] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (370:12,70 [22] ComplexTagHelpers.cshtml) - Html - Enter in a new time...
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
-                        CSharpStatement - (350:11,99 [66] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (350:11,99 [66] ComplexTagHelpers.cshtml) - CSharp - \n            }\n            else\n            {\n                
-                        TagHelper - (416:15,16 [58] ComplexTagHelpers.cshtml)
+                        CSharpStatement - (399:12,99 [66] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (399:12,99 [66] ComplexTagHelpers.cshtml) - CSharp - \n            }\n            else\n            {\n                
+                        TagHelper - (465:16,16 [58] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                HtmlContent - (419:15,19 [14] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (419:15,19 [14] ComplexTagHelpers.cshtml) - Html - Current Time: 
-                                TagHelper - (433:15,33 [37] ComplexTagHelpers.cshtml)
+                                HtmlContent - (468:16,19 [14] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (468:16,19 [14] ComplexTagHelpers.cshtml) - Html - Current Time: 
+                                TagHelper - (482:16,33 [37] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
                                     CreateTagHelper -  - TestNamespace.InputTagHelper2
-                                    SetTagHelperProperty - (445:15,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                        CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
-                                    SetTagHelperProperty - (445:15,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                        CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
-                                    SetTagHelperProperty - (463:15,63 [4] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (463:15,63 [4] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (463:15,63 [4] ComplexTagHelpers.cshtml) - Html - true
+                                    SetTagHelperProperty - (494:16,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (495:16,46 [8] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (495:16,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
+                                    SetTagHelperProperty - (494:16,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (495:16,46 [8] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (495:16,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
+                                    SetTagHelperProperty - (512:16,63 [4] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                        RazorIRToken - (512:16,63 [4] ComplexTagHelpers.cshtml) - CSharp - true
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
-                        CSharpStatement - (474:15,74 [18] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (474:15,74 [18] ComplexTagHelpers.cshtml) - CSharp - \n                
-                        TagHelper - (492:16,16 [50] ComplexTagHelpers.cshtml)
+                        CSharpStatement - (523:16,74 [18] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (523:16,74 [18] ComplexTagHelpers.cshtml) - CSharp - \n                
+                        TagHelper - (541:17,16 [50] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (505:16,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
-                                CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
-                            SetTagHelperProperty - (505:16,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
-                                CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
+                            SetTagHelperProperty - (554:17,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpExpression - (556:17,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (556:17,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
+                            SetTagHelperProperty - (554:17,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpExpression - (556:17,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (556:17,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
                             ExecuteTagHelpers - 
-                        CSharpStatement - (542:16,66 [18] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (542:16,66 [18] ComplexTagHelpers.cshtml) - CSharp - \n                
-                        TagHelper - (560:17,16 [81] ComplexTagHelpers.cshtml)
+                        CSharpStatement - (591:17,66 [18] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (591:17,66 [18] ComplexTagHelpers.cshtml) - CSharp - \n                
+                        TagHelper - (609:18,16 [81] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (573:17,29 [66] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
-                                CSharpStatement - (574:17,30 [11] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (574:17,30 [11] ComplexTagHelpers.cshtml) - CSharp - if(true) { 
-                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (591:17,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
-                                CSharpStatement - (606:17,62 [10] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (606:17,62 [10] ComplexTagHelpers.cshtml) - CSharp -  } else { 
-                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (622:17,78 [8] ComplexTagHelpers.cshtml) - Html - anything
-                                CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (637:17,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
-                            SetTagHelperProperty - (573:17,29 [66] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
-                                CSharpStatement - (574:17,30 [11] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (574:17,30 [11] ComplexTagHelpers.cshtml) - CSharp - if(true) { 
-                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (591:17,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
-                                CSharpStatement - (606:17,62 [10] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (606:17,62 [10] ComplexTagHelpers.cshtml) - CSharp -  } else { 
-                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (622:17,78 [8] ComplexTagHelpers.cshtml) - Html - anything
-                                CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (637:17,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
+                            SetTagHelperProperty - (622:18,29 [66] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpStatement - (623:18,30 [11] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (623:18,30 [11] ComplexTagHelpers.cshtml) - CSharp - if(true) { 
+                                HtmlContent - (640:18,47 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (640:18,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
+                                CSharpStatement - (655:18,62 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (655:18,62 [10] ComplexTagHelpers.cshtml) - CSharp -  } else { 
+                                HtmlContent - (671:18,78 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (671:18,78 [8] ComplexTagHelpers.cshtml) - Html - anything
+                                CSharpStatement - (686:18,93 [2] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (686:18,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
+                            SetTagHelperProperty - (622:18,29 [66] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpStatement - (623:18,30 [11] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (623:18,30 [11] ComplexTagHelpers.cshtml) - CSharp - if(true) { 
+                                HtmlContent - (640:18,47 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (640:18,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
+                                CSharpStatement - (655:18,62 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (655:18,62 [10] ComplexTagHelpers.cshtml) - CSharp -  } else { 
+                                HtmlContent - (671:18,78 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (671:18,78 [8] ComplexTagHelpers.cshtml) - Html - anything
+                                CSharpStatement - (686:18,93 [2] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (686:18,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
                             ExecuteTagHelpers - 
-                        CSharpStatement - (641:17,97 [15] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (641:17,97 [15] ComplexTagHelpers.cshtml) - CSharp - \n            }
-                        HtmlContent - (656:18,13 [10] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (656:18,13 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                        CSharpStatement - (690:18,97 [15] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (690:18,97 [15] ComplexTagHelpers.cshtml) - CSharp - \n            }
+                        HtmlContent - (705:19,13 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (705:19,13 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - time - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlAttributeValue - (148:7,17 [7] ComplexTagHelpers.cshtml) -  - Current
-                        HtmlAttributeValue - (155:7,24 [6] ComplexTagHelpers.cshtml) -   - Time:
-                        CSharpAttributeValue - (161:7,30 [14] ComplexTagHelpers.cshtml) -  
-                            CSharpExpression - (163:7,32 [12] ComplexTagHelpers.cshtml)
-                                RazorIRToken - (163:7,32 [12] ComplexTagHelpers.cshtml) - CSharp - DateTime.Now
+                        HtmlAttributeValue - (197:8,17 [7] ComplexTagHelpers.cshtml) -  - Current
+                        HtmlAttributeValue - (204:8,24 [6] ComplexTagHelpers.cshtml) -   - Time:
+                        CSharpAttributeValue - (210:8,30 [14] ComplexTagHelpers.cshtml) -  
+                            CSharpExpression - (212:8,32 [12] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (212:8,32 [12] ComplexTagHelpers.cshtml) - CSharp - DateTime.Now
                     ExecuteTagHelpers - 
-                HtmlContent - (670:19,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (670:19,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (680:20,8 [181] ComplexTagHelpers.cshtml)
+                HtmlContent - (719:20,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (719:20,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (729:21,8 [181] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (767:20,95 [14] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (767:20,95 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                        CSharpStatement - (783:21,14 [21] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (783:21,14 [21] ComplexTagHelpers.cshtml) - CSharp -  var @object = false;
-                        HtmlContent - (807:22,0 [12] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (807:22,0 [12] ComplexTagHelpers.cshtml) - Html -             
-                        TagHelper - (819:22,12 [28] ComplexTagHelpers.cshtml)
+                        HtmlContent - (816:21,95 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (816:21,95 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                        CSharpStatement - (832:22,14 [21] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (832:22,14 [21] ComplexTagHelpers.cshtml) - CSharp -  var @object = false;
+                        HtmlContent - (856:23,0 [12] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (856:23,0 [12] ComplexTagHelpers.cshtml) - Html -             
+                        TagHelper - (868:23,12 [28] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (835:22,28 [10] ComplexTagHelpers.cshtml) - ChecKED - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                CSharpExpression - (836:22,29 [9] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (836:22,29 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (836:22,29 [1] ComplexTagHelpers.cshtml) - Html - (
-                                    RazorIRToken - (837:22,30 [7] ComplexTagHelpers.cshtml) - CSharp - @object
-                                    HtmlContent - (844:22,37 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (844:22,37 [1] ComplexTagHelpers.cshtml) - Html - )
+                            SetTagHelperProperty - (884:23,28 [10] ComplexTagHelpers.cshtml) - ChecKED - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - (885:23,29 [9] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (885:23,29 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                                    RazorIRToken - (886:23,30 [7] ComplexTagHelpers.cshtml) - CSharp - @object
+                                    RazorIRToken - (893:23,37 [1] ComplexTagHelpers.cshtml) - CSharp - )
                             ExecuteTagHelpers - 
-                        HtmlContent - (847:22,40 [10] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (847:22,40 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                        HtmlContent - (896:23,40 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (896:23,40 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (692:20,20 [11] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (692:20,20 [11] ComplexTagHelpers.cshtml) - Html - first value
-                    SetTagHelperProperty - (710:20,38 [31] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        CSharpExpression - (711:20,39 [23] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (711:20,39 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
-                        HtmlContent - (734:20,62 [7] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (734:20,62 [2] ComplexTagHelpers.cshtml) - Html -  -
-                            RazorIRToken - (736:20,64 [5] ComplexTagHelpers.cshtml) - Html -  1970
+                        HtmlContent - (741:21,20 [11] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (741:21,20 [11] ComplexTagHelpers.cshtml) - Html - first value
+                    SetTagHelperProperty - (759:21,38 [31] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (760:21,39 [23] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (760:21,39 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
+                        RazorIRToken - (783:21,62 [2] ComplexTagHelpers.cshtml) - CSharp -  -
+                        RazorIRToken - (785:21,64 [5] ComplexTagHelpers.cshtml) - CSharp -  1970
                     AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (752:20,80 [12] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (752:20,80 [12] ComplexTagHelpers.cshtml) - Html - second value
+                        HtmlContent - (801:21,80 [12] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (801:21,80 [12] ComplexTagHelpers.cshtml) - Html - second value
                     ExecuteTagHelpers - 
-                HtmlContent - (861:23,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (861:23,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (871:24,8 [155] ComplexTagHelpers.cshtml)
+                HtmlContent - (910:24,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (910:24,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (920:25,8 [155] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (913:24,50 [14] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (913:24,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                        TagHelper - (927:25,12 [85] ComplexTagHelpers.cshtml)
+                        HtmlContent - (962:25,50 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (962:25,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                        TagHelper - (976:26,12 [85] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (943:25,28 [5] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (943:25,28 [5] ComplexTagHelpers.cshtml) - Html - hello
+                                HtmlContent - (992:26,28 [5] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (992:26,28 [5] ComplexTagHelpers.cshtml) - Html - hello
                             AddTagHelperHtmlAttribute -  - unbound - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (959:25,44 [5] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (959:25,44 [5] ComplexTagHelpers.cshtml) - Html - world
-                            SetTagHelperProperty - (975:25,60 [33] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                CSharpExpression - (976:25,61 [32] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (976:25,61 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (976:25,61 [1] ComplexTagHelpers.cshtml) - Html - (
-                                    RazorIRToken - (977:25,62 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
-                                    HtmlContent - (1007:25,92 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (1007:25,92 [1] ComplexTagHelpers.cshtml) - Html - )
+                                HtmlContent - (1008:26,44 [5] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1008:26,44 [5] ComplexTagHelpers.cshtml) - Html - world
+                            SetTagHelperProperty - (1024:26,60 [33] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - (1025:26,61 [32] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1025:26,61 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                                    RazorIRToken - (1026:26,62 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
+                                    RazorIRToken - (1056:26,92 [1] ComplexTagHelpers.cshtml) - CSharp - )
                             ExecuteTagHelpers - 
-                        HtmlContent - (1012:25,97 [10] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1012:25,97 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                        HtmlContent - (1061:26,97 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1061:26,97 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
-                    SetTagHelperProperty - (879:24,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (879:24,16 [8] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (879:24,16 [5] ComplexTagHelpers.cshtml) - Html - -1970
-                            RazorIRToken - (884:24,21 [2] ComplexTagHelpers.cshtml) - Html -  +
-                            RazorIRToken - (886:24,23 [1] ComplexTagHelpers.cshtml) - Html -  
-                        CSharpExpression - (887:24,24 [24] ComplexTagHelpers.cshtml)
-                            HtmlContent - (887:24,24 [1] ComplexTagHelpers.cshtml)
-                                RazorIRToken - (887:24,24 [1] ComplexTagHelpers.cshtml) - Html - @
-                            RazorIRToken - (888:24,25 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
+                    SetTagHelperProperty - (928:25,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        RazorIRToken - (928:25,16 [5] ComplexTagHelpers.cshtml) - CSharp - -1970
+                        RazorIRToken - (933:25,21 [2] ComplexTagHelpers.cshtml) - CSharp -  +
+                        RazorIRToken - (935:25,23 [1] ComplexTagHelpers.cshtml) - CSharp -  
+                        CSharpExpression - (936:25,24 [24] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (936:25,24 [1] ComplexTagHelpers.cshtml) - CSharp - @
+                            RazorIRToken - (937:25,25 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
                     ExecuteTagHelpers - 
-                HtmlContent - (1026:26,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1026:26,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (1036:27,8 [116] ComplexTagHelpers.cshtml)
+                HtmlContent - (1075:27,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1075:27,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (1085:28,8 [116] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (1076:27,48 [14] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1076:27,48 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                        TagHelper - (1090:28,12 [48] ComplexTagHelpers.cshtml)
+                        HtmlContent - (1125:28,48 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1125:28,48 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                        TagHelper - (1139:29,12 [48] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (1106:28,28 [30] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1106:28,28 [30] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (1106:28,28 [30] ComplexTagHelpers.cshtml) - Html - DateTimeOffset.Now.Year > 2014
+                            SetTagHelperProperty - (1155:29,28 [30] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                RazorIRToken - (1155:29,28 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
                             ExecuteTagHelpers - 
-                        HtmlContent - (1138:28,60 [10] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1138:28,60 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                        HtmlContent - (1187:29,60 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1187:29,60 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
-                    SetTagHelperProperty - (1044:27,16 [30] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (1044:27,16 [30] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1044:27,16 [30] ComplexTagHelpers.cshtml) - Html - DateTimeOffset.Now.Year\-1970
+                    SetTagHelperProperty - (1093:28,16 [30] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        RazorIRToken - (1093:28,16 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year\-1970
                     ExecuteTagHelpers - 
-                HtmlContent - (1152:29,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1152:29,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (1162:30,8 [133] ComplexTagHelpers.cshtml)
+                HtmlContent - (1201:30,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1201:30,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (1211:31,8 [133] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (1204:30,50 [14] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1204:30,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                        TagHelper - (1218:31,12 [63] ComplexTagHelpers.cshtml)
+                        HtmlContent - (1253:31,50 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1253:31,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                        TagHelper - (1267:32,12 [63] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (1234:31,28 [43] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1234:31,28 [3] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (1234:31,28 [3] ComplexTagHelpers.cshtml) - Html -    
-                                CSharpExpression - (1237:31,31 [30] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (1237:31,31 [2] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (1237:31,31 [1] ComplexTagHelpers.cshtml) - Html - @
-                                        RazorIRToken - (1238:31,32 [1] ComplexTagHelpers.cshtml) - Html - (
-                                    RazorIRToken - (1239:31,33 [27] ComplexTagHelpers.cshtml) - CSharp -   DateTimeOffset.Now.Year  
-                                    HtmlContent - (1266:31,60 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (1266:31,60 [1] ComplexTagHelpers.cshtml) - Html - )
-                                HtmlContent - (1267:31,61 [10] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (1267:31,61 [2] ComplexTagHelpers.cshtml) - Html -  >
-                                    RazorIRToken - (1269:31,63 [5] ComplexTagHelpers.cshtml) - Html -  2014
-                                    RazorIRToken - (1274:31,68 [3] ComplexTagHelpers.cshtml) - Html -    
+                            SetTagHelperProperty - (1283:32,28 [43] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                RazorIRToken - (1283:32,28 [3] ComplexTagHelpers.cshtml) - CSharp -    
+                                CSharpExpression - (1286:32,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1286:32,31 [1] ComplexTagHelpers.cshtml) - CSharp - @
+                                    RazorIRToken - (1287:32,32 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                                    RazorIRToken - (1288:32,33 [27] ComplexTagHelpers.cshtml) - CSharp -   DateTimeOffset.Now.Year  
+                                    RazorIRToken - (1315:32,60 [1] ComplexTagHelpers.cshtml) - CSharp - )
+                                RazorIRToken - (1316:32,61 [2] ComplexTagHelpers.cshtml) - CSharp -  >
+                                RazorIRToken - (1318:32,63 [5] ComplexTagHelpers.cshtml) - CSharp -  2014
+                                RazorIRToken - (1323:32,68 [3] ComplexTagHelpers.cshtml) - CSharp -    
                             ExecuteTagHelpers - 
-                        HtmlContent - (1281:31,75 [10] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1281:31,75 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                        HtmlContent - (1330:32,75 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1330:32,75 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
-                    SetTagHelperProperty - (1170:30,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        CSharpExpression - (1171:30,17 [31] ComplexTagHelpers.cshtml)
-                            HtmlContent - (1171:30,17 [1] ComplexTagHelpers.cshtml)
-                                RazorIRToken - (1171:30,17 [1] ComplexTagHelpers.cshtml) - Html - (
-                            RazorIRToken - (1172:30,18 [29] ComplexTagHelpers.cshtml) - CSharp - "My age is this long.".Length
-                            HtmlContent - (1201:30,47 [1] ComplexTagHelpers.cshtml)
-                                RazorIRToken - (1201:30,47 [1] ComplexTagHelpers.cshtml) - Html - )
+                    SetTagHelperProperty - (1219:31,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (1220:31,17 [31] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1220:31,17 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                            RazorIRToken - (1221:31,18 [29] ComplexTagHelpers.cshtml) - CSharp - "My age is this long.".Length
+                            RazorIRToken - (1250:31,47 [1] ComplexTagHelpers.cshtml) - CSharp - )
                     ExecuteTagHelpers - 
-                HtmlContent - (1295:32,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1295:32,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                CSharpExpression - (1306:33,9 [69] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1306:33,9 [11] ComplexTagHelpers.cshtml) - CSharp - someMethod(
-                    Template - (1318:33,21 [57] ComplexTagHelpers.cshtml)
-                        TagHelper - (1318:33,21 [57] ComplexTagHelpers.cshtml)
+                HtmlContent - (1344:33,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1344:33,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                CSharpExpression - (1355:34,9 [69] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1355:34,9 [11] ComplexTagHelpers.cshtml) - CSharp - someMethod(
+                    Template - (1367:34,21 [57] ComplexTagHelpers.cshtml)
+                        TagHelper - (1367:34,21 [57] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                TagHelper - (1345:33,48 [26] ComplexTagHelpers.cshtml)
+                                TagHelper - (1394:34,48 [26] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
                                     CreateTagHelper -  - TestNamespace.InputTagHelper2
-                                    SetTagHelperProperty - (1360:33,63 [8] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                        CSharpExpression - (1361:33,64 [7] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (1361:33,64 [7] ComplexTagHelpers.cshtml) - CSharp - checked
+                                    SetTagHelperProperty - (1409:34,63 [8] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (1410:34,64 [7] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (1410:34,64 [7] ComplexTagHelpers.cshtml) - CSharp - checked
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
-                            SetTagHelperProperty - (1326:33,29 [3] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1326:33,29 [3] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (1326:33,29 [3] ComplexTagHelpers.cshtml) - Html - 123
+                            SetTagHelperProperty - (1375:34,29 [3] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                                RazorIRToken - (1375:34,29 [3] ComplexTagHelpers.cshtml) - CSharp - 123
                             AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1338:33,41 [5] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (1338:33,41 [5] ComplexTagHelpers.cshtml) - Html - hello
+                                HtmlContent - (1387:34,41 [5] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1387:34,41 [5] ComplexTagHelpers.cshtml) - Html - hello
                             ExecuteTagHelpers - 
-                    RazorIRToken - (1375:33,78 [1] ComplexTagHelpers.cshtml) - CSharp - )
-                HtmlContent - (1376:33,79 [12] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1376:33,79 [6] ComplexTagHelpers.cshtml) - Html - \n    
-                    RazorIRToken - (1382:34,4 [6] ComplexTagHelpers.cshtml) - Html - </div>
-                CSharpStatement - (1388:34,10 [3] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1388:34,10 [3] ComplexTagHelpers.cshtml) - CSharp - \n}
+                    RazorIRToken - (1424:34,78 [1] ComplexTagHelpers.cshtml) - CSharp - )
+                HtmlContent - (1425:34,79 [12] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1425:34,79 [6] ComplexTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (1431:35,4 [6] ComplexTagHelpers.cshtml) - Html - </div>
+                CSharpStatement - (1437:35,10 [3] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1437:35,10 [3] ComplexTagHelpers.cshtml) - CSharp - \n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
@@ -16,248 +16,278 @@ Generated Location: (996:21,1 [52] )
 
     |
 
-Source Location: (224:9,13 [43] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (147:7,16 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|@|
+Generated Location: (1302:31,33 [1] )
+|@|
+
+Source Location: (149:7,18 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+||
+Generated Location: (1303:31,34 [0] )
+||
+
+Source Location: (149:7,18 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|@|
+Generated Location: (1303:31,34 [1] )
+|@|
+
+Source Location: (150:7,19 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|(|
+Generated Location: (1304:31,35 [1] )
+|(|
+
+Source Location: (151:7,20 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|1+2|
+Generated Location: (1305:31,36 [3] )
+|1+2|
+
+Source Location: (154:7,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+|)|
+Generated Location: (1308:31,39 [1] )
+|)|
+
+Source Location: (273:10,13 [43] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if (false)
             {
                 |
-Generated Location: (1188:30,13 [43] )
+Generated Location: (1450:36,13 [43] )
 |if (false)
             {
                 |
 
-Source Location: (350:11,99 [66] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (399:12,99 [66] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
             }
             else
             {
                 |
-Generated Location: (1908:42,99 [66] )
+Generated Location: (2170:48,99 [66] )
 |
             }
             else
             {
                 |
 
-Source Location: (446:15,46 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (495:16,46 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checkbox|
-Generated Location: (2355:53,46 [8] )
+Generated Location: (2617:59,46 [8] )
 |checkbox|
 
-Source Location: (463:15,63 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (512:16,63 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true|
-Generated Location: (2708:60,63 [4] )
+Generated Location: (2970:66,63 [4] )
 |true|
 
-Source Location: (474:15,74 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (523:16,74 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (2927:65,86 [18] )
+Generated Location: (3189:71,86 [18] )
 |
                 |
 
-Source Location: (507:16,31 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (556:17,31 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true ? "checkbox" : "anything"|
-Generated Location: (3280:70,31 [30] )
+Generated Location: (3542:76,31 [30] )
 |true ? "checkbox" : "anything"|
 
-Source Location: (542:16,66 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (591:17,66 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (3576:76,78 [18] )
+Generated Location: (3838:82,78 [18] )
 |
                 |
 
-Source Location: (574:17,30 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (623:18,30 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if(true) { |
-Generated Location: (3928:81,30 [11] )
+Generated Location: (4190:87,30 [11] )
 |if(true) { |
 
-Source Location: (606:17,62 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (655:18,62 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | } else { |
-Generated Location: (4128:86,62 [10] )
+Generated Location: (4390:92,62 [10] )
 | } else { |
 
-Source Location: (637:17,93 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (686:18,93 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | }|
-Generated Location: (4358:91,93 [2] )
+Generated Location: (4620:97,93 [2] )
 | }|
 
-Source Location: (641:17,97 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (690:18,97 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
             }|
-Generated Location: (4738:98,97 [15] )
+Generated Location: (5000:104,97 [15] )
 |
             }|
 
-Source Location: (163:7,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (212:8,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (5006:105,32 [12] )
+Generated Location: (5268:111,32 [12] )
 |DateTime.Now|
 
-Source Location: (783:21,14 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (832:22,14 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | var @object = false;|
-Generated Location: (5160:110,14 [21] )
+Generated Location: (5422:116,14 [21] )
 | var @object = false;|
 
-Source Location: (836:22,29 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (885:23,29 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (5558:117,42 [1] )
+Generated Location: (5820:123,42 [1] )
 |(|
 
-Source Location: (837:22,30 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (886:23,30 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@object|
-Generated Location: (5559:117,43 [7] )
+Generated Location: (5821:123,43 [7] )
 |@object|
 
-Source Location: (844:22,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (893:23,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (5566:117,50 [1] )
+Generated Location: (5828:123,50 [1] )
 |)|
 
-Source Location: (711:20,39 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (760:21,39 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (5828:123,38 [23] )
+Generated Location: (6090:129,38 [23] )
 |DateTimeOffset.Now.Year|
 
-Source Location: (734:20,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (783:21,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | -|
-Generated Location: (5851:123,61 [2] )
+Generated Location: (6113:129,61 [2] )
 | -|
 
-Source Location: (736:20,64 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (785:21,64 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 1970|
-Generated Location: (5853:123,63 [5] )
+Generated Location: (6115:129,63 [5] )
 | 1970|
 
-Source Location: (976:25,61 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1025:26,61 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (6254:130,60 [1] )
+Generated Location: (6516:136,60 [1] )
 |(|
 
-Source Location: (977:25,62 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1026:26,62 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (6255:130,61 [30] )
+Generated Location: (6517:136,61 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
-Source Location: (1007:25,92 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1056:26,92 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (6285:130,91 [1] )
+Generated Location: (6547:136,91 [1] )
 |)|
 
-Source Location: (879:24,16 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (928:25,16 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |-1970|
-Generated Location: (6542:136,33 [5] )
+Generated Location: (6804:142,33 [5] )
 |-1970|
 
-Source Location: (884:24,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (933:25,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | +|
-Generated Location: (6547:136,38 [2] )
+Generated Location: (6809:142,38 [2] )
 | +|
 
-Source Location: (886:24,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (935:25,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | |
-Generated Location: (6549:136,40 [1] )
+Generated Location: (6811:142,40 [1] )
 | |
 
-Source Location: (887:24,24 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (936:25,24 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (6550:136,41 [1] )
+Generated Location: (6812:142,41 [1] )
 |@|
 
-Source Location: (888:24,25 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (937:25,25 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (6551:136,42 [23] )
+Generated Location: (6813:142,42 [23] )
 |DateTimeOffset.Now.Year|
 
-Source Location: (1106:28,28 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1155:29,28 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (6952:143,42 [30] )
+Generated Location: (7214:149,42 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
-Source Location: (1044:27,16 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1093:28,16 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year - 1970|
-Generated Location: (7238:149,33 [30] )
+Generated Location: (7500:155,33 [30] )
 |DateTimeOffset.Now.Year - 1970|
 
-Source Location: (1234:31,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1283:32,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (7646:156,42 [3] )
+Generated Location: (7908:162,42 [3] )
 |   |
 
-Source Location: (1237:31,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1286:32,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (7649:156,45 [1] )
+Generated Location: (7911:162,45 [1] )
 |@|
 
-Source Location: (1238:31,32 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1287:32,32 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (7650:156,46 [1] )
+Generated Location: (7912:162,46 [1] )
 |(|
 
-Source Location: (1239:31,33 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1288:32,33 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |  DateTimeOffset.Now.Year  |
-Generated Location: (7651:156,47 [27] )
+Generated Location: (7913:162,47 [27] )
 |  DateTimeOffset.Now.Year  |
 
-Source Location: (1266:31,60 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1315:32,60 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (7678:156,74 [1] )
+Generated Location: (7940:162,74 [1] )
 |)|
 
-Source Location: (1267:31,61 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1316:32,61 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | >|
-Generated Location: (7679:156,75 [2] )
+Generated Location: (7941:162,75 [2] )
 | >|
 
-Source Location: (1269:31,63 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1318:32,63 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 2014|
-Generated Location: (7681:156,77 [5] )
+Generated Location: (7943:162,77 [5] )
 | 2014|
 
-Source Location: (1274:31,68 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1323:32,68 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (7686:156,82 [3] )
+Generated Location: (7948:162,82 [3] )
 |   |
 
-Source Location: (1171:30,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1220:31,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (7945:162,33 [1] )
+Generated Location: (8207:168,33 [1] )
 |(|
 
-Source Location: (1172:30,18 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1221:31,18 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"My age is this long.".Length|
-Generated Location: (7946:162,34 [29] )
+Generated Location: (8208:168,34 [29] )
 |"My age is this long.".Length|
 
-Source Location: (1201:30,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1250:31,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (7975:162,63 [1] )
+Generated Location: (8237:168,63 [1] )
 |)|
 
-Source Location: (1306:33,9 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1355:34,9 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |someMethod(|
-Generated Location: (8113:167,9 [11] )
+Generated Location: (8375:173,9 [11] )
 |someMethod(|
 
-Source Location: (1361:33,64 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1410:34,64 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checked|
-Generated Location: (8566:171,63 [7] )
+Generated Location: (8828:177,63 [7] )
 |checked|
 
-Source Location: (1326:33,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1375:34,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |123|
-Generated Location: (8821:177,33 [3] )
+Generated Location: (9083:183,33 [3] )
 |123|
 
-Source Location: (1375:33,78 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1424:34,78 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (8862:182,1 [1] )
+Generated Location: (9124:188,1 [1] )
 |)|
 
-Source Location: (1388:34,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
+Source Location: (1437:35,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
 }|
-Generated Location: (9001:187,10 [3] )
+Generated Location: (9263:193,10 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "51e77018024aeb0f14e5fc30bf13b895e48b90e2"
+#pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "6c8cd00002dfc24a4fd1b1c3f079728b7697257f"
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 {
     #line hidden
@@ -47,8 +47,32 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 #line hidden
             WriteLiteral("    <div class=\"randomNonTagHelperAttribute\">\r\n        ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
+            }
+            );
+            __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+            __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
+#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+__TestNamespace_PTagHelper.Age = @@(1+2);
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+            BeginWriteTagHelperAttribute();
+            WriteLiteral("@");
+            WriteLiteral("string");
+            __tagHelperStringValueBuffer = EndWriteTagHelperAttribute();
+            __tagHelperExecutionContext.AddHtmlAttribute("class", Html.Raw(__tagHelperStringValueBuffer), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
+            await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
+            if (!__tagHelperExecutionContext.Output.IsContentModified)
+            {
+                await __tagHelperExecutionContext.SetOutputContentAsync();
+            }
+            Write(__tagHelperExecutionContext.Output);
+            __tagHelperExecutionContext = __tagHelperScopeManager.End();
+            WriteLiteral("\r\n        ");
+            __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 WriteLiteral("\r\n            <h1>Set Time:</h1>\r\n");
-#line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
              if (false)
             {
 
@@ -89,7 +113,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n");
-#line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
             }
             else
             {
@@ -107,7 +131,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                     __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                     __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                     BeginWriteTagHelperAttribute();
-#line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                  WriteLiteral(checkbox);
 
 #line default
@@ -116,7 +140,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                     __TestNamespace_InputTagHelper.Type = __tagHelperStringValueBuffer;
                     __tagHelperExecutionContext.AddTagHelperAttribute("type", __TestNamespace_InputTagHelper.Type, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                     __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
-#line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = true;
 
 #line default
@@ -149,7 +173,7 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 BeginWriteTagHelperAttribute();
-#line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                   WriteLiteral(true ? "checkbox" : "anything");
 
 #line default
@@ -174,19 +198,19 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 BeginWriteTagHelperAttribute();
-#line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                               if(true) {
 
 #line default
 #line hidden
                 WriteLiteral("checkbox");
-#line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                } else {
 
 #line default
 #line hidden
                 WriteLiteral("anything");
-#line 18 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                                                                                               }
 
 #line default
@@ -203,7 +227,7 @@ __TestNamespace_InputTagHelper2.Checked = true;
                 Write(__tagHelperExecutionContext.Output);
                 __tagHelperExecutionContext = __tagHelperScopeManager.End();
                 WriteLiteral("\r\n");
-#line 19 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 20 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
             }
 
 #line default
@@ -214,10 +238,10 @@ __TestNamespace_InputTagHelper2.Checked = true;
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
             BeginAddHtmlAttributeValues(__tagHelperExecutionContext, "time", 3, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
-            AddHtmlAttributeValue("", 148, "Current", 148, 7, true);
-            AddHtmlAttributeValue(" ", 155, "Time:", 156, 6, true);
-#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
-AddHtmlAttributeValue(" ", 161, DateTime.Now, 162, 13, false);
+            AddHtmlAttributeValue("", 197, "Current", 197, 7, true);
+            AddHtmlAttributeValue(" ", 204, "Time:", 205, 6, true);
+#line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+AddHtmlAttributeValue(" ", 210, DateTime.Now, 211, 13, false);
 
 #line default
 #line hidden
@@ -232,7 +256,7 @@ AddHtmlAttributeValue(" ", 161, DateTime.Now, 162, 13, false);
             WriteLiteral("\r\n        ");
             __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                 WriteLiteral("\r\n");
-#line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
                var @object = false;
 
 #line default
@@ -245,7 +269,7 @@ AddHtmlAttributeValue(" ", 161, DateTime.Now, 162, 13, false);
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-#line 23 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 24 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = (@object);
 
 #line default
@@ -264,7 +288,7 @@ __TestNamespace_InputTagHelper2.Checked = (@object);
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_3);
-#line 21 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
 
 #line default
@@ -290,7 +314,7 @@ __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_5);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_6);
-#line 26 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 27 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = (DateTimeOffset.Now.Year > 2014);
 
 #line default
@@ -308,7 +332,7 @@ __TestNamespace_InputTagHelper2.Checked = (DateTimeOffset.Now.Year > 2014);
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-#line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 26 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = -1970 + @DateTimeOffset.Now.Year;
 
 #line default
@@ -331,7 +355,7 @@ __TestNamespace_PTagHelper.Age = -1970 + @DateTimeOffset.Now.Year;
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-#line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 30 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
 
 #line default
@@ -349,7 +373,7 @@ __TestNamespace_InputTagHelper2.Checked = DateTimeOffset.Now.Year > 2014;
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-#line 28 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 29 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
 
 #line default
@@ -372,7 +396,7 @@ __TestNamespace_PTagHelper.Age = DateTimeOffset.Now.Year - 1970;
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
                 __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
                 __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-#line 32 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 33 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked =    @(  DateTimeOffset.Now.Year  ) > 2014   ;
 
 #line default
@@ -390,7 +414,7 @@ __TestNamespace_InputTagHelper2.Checked =    @(  DateTimeOffset.Now.Year  ) > 20
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-#line 31 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 32 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
 
 #line default
@@ -404,7 +428,7 @@ __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
             Write(__tagHelperExecutionContext.Output);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             WriteLiteral("\r\n        ");
-#line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
    Write(someMethod(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
     PushWriter(__razor_template_writer);
     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
@@ -415,7 +439,7 @@ __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
         __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper);
         __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
         __tagHelperExecutionContext.Add(__TestNamespace_InputTagHelper2);
-#line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_InputTagHelper2.Checked = checked;
 
 #line default
@@ -432,7 +456,7 @@ __TestNamespace_InputTagHelper2.Checked = checked;
     );
     __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
     __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-#line 34 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 __TestNamespace_PTagHelper.Age = 123;
 
 #line default
@@ -453,7 +477,7 @@ __TestNamespace_PTagHelper.Age = 123;
 #line default
 #line hidden
             WriteLiteral("\r\n    </div>\r\n");
-#line 36 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
+#line 37 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 }
 
 #line default

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.ir.txt
@@ -22,25 +22,44 @@ Document -
                     RazorIRToken - (92:6,8 [36] ComplexTagHelpers.cshtml) - Html -  class="randomNonTagHelperAttribute"
                     RazorIRToken - (128:6,44 [1] ComplexTagHelpers.cshtml) - Html - >
                     RazorIRToken - (129:6,45 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (139:7,8 [529] ComplexTagHelpers.cshtml)
+                TagHelper - (139:7,8 [39] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (177:7,46 [34] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (177:7,46 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                            RazorIRToken - (191:8,12 [4] ComplexTagHelpers.cshtml) - Html - <h1>
-                            RazorIRToken - (195:8,16 [9] ComplexTagHelpers.cshtml) - Html - Set Time:
-                            RazorIRToken - (204:8,25 [5] ComplexTagHelpers.cshtml) - Html - </h1>
-                            RazorIRToken - (209:8,30 [2] ComplexTagHelpers.cshtml) - Html - \n
-                        CSharpStatement - (211:9,0 [12] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (211:9,0 [12] ComplexTagHelpers.cshtml) - CSharp -             
-                        CSharpStatement - (224:9,13 [27] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (224:9,13 [27] ComplexTagHelpers.cshtml) - CSharp - if (false)\n            {\n
-                        HtmlContent - (251:11,0 [16] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (251:11,0 [16] ComplexTagHelpers.cshtml) - Html -                 
-                        TagHelper - (267:11,16 [83] ComplexTagHelpers.cshtml)
+                    CreateTagHelper -  - TestNamespace.PTagHelper
+                    SetTagHelperProperty - (147:7,16 [8] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        RazorIRToken - (147:7,16 [1] ComplexTagHelpers.cshtml) - CSharp - @
+                        RazorIRToken - (149:7,18 [0] ComplexTagHelpers.cshtml) - CSharp - 
+                        CSharpExpression - (149:7,18 [6] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (149:7,18 [1] ComplexTagHelpers.cshtml) - CSharp - @
+                            RazorIRToken - (150:7,19 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                            RazorIRToken - (151:7,20 [3] ComplexTagHelpers.cshtml) - CSharp - 1+2
+                            RazorIRToken - (154:7,23 [1] ComplexTagHelpers.cshtml) - CSharp - )
+                    AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
+                        HtmlContent - (164:7,33 [1] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (164:7,33 [1] ComplexTagHelpers.cshtml) - Html - @
+                        HtmlContent - (166:7,35 [6] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (166:7,35 [6] ComplexTagHelpers.cshtml) - Html - string
+                    ExecuteTagHelpers - 
+                HtmlContent - (178:7,47 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (178:7,47 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (188:8,8 [529] ComplexTagHelpers.cshtml)
+                    InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
+                        HtmlContent - (226:8,46 [34] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (226:8,46 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                            RazorIRToken - (240:9,12 [4] ComplexTagHelpers.cshtml) - Html - <h1>
+                            RazorIRToken - (244:9,16 [9] ComplexTagHelpers.cshtml) - Html - Set Time:
+                            RazorIRToken - (253:9,25 [5] ComplexTagHelpers.cshtml) - Html - </h1>
+                            RazorIRToken - (258:9,30 [2] ComplexTagHelpers.cshtml) - Html - \n
+                        CSharpStatement - (260:10,0 [12] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (260:10,0 [12] ComplexTagHelpers.cshtml) - CSharp -             
+                        CSharpStatement - (273:10,13 [27] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (273:10,13 [27] ComplexTagHelpers.cshtml) - CSharp - if (false)\n            {\n
+                        HtmlContent - (300:12,0 [16] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (300:12,0 [16] ComplexTagHelpers.cshtml) - Html -                 
+                        TagHelper - (316:12,16 [83] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                HtmlContent - (270:11,19 [10] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (270:11,19 [10] ComplexTagHelpers.cshtml) - Html - New Time: 
-                                TagHelper - (280:11,29 [66] ComplexTagHelpers.cshtml)
+                                HtmlContent - (319:12,19 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (319:12,19 [10] ComplexTagHelpers.cshtml) - Html - New Time: 
+                                TagHelper - (329:12,29 [66] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
                                     CreateTagHelper -  - TestNamespace.InputTagHelper2
@@ -51,242 +70,225 @@ Document -
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
-                        HtmlContent - (350:11,99 [2] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (350:11,99 [2] ComplexTagHelpers.cshtml) - Html - \n
-                        CSharpStatement - (352:12,0 [48] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (352:12,0 [48] ComplexTagHelpers.cshtml) - CSharp -             }\n            else\n            {\n
-                        HtmlContent - (400:15,0 [16] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (400:15,0 [16] ComplexTagHelpers.cshtml) - Html -                 
-                        TagHelper - (416:15,16 [58] ComplexTagHelpers.cshtml)
+                        HtmlContent - (399:12,99 [2] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (399:12,99 [2] ComplexTagHelpers.cshtml) - Html - \n
+                        CSharpStatement - (401:13,0 [48] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (401:13,0 [48] ComplexTagHelpers.cshtml) - CSharp -             }\n            else\n            {\n
+                        HtmlContent - (449:16,0 [16] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (449:16,0 [16] ComplexTagHelpers.cshtml) - Html -                 
+                        TagHelper - (465:16,16 [58] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                HtmlContent - (419:15,19 [14] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (419:15,19 [14] ComplexTagHelpers.cshtml) - Html - Current Time: 
-                                TagHelper - (433:15,33 [37] ComplexTagHelpers.cshtml)
+                                HtmlContent - (468:16,19 [14] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (468:16,19 [14] ComplexTagHelpers.cshtml) - Html - Current Time: 
+                                TagHelper - (482:16,33 [37] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
                                     CreateTagHelper -  - TestNamespace.InputTagHelper2
-                                    SetTagHelperProperty - (445:15,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                        CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
-                                    SetTagHelperProperty - (445:15,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
-                                        CSharpExpression - (446:15,46 [8] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (446:15,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
-                                    SetTagHelperProperty - (463:15,63 [4] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                        HtmlContent - (463:15,63 [4] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (463:15,63 [4] ComplexTagHelpers.cshtml) - Html - true
+                                    SetTagHelperProperty - (494:16,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (495:16,46 [8] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (495:16,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
+                                    SetTagHelperProperty - (494:16,45 [9] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (495:16,46 [8] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (495:16,46 [8] ComplexTagHelpers.cshtml) - CSharp - checkbox
+                                    SetTagHelperProperty - (512:16,63 [4] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                        RazorIRToken - (512:16,63 [4] ComplexTagHelpers.cshtml) - CSharp - true
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
                             ExecuteTagHelpers - 
-                        HtmlContent - (474:15,74 [18] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (474:15,74 [2] ComplexTagHelpers.cshtml) - Html - \n
-                            RazorIRToken - (476:16,0 [16] ComplexTagHelpers.cshtml) - Html -                 
-                        TagHelper - (492:16,16 [50] ComplexTagHelpers.cshtml)
+                        HtmlContent - (523:16,74 [18] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (523:16,74 [2] ComplexTagHelpers.cshtml) - Html - \n
+                            RazorIRToken - (525:17,0 [16] ComplexTagHelpers.cshtml) - Html -                 
+                        TagHelper - (541:17,16 [50] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (505:16,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
-                                CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
-                            SetTagHelperProperty - (505:16,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
-                                CSharpExpression - (507:16,31 [30] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (507:16,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
+                            SetTagHelperProperty - (554:17,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpExpression - (556:17,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (556:17,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
+                            SetTagHelperProperty - (554:17,29 [33] ComplexTagHelpers.cshtml) - tYPe - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpExpression - (556:17,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (556:17,31 [30] ComplexTagHelpers.cshtml) - CSharp - true ? "checkbox" : "anything"
                             ExecuteTagHelpers - 
-                        HtmlContent - (542:16,66 [18] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (542:16,66 [2] ComplexTagHelpers.cshtml) - Html - \n
-                            RazorIRToken - (544:17,0 [16] ComplexTagHelpers.cshtml) - Html -                 
-                        TagHelper - (560:17,16 [79] ComplexTagHelpers.cshtml)
+                        HtmlContent - (591:17,66 [18] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (591:17,66 [2] ComplexTagHelpers.cshtml) - Html - \n
+                            RazorIRToken - (593:18,0 [16] ComplexTagHelpers.cshtml) - Html -                 
+                        TagHelper - (609:18,16 [79] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (573:17,29 [64] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
-                                CSharpStatement - (574:17,30 [10] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (574:17,30 [10] ComplexTagHelpers.cshtml) - CSharp - if(true) {
-                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (591:17,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
-                                CSharpStatement - (606:17,62 [9] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (606:17,62 [9] ComplexTagHelpers.cshtml) - CSharp -  } else {
-                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (622:17,78 [8] ComplexTagHelpers.cshtml) - Html - anything
-                                CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (637:17,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
-                            SetTagHelperProperty - (573:17,29 [64] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
-                                CSharpStatement - (574:17,30 [10] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (574:17,30 [10] ComplexTagHelpers.cshtml) - CSharp - if(true) {
-                                HtmlContent - (591:17,47 [8] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (591:17,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
-                                CSharpStatement - (606:17,62 [9] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (606:17,62 [9] ComplexTagHelpers.cshtml) - CSharp -  } else {
-                                HtmlContent - (622:17,78 [8] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (622:17,78 [8] ComplexTagHelpers.cshtml) - Html - anything
-                                CSharpStatement - (637:17,93 [2] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (637:17,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
+                            SetTagHelperProperty - (622:18,29 [64] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpStatement - (623:18,30 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (623:18,30 [10] ComplexTagHelpers.cshtml) - CSharp - if(true) {
+                                HtmlContent - (640:18,47 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (640:18,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
+                                CSharpStatement - (655:18,62 [9] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (655:18,62 [9] ComplexTagHelpers.cshtml) - CSharp -  } else {
+                                HtmlContent - (671:18,78 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (671:18,78 [8] ComplexTagHelpers.cshtml) - Html - anything
+                                CSharpStatement - (686:18,93 [2] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (686:18,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
+                            SetTagHelperProperty - (622:18,29 [64] ComplexTagHelpers.cshtml) - type - Type - HtmlAttributeValueStyle.SingleQuotes
+                                CSharpStatement - (623:18,30 [10] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (623:18,30 [10] ComplexTagHelpers.cshtml) - CSharp - if(true) {
+                                HtmlContent - (640:18,47 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (640:18,47 [8] ComplexTagHelpers.cshtml) - Html - checkbox
+                                CSharpStatement - (655:18,62 [9] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (655:18,62 [9] ComplexTagHelpers.cshtml) - CSharp -  } else {
+                                HtmlContent - (671:18,78 [8] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (671:18,78 [8] ComplexTagHelpers.cshtml) - Html - anything
+                                CSharpStatement - (686:18,93 [2] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (686:18,93 [2] ComplexTagHelpers.cshtml) - CSharp -  }
                             ExecuteTagHelpers - 
-                        HtmlContent - (641:17,97 [2] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (641:17,97 [2] ComplexTagHelpers.cshtml) - Html - \n
-                        CSharpStatement - (643:18,0 [15] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (643:18,0 [15] ComplexTagHelpers.cshtml) - CSharp -             }\n
-                        HtmlContent - (658:19,0 [8] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (658:19,0 [8] ComplexTagHelpers.cshtml) - Html -         
+                        HtmlContent - (690:18,97 [2] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (690:18,97 [2] ComplexTagHelpers.cshtml) - Html - \n
+                        CSharpStatement - (692:19,0 [15] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (692:19,0 [15] ComplexTagHelpers.cshtml) - CSharp -             }\n
+                        HtmlContent - (707:20,0 [8] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (707:20,0 [8] ComplexTagHelpers.cshtml) - Html -         
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddTagHelperHtmlAttribute -  - time - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlAttributeValue - (148:7,17 [7] ComplexTagHelpers.cshtml) -  - Current
-                        HtmlAttributeValue - (155:7,24 [6] ComplexTagHelpers.cshtml) -   - Time:
-                        CSharpAttributeValue - (161:7,30 [14] ComplexTagHelpers.cshtml) -  
-                            CSharpExpression - (163:7,32 [12] ComplexTagHelpers.cshtml)
-                                RazorIRToken - (163:7,32 [12] ComplexTagHelpers.cshtml) - CSharp - DateTime.Now
+                        HtmlAttributeValue - (197:8,17 [7] ComplexTagHelpers.cshtml) -  - Current
+                        HtmlAttributeValue - (204:8,24 [6] ComplexTagHelpers.cshtml) -   - Time:
+                        CSharpAttributeValue - (210:8,30 [14] ComplexTagHelpers.cshtml) -  
+                            CSharpExpression - (212:8,32 [12] ComplexTagHelpers.cshtml)
+                                RazorIRToken - (212:8,32 [12] ComplexTagHelpers.cshtml) - CSharp - DateTime.Now
                     ExecuteTagHelpers - 
-                HtmlContent - (670:19,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (670:19,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (680:20,8 [181] ComplexTagHelpers.cshtml)
+                HtmlContent - (719:20,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (719:20,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (729:21,8 [181] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (767:20,95 [2] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (767:20,95 [2] ComplexTagHelpers.cshtml) - Html - \n
-                        CSharpStatement - (769:21,0 [12] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (769:21,0 [12] ComplexTagHelpers.cshtml) - CSharp -             
-                        CSharpStatement - (783:21,14 [21] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (783:21,14 [21] ComplexTagHelpers.cshtml) - CSharp -  var @object = false;
-                        HtmlContent - (807:22,0 [12] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (807:22,0 [12] ComplexTagHelpers.cshtml) - Html -             
-                        TagHelper - (819:22,12 [28] ComplexTagHelpers.cshtml)
+                        HtmlContent - (816:21,95 [2] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (816:21,95 [2] ComplexTagHelpers.cshtml) - Html - \n
+                        CSharpStatement - (818:22,0 [12] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (818:22,0 [12] ComplexTagHelpers.cshtml) - CSharp -             
+                        CSharpStatement - (832:22,14 [21] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (832:22,14 [21] ComplexTagHelpers.cshtml) - CSharp -  var @object = false;
+                        HtmlContent - (856:23,0 [12] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (856:23,0 [12] ComplexTagHelpers.cshtml) - Html -             
+                        TagHelper - (868:23,12 [28] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (835:22,28 [10] ComplexTagHelpers.cshtml) - ChecKED - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                CSharpExpression - (836:22,29 [9] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (836:22,29 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (836:22,29 [1] ComplexTagHelpers.cshtml) - Html - (
-                                    RazorIRToken - (837:22,30 [7] ComplexTagHelpers.cshtml) - CSharp - @object
-                                    HtmlContent - (844:22,37 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (844:22,37 [1] ComplexTagHelpers.cshtml) - Html - )
+                            SetTagHelperProperty - (884:23,28 [10] ComplexTagHelpers.cshtml) - ChecKED - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - (885:23,29 [9] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (885:23,29 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                                    RazorIRToken - (886:23,30 [7] ComplexTagHelpers.cshtml) - CSharp - @object
+                                    RazorIRToken - (893:23,37 [1] ComplexTagHelpers.cshtml) - CSharp - )
                             ExecuteTagHelpers - 
-                        HtmlContent - (847:22,40 [10] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (847:22,40 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                        HtmlContent - (896:23,40 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (896:23,40 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
-                    SetTagHelperProperty - (710:20,38 [31] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        CSharpExpression - (711:20,39 [23] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (711:20,39 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
-                        HtmlContent - (734:20,62 [7] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (734:20,62 [2] ComplexTagHelpers.cshtml) - Html -  -
-                            RazorIRToken - (736:20,64 [5] ComplexTagHelpers.cshtml) - Html -  1970
+                    SetTagHelperProperty - (759:21,38 [31] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (760:21,39 [23] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (760:21,39 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
+                        RazorIRToken - (783:21,62 [2] ComplexTagHelpers.cshtml) - CSharp -  -
+                        RazorIRToken - (785:21,64 [5] ComplexTagHelpers.cshtml) - CSharp -  1970
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_4
                     ExecuteTagHelpers - 
-                HtmlContent - (861:23,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (861:23,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (871:24,8 [155] ComplexTagHelpers.cshtml)
+                HtmlContent - (910:24,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (910:24,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (920:25,8 [155] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (913:24,50 [14] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (913:24,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                        TagHelper - (927:25,12 [85] ComplexTagHelpers.cshtml)
+                        HtmlContent - (962:25,50 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (962:25,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                        TagHelper - (976:26,12 [85] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_6
-                            SetTagHelperProperty - (975:25,60 [33] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                CSharpExpression - (976:25,61 [32] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (976:25,61 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (976:25,61 [1] ComplexTagHelpers.cshtml) - Html - (
-                                    RazorIRToken - (977:25,62 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
-                                    HtmlContent - (1007:25,92 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (1007:25,92 [1] ComplexTagHelpers.cshtml) - Html - )
+                            SetTagHelperProperty - (1024:26,60 [33] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - (1025:26,61 [32] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1025:26,61 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                                    RazorIRToken - (1026:26,62 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
+                                    RazorIRToken - (1056:26,92 [1] ComplexTagHelpers.cshtml) - CSharp - )
                             ExecuteTagHelpers - 
-                        HtmlContent - (1012:25,97 [10] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1012:25,97 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                        HtmlContent - (1061:26,97 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1061:26,97 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
-                    SetTagHelperProperty - (879:24,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (879:24,16 [8] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (879:24,16 [5] ComplexTagHelpers.cshtml) - Html - -1970
-                            RazorIRToken - (884:24,21 [2] ComplexTagHelpers.cshtml) - Html -  +
-                            RazorIRToken - (886:24,23 [1] ComplexTagHelpers.cshtml) - Html -  
-                        CSharpExpression - (887:24,24 [24] ComplexTagHelpers.cshtml)
-                            HtmlContent - (887:24,24 [1] ComplexTagHelpers.cshtml)
-                                RazorIRToken - (887:24,24 [1] ComplexTagHelpers.cshtml) - Html - @
-                            RazorIRToken - (888:24,25 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
+                    SetTagHelperProperty - (928:25,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        RazorIRToken - (928:25,16 [5] ComplexTagHelpers.cshtml) - CSharp - -1970
+                        RazorIRToken - (933:25,21 [2] ComplexTagHelpers.cshtml) - CSharp -  +
+                        RazorIRToken - (935:25,23 [1] ComplexTagHelpers.cshtml) - CSharp -  
+                        CSharpExpression - (936:25,24 [24] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (936:25,24 [1] ComplexTagHelpers.cshtml) - CSharp - @
+                            RazorIRToken - (937:25,25 [23] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year
                     ExecuteTagHelpers - 
-                HtmlContent - (1026:26,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1026:26,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (1036:27,8 [116] ComplexTagHelpers.cshtml)
+                HtmlContent - (1075:27,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1075:27,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (1085:28,8 [116] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (1076:27,48 [14] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1076:27,48 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                        TagHelper - (1090:28,12 [48] ComplexTagHelpers.cshtml)
+                        HtmlContent - (1125:28,48 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1125:28,48 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                        TagHelper - (1139:29,12 [48] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.StartTagOnly
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (1106:28,28 [30] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1106:28,28 [30] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (1106:28,28 [30] ComplexTagHelpers.cshtml) - Html - DateTimeOffset.Now.Year > 2014
+                            SetTagHelperProperty - (1155:29,28 [30] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                RazorIRToken - (1155:29,28 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year > 2014
                             ExecuteTagHelpers - 
-                        HtmlContent - (1138:28,60 [10] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1138:28,60 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                        HtmlContent - (1187:29,60 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1187:29,60 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
-                    SetTagHelperProperty - (1044:27,16 [30] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (1044:27,16 [30] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1044:27,16 [30] ComplexTagHelpers.cshtml) - Html - DateTimeOffset.Now.Year\-1970
+                    SetTagHelperProperty - (1093:28,16 [30] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        RazorIRToken - (1093:28,16 [30] ComplexTagHelpers.cshtml) - CSharp - DateTimeOffset.Now.Year\-1970
                     ExecuteTagHelpers - 
-                HtmlContent - (1152:29,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1152:29,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
-                TagHelper - (1162:30,8 [133] ComplexTagHelpers.cshtml)
+                HtmlContent - (1201:30,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1201:30,12 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                TagHelper - (1211:31,8 [133] ComplexTagHelpers.cshtml)
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                        HtmlContent - (1204:30,50 [14] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1204:30,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
-                        TagHelper - (1218:31,12 [63] ComplexTagHelpers.cshtml)
+                        HtmlContent - (1253:31,50 [14] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1253:31,50 [14] ComplexTagHelpers.cshtml) - Html - \n            
+                        TagHelper - (1267:32,12 [63] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                             CreateTagHelper -  - TestNamespace.InputTagHelper
                             CreateTagHelper -  - TestNamespace.InputTagHelper2
-                            SetTagHelperProperty - (1234:31,28 [43] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1234:31,28 [3] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (1234:31,28 [3] ComplexTagHelpers.cshtml) - Html -    
-                                CSharpExpression - (1237:31,31 [30] ComplexTagHelpers.cshtml)
-                                    HtmlContent - (1237:31,31 [2] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (1237:31,31 [1] ComplexTagHelpers.cshtml) - Html - @
-                                        RazorIRToken - (1238:31,32 [1] ComplexTagHelpers.cshtml) - Html - (
-                                    RazorIRToken - (1239:31,33 [27] ComplexTagHelpers.cshtml) - CSharp -   DateTimeOffset.Now.Year  
-                                    HtmlContent - (1266:31,60 [1] ComplexTagHelpers.cshtml)
-                                        RazorIRToken - (1266:31,60 [1] ComplexTagHelpers.cshtml) - Html - )
-                                HtmlContent - (1267:31,61 [10] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (1267:31,61 [2] ComplexTagHelpers.cshtml) - Html -  >
-                                    RazorIRToken - (1269:31,63 [5] ComplexTagHelpers.cshtml) - Html -  2014
-                                    RazorIRToken - (1274:31,68 [3] ComplexTagHelpers.cshtml) - Html -    
+                            SetTagHelperProperty - (1283:32,28 [43] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                RazorIRToken - (1283:32,28 [3] ComplexTagHelpers.cshtml) - CSharp -    
+                                CSharpExpression - (1286:32,31 [30] ComplexTagHelpers.cshtml)
+                                    RazorIRToken - (1286:32,31 [1] ComplexTagHelpers.cshtml) - CSharp - @
+                                    RazorIRToken - (1287:32,32 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                                    RazorIRToken - (1288:32,33 [27] ComplexTagHelpers.cshtml) - CSharp -   DateTimeOffset.Now.Year  
+                                    RazorIRToken - (1315:32,60 [1] ComplexTagHelpers.cshtml) - CSharp - )
+                                RazorIRToken - (1316:32,61 [2] ComplexTagHelpers.cshtml) - CSharp -  >
+                                RazorIRToken - (1318:32,63 [5] ComplexTagHelpers.cshtml) - CSharp -  2014
+                                RazorIRToken - (1323:32,68 [3] ComplexTagHelpers.cshtml) - CSharp -    
                             ExecuteTagHelpers - 
-                        HtmlContent - (1281:31,75 [10] ComplexTagHelpers.cshtml)
-                            RazorIRToken - (1281:31,75 [10] ComplexTagHelpers.cshtml) - Html - \n        
+                        HtmlContent - (1330:32,75 [10] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1330:32,75 [10] ComplexTagHelpers.cshtml) - Html - \n        
                     CreateTagHelper -  - TestNamespace.PTagHelper
-                    SetTagHelperProperty - (1170:30,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        CSharpExpression - (1171:30,17 [31] ComplexTagHelpers.cshtml)
-                            HtmlContent - (1171:30,17 [1] ComplexTagHelpers.cshtml)
-                                RazorIRToken - (1171:30,17 [1] ComplexTagHelpers.cshtml) - Html - (
-                            RazorIRToken - (1172:30,18 [29] ComplexTagHelpers.cshtml) - CSharp - "My age is this long.".Length
-                            HtmlContent - (1201:30,47 [1] ComplexTagHelpers.cshtml)
-                                RazorIRToken - (1201:30,47 [1] ComplexTagHelpers.cshtml) - Html - )
+                    SetTagHelperProperty - (1219:31,16 [32] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - (1220:31,17 [31] ComplexTagHelpers.cshtml)
+                            RazorIRToken - (1220:31,17 [1] ComplexTagHelpers.cshtml) - CSharp - (
+                            RazorIRToken - (1221:31,18 [29] ComplexTagHelpers.cshtml) - CSharp - "My age is this long.".Length
+                            RazorIRToken - (1250:31,47 [1] ComplexTagHelpers.cshtml) - CSharp - )
                     ExecuteTagHelpers - 
-                HtmlContent - (1295:32,12 [10] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1295:32,12 [2] ComplexTagHelpers.cshtml) - Html - \n
-                    RazorIRToken - (1297:33,0 [8] ComplexTagHelpers.cshtml) - Html -         
-                CSharpExpression - (1306:33,9 [69] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1306:33,9 [11] ComplexTagHelpers.cshtml) - CSharp - someMethod(
-                    Template - (1318:33,21 [57] ComplexTagHelpers.cshtml)
-                        TagHelper - (1318:33,21 [57] ComplexTagHelpers.cshtml)
+                HtmlContent - (1344:33,12 [10] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1344:33,12 [2] ComplexTagHelpers.cshtml) - Html - \n
+                    RazorIRToken - (1346:34,0 [8] ComplexTagHelpers.cshtml) - Html -         
+                CSharpExpression - (1355:34,9 [69] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1355:34,9 [11] ComplexTagHelpers.cshtml) - CSharp - someMethod(
+                    Template - (1367:34,21 [57] ComplexTagHelpers.cshtml)
+                        TagHelper - (1367:34,21 [57] ComplexTagHelpers.cshtml)
                             InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
-                                TagHelper - (1345:33,48 [26] ComplexTagHelpers.cshtml)
+                                TagHelper - (1394:34,48 [26] ComplexTagHelpers.cshtml)
                                     InitializeTagHelperStructure -  - input - TagMode.SelfClosing
                                     CreateTagHelper -  - TestNamespace.InputTagHelper
                                     CreateTagHelper -  - TestNamespace.InputTagHelper2
-                                    SetTagHelperProperty - (1360:33,63 [8] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                        CSharpExpression - (1361:33,64 [7] ComplexTagHelpers.cshtml)
-                                            RazorIRToken - (1361:33,64 [7] ComplexTagHelpers.cshtml) - CSharp - checked
+                                    SetTagHelperProperty - (1409:34,63 [8] ComplexTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                        CSharpExpression - (1410:34,64 [7] ComplexTagHelpers.cshtml)
+                                            RazorIRToken - (1410:34,64 [7] ComplexTagHelpers.cshtml) - CSharp - checked
                                     ExecuteTagHelpers - 
                             CreateTagHelper -  - TestNamespace.PTagHelper
-                            SetTagHelperProperty - (1326:33,29 [3] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (1326:33,29 [3] ComplexTagHelpers.cshtml)
-                                    RazorIRToken - (1326:33,29 [3] ComplexTagHelpers.cshtml) - Html - 123
+                            SetTagHelperProperty - (1375:34,29 [3] ComplexTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
+                                RazorIRToken - (1375:34,29 [3] ComplexTagHelpers.cshtml) - CSharp - 123
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7
                             ExecuteTagHelpers - 
-                    RazorIRToken - (1375:33,78 [1] ComplexTagHelpers.cshtml) - CSharp - )
-                HtmlContent - (1376:33,79 [14] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1376:33,79 [6] ComplexTagHelpers.cshtml) - Html - \n    
-                    RazorIRToken - (1382:34,4 [6] ComplexTagHelpers.cshtml) - Html - </div>
-                    RazorIRToken - (1388:34,10 [2] ComplexTagHelpers.cshtml) - Html - \n
-                CSharpStatement - (1390:35,0 [1] ComplexTagHelpers.cshtml)
-                    RazorIRToken - (1390:35,0 [1] ComplexTagHelpers.cshtml) - CSharp - }
+                    RazorIRToken - (1424:34,78 [1] ComplexTagHelpers.cshtml) - CSharp - )
+                HtmlContent - (1425:34,79 [14] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1425:34,79 [6] ComplexTagHelpers.cshtml) - Html - \n    
+                    RazorIRToken - (1431:35,4 [6] ComplexTagHelpers.cshtml) - Html - </div>
+                    RazorIRToken - (1437:35,10 [2] ComplexTagHelpers.cshtml) - Html - \n
+                CSharpStatement - (1439:36,0 [1] ComplexTagHelpers.cshtml)
+                    RazorIRToken - (1439:36,0 [1] ComplexTagHelpers.cshtml) - CSharp - }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.ir.txt
@@ -41,8 +41,7 @@ Document -
                                 HtmlContent - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml)
                                     RazorIRToken - (129:4,17 [6] DuplicateAttributeTagHelpers.cshtml) - Html - button
                             SetTagHelperProperty - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml)
-                                    RazorIRToken - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - CSharp - true
                             AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
                                 HtmlContent - (158:4,46 [8] DuplicateAttributeTagHelpers.cshtml)
                                     RazorIRToken - (158:4,46 [8] DuplicateAttributeTagHelpers.cshtml) - Html - checkbox
@@ -63,8 +62,7 @@ Document -
                                 HtmlContent - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml)
                                     RazorIRToken - (205:5,17 [6] DuplicateAttributeTagHelpers.cshtml) - Html - button
                             SetTagHelperProperty - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml)
-                                    RazorIRToken - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - CSharp - true
                             AddTagHelperHtmlAttribute -  - type - HtmlAttributeValueStyle.DoubleQuotes
                                 HtmlContent - (233:5,45 [8] DuplicateAttributeTagHelpers.cshtml)
                                     RazorIRToken - (233:5,45 [8] DuplicateAttributeTagHelpers.cshtml) - Html - checkbox
@@ -82,8 +80,7 @@ Document -
                             RazorIRToken - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml)
-                            RazorIRToken - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - Html - 3
+                        RazorIRToken - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - CSharp - 3
                     AddTagHelperHtmlAttribute -  - AGE - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (51:2,16 [2] DuplicateAttributeTagHelpers.cshtml)
                             RazorIRToken - (51:2,16 [2] DuplicateAttributeTagHelpers.cshtml) - Html - 40

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.ir.txt
@@ -36,8 +36,7 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetTagHelperProperty - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml)
-                                    RazorIRToken - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (146:4,34 [4] DuplicateAttributeTagHelpers.cshtml) - CSharp - true
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                             ExecuteTagHelpers - 
@@ -50,8 +49,7 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - type - Type
                             SetTagHelperProperty - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml)
-                                    RazorIRToken - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (222:5,34 [4] DuplicateAttributeTagHelpers.cshtml) - CSharp - true
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_5
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
@@ -61,8 +59,7 @@ Document -
                             RazorIRToken - (288:5,100 [2] DuplicateAttributeTagHelpers.cshtml) - Html - \n
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml)
-                            RazorIRToken - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - Html - 3
+                        RazorIRToken - (43:2,8 [1] DuplicateAttributeTagHelpers.cshtml) - CSharp - 3
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_7
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_8
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
@@ -23,8 +23,7 @@ Document -
                         HtmlContent - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml)
                             RazorIRToken - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                     SetTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml)
-                            RazorIRToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
+                        RazorIRToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml)
                             RazorIRToken - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
@@ -46,8 +45,7 @@ Document -
                                 HtmlContent - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml)
                                     RazorIRToken - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
                             SetTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml)
-                                    RazorIRToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
+                                RazorIRToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                             AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                                 HtmlContent - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml)
                                     RazorIRToken - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
@@ -56,8 +54,7 @@ Document -
                             RazorIRToken - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml)
-                            RazorIRToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
+                        RazorIRToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                     ExecuteTagHelpers - 
                 HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml)
                     RazorIRToken - (148:6,8 [2] EmptyAttributeTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
@@ -17,8 +17,7 @@ Document -
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                     SetTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml)
-                            RazorIRToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
+                        RazorIRToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     ExecuteTagHelpers - 
                 HtmlContent - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml)
@@ -34,16 +33,14 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml)
-                                    RazorIRToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
+                                RazorIRToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                             AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                             ExecuteTagHelpers - 
                         HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml)
                             RazorIRToken - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - Age - HtmlAttributeValueStyle.SingleQuotes
-                        HtmlContent - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml)
-                            RazorIRToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
+                        RazorIRToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                     ExecuteTagHelpers - 
                 HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml)
                     RazorIRToken - (148:6,8 [2] EmptyAttributeTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.ir.txt
@@ -40,8 +40,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     SetTagHelperProperty - (171:8,14 [7] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (171:8,14 [7] EnumTagHelpers.cshtml)
-                            RazorIRToken - (171:8,14 [7] EnumTagHelpers.cshtml) - Html - MyValue
+                        RazorIRToken - (171:8,14 [7] EnumTagHelpers.cshtml) - CSharp - MyValue
                     ExecuteTagHelpers - 
                 HtmlContent - (182:8,25 [2] EnumTagHelpers.cshtml)
                     RazorIRToken - (182:8,25 [2] EnumTagHelpers.cshtml) - Html - \n
@@ -50,11 +49,9 @@ Document -
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     SetTagHelperProperty - (198:9,14 [13] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (198:9,14 [13] EnumTagHelpers.cshtml)
-                            RazorIRToken - (198:9,14 [13] EnumTagHelpers.cshtml) - Html - MySecondValue
+                        RazorIRToken - (198:9,14 [13] EnumTagHelpers.cshtml) - CSharp - MySecondValue
                     SetTagHelperProperty - (224:9,40 [7] EnumTagHelpers.cshtml) - catch-all - CatchAll - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (224:9,40 [7] EnumTagHelpers.cshtml)
-                            RazorIRToken - (224:9,40 [7] EnumTagHelpers.cshtml) - Html - MyValue
+                        RazorIRToken - (224:9,40 [7] EnumTagHelpers.cshtml) - CSharp - MyValue
                     ExecuteTagHelpers - 
                 HtmlContent - (234:9,50 [2] EnumTagHelpers.cshtml)
                     RazorIRToken - (234:9,50 [2] EnumTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.ir.txt
@@ -36,8 +36,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     SetTagHelperProperty - (171:8,14 [7] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (171:8,14 [7] EnumTagHelpers.cshtml)
-                            RazorIRToken - (171:8,14 [7] EnumTagHelpers.cshtml) - Html - MyValue
+                        RazorIRToken - (171:8,14 [7] EnumTagHelpers.cshtml) - CSharp - MyValue
                     ExecuteTagHelpers - 
                 HtmlContent - (182:8,25 [2] EnumTagHelpers.cshtml)
                     RazorIRToken - (182:8,25 [2] EnumTagHelpers.cshtml) - Html - \n
@@ -46,11 +45,9 @@ Document -
                     CreateTagHelper -  - TestNamespace.InputTagHelper
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     SetTagHelperProperty - (198:9,14 [13] EnumTagHelpers.cshtml) - value - Value - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (198:9,14 [13] EnumTagHelpers.cshtml)
-                            RazorIRToken - (198:9,14 [13] EnumTagHelpers.cshtml) - Html - MySecondValue
+                        RazorIRToken - (198:9,14 [13] EnumTagHelpers.cshtml) - CSharp - MySecondValue
                     SetTagHelperProperty - (224:9,40 [7] EnumTagHelpers.cshtml) - catch-all - CatchAll - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (224:9,40 [7] EnumTagHelpers.cshtml)
-                            RazorIRToken - (224:9,40 [7] EnumTagHelpers.cshtml) - Html - MyValue
+                        RazorIRToken - (224:9,40 [7] EnumTagHelpers.cshtml) - CSharp - MyValue
                     ExecuteTagHelpers - 
                 HtmlContent - (234:9,50 [2] EnumTagHelpers.cshtml)
                     RazorIRToken - (234:9,50 [2] EnumTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.ir.txt
@@ -51,8 +51,7 @@ Document -
                         CSharpExpression - (204:5,51 [12] EscapedTagHelpers.cshtml)
                             RazorIRToken - (204:5,51 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
                     SetTagHelperProperty - (227:5,74 [4] EscapedTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (227:5,74 [4] EscapedTagHelpers.cshtml)
-                            RazorIRToken - (227:5,74 [4] EscapedTagHelpers.cshtml) - Html - true
+                        RazorIRToken - (227:5,74 [4] EscapedTagHelpers.cshtml) - CSharp - true
                     ExecuteTagHelpers - 
                 HtmlContent - (235:5,82 [8] EscapedTagHelpers.cshtml)
                     RazorIRToken - (235:5,82 [6] EscapedTagHelpers.cshtml) - Html - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.ir.txt
@@ -47,8 +47,7 @@ Document -
                         CSharpExpression - (204:5,51 [12] EscapedTagHelpers.cshtml)
                             RazorIRToken - (204:5,51 [12] EscapedTagHelpers.cshtml) - CSharp - DateTime.Now
                     SetTagHelperProperty - (227:5,74 [4] EscapedTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (227:5,74 [4] EscapedTagHelpers.cshtml)
-                            RazorIRToken - (227:5,74 [4] EscapedTagHelpers.cshtml) - Html - true
+                        RazorIRToken - (227:5,74 [4] EscapedTagHelpers.cshtml) - CSharp - true
                     ExecuteTagHelpers - 
                 HtmlContent - (235:5,82 [8] EscapedTagHelpers.cshtml)
                     RazorIRToken - (235:5,82 [6] EscapedTagHelpers.cshtml) - Html - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.ir.txt
@@ -51,8 +51,7 @@ Document -
                                 HtmlContent - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml)
                                     RazorIRToken - (374:7,85 [4] NestedScriptTagTagHelpers.cshtml) - Html - text
                             SetTagHelperProperty - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml)
-                                    RazorIRToken - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - CSharp - true
                             ExecuteTagHelpers - 
                         HtmlContent - (395:7,106 [27] NestedScriptTagTagHelpers.cshtml)
                             RazorIRToken - (395:7,106 [18] NestedScriptTagTagHelpers.cshtml) - Html - \n                

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.ir.txt
@@ -49,8 +49,7 @@ Document -
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_0 - type - Type
                             SetTagHelperProperty - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - checked - Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                HtmlContent - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml)
-                                    RazorIRToken - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - Html - true
+                                RazorIRToken - (389:7,100 [4] NestedScriptTagTagHelpers.cshtml) - CSharp - true
                             ExecuteTagHelpers - 
                         HtmlContent - (395:7,106 [29] NestedScriptTagTagHelpers.cshtml)
                             RazorIRToken - (395:7,106 [18] NestedScriptTagTagHelpers.cshtml) - Html - \n                

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.ir.txt
@@ -26,17 +26,13 @@ Document -
                         HtmlContent - (344:15,17 [8] PrefixedAttributeTagHelpers.cshtml)
                             RazorIRToken - (344:15,17 [8] PrefixedAttributeTagHelpers.cshtml) - Html - checkbox
                     SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
+                        RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - CSharp - intDictionary
                     SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
+                        RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - CSharp - intDictionary
                     SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - Html - stringDictionary
+                        RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - CSharp - stringDictionary
                     SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - Html - stringDictionary
+                        RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - CSharp - stringDictionary
                     ExecuteTagHelpers - 
                 HtmlContent - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml)
                     RazorIRToken - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
@@ -48,23 +44,17 @@ Document -
                         HtmlContent - (442:16,17 [8] PrefixedAttributeTagHelpers.cshtml)
                             RazorIRToken - (442:16,17 [8] PrefixedAttributeTagHelpers.cshtml) - Html - password
                     SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
+                        RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - CSharp - intDictionary
                     SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
+                        RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - CSharp - intDictionary
                     SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
+                        RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 42
                     SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
+                        RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 42
                     ExecuteTagHelpers - 
                 HtmlContent - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml)
                     RazorIRToken - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
@@ -76,23 +66,17 @@ Document -
                         HtmlContent - (551:17,17 [5] PrefixedAttributeTagHelpers.cshtml)
                             RazorIRToken - (551:17,17 [5] PrefixedAttributeTagHelpers.cshtml) - Html - radio
                     SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
+                        RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 42
                     SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
+                        RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 42
                     SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 98
+                        RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 98
                     SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 98
+                        RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 98
                     AddTagHelperHtmlAttribute -  - int-prefix-salt - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (655:18,96 [1] PrefixedAttributeTagHelpers.cshtml)
                             RazorIRToken - (655:18,96 [1] PrefixedAttributeTagHelpers.cshtml) - Html - 8
@@ -132,11 +116,9 @@ Document -
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - string-prefix-thyme - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml)
                             RazorIRToken - (851:21,54 [6] PrefixedAttributeTagHelpers.cshtml) - Html - string

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.ir.txt
@@ -27,17 +27,13 @@ Document -
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
+                        RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - CSharp - intDictionary
                     SetTagHelperProperty - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
+                        RazorIRToken - (370:15,43 [13] PrefixedAttributeTagHelpers.cshtml) - CSharp - intDictionary
                     SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - Html - stringDictionary
+                        RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - CSharp - stringDictionary
                     SetTagHelperProperty - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - string-dictionary - StringDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - Html - stringDictionary
+                        RazorIRToken - (404:15,77 [16] PrefixedAttributeTagHelpers.cshtml) - CSharp - stringDictionary
                     ExecuteTagHelpers - 
                 HtmlContent - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml)
                     RazorIRToken - (423:15,96 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
@@ -47,23 +43,17 @@ Document -
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
+                        RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - CSharp - intDictionary
                     SetTagHelperProperty - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - int-dictionary - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - Html - intDictionary
+                        RazorIRToken - (468:16,43 [13] PrefixedAttributeTagHelpers.cshtml) - CSharp - intDictionary
                     SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-garlic - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (502:16,77 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
+                        RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 42
                     SetTagHelperProperty - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
+                        RazorIRToken - (526:16,101 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 42
                     ExecuteTagHelpers - 
                 HtmlContent - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml)
                     RazorIRToken - (532:16,107 [6] PrefixedAttributeTagHelpers.cshtml) - Html - \n    
@@ -73,23 +63,17 @@ Document -
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
+                        RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 42
                     SetTagHelperProperty - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-grabber - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 42
+                        RazorIRToken - (590:18,31 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 42
                     SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-salt - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (611:18,52 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 98
+                        RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 98
                     SetTagHelperProperty - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-pepper - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 98
+                        RazorIRToken - (634:18,75 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 98
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - string-prefix-grabber - StringProperty
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_4 - string-prefix-grabber - StringDictionaryProperty
@@ -119,11 +103,9 @@ Document -
                     CreateTagHelper -  - TestNamespace.InputTagHelper1
                     CreateTagHelper -  - TestNamespace.InputTagHelper2
                     SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetTagHelperProperty - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - int-prefix-value - IntDictionaryProperty - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml)
-                            RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - Html - 37
+                        RazorIRToken - (826:21,29 [2] PrefixedAttributeTagHelpers.cshtml) - CSharp - 37
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - string-prefix-thyme - StringDictionaryProperty
                     SetPreallocatedTagHelperProperty -  - __tagHelperAttribute_6 - string-prefix-thyme - StringDictionaryProperty
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.ir.txt
@@ -19,6 +19,5 @@ Document -
                         HtmlContent - (49:3,10 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
                             RazorIRToken - (49:3,10 [11] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - Hello World
                     SetTagHelperProperty - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
-                            RazorIRToken - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - 1337
+                        RazorIRToken - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - CSharp - 1337
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.ir.txt
@@ -14,6 +14,5 @@ Document -
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
-                            RazorIRToken - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - 1337
+                        RazorIRToken - (67:3,28 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - CSharp - 1337
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.ir.txt
@@ -19,6 +19,5 @@ Document -
                         HtmlContent - (45:2,10 [11] SingleTagHelper.cshtml)
                             RazorIRToken - (45:2,10 [11] SingleTagHelper.cshtml) - Html - Hello World
                     SetTagHelperProperty - (63:2,28 [4] SingleTagHelper.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (63:2,28 [4] SingleTagHelper.cshtml)
-                            RazorIRToken - (63:2,28 [4] SingleTagHelper.cshtml) - Html - 1337
+                        RazorIRToken - (63:2,28 [4] SingleTagHelper.cshtml) - CSharp - 1337
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.ir.txt
@@ -14,6 +14,5 @@ Document -
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (63:2,28 [4] SingleTagHelper.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (63:2,28 [4] SingleTagHelper.cshtml)
-                            RazorIRToken - (63:2,28 [4] SingleTagHelper.cshtml) - Html - 1337
+                        RazorIRToken - (63:2,28 [4] SingleTagHelper.cshtml) - CSharp - 1337
                     ExecuteTagHelpers - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.ir.txt
@@ -53,8 +53,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (302:11,18 [5] SymbolBoundAttributes.cshtml) - [item] - ListItems - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (302:11,18 [5] SymbolBoundAttributes.cshtml)
-                            RazorIRToken - (302:11,18 [5] SymbolBoundAttributes.cshtml) - Html - items
+                        RazorIRToken - (302:11,18 [5] SymbolBoundAttributes.cshtml) - CSharp - items
                     AddTagHelperHtmlAttribute -  - [item] - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (317:11,33 [5] SymbolBoundAttributes.cshtml)
                             RazorIRToken - (317:11,33 [5] SymbolBoundAttributes.cshtml) - Html - items
@@ -66,8 +65,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (351:12,20 [5] SymbolBoundAttributes.cshtml) - [(item)] - ArrayItems - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (351:12,20 [5] SymbolBoundAttributes.cshtml)
-                            RazorIRToken - (351:12,20 [5] SymbolBoundAttributes.cshtml) - Html - items
+                        RazorIRToken - (351:12,20 [5] SymbolBoundAttributes.cshtml) - CSharp - items
                     AddTagHelperHtmlAttribute -  - [(item)] - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (368:12,37 [5] SymbolBoundAttributes.cshtml)
                             RazorIRToken - (368:12,37 [5] SymbolBoundAttributes.cshtml) - Html - items
@@ -81,8 +79,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (405:13,23 [13] SymbolBoundAttributes.cshtml) - (click) - Event1 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (405:13,23 [13] SymbolBoundAttributes.cshtml)
-                            RazorIRToken - (405:13,23 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
+                        RazorIRToken - (405:13,23 [13] SymbolBoundAttributes.cshtml) - CSharp - doSomething()
                     AddTagHelperHtmlAttribute -  - (click) - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (429:13,47 [13] SymbolBoundAttributes.cshtml)
                             RazorIRToken - (429:13,47 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
@@ -96,8 +93,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (487:14,24 [13] SymbolBoundAttributes.cshtml) - (^click) - Event2 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (487:14,24 [13] SymbolBoundAttributes.cshtml)
-                            RazorIRToken - (487:14,24 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
+                        RazorIRToken - (487:14,24 [13] SymbolBoundAttributes.cshtml) - CSharp - doSomething()
                     AddTagHelperHtmlAttribute -  - (^click) - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (512:14,49 [13] SymbolBoundAttributes.cshtml)
                             RazorIRToken - (512:14,49 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.ir.txt
@@ -57,8 +57,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (302:11,18 [5] SymbolBoundAttributes.cshtml) - [item] - ListItems - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (302:11,18 [5] SymbolBoundAttributes.cshtml)
-                            RazorIRToken - (302:11,18 [5] SymbolBoundAttributes.cshtml) - Html - items
+                        RazorIRToken - (302:11,18 [5] SymbolBoundAttributes.cshtml) - CSharp - items
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     ExecuteTagHelpers - 
                 HtmlContent - (329:11,45 [2] SymbolBoundAttributes.cshtml)
@@ -68,8 +67,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (351:12,20 [5] SymbolBoundAttributes.cshtml) - [(item)] - ArrayItems - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (351:12,20 [5] SymbolBoundAttributes.cshtml)
-                            RazorIRToken - (351:12,20 [5] SymbolBoundAttributes.cshtml) - Html - items
+                        RazorIRToken - (351:12,20 [5] SymbolBoundAttributes.cshtml) - CSharp - items
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     ExecuteTagHelpers - 
                 HtmlContent - (380:12,49 [2] SymbolBoundAttributes.cshtml)
@@ -81,8 +79,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (405:13,23 [13] SymbolBoundAttributes.cshtml) - (click) - Event1 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (405:13,23 [13] SymbolBoundAttributes.cshtml)
-                            RazorIRToken - (405:13,23 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
+                        RazorIRToken - (405:13,23 [13] SymbolBoundAttributes.cshtml) - CSharp - doSomething()
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_2
                     ExecuteTagHelpers - 
                 HtmlContent - (461:13,79 [2] SymbolBoundAttributes.cshtml)
@@ -94,8 +91,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.CatchAllTagHelper
                     AddTagHelperHtmlAttribute -  - bound - HtmlAttributeValueStyle.Minimized
                     SetTagHelperProperty - (487:14,24 [13] SymbolBoundAttributes.cshtml) - (^click) - Event2 - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (487:14,24 [13] SymbolBoundAttributes.cshtml)
-                            RazorIRToken - (487:14,24 [13] SymbolBoundAttributes.cshtml) - Html - doSomething()
+                        RazorIRToken - (487:14,24 [13] SymbolBoundAttributes.cshtml) - CSharp - doSomething()
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                     ExecuteTagHelpers - 
                 HtmlContent - (544:14,81 [2] SymbolBoundAttributes.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.ir.txt
@@ -19,8 +19,7 @@ Document -
                         HtmlContent - (54:5,1 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                             RazorIRToken - (54:5,1 [11] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - Hello World
                     SetTagHelperProperty - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
-                            RazorIRToken - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - 1337
+                        RazorIRToken - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - 1337
                     AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                             RazorIRToken - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - true
@@ -47,8 +46,7 @@ Document -
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
-                            RazorIRToken - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - 1234
+                        RazorIRToken - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - 1234
                     AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.SingleQuotes
                         HtmlContent - (209:11,3 [6] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                             RazorIRToken - (209:11,3 [6] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - hello2

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.ir.txt
@@ -19,8 +19,7 @@ Document -
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
-                            RazorIRToken - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - 1337
+                        RazorIRToken - (74:5,21 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - 1337
                     AddTagHelperHtmlAttribute -  - data-content - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                             RazorIRToken - (99:6,19 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - true
@@ -41,8 +40,7 @@ Document -
                     InitializeTagHelperStructure -  - p - TagMode.StartTagAndEndTag
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     SetTagHelperProperty - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
-                            RazorIRToken - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - 1234
+                        RazorIRToken - (186:10,11 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - CSharp - 1234
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_3
                     ExecuteTagHelpers - 
                 HtmlContent - (221:11,15 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.ir.txt
@@ -22,8 +22,7 @@ Document -
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpAttributeValue - (109:6,10 [6] TransitionsInTagHelperAttributes.cshtml) - 
                     SetTagHelperProperty - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml)
-                            RazorIRToken - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - Html - 1337
+                        RazorIRToken - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - CSharp - 1337
                     ExecuteTagHelpers - 
                 HtmlContent - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
@@ -35,8 +34,7 @@ Document -
                             CSharpExpression - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml)
                                 RazorIRToken - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
                     SetTagHelperProperty - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml)
-                            RazorIRToken - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - Html - 42
+                        RazorIRToken - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - CSharp - 42
                     ExecuteTagHelpers - 
                 HtmlContent - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
@@ -47,13 +45,11 @@ Document -
                         HtmlContent - (191:8,10 [4] TransitionsInTagHelperAttributes.cshtml)
                             RazorIRToken - (191:8,10 [4] TransitionsInTagHelperAttributes.cshtml) - Html - test
                     SetTagHelperProperty - (202:8,21 [9] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (202:8,21 [5] TransitionsInTagHelperAttributes.cshtml)
-                            RazorIRToken - (202:8,21 [2] TransitionsInTagHelperAttributes.cshtml) - Html - 42
-                            RazorIRToken - (204:8,23 [2] TransitionsInTagHelperAttributes.cshtml) - Html -  +
-                            RazorIRToken - (206:8,25 [1] TransitionsInTagHelperAttributes.cshtml) - Html -  
+                        RazorIRToken - (202:8,21 [2] TransitionsInTagHelperAttributes.cshtml) - CSharp - 42
+                        RazorIRToken - (204:8,23 [2] TransitionsInTagHelperAttributes.cshtml) - CSharp -  +
+                        RazorIRToken - (206:8,25 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp -  
                         CSharpExpression - (207:8,26 [4] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - Html - @
+                            RazorIRToken - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - @
                             RazorIRToken - (208:8,27 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
                     ExecuteTagHelpers - 
                 HtmlContent - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml)
@@ -78,11 +74,9 @@ Document -
                             RazorIRToken - (262:10,10 [4] TransitionsInTagHelperAttributes.cshtml) - Html - test
                     SetTagHelperProperty - (273:10,21 [7] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (274:10,22 [6] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - Html - (
+                            RazorIRToken - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - (
                             RazorIRToken - (275:10,23 [4] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int
-                            HtmlContent - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - Html - )
+                            RazorIRToken - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - )
                     ExecuteTagHelpers - 
                 HtmlContent - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
@@ -95,17 +89,14 @@ Document -
                             CSharpExpression - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml)
                                 RazorIRToken - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
                     SetTagHelperProperty - (321:11,33 [15] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (321:11,33 [4] TransitionsInTagHelperAttributes.cshtml)
-                            RazorIRToken - (321:11,33 [1] TransitionsInTagHelperAttributes.cshtml) - Html - 4
-                            RazorIRToken - (322:11,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html -  *
-                            RazorIRToken - (324:11,36 [1] TransitionsInTagHelperAttributes.cshtml) - Html -  
+                        RazorIRToken - (321:11,33 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - 4
+                        RazorIRToken - (322:11,34 [2] TransitionsInTagHelperAttributes.cshtml) - CSharp -  *
+                        RazorIRToken - (324:11,36 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp -  
                         CSharpExpression - (325:11,37 [11] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (325:11,37 [2] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (325:11,37 [1] TransitionsInTagHelperAttributes.cshtml) - Html - @
-                                RazorIRToken - (326:11,38 [1] TransitionsInTagHelperAttributes.cshtml) - Html - (
+                            RazorIRToken - (325:11,37 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - @
+                            RazorIRToken - (326:11,38 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - (
                             RazorIRToken - (327:11,39 [8] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int + 2
-                            HtmlContent - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - Html - )
+                            RazorIRToken - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - )
                     ExecuteTagHelpers - 
                 HtmlContent - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.ir.txt
@@ -17,8 +17,7 @@ Document -
                     AddTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpAttributeValue - (109:6,10 [6] TransitionsInTagHelperAttributes.cshtml) - 
                     SetTagHelperProperty - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml)
-                            RazorIRToken - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - Html - 1337
+                        RazorIRToken - (122:6,23 [4] TransitionsInTagHelperAttributes.cshtml) - CSharp - 1337
                     ExecuteTagHelpers - 
                 HtmlContent - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (143:6,44 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
@@ -30,8 +29,7 @@ Document -
                             CSharpExpression - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml)
                                 RazorIRToken - (157:7,12 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
                     SetTagHelperProperty - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml)
-                            RazorIRToken - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - Html - 42
+                        RazorIRToken - (171:7,26 [2] TransitionsInTagHelperAttributes.cshtml) - CSharp - 42
                     ExecuteTagHelpers - 
                 HtmlContent - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (179:7,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
@@ -40,13 +38,11 @@ Document -
                     CreateTagHelper -  - TestNamespace.PTagHelper
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (202:8,21 [9] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (202:8,21 [5] TransitionsInTagHelperAttributes.cshtml)
-                            RazorIRToken - (202:8,21 [2] TransitionsInTagHelperAttributes.cshtml) - Html - 42
-                            RazorIRToken - (204:8,23 [2] TransitionsInTagHelperAttributes.cshtml) - Html -  +
-                            RazorIRToken - (206:8,25 [1] TransitionsInTagHelperAttributes.cshtml) - Html -  
+                        RazorIRToken - (202:8,21 [2] TransitionsInTagHelperAttributes.cshtml) - CSharp - 42
+                        RazorIRToken - (204:8,23 [2] TransitionsInTagHelperAttributes.cshtml) - CSharp -  +
+                        RazorIRToken - (206:8,25 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp -  
                         CSharpExpression - (207:8,26 [4] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - Html - @
+                            RazorIRToken - (207:8,26 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - @
                             RazorIRToken - (208:8,27 [3] TransitionsInTagHelperAttributes.cshtml) - CSharp - int
                     ExecuteTagHelpers - 
                 HtmlContent - (217:8,36 [2] TransitionsInTagHelperAttributes.cshtml)
@@ -67,11 +63,9 @@ Document -
                     AddPreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_0
                     SetTagHelperProperty - (273:10,21 [7] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
                         CSharpExpression - (274:10,22 [6] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - Html - (
+                            RazorIRToken - (274:10,22 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - (
                             RazorIRToken - (275:10,23 [4] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int
-                            HtmlContent - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - Html - )
+                            RazorIRToken - (279:10,27 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - )
                     ExecuteTagHelpers - 
                 HtmlContent - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (286:10,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n
@@ -84,17 +78,14 @@ Document -
                             CSharpExpression - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml)
                                 RazorIRToken - (307:11,19 [6] TransitionsInTagHelperAttributes.cshtml) - CSharp - @class
                     SetTagHelperProperty - (321:11,33 [15] TransitionsInTagHelperAttributes.cshtml) - age - Age - HtmlAttributeValueStyle.DoubleQuotes
-                        HtmlContent - (321:11,33 [4] TransitionsInTagHelperAttributes.cshtml)
-                            RazorIRToken - (321:11,33 [1] TransitionsInTagHelperAttributes.cshtml) - Html - 4
-                            RazorIRToken - (322:11,34 [2] TransitionsInTagHelperAttributes.cshtml) - Html -  *
-                            RazorIRToken - (324:11,36 [1] TransitionsInTagHelperAttributes.cshtml) - Html -  
+                        RazorIRToken - (321:11,33 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - 4
+                        RazorIRToken - (322:11,34 [2] TransitionsInTagHelperAttributes.cshtml) - CSharp -  *
+                        RazorIRToken - (324:11,36 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp -  
                         CSharpExpression - (325:11,37 [11] TransitionsInTagHelperAttributes.cshtml)
-                            HtmlContent - (325:11,37 [2] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (325:11,37 [1] TransitionsInTagHelperAttributes.cshtml) - Html - @
-                                RazorIRToken - (326:11,38 [1] TransitionsInTagHelperAttributes.cshtml) - Html - (
+                            RazorIRToken - (325:11,37 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - @
+                            RazorIRToken - (326:11,38 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - (
                             RazorIRToken - (327:11,39 [8] TransitionsInTagHelperAttributes.cshtml) - CSharp - @int + 2
-                            HtmlContent - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml)
-                                RazorIRToken - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - Html - )
+                            RazorIRToken - (335:11,47 [1] TransitionsInTagHelperAttributes.cshtml) - CSharp - )
                     ExecuteTagHelpers - 
                 HtmlContent - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml)
                     RazorIRToken - (342:11,54 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n


### PR DESCRIPTION
https://github.com/aspnet/Razor/issues/963

@NTaylorMullen @rynowak 

When we configure the SpanBuilder from non-string attributes, we were not setting the correct chunk generator. Setting it to `ExpressionChunkGenerator` results in the correct IR being generated.
This is a change from the behavior of old Razor. I am not sure why it was that way @NTaylorMullen?
