### PR TITLE
Fix unexpected indentation when autoformatting in VS

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -1674,7 +1674,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             CurrentSymbol.Content.Length);
                     }
 
-                    Output(SpanKind.Markup, AcceptedCharacters.WhiteSpace);
+                    Output(SpanKind.MetaCode, AcceptedCharacters.WhiteSpace);
                     break;
                 case DirectiveKind.RazorBlock:
                     AcceptWhile(IsSpacingToken(includeNewLines: true, includeComments: true));

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
@@ -420,8 +420,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.Span(SpanKind.Code, "       ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
                     Factory.Span(SpanKind.Code, "Some_Member", markup: false).AsDirectiveToken(descriptor.Tokens[1]),
 
-                    Factory.Span(SpanKind.Markup, "    ", markup: false)
-                        .Accepts(AcceptedCharacters.WhiteSpace)));
+                    Factory.MetaCode("    ").Accepts(AcceptedCharacters.WhiteSpace)));
         }
 
         [Fact]
@@ -469,7 +468,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.MetaCode("custom").Accepts(AcceptedCharacters.None),
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
                     Factory.Span(SpanKind.Code, "\"hello\"", markup: false).AsDirectiveToken(descriptor.Tokens[0]),
-                    Factory.Span(SpanKind.Markup, " ;  ", markup: false).Accepts(AcceptedCharacters.WhiteSpace)));
+                    Factory.MetaCode(" ;  ").Accepts(AcceptedCharacters.WhiteSpace)));
         }
 
         [Fact]
@@ -497,7 +496,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace),
                     Factory.Span(SpanKind.Code, "\"hello\"", markup: false).AsDirectiveToken(descriptor.Tokens[0]),
 
-                    Factory.Span(SpanKind.Markup, " ", markup: false).Accepts(AcceptedCharacters.WhiteSpace)),
+                    Factory.MetaCode(" ").Accepts(AcceptedCharacters.WhiteSpace)),
                 expectedErorr);
         }
 


### PR DESCRIPTION
Issue - #1394 

@NTaylorMullen @rynowak @anurse 

We were incorrectly outputting the whitespace and newline at the end of a single line directive as markup which caused VS to indent everything below the directive. We should instead output it as MetaCode.