### PR TITLE
Fix #1399 Exception in Tag Helper discovery

### DIFF
--- a/test/Microsoft.CodeAnalysis.Razor.Test/ViewComponentTagHelperDescriptorFactoryTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Test/ViewComponentTagHelperDescriptorFactoryTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Xunit;
 
@@ -124,6 +125,134 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
             // Assert
             Assert.Equal(expectedDescriptor, descriptor, TagHelperDescriptorComparer.CaseSensitive);
         }
+
+        [Fact]
+        public void CreateDescriptor_ForViewComponentWithNoInvokeMethod()
+        {
+            // Arrange
+            var testCompilation = TestCompilation.Create();
+            var factory = new ViewComponentTagHelperDescriptorFactory(testCompilation);
+
+            var viewComponent = testCompilation.GetTypeByMetadataName(typeof(ViewComponentWithoutInvokeMethod).FullName);
+
+            // Act
+            var descriptor = factory.CreateDescriptor(viewComponent);
+
+            // Assert
+            Assert.Empty(descriptor.BoundAttributes);
+        }
+
+        [Fact]
+        public void CreateDescriptor_ForViewComponentWithInvokeAsync_UnderstandsGenericTask()
+        {
+            // Arrange
+            var testCompilation = TestCompilation.Create();
+            var factory = new ViewComponentTagHelperDescriptorFactory(testCompilation);
+
+            var viewComponent = testCompilation.GetTypeByMetadataName(typeof(AsyncViewComponentWithGenericTask).FullName);
+
+            // Act
+            var descriptor = factory.CreateDescriptor(viewComponent);
+
+            // Assert
+            Assert.Empty(descriptor.GetAllDiagnostics());
+        }
+
+        [Fact]
+        public void CreateDescriptor_ForViewComponentWithInvokeAsync_UnderstandsNonGenericTask()
+        {
+            // Arrange
+            var testCompilation = TestCompilation.Create();
+            var factory = new ViewComponentTagHelperDescriptorFactory(testCompilation);
+
+            var viewComponent = testCompilation.GetTypeByMetadataName(typeof(AsyncViewComponentWithNonGenericTask).FullName);
+
+            // Act
+            var descriptor = factory.CreateDescriptor(viewComponent);
+
+            // Assert
+            Assert.Empty(descriptor.GetAllDiagnostics());
+        }
+
+        [Fact]
+        public void CreateDescriptor_ForViewComponentWithInvokeAsync_DoesNotUnderstandVoid()
+        {
+            // Arrange
+            var testCompilation = TestCompilation.Create();
+            var factory = new ViewComponentTagHelperDescriptorFactory(testCompilation);
+
+            var viewComponent = testCompilation.GetTypeByMetadataName(typeof(AsyncViewComponentWithString).FullName);
+
+            // Act
+            var descriptor = factory.CreateDescriptor(viewComponent);
+
+            // Assert
+            Assert.Empty(descriptor.BoundAttributes);
+        }
+
+        [Fact]
+        public void CreateDescriptor_ForViewComponentWithInvokeAsync_DoesNotUnderstandString()
+        {
+            // Arrange
+            var testCompilation = TestCompilation.Create();
+            var factory = new ViewComponentTagHelperDescriptorFactory(testCompilation);
+
+            var viewComponent = testCompilation.GetTypeByMetadataName(typeof(AsyncViewComponentWithString).FullName);
+
+            // Act
+            var descriptor = factory.CreateDescriptor(viewComponent);
+
+            // Assert
+            Assert.Empty(descriptor.BoundAttributes);
+        }
+
+        [Fact]
+        public void CreateDescriptor_ForViewComponentWithInvoke_DoesNotUnderstandVoid()
+        {
+            // Arrange
+            var testCompilation = TestCompilation.Create();
+            var factory = new ViewComponentTagHelperDescriptorFactory(testCompilation);
+
+            var viewComponent = testCompilation.GetTypeByMetadataName(typeof(SyncViewComponentWithVoid).FullName);
+
+            // Act
+            var descriptor = factory.CreateDescriptor(viewComponent);
+
+            // Assert
+            Assert.Empty(descriptor.BoundAttributes);
+        }
+
+        [Fact]
+        public void CreateDescriptor_ForViewComponentWithInvoke_DoesNotUnderstandNonGenericTask()
+        {
+            // Arrange
+            var testCompilation = TestCompilation.Create();
+            var factory = new ViewComponentTagHelperDescriptorFactory(testCompilation);
+
+            var viewComponent = testCompilation.GetTypeByMetadataName(typeof(SyncViewComponentWithNonGenericTask).FullName);
+
+            // Act
+            var descriptor = factory.CreateDescriptor(viewComponent);
+
+            // Assert
+            Assert.Empty(descriptor.BoundAttributes);
+        }
+
+        [Fact]
+        public void CreateDescriptor_ForViewComponentWithInvoke_DoesNotUnderstandGenericTask()
+        {
+            // Arrange
+            var testCompilation = TestCompilation.Create();
+            var factory = new ViewComponentTagHelperDescriptorFactory(testCompilation);
+
+            var viewComponent = testCompilation.GetTypeByMetadataName(typeof(SyncViewComponentWithGenericTask).FullName);
+
+            // Act
+            var descriptor = factory.CreateDescriptor(viewComponent);
+
+            // Assert
+            Assert.Empty(descriptor.BoundAttributes);
+        }
     }
 
     public class StringParameterViewComponent
@@ -146,5 +275,44 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces
     public class GenericParameterViewComponent
     {
         public string Invoke(List<string> Foo, Dictionary<string, int> Bar) => null;
+    }
+
+    public class ViewComponentWithoutInvokeMethod
+    {
+    }
+
+    public class AsyncViewComponentWithGenericTask
+    {
+        public Task<string> InvokeAsync() => null;
+    }
+
+    public class AsyncViewComponentWithNonGenericTask
+    {
+        public Task InvokeAsync() => null;
+    }
+
+    public class AsyncViewComponentWithVoid
+    {
+        public void InvokeAsync() { }
+    }
+
+    public class AsyncViewComponentWithString
+    {
+        public string InvokeAsync() => null;
+    }
+
+    public class SyncViewComponentWithVoid
+    {
+        public void Invoke() { }
+    }
+
+    public class SyncViewComponentWithNonGenericTask
+    {
+        public Task Invoke() => null;
+    }
+
+    public class SyncViewComponentWithGenericTask
+    {
+        public Task<string> Invoke() => null;
     }
 }


### PR DESCRIPTION
This change fixes #1399 by porting logic for VCTH validation from the
dev branch, and bailing out of parameter discovery rather than throwing
an exception.

Ported unit tests from dev and verified manually that this fixes the
issue with ViewComponents that return Task<T>.