### PR TITLE
Allow directive string tokens to be colorized.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -1559,7 +1559,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     return;
                 }
 
-                var outputKind = SpanKind.Markup;
                 switch (tokenDescriptor.Kind)
                 {
                     case DirectiveTokenKind.Type:
@@ -1572,8 +1571,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
                             return;
                         }
-
-                        outputKind = SpanKind.Code;
                         break;
 
                     case DirectiveTokenKind.Namespace:
@@ -1586,8 +1583,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
                             return;
                         }
-
-                        outputKind = SpanKind.Code;
                         break;
 
                     case DirectiveTokenKind.Member:
@@ -1603,8 +1598,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 CurrentSymbol.Content.Length);
                             return;
                         }
-
-                        outputKind = SpanKind.Code;
                         break;
 
                     case DirectiveTokenKind.String:
@@ -1624,7 +1617,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 }
 
                 Span.ChunkGenerator = new DirectiveTokenChunkGenerator(tokenDescriptor);
-                Output(outputKind, AcceptedCharacters.NonWhiteSpace);
+                Output(SpanKind.Code, AcceptedCharacters.NonWhiteSpace);
             }
 
             AcceptWhile(IsSpacingToken(includeNewLines: false, includeComments: true));

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"AString\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"AString\"", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace)));
         }
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .Accepts(AcceptedCharacters.NonWhiteSpace),
 
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"AString\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"AString\"", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[2]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace)));
         }
@@ -278,7 +278,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"Header\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"Header\"", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.AllWhiteSpace),
@@ -314,7 +314,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"Name\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"Name\"", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.AllWhiteSpace),
@@ -401,7 +401,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"hello\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"hello\"", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace),
                     Factory.Span(SpanKind.Markup, " ;  ", markup: false).Accepts(AcceptedCharacters.WhiteSpace)));
@@ -430,7 +430,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"hello\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"hello\"", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace),
 
@@ -461,7 +461,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"Hello\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"Hello\"", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace),
 
@@ -492,7 +492,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"Hello\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"Hello\"", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace)),
                 expectedErorr);
@@ -521,7 +521,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"Hello\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"Hello\"", markup: false)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens[0]))
                         .Accepts(AcceptedCharacters.NonWhiteSpace),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.AllWhiteSpace),
@@ -979,7 +979,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"simple-value\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"simple-value\"", markup: false)
                         .Accepts(AcceptedCharacters.NonWhiteSpace)
                         .With(chunkGenerator)));
         }
@@ -1004,7 +1004,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"{formaction}?/{id}?\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"{formaction}?/{id}?\"", markup: false)
                         .Accepts(AcceptedCharacters.NonWhiteSpace)
                         .With(chunkGenerator)));
         }
@@ -1027,7 +1027,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
-                    Factory.Span(SpanKind.Markup, "\"{formaction}?/{id}?\"", markup: false)
+                    Factory.Span(SpanKind.Code, "\"{formaction}?/{id}?\"", markup: false)
                         .Accepts(AcceptedCharacters.NonWhiteSpace)
                         .With(new DirectiveTokenChunkGenerator(descriptor.Tokens.First())),
                     Factory.Span(SpanKind.Code, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),


### PR DESCRIPTION
### Before
![image](https://cloud.githubusercontent.com/assets/2008729/26180789/6f195d4e-3b20-11e7-9343-8c1549507b70.png)

### After
![image](https://cloud.githubusercontent.com/assets/2008729/26180787/695078ca-3b20-11e7-93a1-8420be78ef2c.png)

- Without a directive string token having a `SpanKind.Code` it cannot have any sort of C# coloring associated with it.
- Updated tests to reflect new `SpanKind` expectations.

#1269

Positioned this guy to go into **rel/15.3** @rynowak let me know if you feel like it's not worth.