### PR TITLE
Change ParserContext to take a RazorSourceDocument.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
@@ -9,14 +9,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     internal partial class ParserContext
     {
-        public ParserContext(ITextDocument source, RazorParserOptions options)
+        public ParserContext(RazorSourceDocument source, RazorParserOptions options)
         {
             if (source == null)
             {
                 throw new ArgumentNullException(nameof(source));
             }
 
-            Source = source;
+            SourceDocument = source;
+            var chars = new char[source.Length];
+            source.CopyTo(0, chars, 0, source.Length);
+
+            Source = new SeekableTextReader(chars, source.FileName);
             DesignTimeMode = options.DesignTime;
             ParseOnlyLeadingDirectives = options.ParseOnlyLeadingDirectives;
             Builder = new SyntaxTreeBuilder();
@@ -28,6 +32,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         public ErrorSink ErrorSink { get; }
 
         public ITextDocument Source { get; }
+
+        public RazorSourceDocument SourceDocument { get; }
 
         public bool DesignTimeMode { get; }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/RazorParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/RazorParser.cs
@@ -32,13 +32,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 throw new ArgumentNullException(nameof(source));
             }
 
-            var chars = new char[source.Length];
-            source.CopyTo(0, chars, 0, source.Length);
-
-            var reader = new SeekableTextReader(chars, source.FileName);
-
-            var context = new ParserContext(reader, Options);
-
+            var context = new ParserContext(source, Options);
             var codeParser = new CSharpCodeParser(Options.Directives, context);
             var markupParser = new HtmlMarkupParser(context);
 

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorSourceLineCollection.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorSourceLineCollection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language.Legacy;
-
 namespace Microsoft.AspNetCore.Razor.Language
 {
     public abstract class RazorSourceLineCollection


### PR DESCRIPTION
- This moves ParserContext closer to operating on a RazorSourceDocument and exposes it at the parsing layer.
- Was not able to replace the `ITextDocument` property on `ParserContext` due to its current wiring. Our tokenizers rely on a single reader that iterates over the document and take turns tokenizing characters from that reader. The reader that the tokenizers pull from is also highly coupled with the parsers implementations; they end up moving the readers pointer frequently.

I recommend looking over this pr with `?w=1`.