### PR TITLE
Fix aspnet/Mvc#6296 sanitize class and namespace

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/CSharpIdentifier.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/CSharpIdentifier.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 {
-    internal static class ClassName
+    internal static class CSharpIdentifier
     {
         public static string GetClassNameFromPath(string path)
         {

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ClassName.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ClassName.cs
@@ -4,9 +4,9 @@
 using System.Globalization;
 using System.Text;
 
-namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Internal
+namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 {
-    public static class ClassName
+    internal static class ClassName
     {
         public static string GetClassNameFromPath(string path)
         {
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Internal
                 category == UnicodeCategory.Format; // Cf
         }
 
-        private static string SanitizeClassName(string inputName)
+        public static string SanitizeClassName(string inputName)
         {
             if (!IsIdentifierStart(inputName[0]) && IsIdentifierPart(inputName[0]))
             {

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcRazorTemplateEngine.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcRazorTemplateEngine.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Text;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions.Internal;
 using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Extensions

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcViewDocumentClassifierPass.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcViewDocumentClassifierPass.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Mvc.Razor.Extensions.Internal;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcViewDocumentClassifierPass.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcViewDocumentClassifierPass.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             var filePath = codeDocument.GetRelativePath() ?? codeDocument.Source.FileName;
 
             base.OnDocumentStructureCreated(codeDocument, @namespace, @class, method);
-            @class.Name = ClassName.GetClassNameFromPath(filePath);
+            @class.Name = CSharpIdentifier.GetClassNameFromPath(filePath);
             @class.BaseType = "global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<TModel>";
             @class.AccessModifier = "public";
             @namespace.Content = "AspNetCore";

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/NamespaceDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/NamespaceDirective.cs
@@ -63,13 +63,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 {
                     // Beautify the class name since we're using a hierarchy for namespaces.
                     var @class = visitor.FirstClass;
+                    var prefix = Path.GetFileNameWithoutExtension(codeDocument.Source.FileName);
                     if (@class != null && irDocument.DocumentKind == RazorPageDocumentClassifierPass.RazorPageDocumentKind)
                     {
-                        @class.Name = Path.GetFileNameWithoutExtension(codeDocument.Source.FileName) + "_Page";
+                        @class.Name = ClassName.SanitizeClassName(prefix + "_Page");
                     }
                     else if (@class != null && irDocument.DocumentKind == MvcViewDocumentClassifierPass.MvcViewDocumentKind)
                     {
-                        @class.Name = Path.GetFileNameWithoutExtension(codeDocument.Source.FileName) + "_View";
+                        @class.Name = ClassName.SanitizeClassName(prefix + "_View");
                     }
                 }
 
@@ -125,7 +126,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             for (var i = 0; i < segments.Length - 1; i++)
             {
                 builder.Append('.');
-                builder.Append(segments[i]);
+                builder.Append(ClassName.SanitizeClassName(segments[i]));
             }
 
             @namespace = builder.ToString();

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/NamespaceDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/NamespaceDirective.cs
@@ -63,14 +63,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 {
                     // Beautify the class name since we're using a hierarchy for namespaces.
                     var @class = visitor.FirstClass;
-                    var prefix = Path.GetFileNameWithoutExtension(codeDocument.Source.FileName);
+                    var prefix = CSharpIdentifier.SanitizeClassName(Path.GetFileNameWithoutExtension(codeDocument.Source.FileName));
                     if (@class != null && irDocument.DocumentKind == RazorPageDocumentClassifierPass.RazorPageDocumentKind)
                     {
-                        @class.Name = ClassName.SanitizeClassName(prefix + "_Page");
+                        @class.Name = prefix + "_Page";
                     }
                     else if (@class != null && irDocument.DocumentKind == MvcViewDocumentClassifierPass.MvcViewDocumentKind)
                     {
-                        @class.Name = ClassName.SanitizeClassName(prefix + "_View");
+                        @class.Name = prefix + "_View";
                     }
                 }
 
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             for (var i = 0; i < segments.Length - 1; i++)
             {
                 builder.Append('.');
-                builder.Append(ClassName.SanitizeClassName(segments[i]));
+                builder.Append(CSharpIdentifier.SanitizeClassName(segments[i]));
             }
 
             @namespace = builder.ToString();

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorCodeDocumentExtensions.cs
@@ -4,9 +4,9 @@
 using System;
 using Microsoft.AspNetCore.Razor.Language;
 
-namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Internal
+namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 {
-    public static class RazorCodeDocumentExtensions
+    internal static class RazorCodeDocumentExtensions
     {
         private const string RelativePathKey = "relative-path";
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorPageDocumentClassifierPass.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorPageDocumentClassifierPass.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Mvc.Razor.Extensions.Internal;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorPageDocumentClassifierPass.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorPageDocumentClassifierPass.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
             base.OnDocumentStructureCreated(codeDocument, @namespace, @class, method);
             @class.BaseType = "global::Microsoft.AspNetCore.Mvc.RazorPages.Page";
-            @class.Name = ClassName.GetClassNameFromPath(filePath);
+            @class.Name = CSharpIdentifier.GetClassNameFromPath(filePath);
             @class.AccessModifier = "public";
             @namespace.Content = "AspNetCore";
             method.Name = "ExecuteAsync";

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/MvcRazorTemplateEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/MvcRazorTemplateEngineTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions.Internal;
 using Microsoft.AspNetCore.Razor.Language;
 using Moq;
 using Xunit;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/MvcViewDocumentClassifierPassTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/MvcViewDocumentClassifierPassTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions.Internal;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Xunit;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/RazorPageDocumentClassifierPassTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/RazorPageDocumentClassifierPassTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions.Internal;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Xunit;


### PR DESCRIPTION
The new @namespace directive isn't sanitizing class and namespace names
when generating them. This means that a file-system-legal character like
'-' will show up in a class name, and that's not good.

Note that the old code paths (document classifiers) already had tests for
this and did it properly. It was only missing from @namespace.