### PR TITLE
Log errors if directives do not start at beginning of line.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -430,6 +430,20 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static string FormatDiagnostic_CodeTarget_UnsupportedExtension(object p0, object p1)
             => string.Format(CultureInfo.CurrentCulture, GetString("Diagnostic_CodeTarget_UnsupportedExtension"), p0, p1);
 
+        /// <summary>
+        /// The '{0}` directive must appear at the start of the line.
+        /// </summary>
+        internal static string DirectiveMustAppearAtStartOfLine
+        {
+            get => GetString("DirectiveMustAppearAtStartOfLine");
+        }
+
+        /// <summary>
+        /// The '{0}` directive must appear at the start of the line.
+        /// </summary>
+        internal static string FormatDirectiveMustAppearAtStartOfLine(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("DirectiveMustAppearAtStartOfLine"), p0);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -207,4 +207,7 @@
   <data name="Diagnostic_CodeTarget_UnsupportedExtension" xml:space="preserve">
     <value>The document type '{0}' does not support the extension '{1}'.</value>
   </data>
+  <data name="DirectiveMustAppearAtStartOfLine" xml:space="preserve">
+    <value>The '{0}` directive must appear at the start of the line.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpSectionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpSectionTest.cs
@@ -165,6 +165,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         Factory.MetaCode("}").Accepts(AcceptedCharactersInternal.None)),
                     Factory.EmptyHtml()),
                 new RazorError(
+                    Resources.FormatDirectiveMustAppearAtStartOfLine("section"),
+                    new SourceLocation(16, 0, 16),
+                    7),
+                new RazorError(
                     LegacyResources.FormatParseError_Sections_Cannot_Be_Nested(LegacyResources.SectionExample_CS),
                     new SourceLocation(15, 0, 15),
                     8));


### PR DESCRIPTION
- Updated tests to validate expectations.
- Added two additional tests to validate extensible directives and built-in directives get start at line verification.

#1201