### PR TITLE
Remove workaround from test csproj files

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test.csproj
@@ -7,8 +7,6 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**</DefaultItemExcludes>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.CodeAnalysis.Razor.Test/Microsoft.CodeAnalysis.Razor.Test.csproj
+++ b/test/Microsoft.CodeAnalysis.Razor.Test/Microsoft.CodeAnalysis.Razor.Test.csproj
@@ -7,8 +7,6 @@
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -6,13 +6,6 @@
     <TargetFrameworks>net46</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestFiles\**\*</DefaultItemExcludes>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-
-    <!--
-      Work around https://github.com/Microsoft/vstest/issues/428 aka https://github.com/aspnet/Mvc/issues/5873.
-      Create the appropriate binding redirects.
-    -->
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">


### PR DESCRIPTION
One more cleanup as a result of #1338 . These properties are no longer necessary now that are using VS Test 15.3.