### PR TITLE
Make extensible directive type token rendering allow value types.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeDirectiveTargetExtension.cs
@@ -56,14 +56,16 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
                 {
                     case DirectiveTokenKind.Type:
 
-                        // {node.Content} __typeHelper = null;
+                        // {node.Content} __typeHelper = default({node.Content});
 
                         context.AddLineMappingFor(node);
                         context.Writer
                             .Write(node.Content)
                             .Write(" ")
                             .WriteStartAssignment(TypeHelper)
-                            .WriteLine("null;");
+                            .Write("default(")
+                            .Write(node.Content)
+                            .WriteLine(");");
                         break;
 
                     case DirectiveTokenKind.Member:

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -14,7 +14,7 @@ namespace
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-MyService<TModel> __typeHelper = null;
+MyService<TModel> __typeHelper = default(MyService<TModel>);
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
@@ -14,11 +14,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-MyBasePageForViews<TModel> __typeHelper = null;
+MyBasePageForViews<TModel> __typeHelper = default(MyBasePageForViews<TModel>);
         }
         ))();
         ((System.Action)(() => {
-MyModel __typeHelper = null;
+MyModel __typeHelper = default(MyModel);
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (602:16,0 [26] )
 
 Source Location: (45:1,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
 |MyModel|
-Generated Location: (711:20,0 [7] )
+Generated Location: (742:20,0 [7] )
 |MyModel|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
@@ -14,7 +14,7 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-MyModel __typeHelper = null;
+MyModel __typeHelper = default(MyModel);
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
@@ -14,11 +14,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-MyModel __typeHelper = null;
+MyModel __typeHelper = default(MyModel);
         }
         ))();
         ((System.Action)(() => {
-MyApp __typeHelper = null;
+MyApp __typeHelper = default(MyApp);
         }
         ))();
         ((System.Action)(() => {
@@ -26,7 +26,7 @@ global::System.Object MyPropertyName = null;
         }
         ))();
         ((System.Action)(() => {
-MyService<TModel> __typeHelper = null;
+MyService<TModel> __typeHelper = default(MyService<TModel>);
         }
         ))();
         ((System.Action)(() => {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (630:16,0 [7] )
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyApp|
-Generated Location: (720:20,0 [5] )
+Generated Location: (732:20,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyPropertyName|
-Generated Location: (830:24,22 [14] )
+Generated Location: (852:24,22 [14] )
 |MyPropertyName|
 
 Source Location: (54:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyService<TModel>|
-Generated Location: (914:28,0 [17] )
+Generated Location: (936:28,0 [17] )
 |MyService<TModel>|
 
 Source Location: (72:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |Html|
-Generated Location: (1036:32,22 [4] )
+Generated Location: (1080:32,22 [4] )
 |Html|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
@@ -14,11 +14,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-MyModel __typeHelper = null;
+MyModel __typeHelper = default(MyModel);
         }
         ))();
         ((System.Action)(() => {
-MyApp __typeHelper = null;
+MyApp __typeHelper = default(MyApp);
         }
         ))();
         ((System.Action)(() => {
@@ -26,7 +26,7 @@ global::System.Object MyPropertyName = null;
         }
         ))();
         ((System.Action)(() => {
-MyService<TModel> __typeHelper = null;
+MyService<TModel> __typeHelper = default(MyService<TModel>);
         }
         ))();
         ((System.Action)(() => {
@@ -34,7 +34,7 @@ global::System.Object Html = null;
         }
         ))();
         ((System.Action)(() => {
-MyApp __typeHelper = null;
+MyApp __typeHelper = default(MyApp);
         }
         ))();
         ((System.Action)(() => {
@@ -42,7 +42,7 @@ global::System.Object MyPropertyName2 = null;
         }
         ))();
         ((System.Action)(() => {
-MyService<TModel> __typeHelper = null;
+MyService<TModel> __typeHelper = default(MyService<TModel>);
         }
         ))();
         ((System.Action)(() => {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
@@ -5,41 +5,41 @@ Generated Location: (634:16,0 [7] )
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (724:20,0 [5] )
+Generated Location: (736:20,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName|
-Generated Location: (834:24,22 [14] )
+Generated Location: (856:24,22 [14] )
 |MyPropertyName|
 
 Source Location: (58:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (918:28,0 [17] )
+Generated Location: (940:28,0 [17] )
 |MyService<TModel>|
 
 Source Location: (76:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html|
-Generated Location: (1040:32,22 [4] )
+Generated Location: (1084:32,22 [4] )
 |Html|
 
 Source Location: (93:3,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1114:36,0 [5] )
+Generated Location: (1158:36,0 [5] )
 |MyApp|
 
 Source Location: (99:3,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName2|
-Generated Location: (1224:40,22 [15] )
+Generated Location: (1278:40,22 [15] )
 |MyPropertyName2|
 
 Source Location: (129:4,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (1309:44,0 [17] )
+Generated Location: (1363:44,0 [17] )
 |MyService<TModel>|
 
 Source Location: (147:4,26 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html2|
-Generated Location: (1431:48,22 [5] )
+Generated Location: (1507:48,22 [5] )
 |Html2|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
@@ -14,7 +14,7 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-MyApp __typeHelper = null;
+MyApp __typeHelper = default(MyApp);
         }
         ))();
         ((System.Action)(() => {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (621:16,0 [5] )
 
 Source Location: (14:0,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyPropertyName|
-Generated Location: (731:20,22 [14] )
+Generated Location: (741:20,22 [14] )
 |MyPropertyName|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -14,7 +14,7 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-DateTime __typeHelper = null;
+DateTime __typeHelper = default(DateTime);
         }
         ))();
         ((System.Action)(() => {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
@@ -14,7 +14,7 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-System.Collections.IEnumerable __typeHelper = null;
+System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -14,11 +14,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-ThisShouldBeGenerated __typeHelper = null;
+ThisShouldBeGenerated __typeHelper = default(ThisShouldBeGenerated);
         }
         ))();
         ((System.Action)(() => {
-System.Collections.IEnumerable __typeHelper = null;
+System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (652:16,0 [21] )
 
 Source Location: (37:1,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (756:20,0 [30] )
+Generated Location: (782:20,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -19,7 +19,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-NewModel __typeHelper = null;
+NewModel __typeHelper = default(NewModel);
         }
         ))();
         ((System.Action)(() => {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -10,12 +10,12 @@ Generated Location: (777:21,0 [8] )
 
 Source Location: (40:3,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |"*, AppCode"|
-Generated Location: (905:25,37 [12] )
+Generated Location: (918:25,37 [12] )
 |"*, AppCode"|
 
 Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |Model.Name|
-Generated Location: (1441:37,47 [10] )
+Generated Location: (1454:37,47 [10] )
 |Model.Name|
 
 Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegr
         public string Name { get; set; }
     }
 |
-Generated Location: (1916:48,12 [360] )
+Generated Location: (1929:48,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
@@ -14,7 +14,7 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-IHtmlHelper<TModel> __typeHelper = null;
+IHtmlHelper<TModel> __typeHelper = default(IHtmlHelper<TModel>);
         }
         ))();
         ((System.Action)(() => {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (627:16,0 [19] )
 
 Source Location: (28:0,28 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |Model|
-Generated Location: (751:20,22 [5] )
+Generated Location: (775:20,22 [5] )
 |Model|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/DesignTimeDirectiveTargetExtensionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/DesignTimeDirectiveTargetExtensionTest.cs
@@ -65,7 +65,7 @@ private void __RazorDirectiveTokenHelpers__() {
 @"#pragma warning disable 219
 private void __RazorDirectiveTokenHelpers__() {
 ((System.Action)(() => {
-System.String __typeHelper = null;
+System.String __typeHelper = default(System.String);
 }
 ))();
 }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-foo.bar<baz<biz>>.boz __typeHelper = null;
+foo.bar<baz<biz>>.boz __typeHelper = default(foo.bar<baz<biz>>.boz);
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (349:8,0 [21] )
 
 Source Location: (1:0,1 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
 |foo()|
-Generated Location: (721:18,6 [5] )
+Generated Location: (747:18,6 [5] )
 |foo()|
 


### PR DESCRIPTION
- Instead of rendering a null assigning statement for a type token we now render a `default(TTypeToken)`. With this approach type tokens can be value types without creating a design time error.
- Re-generated baseline files to reflect new directive token code generation.

#1176