### PR TITLE
Rename HtmlCase => HtmlConventions.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/HtmlConventions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/HtmlConventions.cs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public static class HtmlCase
+    public static class HtmlConventions
     {
         private const string HtmlCaseRegexReplacement = "-$1$2";
 
@@ -19,6 +20,9 @@ namespace Microsoft.AspNetCore.Razor.Language
                 "(?<!^)((?<=[a-zA-Z0-9])[A-Z][a-z])|((?<=[a-z])[A-Z])",
                 RegexOptions.None,
                 TimeSpan.FromMilliseconds(500));
+
+        public static IReadOnlyCollection<char> InvalidNonWhitespaceHtmlCharacters { get; } = new HashSet<char>(
+            new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*' });
 
         /// <summary>
         /// Converts from pascal/camel case to lower kebab-case.

--- a/src/Microsoft.AspNetCore.Razor.Language/RequiredAttributeDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RequiredAttributeDescriptorBuilder.cs
@@ -9,9 +9,6 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public sealed class RequiredAttributeDescriptorBuilder
     {
-        private static ICollection<char> InvalidNonWhitespaceAttributeNameCharacters { get; } = new HashSet<char>(
-            new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*' });
-
         private string _name;
         private RequiredAttributeDescriptor.NameComparisonMode _nameComparison;
         private string _value;
@@ -105,7 +102,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             {
                 foreach (var character in _name)
                 {
-                    if (char.IsWhiteSpace(character) || InvalidNonWhitespaceAttributeNameCharacters.Contains(character))
+                    if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
                     {
                         var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidTargetedAttributeName(_name, character);
 

--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperBoundAttributeDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperBoundAttributeDescriptorBuilder.cs
@@ -31,9 +31,6 @@ namespace Microsoft.AspNetCore.Razor.Language
             [typeof(decimal).FullName] = "decimal",
         };
 
-        private static ICollection<char> InvalidNonWhitespaceAttributeNameCharacters { get; } = new HashSet<char>(
-            new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*' });
-
         private bool _isEnum;
         private bool _hasIndexer;
         private string _indexerValueTypeName;
@@ -191,7 +188,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
                 foreach (var character in _name)
                 {
-                    if (char.IsWhiteSpace(character) || InvalidNonWhitespaceAttributeNameCharacters.Contains(character))
+                    if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
                     {
                         var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidBoundAttributeName(
                             _containingTypeName,
@@ -227,7 +224,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     foreach (var character in _indexerNamePrefix)
                     {
-                        if (char.IsWhiteSpace(character) || InvalidNonWhitespaceAttributeNameCharacters.Contains(character))
+                        if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
                         {
                             var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidBoundAttributePrefix(
                                 _containingTypeName,

--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorBuilder.cs
@@ -12,10 +12,6 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal const string DescriptorKind = "ITagHelper";
         internal const string TypeNameKey = "ITagHelper.TypeName";
 
-        private static ICollection<char> InvalidNonWhitespaceAllowedChildCharacters { get; } = new HashSet<char>(
-            new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*' });
-
-
         private string _displayName;
         private string _documentation;
         private string _tagOutputHint;
@@ -199,7 +195,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                     {
                         foreach (var character in name)
                         {
-                            if (char.IsWhiteSpace(character) || InvalidNonWhitespaceAllowedChildCharacters.Contains(character))
+                            if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
                             {
                                 var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidRestrictedChild(name, _typeName, character);
 

--- a/src/Microsoft.AspNetCore.Razor.Language/TagMatchingRuleBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagMatchingRuleBuilder.cs
@@ -10,9 +10,6 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public sealed class TagMatchingRuleBuilder
     {
-        private static ICollection<char> InvalidNonWhitespaceTagNameCharacters { get; } = new HashSet<char>(
-            new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*' });
-
         private string _tagName;
         private string _parentTag;
         private TagStructure _tagStructure;
@@ -126,7 +123,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             {
                 foreach (var character in _tagName)
                 {
-                    if (char.IsWhiteSpace(character) || InvalidNonWhitespaceTagNameCharacters.Contains(character))
+                    if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
                     {
                         var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidTargetedTagName(_tagName, character);
 
@@ -147,7 +144,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     foreach (var character in _parentTag)
                     {
-                        if (char.IsWhiteSpace(character) || InvalidNonWhitespaceTagNameCharacters.Contains(character))
+                        if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
                         {
                             var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidTargetedParentTagName(_parentTag, character);
 

--- a/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorFactory.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Razor
 
                 descriptorBuilder.TagMatchingRule(ruleBuilder =>
                 {
-                    var htmlCasedName = HtmlCase.ToHtmlCase(name);
+                    var htmlCasedName = HtmlConventions.ToHtmlCase(name);
                     ruleBuilder.RequireTagName(htmlCasedName);
                 });
 
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 string.IsNullOrEmpty((string)attributeNameAttribute.ConstructorArguments[0].Value))
             {
                 hasExplicitName = false;
-                attributeName = HtmlCase.ToHtmlCase(property.Name);
+                attributeName = HtmlConventions.ToHtmlCase(property.Name);
             }
             else
             {

--- a/src/Microsoft.CodeAnalysis.Razor/ViewComponentTagHelperDescriptorFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/ViewComponentTagHelperDescriptorFactory.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Razor
         {
             var assemblyName = type.ContainingAssembly.Name;
             var shortName = GetShortName(type);
-            var tagName = $"vc:{HtmlCase.ToHtmlCase(shortName)}";
+            var tagName = $"vc:{HtmlConventions.ToHtmlCase(shortName)}";
             var typeName = $"__Generated__{shortName}ViewComponentTagHelper";
             var displayName = shortName + "ViewComponentTagHelper";
             var descriptorBuilder = TagHelperDescriptorBuilder.Create(typeName, assemblyName)
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.Razor
                     // because there are two ways of setting values for the attribute.
                     builder.RequireAttribute(attributeBuilder =>
                     {
-                        var lowerKebabName = HtmlCase.ToHtmlCase(parameter.Name);
+                        var lowerKebabName = HtmlConventions.ToHtmlCase(parameter.Name);
                         attributeBuilder.Name(lowerKebabName);
                     });
                 }
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Razor
         {
             foreach (var parameter in methodParameters)
             {
-                var lowerKebabName = HtmlCase.ToHtmlCase(parameter.Name);
+                var lowerKebabName = HtmlConventions.ToHtmlCase(parameter.Name);
                 var typeName = parameter.Type.ToDisplayString(FullNameTypeDisplayFormat);
                 builder.BindAttribute(attributeBuilder =>
                 {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/HtmlConventionsTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/HtmlConventionsTest.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public class HtmlCaseTest
+    public class HtmlConventionsTest
     {
         public static TheoryData HtmlConversionData
         {
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public void ToHtmlCase_ReturnsExpectedConversions(string input, string expectedOutput)
         {
             // Arrange, Act
-            var output = HtmlCase.ToHtmlCase(input);
+            var output = HtmlConventions.ToHtmlCase(input);
 
             // Assert
             Assert.Equal(output, expectedOutput);


### PR DESCRIPTION
- Moved the invalid non-whitespace html character entries from the various builders into the new HtmlConventions class.
- Updated test file name.

FYI only