### PR TITLE
Make ViewComponentTagHelper's display name nicer.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorBuilder.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         private static ICollection<char> InvalidNonWhitespaceAllowedChildCharacters { get; } = new HashSet<char>(
             new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*' });
 
+        private string _displayName;
         private string _documentation;
         private string _tagOutputHint;
         private HashSet<string> _allowedChildTags;
@@ -29,6 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         private TagHelperDescriptorBuilder(string typeName, string assemblyName)
         {
             _typeName = typeName;
+            _displayName = _typeName;
             _assemblyName = assemblyName;
             _metadata = new Dictionary<string, string>(StringComparer.Ordinal);
         }
@@ -133,6 +135,18 @@ namespace Microsoft.AspNetCore.Razor.Language
             return this;
         }
 
+        public TagHelperDescriptorBuilder DisplayName(string displayName)
+        {
+            if (displayName == null)
+            {
+                throw new ArgumentNullException(nameof(displayName));
+            }
+
+            _displayName = displayName;
+
+            return this;
+        }
+
         public TagHelperDescriptor Build()
         {
             var validationDiagnostics = Validate();
@@ -146,7 +160,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 _typeName,
                 _assemblyName,
                 _typeName /* Name */,
-                _typeName /* DisplayName */,
+                _displayName,
                 _documentation,
                 _tagOutputHint,
                 _tagMatchingRules ?? Enumerable.Empty<TagMatchingRule>(),

--- a/src/Microsoft.CodeAnalysis.Razor/ViewComponentTagHelperDescriptorFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/ViewComponentTagHelperDescriptorFactory.cs
@@ -35,9 +35,11 @@ namespace Microsoft.CodeAnalysis.Razor
             var shortName = GetShortName(type);
             var tagName = $"vc:{DefaultTagHelperDescriptorFactory.ToHtmlCase(shortName)}";
             var typeName = $"__Generated__{shortName}ViewComponentTagHelper";
-            var descriptorBuilder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);
+            var displayName = shortName + "ViewComponentTagHelper";
             var methodParameters = GetInvokeMethodParameters(type);
-            descriptorBuilder.TagMatchingRule(ruleBuilder =>
+            var descriptorBuilder = TagHelperDescriptorBuilder.Create(typeName, assemblyName)
+                .DisplayName(displayName)
+                .TagMatchingRule(ruleBuilder =>
             {
                 ruleBuilder.RequireTagName(tagName);
                 AddRequiredAttributes(methodParameters, ruleBuilder);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TagHelperDescriptorBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TagHelperDescriptorBuilderTest.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class TagHelperDescriptorBuilderTest
+    {
+        [Fact]
+        public void DisplayName_SetsDescriptorsDisplayName()
+        {
+            // Arrange
+            var expectedDisplayName = "ExpectedDisplayName";
+            var builder = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
+
+            // Act
+            var descriptor = builder.DisplayName(expectedDisplayName).Build();
+
+            // Assert
+            Assert.Equal(expectedDisplayName, descriptor.DisplayName);
+        }
+
+        [Fact]
+        public void DisplayName_DefaultsToTypeName()
+        {
+            // Arrange
+            var expectedDisplayName = "TestTagHelper";
+            var builder = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
+
+            // Act
+            var descriptor = builder.Build();
+
+            // Assert
+            Assert.Equal(expectedDisplayName, descriptor.DisplayName);
+        }
+    }
+}

--- a/test/Microsoft.CodeAnalysis.Razor.Test/ViewComponentTagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Test/ViewComponentTagHelperDescriptorFactoryTest.cs
@@ -1,11 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language;
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.AspNetCore.Razor.Language;
 using Xunit;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 
 namespace Microsoft.CodeAnalysis.Razor.Workspaces
 {
@@ -21,6 +20,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             var expectedDescriptor = TagHelperDescriptorBuilder.Create(
                 "__Generated__StringParameterViewComponentTagHelper",
                 typeof(StringParameterViewComponent).GetTypeInfo().Assembly.GetName().Name)
+                .DisplayName("StringParameterViewComponentTagHelper")
                 .TagMatchingRule(rule =>
                     rule
                     .RequireTagName("vc:string-parameter")
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             var expectedDescriptor = TagHelperDescriptorBuilder.Create(
                 "__Generated__VariousParameterViewComponentTagHelper",
                 typeof(VariousParameterViewComponent).GetTypeInfo().Assembly.GetName().Name)
+                .DisplayName("VariousParameterViewComponentTagHelper")
                 .TagMatchingRule(rule =>
                     rule
                     .RequireTagName("vc:various-parameter")
@@ -98,6 +99,7 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             var expectedDescriptor = TagHelperDescriptorBuilder.Create(
                 "__Generated__GenericParameterViewComponentTagHelper",
                 typeof(GenericParameterViewComponent).GetTypeInfo().Assembly.GetName().Name)
+                .DisplayName("GenericParameterViewComponentTagHelper")
                 .TagMatchingRule(rule =>
                     rule
                     .RequireTagName("vc:generic-parameter")


### PR DESCRIPTION
- Went from `__Generated__SomeViewComponentTagHelper` to `SomeViewComponentTagHelper`.
- Updated `TagHelperDescriptorBuilder` to allow setting of `DisplayName`.
- Added `TagHelperDescriptorBuilderTest` class to verify new `DisplayName` additions.
- Updated `ViewComponentTagHelperDescriptorFactoryTest` expectations.

#1251