### PR TITLE
Remove Roslyn from NuGet.config.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
     <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -12,7 +12,7 @@
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
     <RoslynVersion>2.0.0</RoslynVersion>
     <RoslynDevVersion>2.3.0-beta1-61624-03</RoslynDevVersion>
-    <StreamJsonRpcVersion>1.0.2-rc</StreamJsonRpcVersion>
+    <StreamJsonRpcVersion>1.0.36</StreamJsonRpcVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <VsShellVersion>15.0.26201</VsShellVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>


### PR DESCRIPTION
Update StreamRpcJson to 1.0.36. This package has an assembly version that matches the version shipped in VS 2017 RTM.