### PR TITLE
Validate line mappings for integration tests in Razor.Extensions.

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -487,6 +487,7 @@ public class DivTagHelper : {typeof(TagHelper).FullName}
             // Assert
             AssertIRMatchesBaseline(document.GetIRDocument());
             AssertCSharpDocumentMatchesBaseline(document.GetCSharpDocument());
+            AssertLineMappingsMatchBaseline(document);
             AssertDocumentCompiles(document, compilationReferences, expectedErrors);
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
-Source Location: (13:0,13 [4] /TestFiles/Input/Basic.cshtml)
-|logo|
-Generated Location: (829:22,13 [4] )
-|logo|
+Source Location: (13:0,13 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml)
+|this.ToString()|
+Generated Location: (909:22,13 [15] )
+|this.ToString()|
 
-Source Location: (43:2,5 [21] /TestFiles/Input/Basic.cshtml)
-|Html.Input("SomeKey")|
-Generated Location: (914:27,6 [21] )
-|Html.Input("SomeKey")|
+Source Location: (54:2,5 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml)
+|string.Format("{0}", "Hello")|
+Generated Location: (1045:27,6 [29] )
+|string.Format("{0}", "Hello")|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (159:11,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+|MyService<TModel>|
+Generated Location: (616:16,0 [17] )
+|MyService<TModel>|
+

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
@@ -1,0 +1,10 @@
+Source Location: (10:0,10 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
+|MyBasePageForViews<TModel>|
+Generated Location: (602:16,0 [26] )
+|MyBasePageForViews<TModel>|
+
+Source Location: (45:1,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
+|MyModel|
+Generated Location: (711:20,0 [7] )
+|MyModel|
+

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (14:1,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports.cshtml)
+|MyModel|
+Generated Location: (601:16,0 [7] )
+|MyModel|
+

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
-Source Location: (7:0,7 [7] /TestFiles/Input/InjectWithModel.cshtml)
+Source Location: (7:0,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyModel|
-Generated Location: (576:16,0 [7] )
+Generated Location: (630:16,0 [7] )
 |MyModel|
 
-Source Location: (24:1,8 [5] /TestFiles/Input/InjectWithModel.cshtml)
+Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyApp|
-Generated Location: (666:20,0 [5] )
+Generated Location: (720:20,0 [5] )
 |MyApp|
 
-Source Location: (30:1,14 [14] /TestFiles/Input/InjectWithModel.cshtml)
+Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyPropertyName|
-Generated Location: (776:24,22 [14] )
+Generated Location: (830:24,22 [14] )
 |MyPropertyName|
 
-Source Location: (54:2,8 [17] /TestFiles/Input/InjectWithModel.cshtml)
+Source Location: (54:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyService<TModel>|
-Generated Location: (860:28,0 [17] )
+Generated Location: (914:28,0 [17] )
 |MyService<TModel>|
 
-Source Location: (72:2,26 [4] /TestFiles/Input/InjectWithModel.cshtml)
+Source Location: (72:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |Html|
-Generated Location: (982:32,22 [4] )
+Generated Location: (1036:32,22 [4] )
 |Html|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
@@ -1,45 +1,45 @@
-Source Location: (7:0,7 [7] /TestFiles/Input/InjectWithSemicolon.cshtml)
+Source Location: (7:0,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyModel|
-Generated Location: (580:16,0 [7] )
+Generated Location: (634:16,0 [7] )
 |MyModel|
 
-Source Location: (24:1,8 [5] /TestFiles/Input/InjectWithSemicolon.cshtml)
+Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (670:20,0 [5] )
+Generated Location: (724:20,0 [5] )
 |MyApp|
 
-Source Location: (30:1,14 [14] /TestFiles/Input/InjectWithSemicolon.cshtml)
+Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName|
-Generated Location: (780:24,22 [14] )
+Generated Location: (834:24,22 [14] )
 |MyPropertyName|
 
-Source Location: (58:2,8 [17] /TestFiles/Input/InjectWithSemicolon.cshtml)
+Source Location: (58:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (864:28,0 [17] )
+Generated Location: (918:28,0 [17] )
 |MyService<TModel>|
 
-Source Location: (76:2,26 [4] /TestFiles/Input/InjectWithSemicolon.cshtml)
+Source Location: (76:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html|
-Generated Location: (986:32,22 [4] )
+Generated Location: (1040:32,22 [4] )
 |Html|
 
-Source Location: (93:3,8 [5] /TestFiles/Input/InjectWithSemicolon.cshtml)
+Source Location: (93:3,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1060:36,0 [5] )
+Generated Location: (1114:36,0 [5] )
 |MyApp|
 
-Source Location: (99:3,14 [15] /TestFiles/Input/InjectWithSemicolon.cshtml)
+Source Location: (99:3,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName2|
-Generated Location: (1170:40,22 [15] )
+Generated Location: (1224:40,22 [15] )
 |MyPropertyName2|
 
-Source Location: (129:4,8 [17] /TestFiles/Input/InjectWithSemicolon.cshtml)
+Source Location: (129:4,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (1255:44,0 [17] )
+Generated Location: (1309:44,0 [17] )
 |MyService<TModel>|
 
-Source Location: (147:4,26 [5] /TestFiles/Input/InjectWithSemicolon.cshtml)
+Source Location: (147:4,26 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html2|
-Generated Location: (1377:48,22 [5] )
+Generated Location: (1431:48,22 [5] )
 |Html2|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
@@ -1,15 +1,10 @@
-Source Location: (1:0,1 [17] /TestFiles/Input/Inject.cshtml)
-|using MyNamespace|
-Generated Location: (379:12,0 [17] )
-|using MyNamespace|
-
-Source Location: (28:1,8 [5] /TestFiles/Input/Inject.cshtml)
+Source Location: (8:0,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyApp|
-Generated Location: (674:21,0 [5] )
+Generated Location: (621:16,0 [5] )
 |MyApp|
 
-Source Location: (34:1,14 [14] /TestFiles/Input/Inject.cshtml)
+Source Location: (14:0,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyPropertyName|
-Generated Location: (784:25,22 [14] )
+Generated Location: (731:20,22 [14] )
 |MyPropertyName|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
-Source Location: (7:0,7 [30] /TestFiles/Input/Model.cshtml)
+Source Location: (7:0,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (612:16,0 [30] )
+Generated Location: (643:16,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
-Source Location: (7:0,7 [21] /TestFiles/Input/MultipleModels.cshtml)
+Source Location: (7:0,7 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |ThisShouldBeGenerated|
-Generated Location: (621:16,0 [21] )
+Generated Location: (652:16,0 [21] )
 |ThisShouldBeGenerated|
 
-Source Location: (37:1,7 [30] /TestFiles/Input/MultipleModels.cshtml)
+Source Location: (37:1,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (725:20,0 [30] )
+Generated Location: (756:20,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (18:1,11 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace.cshtml)
+|Test.Namespace|
+Generated Location: (612:16,44 [14] )
+|Test.Namespace|
+

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
-Source Location: (43:3,1 [41] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
+Source Location: (38:3,1 [41] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |using Microsoft.AspNetCore.Mvc.RazorPages|
-Generated Location: (420:12,0 [41] )
+Generated Location: (435:12,0 [41] )
 |using Microsoft.AspNetCore.Mvc.RazorPages|
 
-Source Location: (23:2,14 [17] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
-|"*, TestAssembly"|
-Generated Location: (783:21,37 [17] )
-|"*, TestAssembly"|
+Source Location: (23:2,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
+|"*, AppCode"|
+Generated Location: (838:21,37 [12] )
+|"*, AppCode"|
 
-Source Location: (571:24,47 [4] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
+Source Location: (566:24,47 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |Name|
-Generated Location: (1296:33,47 [4] )
+Generated Location: (1386:33,47 [4] )
 |Name|
 
-Source Location: (100:5,12 [283] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
+Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |
     public IActionResult OnPost(Customer customer)
     {
@@ -28,7 +28,7 @@ Source Location: (100:5,12 [283] /TestFiles/Input/RazorPagesWithoutModel.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1737:44,12 [283] )
+Generated Location: (1867:44,12 [283] )
 |
     public IActionResult OnPost(Customer customer)
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -1,24 +1,24 @@
-Source Location: (60:4,1 [41] /TestFiles/Input/RazorPages.cshtml)
+Source Location: (55:4,1 [41] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |using Microsoft.AspNetCore.Mvc.RazorPages|
-Generated Location: (370:12,0 [41] )
+Generated Location: (423:12,0 [41] )
 |using Microsoft.AspNetCore.Mvc.RazorPages|
 
-Source Location: (16:2,7 [8] /TestFiles/Input/RazorPages.cshtml)
+Source Location: (16:2,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |NewModel|
-Generated Location: (684:21,0 [8] )
+Generated Location: (777:21,0 [8] )
 |NewModel|
 
-Source Location: (40:3,14 [17] /TestFiles/Input/RazorPages.cshtml)
-|"*, TestAssembly"|
-Generated Location: (812:25,37 [17] )
-|"*, TestAssembly"|
+Source Location: (40:3,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
+|"*, AppCode"|
+Generated Location: (905:25,37 [12] )
+|"*, AppCode"|
 
-Source Location: (666:28,47 [4] /TestFiles/Input/RazorPages.cshtml)
-|Name|
-Generated Location: (1313:37,47 [4] )
-|Name|
+Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
+|Model.Name|
+Generated Location: (1441:37,47 [10] )
+|Model.Name|
 
-Source Location: (117:6,12 [360] /TestFiles/Input/RazorPages.cshtml)
+Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |
     public class NewModel : PageModel
     {
@@ -36,7 +36,7 @@ Source Location: (117:6,12 [360] /TestFiles/Input/RazorPages.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1742:48,12 [360] )
+Generated Location: (1916:48,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.mappings.txt
@@ -1,0 +1,5 @@
+Source Location: (11:0,11 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace.cshtml)
+|Test.Namespace|
+Generated Location: (621:16,44 [14] )
+|Test.Namespace|
+

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
-Source Location: (8:0,8 [19] /TestFiles/Input/_ViewImports.cshtml)
+Source Location: (8:0,8 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |IHtmlHelper<TModel>|
-Generated Location: (587:16,0 [19] )
+Generated Location: (627:16,0 [19] )
 |IHtmlHelper<TModel>|
 
-Source Location: (28:0,28 [5] /TestFiles/Input/_ViewImports.cshtml)
+Source Location: (28:0,28 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |Model|
-Generated Location: (711:20,22 [5] )
+Generated Location: (751:20,22 [5] )
 |Model|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -876,7 +876,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 
             // Assert
             AssertIRMatchesBaseline(document.GetIRDocument());
-            AssertDesignTimeDocumentMatchBaseline(document);
+            AssertCSharpDocumentMatchesBaseline(document.GetCSharpDocument());
+            AssertLineMappingsMatchBaseline(document);
         }
 
         private void RunTimeTest()
@@ -928,7 +929,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 
             // Assert
             AssertIRMatchesBaseline(document.GetIRDocument());
-            AssertDesignTimeDocumentMatchBaseline(document);
+            AssertCSharpDocumentMatchesBaseline(document.GetCSharpDocument());
+            AssertLineMappingsMatchBaseline(document);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ExtensibleDirectiveTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ExtensibleDirectiveTest.cs
@@ -26,7 +26,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 
             // Assert
             AssertIRMatchesBaseline(document.GetIRDocument());
-            AssertDesignTimeDocumentMatchBaseline(document);
+            AssertCSharpDocumentMatchesBaseline(document.GetCSharpDocument());
+            AssertLineMappingsMatchBaseline(document);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Test.Common/Langauge/IntegrationTests/IntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/Langauge/IntegrationTests/IntegrationTestBase.cs
@@ -169,23 +169,16 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             Assert.Equal(baseline, actual);
         }
 
-        protected void AssertDesignTimeDocumentMatchBaseline(RazorCodeDocument document)
+        protected void AssertLineMappingsMatchBaseline(RazorCodeDocument document)
         {
             if (Filename == null)
             {
-                var message = $"{nameof(AssertDesignTimeDocumentMatchBaseline)} should only be called from an integration test ({nameof(Filename)} is null).";
+                var message = $"{nameof(AssertLineMappingsMatchBaseline)} should only be called from an integration test ({nameof(Filename)} is null).";
                 throw new InvalidOperationException(message);
             }
 
             var csharpDocument = document.GetCSharpDocument();
             Assert.NotNull(csharpDocument);
-
-            var syntaxTree = document.GetSyntaxTree();
-            Assert.NotNull(syntaxTree);
-            Assert.True(syntaxTree.Options.DesignTimeMode);
-
-            // Validate generated code.
-            AssertCSharpDocumentMatchesBaseline(csharpDocument);
 
             var baselineFilename = Path.ChangeExtension(Filename, ".mappings.txt");
             var serializedMappings = LineMappingsSerializer.Serialize(csharpDocument, document.Source);


### PR DESCRIPTION
- Split line mapping validation into its own method.
- Prior to this we were calling the wrong method in our design time code generation integration tests within the Razor.Extensions test project.
- Re-generated line mapping baselines to conform with the cshtml files for Razor.extensions code generation integration tests.

#1351