### PR TITLE
Fixes #1245 - Make TemplateCodeExtension public

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 {
@@ -15,6 +16,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             PageDirective.Register(builder);
 
             builder.AddTargetExtension(new InjectDirectiveTargetExtension());
+            builder.AddTargetExtension(new TemplateTargetExtension()
+            {
+                TemplateTypeName = "global::Microsoft.AspNetCore.Mvc.Razor.HelperResult",
+            });
 
             builder.Features.Add(new ModelExpressionPass());
             builder.Features.Add(new PagesPropertyInjectionPass());

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/CSharpRenderingContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/CSharpRenderingContext.cs
@@ -82,6 +82,12 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             return scope;
         }
 
+        public void ReportMissingExtension<TExtension>() where TExtension : ICodeTargetExtension
+        {
+            var documentKind = CodeDocument.GetIRDocument()?.DocumentKind ?? string.Empty;
+            Diagnostics.Add(RazorDiagnosticFactory.CreateCodeTarget_UnsupportedExtension(documentKind, typeof(TExtension)));
+        }
+
         internal TagHelperRenderingContextScope Push(TagHelperRenderingContext context)
         {
             if (context == null)

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeTagHelperWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeTagHelperWriter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 

--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeTagHelperWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/RuntimeTagHelperWriter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIRLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIRLoweringPhase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/ITemplateTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/ITemplateTargetExtension.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 
-namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
-    internal interface ITemplateTargetExtension : ICodeTargetExtension
+    public interface ITemplateTargetExtension : ICodeTargetExtension
     {
         void WriteTemplate(CSharpRenderingContext context, TemplateIRNode node);
     }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/TemplateIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/TemplateIRNode.cs
@@ -4,8 +4,9 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     public sealed class TemplateIRNode : ExtensionIRNode
     {
@@ -28,6 +29,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
         public override void WriteNode(CodeTarget target, CSharpRenderingContext context)
         {
             var extension = target.GetExtension<ITemplateTargetExtension>();
+            if (extension == null)
+            {
+                context.ReportMissingExtension<ITemplateTargetExtension>();
+                return;
+            }
+
             extension.WriteTemplate(context, this);
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/TemplateTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/TemplateTargetExtension.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 
-namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
-    internal class TemplateTargetExtension : ITemplateTargetExtension
+    public class TemplateTargetExtension : ITemplateTargetExtension
     {
-        public static readonly string DefaultTemplateTypeName = "Microsoft.AspNetCore.Mvc.Razor.HelperResult";
+        public static readonly string DefaultTemplateTypeName = "Template";
         public static readonly string DefaultPushWriterMethod = "PushWriter";
         public static readonly string DefaultPopWriterMethod = "PopWriter";
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -416,6 +416,20 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static string FormatFeatureMustBeInitialized(object p0)
             => string.Format(CultureInfo.CurrentCulture, GetString("FeatureMustBeInitialized"), p0);
 
+        /// <summary>
+        /// The document type '{0}' does not support the extension '{1}'.
+        /// </summary>
+        internal static string Diagnostic_CodeTarget_UnsupportedExtension
+        {
+            get => GetString("Diagnostic_CodeTarget_UnsupportedExtension");
+        }
+
+        /// <summary>
+        /// The document type '{0}' does not support the extension '{1}'.
+        /// </summary>
+        internal static string FormatDiagnostic_CodeTarget_UnsupportedExtension(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("Diagnostic_CodeTarget_UnsupportedExtension"), p0, p1);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNetCore.Razor.Language
 {
     internal static class RazorDiagnosticFactory
@@ -9,33 +11,35 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         #region General Errors
 
-        /*
-         * General Errors ID Offset = 0
-         */
+        // General Errors ID Offset = 0
 
         #endregion
 
         #region Language Errors
 
-        /*
-         * Language Errors ID Offset = 1000
-         */
+        // Language Errors ID Offset = 1000
 
         #endregion
 
         #region Semantic Errors
 
-        /*
-         * Semantic Errors ID Offset = 2000
-         */
+        // Semantic Errors ID Offset = 2000
+
+        public static readonly RazorDiagnosticDescriptor CodeTarget_UnsupportedExtension =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}2000",
+                () => Resources.Diagnostic_CodeTarget_UnsupportedExtension,
+                RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateCodeTarget_UnsupportedExtension(string documentKind, Type extensionType)
+        {
+            return RazorDiagnostic.Create(CodeTarget_UnsupportedExtension, SourceSpan.Undefined, documentKind, extensionType.Name);
+        }
 
         #endregion
 
         #region TagHelper Errors
 
-        /*
-         * TagHelper Errors ID Offset = 3000
-         */
+        // TagHelper Errors ID Offset = 3000
 
         private static readonly RazorDiagnosticDescriptor TagHelper_InvalidRestrictedChildNullOrWhitespace =
             new RazorDiagnosticDescriptor(

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
@@ -74,7 +74,6 @@ namespace Microsoft.AspNetCore.Razor.Language
             builder.Features.Add(new DirectiveRemovalIROptimizationPass());
 
             // Default Runtime Targets
-            builder.AddTargetExtension(new TemplateTargetExtension());
             builder.AddTargetExtension(new PreallocatedAttributeTargetExtension());
 
             // Default configuration

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -204,4 +204,7 @@
   <data name="FeatureMustBeInitialized" xml:space="preserve">
     <value>The feature must be initialized by setting the '{0}' property.</value>
   </data>
+  <data name="Diagnostic_CodeTarget_UnsupportedExtension" xml:space="preserve">
+    <value>The document type '{0}' does not support the extension '{1}'.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Razor.Language/SourceSpan.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/SourceSpan.cs
@@ -9,6 +9,8 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public struct SourceSpan : IEquatable<SourceSpan>
     {
+        public static readonly SourceSpan Undefined = new SourceSpan(SourceLocation.Undefined, 0);
+
         public SourceSpan(int absoluteIndex, int length)
             : this(null, absoluteIndex, -1, -1, length)
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/InstrumentationPassIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/InstrumentationPassIntegrationTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Xunit;
 
@@ -46,6 +47,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.IntegrationTests
             {
                 b.AddTagHelpers(descriptors);
                 b.Features.Add(new InstrumentationPass());
+                
+                // This test includes templates
+                b.AddTargetExtension(new TemplateTargetExtension());
             });
 
             var document = CreateCodeDocument();

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
@@ -95,7 +95,7 @@ __InputTagHelper.BarProp = DateTime.Now;
             EndContext();
             BeginContext(217, 29, false);
 #line 9 "TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.cshtml"
-Write(Foo(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+Write(Foo(item => new Template(async(__razor_template_writer) => {
     PushWriter(__razor_template_writer);
     BeginContext(222, 24, true);
     WriteLiteral("<span>Hello world</span>");

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/TemplateTargetExtensionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/TemplateTargetExtensionTest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     public class TemplateTargetExtensionTest
     {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
@@ -868,7 +869,14 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
         private void DesignTimeTest()
         {
             // Arrange
-            var engine = RazorEngine.CreateDesignTime(builder => builder.Features.Add(new ApiSetsIRTestAdapter()));
+            var engine = RazorEngine.CreateDesignTime(builder => 
+            {
+                builder.Features.Add(new ApiSetsIRTestAdapter());
+
+                // Some of these tests use templates
+                builder.AddTargetExtension(new TemplateTargetExtension());
+            });
+
             var document = CreateCodeDocument();
 
             // Act
@@ -883,7 +891,14 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
         private void RunTimeTest()
         {
             // Arrange
-            var engine = RazorEngine.Create(builder => builder.Features.Add(new ApiSetsIRTestAdapter()));
+            var engine = RazorEngine.Create(builder =>
+            {
+                builder.Features.Add(new ApiSetsIRTestAdapter());
+
+                // Some of these tests use templates
+                builder.AddTargetExtension(new TemplateTargetExtension());
+            });
+
             var document = CreateCodeDocument();
 
             // Act
@@ -901,6 +916,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             {
                 builder.Features.Add(new ApiSetsIRTestAdapter());
                 builder.AddTagHelpers(descriptors);
+
+                // Some of these tests use templates
+                builder.AddTargetExtension(new TemplateTargetExtension());
             });
 
             var document = CreateCodeDocument();
@@ -920,6 +938,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             {
                 builder.Features.Add(new ApiSetsIRTestAdapter());
                 builder.AddTagHelpers(descriptors);
+
+                // Some of these tests use templates
+                builder.AddTargetExtension(new TemplateTargetExtension());
             });
 
             var document = CreateCodeDocument();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorEngineTest.cs
@@ -138,9 +138,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var feature = engine.Features.OfType<IRazorTargetExtensionFeature>().FirstOrDefault();
             Assert.NotNull(feature);
 
-            Assert.Collection(
-                feature.TargetExtensions,
-                f => Assert.IsType<TemplateTargetExtension>(f));
+            Assert.Empty(feature.TargetExtensions);
         }
 
         private static void AssertDefaultRuntimeFeatures(IEnumerable<IRazorEngineFeature> features)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
@@ -171,7 +171,7 @@ __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
 #line default
 #line hidden
 #line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
-   __o = someMethod(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+   __o = someMethod(item => new Template(async(__razor_template_writer) => {
     __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
     __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
 #line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
@@ -271,23 +271,23 @@ Generated Location: (8375:173,9 [11] )
 
 Source Location: (1410:34,64 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checked|
-Generated Location: (8828:177,63 [7] )
+Generated Location: (8793:177,63 [7] )
 |checked|
 
 Source Location: (1375:34,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |123|
-Generated Location: (9083:183,33 [3] )
+Generated Location: (9048:183,33 [3] )
 |123|
 
 Source Location: (1424:34,78 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (9124:188,1 [1] )
+Generated Location: (9089:188,1 [1] )
 |)|
 
 Source Location: (1437:35,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
 }|
-Generated Location: (9263:193,10 [3] )
+Generated Location: (9228:193,10 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
@@ -429,7 +429,7 @@ __TestNamespace_PTagHelper.Age = ("My age is this long.".Length);
             __tagHelperExecutionContext = __tagHelperScopeManager.End();
             WriteLiteral("\r\n        ");
 #line 35 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
-   Write(someMethod(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+   Write(someMethod(item => new Template(async(__razor_template_writer) => {
     PushWriter(__razor_template_writer);
     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("p", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
         __tagHelperExecutionContext = __tagHelperScopeManager.Begin("input", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.SelfClosing, "test", async() => {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
@@ -38,7 +38,7 @@ __o = Foo(Bar.Baz);
 #line default
 #line hidden
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml"
-__o = Foo(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+__o = Foo(item => new Template(async(__razor_template_writer) => {
 #line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml"
         __o = baz;
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
@@ -34,16 +34,16 @@ Generated Location: (1305:40,6 [4] )
 
 Source Location: (142:8,14 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |baz|
-Generated Location: (1502:42,14 [3] )
+Generated Location: (1467:42,14 [3] )
 |baz|
 
 Source Location: (153:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |)|
-Generated Location: (1543:47,1 [1] )
+Generated Location: (1508:47,1 [1] )
 |)|
 
 Source Location: (204:13,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |bar|
-Generated Location: (1744:53,6 [3] )
+Generated Location: (1709:53,6 [3] )
 |bar|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.codegen.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup.cshtml"
-  __o = item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+  __o = item => new Template(async(__razor_template_writer) => {
 }
 );
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup.cshtml)
 ||
-Generated Location: (732:16,1 [0] )
+Generated Location: (697:16,1 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_Runtime.codegen.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         {
             WriteLiteral("<div>");
 #line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup.cshtml"
-  Write(item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+  Write(item => new Template(async(__razor_template_writer) => {
     PushWriter(__razor_template_writer);
     WriteLiteral("</div>");
     PopWriter();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.codegen.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+            item => new Template(async(__razor_template_writer) => {
             }
             )
 #line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.mappings.txt
@@ -10,39 +10,39 @@ Generated Location: (597:14,2 [32] )
 Source Location: (45:2,25 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |;
     |
-Generated Location: (910:24,25 [7] )
+Generated Location: (875:24,25 [7] )
 |;
     |
 
 Source Location: (68:4,0 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |    |
-Generated Location: (950:29,0 [4] )
+Generated Location: (915:29,0 [4] )
 |    |
 
 Source Location: (91:4,23 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 |
-Generated Location: (1003:30,35 [2] )
+Generated Location: (968:30,35 [2] )
 |
 |
 
 Source Location: (99:7,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |while(i <= 10) {
     |
-Generated Location: (1096:33,1 [22] )
+Generated Location: (1061:33,1 [22] )
 |while(i <= 10) {
     |
 
 Source Location: (142:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |i|
-Generated Location: (1264:39,25 [1] )
+Generated Location: (1229:39,25 [1] )
 |i|
 
 Source Location: (148:8,31 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
     i += 1;
 }|
-Generated Location: (1418:44,31 [16] )
+Generated Location: (1383:44,31 [16] )
 |
     i += 1;
 }|
@@ -50,14 +50,14 @@ Generated Location: (1418:44,31 [16] )
 Source Location: (169:12,1 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |if(i == 11) {
     |
-Generated Location: (1557:51,1 [19] )
+Generated Location: (1522:51,1 [19] )
 |if(i == 11) {
     |
 
 Source Location: (213:13,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (1727:57,29 [3] )
+Generated Location: (1692:57,29 [3] )
 |
 }|
 
@@ -65,7 +65,7 @@ Source Location: (221:16,1 [35] TestFiles/IntegrationTests/CodeGenerationIntegra
 |switch(i) {
     case 11:
         |
-Generated Location: (1853:63,1 [35] )
+Generated Location: (1818:63,1 [35] )
 |switch(i) {
     case 11:
         |
@@ -75,7 +75,7 @@ Source Location: (292:18,44 [40] TestFiles/IntegrationTests/CodeGenerationIntegr
         break;
     default:
         |
-Generated Location: (2054:70,44 [40] )
+Generated Location: (2019:70,44 [40] )
 |
         break;
     default:
@@ -85,7 +85,7 @@ Source Location: (361:21,37 [19] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
         break;
 }|
-Generated Location: (2253:78,37 [19] )
+Generated Location: (2218:78,37 [19] )
 |
         break;
 }|
@@ -93,26 +93,26 @@ Generated Location: (2253:78,37 [19] )
 Source Location: (385:25,1 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |for(int j = 1; j <= 10; j += 2) {
     |
-Generated Location: (2395:85,1 [39] )
+Generated Location: (2360:85,1 [39] )
 |for(int j = 1; j <= 10; j += 2) {
     |
 
 Source Location: (451:26,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |j|
-Generated Location: (2587:91,31 [1] )
+Generated Location: (2552:91,31 [1] )
 |j|
 
 Source Location: (457:26,37 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (2748:96,37 [3] )
+Generated Location: (2713:96,37 [3] )
 |
 }|
 
 Source Location: (465:29,1 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |try {
     |
-Generated Location: (2874:102,1 [11] )
+Generated Location: (2839:102,1 [11] )
 |try {
     |
 
@@ -120,34 +120,34 @@ Source Location: (511:30,39 [31] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
 } catch(Exception ex) {
     |
-Generated Location: (3046:108,39 [31] )
+Generated Location: (3011:108,39 [31] )
 |
 } catch(Exception ex) {
     |
 
 Source Location: (573:32,35 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |ex.Message|
-Generated Location: (3234:115,35 [10] )
+Generated Location: (3199:115,35 [10] )
 |ex.Message|
 
 Source Location: (588:32,50 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (3417:120,50 [3] )
+Generated Location: (3382:120,50 [3] )
 |
 }|
 
 Source Location: (596:35,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |lock(new object()) {
     |
-Generated Location: (3543:126,1 [26] )
+Generated Location: (3508:126,1 [26] )
 |lock(new object()) {
     |
 
 Source Location: (669:36,51 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (3742:132,51 [3] )
+Generated Location: (3707:132,51 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_Runtime.codegen.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+            item => new Template(async(__razor_template_writer) => {
                 PushWriter(__razor_template_writer);
                 WriteLiteral("<p>Bar</p>");
                 PopWriter();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -44,7 +44,7 @@ global::System.Object NestedDelegates = null;
 
 #line default
 #line hidden
-            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+            item => new Template(async(__razor_template_writer) => {
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
                                    __o = item;
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -34,11 +34,11 @@ Generated Location: (1473:42,6 [27] )
 
 Source Location: (295:15,41 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |item|
-Generated Location: (1764:48,41 [4] )
+Generated Location: (1729:48,41 [4] )
 |item|
 
 Source Location: (306:15,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |; |
-Generated Location: (1969:55,52 [2] )
+Generated Location: (1934:55,52 [2] )
 |; |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_Runtime.codegen.cs
@@ -38,7 +38,7 @@ WriteAttributeValue(" ", 121, thing, 122, 6, false);
 
 #line default
 #line hidden
-            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+            item => new Template(async(__razor_template_writer) => {
                 PushWriter(__razor_template_writer);
                 WriteLiteral("<span>");
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
@@ -25,7 +25,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
 
 #line default
 #line hidden
-            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+            item => new Template(async(__razor_template_writer) => {
 #line 16 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
                                   __o = item;
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
@@ -16,13 +16,13 @@ Generated Location: (865:20,6 [66] )
 
 Source Location: (427:15,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |item|
-Generated Location: (1208:29,40 [4] )
+Generated Location: (1173:29,40 [4] )
 |item|
 
 Source Location: (482:15,95 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |);
     |
-Generated Location: (1624:38,95 [8] )
+Generated Location: (1589:38,95 [8] )
 |);
     |
 
@@ -35,7 +35,7 @@ Source Location: (47:2,12 [268] TestFiles/IntegrationTests/CodeGenerationIntegra
         helperResult.WriteTo(Output, HtmlEncoder);
     }
 |
-Generated Location: (1895:47,12 [268] )
+Generated Location: (1860:47,12 [268] )
 |
     public void RenderTemplate(string title, Func<string, HelperResult> template)
     {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-                item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+                item => new Template(async(__razor_template_writer) => {
                     PushWriter(__razor_template_writer);
                     __tagHelperExecutionContext = __tagHelperScopeManager.Begin("div", global::Microsoft.AspNetCore.Razor.TagHelpers.TagMode.StartTagAndEndTag, "test", async() => {
                         WriteLiteral("<h3>");

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.codegen.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+            item => new Template(async(__razor_template_writer) => {
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
                                              __o = item;
 
@@ -44,7 +44,7 @@ __o = foo("");
 
 #line default
 #line hidden
-            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+            item => new Template(async(__razor_template_writer) => {
 #line 17 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
                                       __o = item;
 
@@ -66,7 +66,7 @@ __o = bar("myclass");
                                
 
 #line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
-__o = Repeat(10, item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+__o = Repeat(10, item => new Template(async(__razor_template_writer) => {
 #line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
                    __o = item;
 
@@ -79,7 +79,7 @@ __o = Repeat(10, item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(_
 #line hidden
 #line 26 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 __o = Repeat(10,
-    item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+    item => new Template(async(__razor_template_writer) => {
 #line 27 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
                __o = item;
 
@@ -92,7 +92,7 @@ __o = Repeat(10,
 #line hidden
 #line 32 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 __o = Repeat(10,
-    item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+    item => new Template(async(__razor_template_writer) => {
 #line 33 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
                 __o = item;
 
@@ -105,7 +105,7 @@ __o = Repeat(10,
 #line hidden
 #line 38 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 __o = Repeat(10,
-    item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+    item => new Template(async(__razor_template_writer) => {
 #line 39 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
                  __o = item;
 
@@ -117,7 +117,7 @@ __o = Repeat(10,
 #line default
 #line hidden
 #line 45 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
-__o = Repeat(10, item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+__o = Repeat(10, item => new Template(async(__razor_template_writer) => {
 #line 46 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
          __o = item;
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.mappings.txt
@@ -7,143 +7,143 @@ Generated Location: (592:14,2 [34] )
 
 Source Location: (337:11,51 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (901:21,51 [4] )
+Generated Location: (866:21,51 [4] )
 |item|
 
 Source Location: (349:11,63 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |;
     |
-Generated Location: (1118:28,63 [7] )
+Generated Location: (1083:28,63 [7] )
 |;
     |
 
 Source Location: (357:12,5 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |foo("")|
-Generated Location: (1250:34,6 [7] )
+Generated Location: (1215:34,6 [7] )
 |foo("")|
 
 Source Location: (364:12,12 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |
 |
-Generated Location: (1315:38,24 [2] )
+Generated Location: (1280:38,24 [2] )
 |
 |
 
 Source Location: (373:15,2 [35] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 | 
     Func<dynamic, object> bar = |
-Generated Location: (1407:41,2 [35] )
+Generated Location: (1372:41,2 [35] )
 | 
     Func<dynamic, object> bar = |
 
 Source Location: (420:16,44 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (1710:48,44 [4] )
+Generated Location: (1640:48,44 [4] )
 |item|
 
 Source Location: (435:16,59 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |;
     |
-Generated Location: (1923:55,59 [7] )
+Generated Location: (1853:55,59 [7] )
 |;
     |
 
 Source Location: (443:17,5 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |bar("myclass")|
-Generated Location: (2055:61,6 [14] )
+Generated Location: (1985:61,6 [14] )
 |bar("myclass")|
 
 Source Location: (457:17,19 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |
 |
-Generated Location: (2134:65,31 [2] )
+Generated Location: (2064:65,31 [2] )
 |
 |
 
 Source Location: (472:21,2 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10, |
-Generated Location: (2230:68,6 [11] )
+Generated Location: (2160:68,6 [11] )
 |Repeat(10, |
 
 Source Location: (495:21,25 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2445:70,25 [4] )
+Generated Location: (2340:70,25 [4] )
 |item|
 
 Source Location: (504:21,34 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2487:75,1 [1] )
+Generated Location: (2382:75,1 [1] )
 |)|
 
 Source Location: (523:25,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (2614:80,6 [16] )
+Generated Location: (2509:80,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (556:26,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2830:83,21 [4] )
+Generated Location: (2690:83,21 [4] )
 |item|
 
 Source Location: (577:27,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2872:88,1 [1] )
+Generated Location: (2732:88,1 [1] )
 |)|
 
 Source Location: (594:31,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (2999:93,6 [16] )
+Generated Location: (2859:93,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (628:32,22 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (3216:96,22 [4] )
+Generated Location: (3041:96,22 [4] )
 |item|
 
 Source Location: (650:33,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (3258:101,1 [1] )
+Generated Location: (3083:101,1 [1] )
 |)|
 
 Source Location: (667:37,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (3385:106,6 [16] )
+Generated Location: (3210:106,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (702:38,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (3603:109,23 [4] )
+Generated Location: (3393:109,23 [4] )
 |item|
 
 Source Location: (724:39,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (3645:114,1 [1] )
+Generated Location: (3435:114,1 [1] )
 |)|
 
 Source Location: (748:44,5 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10, |
-Generated Location: (3772:119,6 [11] )
+Generated Location: (3562:119,6 [11] )
 |Repeat(10, |
 
 Source Location: (781:45,15 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (3977:121,15 [4] )
+Generated Location: (3732:121,15 [4] )
 |item|
 
 Source Location: (797:46,10 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |var parent = item;|
-Generated Location: (4111:126,10 [18] )
+Generated Location: (3866:126,10 [18] )
 |var parent = item;|
 
 Source Location: (956:51,9 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (4166:131,1 [1] )
+Generated Location: (3921:131,1 [1] )
 |)|
 
 Source Location: (12:0,12 [265] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
@@ -156,7 +156,7 @@ Source Location: (12:0,12 [265] TestFiles/IntegrationTests/CodeGenerationIntegra
         });
     }
 |
-Generated Location: (4347:138,12 [265] )
+Generated Location: (4102:138,12 [265] )
 |
     public HelperResult Repeat(int times, Func<int, object> template) {
         return new HelperResult((writer) => {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_Runtime.codegen.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 
 #line default
 #line hidden
-            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+            item => new Template(async(__razor_template_writer) => {
                 PushWriter(__razor_template_writer);
                 WriteLiteral("This works ");
 #line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
@@ -44,7 +44,7 @@ Write(foo(""));
 
 #line default
 #line hidden
-            item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+            item => new Template(async(__razor_template_writer) => {
                 PushWriter(__razor_template_writer);
                 WriteLiteral("<p");
                 BeginWriteAttribute("class", " class=\"", 411, "\"", 424, 1);
@@ -71,7 +71,7 @@ Write(bar("myclass"));
 #line hidden
             WriteLiteral("\r\n<ul>\r\n");
 #line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
-Write(Repeat(10, item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+Write(Repeat(10, item => new Template(async(__razor_template_writer) => {
     PushWriter(__razor_template_writer);
     WriteLiteral("<li>Item #");
 #line 22 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
@@ -89,7 +89,7 @@ Write(Repeat(10, item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(_
             WriteLiteral("\r\n</ul>\r\n\r\n<p>\r\n");
 #line 26 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 Write(Repeat(10,
-    item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+    item => new Template(async(__razor_template_writer) => {
     PushWriter(__razor_template_writer);
     WriteLiteral(" This is line#");
 #line 27 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
@@ -107,7 +107,7 @@ Write(Repeat(10,
             WriteLiteral("\r\n</p>\r\n\r\n<p>\r\n");
 #line 32 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 Write(Repeat(10,
-    item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+    item => new Template(async(__razor_template_writer) => {
     PushWriter(__razor_template_writer);
     WriteLiteral(": This is line#");
 #line 33 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
@@ -125,7 +125,7 @@ Write(Repeat(10,
             WriteLiteral("\r\n</p>\r\n\r\n<p>\r\n");
 #line 38 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
 Write(Repeat(10,
-    item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+    item => new Template(async(__razor_template_writer) => {
     PushWriter(__razor_template_writer);
     WriteLiteral(":: This is line#");
 #line 39 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
@@ -142,7 +142,7 @@ Write(Repeat(10,
 #line hidden
             WriteLiteral("\r\n</p>\r\n\r\n\r\n<ul>\r\n    ");
 #line 45 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"
-Write(Repeat(10, item => new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_template_writer) => {
+Write(Repeat(10, item => new Template(async(__razor_template_writer) => {
     PushWriter(__razor_template_writer);
     WriteLiteral("<li>\r\n        Item #");
 #line 46 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml"


### PR DESCRIPTION
This removes the hardcoding of an MVC type from Razor.