### PR TITLE
Implement consistent error story for directives.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultDirectiveSyntaxTreePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultDirectiveSyntaxTreePass.cs
@@ -24,18 +24,8 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(syntaxTree));
             }
 
-            var errorSink = new ErrorSink();
             var sectionVerifier = new NestedSectionVerifier();
-            sectionVerifier.Verify(syntaxTree, errorSink);
-
-            if (errorSink.Errors.Count > 0)
-            {
-                // Temporary code while we're still using legacy diagnostics in the SyntaxTree.
-                var errors = errorSink.Errors.Select(error => RazorDiagnostic.Create(error));
-
-                var combinedErrors = syntaxTree.Diagnostics.Concat(errors);
-                syntaxTree = RazorSyntaxTree.Create(syntaxTree.Root, syntaxTree.Source, combinedErrors, syntaxTree.Options);
-            }
+            sectionVerifier.Verify(syntaxTree);
 
             return syntaxTree;
         }
@@ -43,11 +33,9 @@ namespace Microsoft.AspNetCore.Razor.Language
         private class NestedSectionVerifier : ParserVisitor
         {
             private int _nestedLevel;
-            private ErrorSink _errorSink;
 
-            public void Verify(RazorSyntaxTree tree, ErrorSink errorSink)
+            public void Verify(RazorSyntaxTree tree)
             {
-                _errorSink = errorSink;
                 tree.Root.Accept(this);
             }
 
@@ -57,10 +45,12 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     var directiveStart = block.Children.First(child => !child.IsBlock && ((Span)child).Kind == SpanKindInternal.Transition).Start;
                     var errorLength = /* @ */ 1 + SectionDirective.Directive.Directive.Length;
-                    _errorSink.OnError(
-                        directiveStart,
-                        LegacyResources.FormatParseError_Sections_Cannot_Be_Nested(LegacyResources.SectionExample_CS),
-                        errorLength);
+                    var error = RazorDiagnostic.Create(
+                        new RazorError(
+                            LegacyResources.FormatParseError_Sections_Cannot_Be_Nested(LegacyResources.SectionExample_CS),
+                            directiveStart,
+                            errorLength));
+                    chunkGenerator.Diagnostics.Add(error);
                 }
 
                 _nestedLevel++;

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIRLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIRLoweringPhase.cs
@@ -131,12 +131,32 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             public override void VisitAddTagHelperSpan(AddTagHelperChunkGenerator chunkGenerator, Span span)
             {
-                _builder.Push(new DirectiveIRNode()
+                RazorIRNode directiveNode;
+                if (IsMalformed(chunkGenerator.Diagnostics))
                 {
-                    Name = CSharpCodeParser.AddTagHelperDirectiveDescriptor.Directive,
-                    Descriptor = CSharpCodeParser.AddTagHelperDirectiveDescriptor,
-                    Source = BuildSourceSpanFromNode(span),
-                });
+                    directiveNode = new MalformedDirectiveIRNode()
+                    {
+                        Name = CSharpCodeParser.AddTagHelperDirectiveDescriptor.Directive,
+                        Descriptor = CSharpCodeParser.AddTagHelperDirectiveDescriptor,
+                        Source = BuildSourceSpanFromNode(span),
+                    };
+                }
+                else
+                {
+                    directiveNode = new DirectiveIRNode()
+                    {
+                        Name = CSharpCodeParser.AddTagHelperDirectiveDescriptor.Directive,
+                        Descriptor = CSharpCodeParser.AddTagHelperDirectiveDescriptor,
+                        Source = BuildSourceSpanFromNode(span),
+                    };
+                }
+
+                for (var i = 0; i < chunkGenerator.Diagnostics.Count; i++)
+                {
+                    directiveNode.Diagnostics.Add(chunkGenerator.Diagnostics[i]);
+                }
+
+                _builder.Push(directiveNode);
 
                 _builder.Add(new DirectiveTokenIRNode()
                 {
@@ -150,12 +170,32 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             public override void VisitRemoveTagHelperSpan(RemoveTagHelperChunkGenerator chunkGenerator, Span span)
             {
-                _builder.Push(new DirectiveIRNode()
+                RazorIRNode directiveNode;
+                if (IsMalformed(chunkGenerator.Diagnostics))
                 {
-                    Name = CSharpCodeParser.RemoveTagHelperDirectiveDescriptor.Directive,
-                    Descriptor = CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
-                    Source = BuildSourceSpanFromNode(span),
-                });
+                    directiveNode = new MalformedDirectiveIRNode()
+                    {
+                        Name = CSharpCodeParser.RemoveTagHelperDirectiveDescriptor.Directive,
+                        Descriptor = CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
+                        Source = BuildSourceSpanFromNode(span),
+                    };
+                }
+                else
+                {
+                    directiveNode = new DirectiveIRNode()
+                    {
+                        Name = CSharpCodeParser.RemoveTagHelperDirectiveDescriptor.Directive,
+                        Descriptor = CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
+                        Source = BuildSourceSpanFromNode(span),
+                    };
+                }
+
+                for (var i = 0; i < chunkGenerator.Diagnostics.Count; i++)
+                {
+                    directiveNode.Diagnostics.Add(chunkGenerator.Diagnostics[i]);
+                }
+
+                _builder.Push(directiveNode);
 
                 _builder.Add(new DirectiveTokenIRNode()
                 {
@@ -169,12 +209,32 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             public override void VisitTagHelperPrefixDirectiveSpan(TagHelperPrefixDirectiveChunkGenerator chunkGenerator, Span span)
             {
-                _builder.Push(new DirectiveIRNode()
+                RazorIRNode directiveNode;
+                if (IsMalformed(chunkGenerator.Diagnostics))
                 {
-                    Name = CSharpCodeParser.TagHelperPrefixDirectiveDescriptor.Directive,
-                    Descriptor = CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
-                    Source = BuildSourceSpanFromNode(span),
-                });
+                    directiveNode = new MalformedDirectiveIRNode()
+                    {
+                        Name = CSharpCodeParser.TagHelperPrefixDirectiveDescriptor.Directive,
+                        Descriptor = CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
+                        Source = BuildSourceSpanFromNode(span),
+                    };
+                }
+                else
+                {
+                    directiveNode = new DirectiveIRNode()
+                    {
+                        Name = CSharpCodeParser.TagHelperPrefixDirectiveDescriptor.Directive,
+                        Descriptor = CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
+                        Source = BuildSourceSpanFromNode(span),
+                    };
+                }
+
+                for (var i = 0; i < chunkGenerator.Diagnostics.Count; i++)
+                {
+                    directiveNode.Diagnostics.Add(chunkGenerator.Diagnostics[i]);
+                }
+
+                _builder.Push(directiveNode);
 
                 _builder.Add(new DirectiveTokenIRNode()
                 {
@@ -235,12 +295,32 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     _insideLineDirective = true;
 
-                    _builder.Push(new DirectiveIRNode()
+                    RazorIRNode directiveNode;
+                    if (IsMalformed(chunkGenerator.Diagnostics))
                     {
-                        Name = chunkGenerator.Descriptor.Directive,
-                        Descriptor = chunkGenerator.Descriptor,
-                        Source = BuildSourceSpanFromNode(block),
-                    });
+                        directiveNode = new MalformedDirectiveIRNode()
+                        {
+                            Name = chunkGenerator.Descriptor.Directive,
+                            Descriptor = chunkGenerator.Descriptor,
+                            Source = BuildSourceSpanFromNode(block),
+                        };
+                    }
+                    else
+                    {
+                        directiveNode = new DirectiveIRNode()
+                        {
+                            Name = chunkGenerator.Descriptor.Directive,
+                            Descriptor = chunkGenerator.Descriptor,
+                            Source = BuildSourceSpanFromNode(block),
+                        };
+                    }
+
+                    for (var i = 0; i < chunkGenerator.Diagnostics.Count; i++)
+                    {
+                        directiveNode.Diagnostics.Add(chunkGenerator.Diagnostics[i]);
+                    }
+
+                    _builder.Push(directiveNode);
 
                     base.VisitDirectiveBlock(chunkGenerator, block);
 
@@ -274,12 +354,32 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             public override void VisitDirectiveBlock(DirectiveChunkGenerator chunkGenerator, Block block)
             {
-                _builder.Push(new DirectiveIRNode()
+                RazorIRNode directiveNode;
+                if (IsMalformed(chunkGenerator.Diagnostics))
                 {
-                    Name = chunkGenerator.Descriptor.Directive,
-                    Descriptor = chunkGenerator.Descriptor,
-                    Source = BuildSourceSpanFromNode(block),
-                });
+                    directiveNode = new MalformedDirectiveIRNode()
+                    {
+                        Name = chunkGenerator.Descriptor.Directive,
+                        Descriptor = chunkGenerator.Descriptor,
+                        Source = BuildSourceSpanFromNode(block),
+                    };
+                }
+                else
+                {
+                    directiveNode = new DirectiveIRNode()
+                    {
+                        Name = chunkGenerator.Descriptor.Directive,
+                        Descriptor = chunkGenerator.Descriptor,
+                        Source = BuildSourceSpanFromNode(block),
+                    };
+                }
+
+                for (var i = 0; i < chunkGenerator.Diagnostics.Count; i++)
+                {
+                    directiveNode.Diagnostics.Add(chunkGenerator.Diagnostics[i]);
+                }
+
+                _builder.Push(directiveNode);
 
                 VisitDefault(block);
 
@@ -675,5 +775,8 @@ namespace Microsoft.AspNetCore.Razor.Language
                 }
             }
         }
+
+        private static bool IsMalformed(List<RazorDiagnostic> diagnostics)
+            => diagnostics.Count > 0 && diagnostics.Any(diagnostic => diagnostic.Severity == RazorDiagnosticSeverity.Error);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/DirectiveRemovalIROptimizationPass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DirectiveRemovalIROptimizationPass.cs
@@ -15,19 +15,19 @@ namespace Microsoft.AspNetCore.Razor.Language
             var visitor = new Visitor();
             visitor.VisitDocument(irDocument);
 
-            foreach (var (node, parent) in visitor.DirectiveNodes)
+            foreach (var nodeReference in visitor.DirectiveNodes)
             {
-                parent.Children.Remove(node);
+                nodeReference.Remove();
             }
         }
 
         private class Visitor : RazorIRNodeWalker
         {
-            public IList<(DirectiveIRNode node, RazorIRNode parent)> DirectiveNodes { get; } = new List<(DirectiveIRNode node, RazorIRNode parent)>();
+            public IList<RazorIRNodeReference> DirectiveNodes { get; } = new List<RazorIRNodeReference>();
 
             public override void VisitDirective(DirectiveIRNode node)
             {
-                DirectiveNodes.Add((node, Parent));
+                DirectiveNodes.Add(new RazorIRNodeReference(Parent, node));
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/MalformedDirectiveIRNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/MalformedDirectiveIRNode.cs
@@ -1,0 +1,45 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+{
+    public sealed class MalformedDirectiveIRNode : RazorIRNode
+    {
+        private RazorDiagnosticCollection _diagnostics;
+
+        public override ItemCollection Annotations { get; }
+
+        public override RazorDiagnosticCollection Diagnostics
+        {
+            get
+            {
+                if (_diagnostics == null)
+                {
+                    _diagnostics = new DefaultDiagnosticCollection();
+                }
+
+                return _diagnostics;
+            }
+        }
+
+        public override RazorIRNodeCollection Children { get; } = new DefaultIRNodeCollection();
+
+        public override SourceSpan? Source { get; set; }
+
+        public override bool HasDiagnostics => _diagnostics != null && _diagnostics.Count > 0;
+
+        public string Name { get; set; }
+
+        public IEnumerable<DirectiveTokenIRNode> Tokens => Children.OfType<DirectiveTokenIRNode>();
+
+        public DirectiveDescriptor Descriptor { get; set; }
+
+        public override void Accept(RazorIRNodeVisitor visitor)
+        {
+            visitor.VisitMalformedDirective(this);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/RazorIRNodeVisitor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/RazorIRNodeVisitor.cs
@@ -29,6 +29,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
             VisitDefault(node);
         }
 
+        public virtual void VisitMalformedDirective(MalformedDirectiveIRNode node)
+        {
+            VisitDefault(node);
+        }
+
         public virtual void VisitExtension(ExtensionIRNode node)
         {
             VisitDefault(node);

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/AddTagHelperChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/AddTagHelperChunkGenerator.cs
@@ -2,18 +2,23 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     internal class AddTagHelperChunkGenerator : SpanChunkGenerator
     {
-        public AddTagHelperChunkGenerator(string lookupText)
+        public AddTagHelperChunkGenerator(string lookupText, List<RazorDiagnostic> diagnostics)
         {
             LookupText = lookupText;
+            Diagnostics = diagnostics;
         }
 
         public string LookupText { get; }
+
+        public List<RazorDiagnostic> Diagnostics { get; }
 
         public override void Accept(ParserVisitor visitor, Span span)
         {
@@ -25,6 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             var other = obj as AddTagHelperChunkGenerator;
             return base.Equals(other) &&
+                Enumerable.SequenceEqual(Diagnostics, other.Diagnostics) &&
                 string.Equals(LookupText, other.LookupText, StringComparison.Ordinal);
         }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/DirectiveChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/DirectiveChunkGenerator.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
@@ -9,6 +12,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
     internal class DirectiveChunkGenerator : ParentChunkGenerator
     {
         private static readonly Type Type = typeof(DirectiveChunkGenerator);
+        private List<RazorDiagnostic> _diagnostics;
 
         public DirectiveChunkGenerator(DirectiveDescriptor descriptor)
         {
@@ -16,6 +20,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         public DirectiveDescriptor Descriptor { get; }
+
+        public List<RazorDiagnostic> Diagnostics
+        {
+            get
+            {
+                if (_diagnostics == null)
+                {
+                    _diagnostics = new List<RazorDiagnostic>();
+                }
+
+                return _diagnostics;
+            }
+        }
 
         public override void Accept(ParserVisitor visitor, Block block)
         {
@@ -26,6 +43,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             var other = obj as DirectiveChunkGenerator;
             return base.Equals(other) &&
+                Enumerable.SequenceEqual(Diagnostics, other.Diagnostics) &&
                 DirectiveDescriptorComparer.Default.Equals(Descriptor, other.Descriptor);
         }
 
@@ -36,6 +54,25 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             combiner.Add(Type);
 
             return combiner.CombinedHash;
+        }
+
+        public override string ToString()
+        {
+            // This is used primarily at test time to show an identifiable representation of the chunk generator.
+
+            var builder = new StringBuilder("Directive {");
+            builder.Append(Descriptor.Directive);
+            builder.Append("}");
+
+            if (Diagnostics.Count > 0)
+            {
+                builder.Append(" [");
+                var ids = string.Join(", ", Diagnostics.Select(diagnostic => diagnostic.Id));
+                builder.Append(ids);
+                builder.Append("]");
+            }
+
+            return builder.ToString();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public SyntaxTreeBuilder Builder { get; }
 
-        public ErrorSink ErrorSink { get; }
+        public ErrorSink ErrorSink { get; set; }
 
         public ITextDocument Source { get; }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/RemoveTagHelperChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/RemoveTagHelperChunkGenerator.cs
@@ -2,18 +2,23 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     internal class RemoveTagHelperChunkGenerator : SpanChunkGenerator
     {
-        public RemoveTagHelperChunkGenerator(string lookupText)
+        public RemoveTagHelperChunkGenerator(string lookupText, List<RazorDiagnostic> diagnostics)
         {
             LookupText = lookupText;
+            Diagnostics = diagnostics;
         }
 
         public string LookupText { get; }
+
+        public List<RazorDiagnostic> Diagnostics { get; }
 
         public override void Accept(ParserVisitor visitor, Span span)
         {
@@ -25,6 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             var other = obj as RemoveTagHelperChunkGenerator;
             return base.Equals(other) &&
+                Enumerable.SequenceEqual(Diagnostics, other.Diagnostics) &&
                 string.Equals(LookupText, other.LookupText, StringComparison.Ordinal);
         }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperDirectiveDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperDirectiveDescriptor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
@@ -41,5 +42,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         /// The <see cref="TagHelperDirectiveType"/> of this directive.
         /// </summary>
         public TagHelperDirectiveType DirectiveType { get; set; }
+
+        public List<RazorDiagnostic> Diagnostics { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperPrefixDirectiveChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperPrefixDirectiveChunkGenerator.cs
@@ -2,18 +2,23 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     internal class TagHelperPrefixDirectiveChunkGenerator : SpanChunkGenerator
     {
-        public TagHelperPrefixDirectiveChunkGenerator(string prefix)
+        public TagHelperPrefixDirectiveChunkGenerator(string prefix, List<RazorDiagnostic> diagnostics)
         {
             Prefix = prefix;
+            Diagnostics = diagnostics;
         }
 
         public string Prefix { get; }
+
+        public List<RazorDiagnostic> Diagnostics { get; }
 
         public override void Accept(ParserVisitor visitor, Span span)
         {
@@ -25,6 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             var other = obj as TagHelperPrefixDirectiveChunkGenerator;
             return base.Equals(other) &&
+                Enumerable.SequenceEqual(Diagnostics, other.Diagnostics) &&
                 string.Equals(Prefix, other.Prefix, StringComparison.Ordinal);
         }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -445,6 +445,20 @@ namespace Microsoft.AspNetCore.Razor.Language
             => string.Format(CultureInfo.CurrentCulture, GetString("DirectiveMustAppearAtStartOfLine"), p0);
 
         /// <summary>
+        /// The '{0}' directives value(s) must be separated by whitespace.
+        /// </summary>
+        internal static string DirectiveTokensMustBeSeparatedByWhitespace
+        {
+            get => GetString("DirectiveTokensMustBeSeparatedByWhitespace");
+        }
+
+        /// <summary>
+        /// The '{0}' directives value(s) must be separated by whitespace.
+        /// </summary>
+        internal static string FormatDirectiveTokensMustBeSeparatedByWhitespace(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("DirectiveTokensMustBeSeparatedByWhitespace"), p0);
+
+        /// <summary>
         /// The key must not be null.
         /// </summary>
         internal static string KeyMustNotBeNull

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -210,6 +210,9 @@
   <data name="DirectiveMustAppearAtStartOfLine" xml:space="preserve">
     <value>The '{0}` directive must appear at the start of the line.</value>
   </data>
+  <data name="DirectiveTokensMustBeSeparatedByWhitespace" xml:space="preserve">
+    <value>The '{0}' directives value(s) must be separated by whitespace.</value>
+  </data>
   <data name="KeyMustNotBeNull" xml:space="preserve">
     <value>The key must not be null.</value>
   </data>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -28,10 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.IntegrationTests
         public void InvalidNamespaceAtEOF_Runtime()
         {
             var references = CreateCompilationReferences(CurrentMvcShim);
-            RunRuntimeTest(references, expectedErrors: new[]
-            {
-                "Identifier expected"
-            });
+            RunRuntimeTest(references);
         }
 
         [Fact]
@@ -44,10 +41,7 @@ public class MyService<TModel>
 }";
             var compilationReferences = CreateCompilationReferences(CurrentMvcShim, appCode);
 
-            RunRuntimeTest(compilationReferences, expectedErrors: new[]
-            {
-                "Identifier expected"
-            });
+            RunRuntimeTest(compilationReferences);
         }
 
         [Fact]
@@ -267,7 +261,7 @@ public class AllTagHelper : {typeof(TagHelper).FullName}
         public void InvalidNamespaceAtEOF_DesignTime()
         {
             var references = CreateCompilationReferences(CurrentMvcShim);
-            RunDesignTimeTest(references, expectedErrors: new[] { "Identifier expected" });
+            RunDesignTimeTest(references);
         }
 
         [Fact]
@@ -281,12 +275,7 @@ public class MyService<TModel>
 ";
 
             var references = CreateCompilationReferences(CurrentMvcShim, appCode);
-            RunDesignTimeTest(
-                references,
-                expectedErrors: new[]
-                {
-                    "Identifier expected"
-                });
+            RunDesignTimeTest(references);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/PageDirectiveTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/PageDirectiveTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Xunit;
@@ -9,24 +10,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 {
     public class PageDirectiveTest
     {
-        [Fact]
-        public void TryGetPageDirective_CanHandleMalformedPageDirectives()
-        {
-            // Arrange
-            var content = "@page \"";
-            var sourceDocument = RazorSourceDocument.Create(content, "file");
-            var codeDocument = RazorCodeDocument.Create(sourceDocument);
-            var engine = CreateEngine();
-            var irDocument = CreateIRDocument(engine, codeDocument);
-
-            // Act
-            var result = PageDirective.TryGetPageDirective(irDocument, out var pageDirective);
-
-            // Assert
-            Assert.True(result);
-            Assert.Null(pageDirective.RouteTemplate);
-        }
-
         [Fact]
         public void TryGetPageDirective_ReturnsFalse_IfPageDoesNotHaveDirective()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -1,4 +1,5 @@
-namespace 
+[assembly:global::Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.RazorPageAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml), null)]
+namespace AspNetCore
 {
     #line hidden
     using TModel = global::System.Object;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -1,5 +1,7 @@
 Document - 
-    NamespaceDeclaration -  - 
+    CSharpCode - 
+        RazorIRToken -  - CSharp - [assembly:global::Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.RazorPageAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml), null)]
+    NamespaceDeclaration -  - AspNetCore
         UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement - (16:1,1 [32] ) - System.Collections.Generic
@@ -29,20 +31,29 @@ Document -
             MethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml)
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     RazorIRToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
+                MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml)
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (121:7,0 [7] IncompleteDirectives.cshtml)
                 HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml)
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (141:10,0 [8] IncompleteDirectives.cshtml)
                 HtmlContent - (149:10,8 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (149:10,8 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (151:11,0 [25] IncompleteDirectives.cshtml)
+                    DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
                 HtmlContent - (176:11,25 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (176:11,25 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml)
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (190:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (192:14,0 [11] IncompleteDirectives.cshtml)
                 HtmlContent - (203:14,11 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (203:14,11 [2] IncompleteDirectives.cshtml) - Html - \n
             InjectDirective - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (159:11,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (616:16,0 [17] )
+Generated Location: (833:17,0 [17] )
 |MyService<TModel>|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
@@ -1,5 +1,6 @@
 #pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "fec5cf763044f842fa2114e997bb07e0bf280cd6"
-namespace 
+[assembly:global::Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.RazorPageAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml), null)]
+namespace AspNetCore
 {
     #line hidden
     using System;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -1,5 +1,7 @@
 Document - 
-    NamespaceDeclaration -  - 
+    CSharpCode - 
+        RazorIRToken -  - CSharp - [assembly:global::Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.RazorPageAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_IncompleteDirectives_cshtml), null)]
+    NamespaceDeclaration -  - AspNetCore
         UsingStatement - (1:0,1 [14] ) - System
         UsingStatement - (16:1,1 [34] ) - System.Collections.Generic
         UsingStatement - (51:2,1 [19] ) - System.Linq
@@ -15,48 +17,57 @@ Document -
                     RazorIRToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 CSharpCode - 
                     RazorIRToken -  - CSharp - EndContext();
+                MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml)
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(108, 5, true);
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     RazorIRToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
                 CSharpCode - 
                     RazorIRToken -  - CSharp - EndContext();
+                MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml)
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(119, 2, true);
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
                 CSharpCode - 
                     RazorIRToken -  - CSharp - EndContext();
+                MalformedDirective - (121:7,0 [7] IncompleteDirectives.cshtml)
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(128, 4, true);
                 HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 CSharpCode - 
                     RazorIRToken -  - CSharp - EndContext();
+                MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml)
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(139, 2, true);
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
                 CSharpCode - 
                     RazorIRToken -  - CSharp - EndContext();
+                MalformedDirective - (141:10,0 [8] IncompleteDirectives.cshtml)
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(149, 2, true);
                 HtmlContent - (149:10,8 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (149:10,8 [2] IncompleteDirectives.cshtml) - Html - \n
                 CSharpCode - 
                     RazorIRToken -  - CSharp - EndContext();
+                MalformedDirective - (151:11,0 [25] IncompleteDirectives.cshtml)
+                    DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(176, 4, true);
                 HtmlContent - (176:11,25 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (176:11,25 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 CSharpCode - 
                     RazorIRToken -  - CSharp - EndContext();
+                MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml)
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(190, 2, true);
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (190:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
                 CSharpCode - 
                     RazorIRToken -  - CSharp - EndContext();
+                MalformedDirective - (192:14,0 [11] IncompleteDirectives.cshtml)
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(203, 2, true);
                 HtmlContent - (203:14,11 [2] IncompleteDirectives.cshtml)

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_DesignTime.codegen.cs
@@ -1,4 +1,5 @@
-namespace 
+[assembly:global::Microsoft.AspNetCore.Mvc.Razor.Compilation.RazorViewAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InvalidNamespaceAtEOF_cshtml))]
+namespace AspNetCore
 {
     #line hidden
     using TModel = global::System.Object;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_DesignTime.ir.txt
@@ -1,5 +1,7 @@
 Document - 
-    NamespaceDeclaration -  - 
+    CSharpCode - 
+        RazorIRToken -  - CSharp - [assembly:global::Microsoft.AspNetCore.Mvc.Razor.Compilation.RazorViewAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InvalidNamespaceAtEOF_cshtml))]
+    NamespaceDeclaration -  - AspNetCore
         UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
         UsingStatement - (16:1,1 [32] ) - System.Collections.Generic
@@ -26,6 +28,7 @@ Document -
             CSharpCode - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             MethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
+                MalformedDirective - (0:0,0 [11] InvalidNamespaceAtEOF.cshtml)
                 HtmlContent - (11:0,11 [5] InvalidNamespaceAtEOF.cshtml)
                     RazorIRToken - (11:0,11 [5] InvalidNamespaceAtEOF.cshtml) - Html - Test.
             InjectDirective - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_Runtime.codegen.cs
@@ -1,5 +1,6 @@
 #pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "de132bd3e2a46a0d2ec953a168427c01e5829cde"
-namespace 
+[assembly:global::Microsoft.AspNetCore.Mvc.Razor.Compilation.RazorViewAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InvalidNamespaceAtEOF_cshtml))]
+namespace AspNetCore
 {
     #line hidden
     using System;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_Runtime.ir.txt
@@ -1,5 +1,7 @@
 Document - 
-    NamespaceDeclaration -  - 
+    CSharpCode - 
+        RazorIRToken -  - CSharp - [assembly:global::Microsoft.AspNetCore.Mvc.Razor.Compilation.RazorViewAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InvalidNamespaceAtEOF_cshtml))]
+    NamespaceDeclaration -  - AspNetCore
         UsingStatement - (1:0,1 [14] ) - System
         UsingStatement - (16:1,1 [34] ) - System.Collections.Generic
         UsingStatement - (51:2,1 [19] ) - System.Linq
@@ -9,6 +11,7 @@ Document -
         UsingStatement - (178:6,1 [45] ) - Microsoft.AspNetCore.Mvc.ViewFeatures
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InvalidNamespaceAtEOF_cshtml - global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic> - 
             MethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
+                MalformedDirective - (0:0,0 [11] InvalidNamespaceAtEOF.cshtml)
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(11, 5, true);
                 HtmlContent - (11:0,11 [5] InvalidNamespaceAtEOF.cshtml)

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.codegen.cs
@@ -1,4 +1,4 @@
-[assembly:global::Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.RazorPageAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml), null)]
+[assembly:global::Microsoft.AspNetCore.Mvc.Razor.Compilation.RazorViewAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml))]
 namespace AspNetCore
 {
     #line hidden
@@ -10,7 +10,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
-    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -31,8 +31,6 @@ namespace AspNetCore
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
         public global::Microsoft.AspNetCore.Mvc.Rendering.IJsonHelper Json { get; private set; }
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
-        public global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml> Html { get; private set; }
-        public global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml> ViewData => (global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml>)PageContext?.ViewData;
-        public TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml Model => ViewData.Model;
+        public global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.ir.txt
@@ -1,6 +1,6 @@
 Document - 
     CSharpCode - 
-        RazorIRToken -  - CSharp - [assembly:global::Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.RazorPageAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml), null)]
+        RazorIRToken -  - CSharp - [assembly:global::Microsoft.AspNetCore.Mvc.Razor.Compilation.RazorViewAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml))]
     NamespaceDeclaration -  - AspNetCore
         UsingStatement -  - TModel = global::System.Object
         UsingStatement - (1:0,1 [12] ) - System
@@ -10,7 +10,7 @@ Document -
         UsingStatement - (102:4,1 [30] ) - Microsoft.AspNetCore.Mvc
         UsingStatement - (135:5,1 [40] ) - Microsoft.AspNetCore.Mvc.Rendering
         UsingStatement - (178:6,1 [43] ) - Microsoft.AspNetCore.Mvc.ViewFeatures
-        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml - global::Microsoft.AspNetCore.Mvc.RazorPages.Page - 
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml - global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic> - 
             DesignTimeDirective - 
                 DirectiveToken - (231:7,8 [62] ) - global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<TModel>
                 DirectiveToken - (294:7,71 [4] ) - Html
@@ -28,6 +28,7 @@ Document -
             CSharpCode - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             MethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
+                MalformedDirective - (0:0,0 [6] MalformedPageDirective.cshtml)
                 HtmlContent - (6:0,6 [49] MalformedPageDirective.cshtml)
                     RazorIRToken - (6:0,6 [8] MalformedPageDirective.cshtml) - Html - "foo\n\n
                     RazorIRToken - (14:2,0 [4] MalformedPageDirective.cshtml) - Html - <h1>
@@ -42,7 +43,3 @@ Document -
             InjectDirective - 
             InjectDirective - 
             InjectDirective - 
-            CSharpCode - 
-                RazorIRToken -  - CSharp - public global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml> ViewData => (global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml>)PageContext?.ViewData;
-            CSharpCode - 
-                RazorIRToken -  - CSharp - public TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml Model => ViewData.Model;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.codegen.cs
@@ -1,5 +1,5 @@
 #pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "5a9ff8440150c6746e4a8ba63bc633ea84930405"
-[assembly:global::Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.RazorPageAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml), null)]
+[assembly:global::Microsoft.AspNetCore.Mvc.Razor.Compilation.RazorViewAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml))]
 namespace AspNetCore
 {
     #line hidden
@@ -10,7 +10,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
-    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml : global::Microsoft.AspNetCore.Mvc.RazorPages.Page
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic>
     {
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
@@ -29,8 +29,6 @@ namespace AspNetCore
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
         public global::Microsoft.AspNetCore.Mvc.Rendering.IJsonHelper Json { get; private set; }
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
-        public global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml> Html { get; private set; }
-        public global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml> ViewData => (global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml>)PageContext?.ViewData;
-        public TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml Model => ViewData.Model;
+        public global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<dynamic> Html { get; private set; }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.ir.txt
@@ -1,6 +1,6 @@
 Document - 
     CSharpCode - 
-        RazorIRToken -  - CSharp - [assembly:global::Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure.RazorPageAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml), null)]
+        RazorIRToken -  - CSharp - [assembly:global::Microsoft.AspNetCore.Mvc.Razor.Compilation.RazorViewAttribute(null, typeof(AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml))]
     NamespaceDeclaration -  - AspNetCore
         UsingStatement - (1:0,1 [14] ) - System
         UsingStatement - (16:1,1 [34] ) - System.Collections.Generic
@@ -9,8 +9,9 @@ Document -
         UsingStatement - (102:4,1 [32] ) - Microsoft.AspNetCore.Mvc
         UsingStatement - (135:5,1 [42] ) - Microsoft.AspNetCore.Mvc.Rendering
         UsingStatement - (178:6,1 [45] ) - Microsoft.AspNetCore.Mvc.ViewFeatures
-        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml - global::Microsoft.AspNetCore.Mvc.RazorPages.Page - 
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml - global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<dynamic> - 
             MethodDeclaration -  - public - async, override - global::System.Threading.Tasks.Task - ExecuteAsync
+                MalformedDirective - (0:0,0 [6] MalformedPageDirective.cshtml)
                 CSharpCode - 
                     RazorIRToken -  - CSharp - BeginContext(6, 49, true);
                 HtmlContent - (6:0,6 [49] MalformedPageDirective.cshtml)
@@ -29,7 +30,3 @@ Document -
             InjectDirective - 
             InjectDirective - 
             InjectDirective - 
-            CSharpCode - 
-                RazorIRToken -  - CSharp - public global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml> ViewData => (global::Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml>)PageContext?.ViewData;
-            CSharpCode - 
-                RazorIRToken -  - CSharp - public TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MalformedPageDirective_cshtml Model => ViewData.Model;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpAutoCompleteTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpAutoCompleteTest.cs
@@ -13,25 +13,42 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         [Fact]
         public void FunctionsDirectiveAutoCompleteAtEOF()
         {
+            // Arrange
+            var chunkGenerator = new DirectiveChunkGenerator(FunctionsDirective.Directive);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF(FunctionsDirective.Directive.Directive, "}", "{"),
+                        new SourceLocation(10, 0, 10),
+                        length: 1)));
+
+            // Act & Assert
             ParseBlockTest(
                 "@functions{",
-                new[] { FunctionsDirective.Directive, },
-                new DirectiveBlock(new DirectiveChunkGenerator(FunctionsDirective.Directive),
+                new[] { FunctionsDirective.Directive },
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("functions").Accepts(AcceptedCharactersInternal.None),
-                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None)),
-                new RazorError(
-                    LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF(FunctionsDirective.Directive.Directive, "}", "{"),
-                    new SourceLocation(10, 0, 10),
-                    length: 1));
+                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None)));
         }
 
         [Fact]
         public void SectionDirectiveAutoCompleteAtEOF()
         {
-            ParseBlockTest("@section Header {",
-                new[] { SectionDirective.Directive, },
-                new DirectiveBlock(new DirectiveChunkGenerator(SectionDirective.Directive),
+            // Arrange
+            var chunkGenerator = new DirectiveChunkGenerator(SectionDirective.Directive);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF("section", "}", "{"),
+                        new SourceLocation(16, 0, 16),
+                        length: 1)));
+
+            // Act & Assert
+            ParseBlockTest(
+                "@section Header {",
+                new[] { SectionDirective.Directive },
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("section").Accepts(AcceptedCharactersInternal.None),
                     Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
@@ -40,55 +57,67 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.Span(SpanKindInternal.Markup, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.AllWhiteSpace),
                     Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None),
                     new MarkupBlock(
-                        Factory.EmptyHtml())),
-                new RazorError(
-                    LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF("section", "}", "{"),
-                    new SourceLocation(16, 0, 16),
-                    length: 1));
+                        Factory.EmptyHtml())));
         }
 
         [Fact]
         public void VerbatimBlockAutoCompleteAtEOF()
         {
             ParseBlockTest("@{",
-                           new StatementBlock(
-                               Factory.CodeTransition(),
-                               Factory.MetaCode("{").Accepts(AcceptedCharactersInternal.None),
-                               Factory.EmptyCSharp()
-                                   .AsStatement()
-                                   .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString) { AutoCompleteString = "}" })
-                               ),
-                           new RazorError(
-                               LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
-                                   LegacyResources.BlockName_Code, "}", "{"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1));
+                new StatementBlock(
+                    Factory.CodeTransition(),
+                    Factory.MetaCode("{").Accepts(AcceptedCharactersInternal.None),
+                    Factory.EmptyCSharp()
+                        .AsStatement()
+                        .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString) { AutoCompleteString = "}" })
+                    ),
+                new RazorError(
+                    LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
+                        LegacyResources.BlockName_Code, "}", "{"),
+                    new SourceLocation(1, 0, 1),
+                    length: 1));
         }
 
         [Fact]
         public void FunctionsDirectiveAutoCompleteAtStartOfFile()
         {
-            ParseBlockTest(
-                "@functions{" + Environment.NewLine + "foo",
-                new[] { FunctionsDirective.Directive, },
-                new DirectiveBlock(new DirectiveChunkGenerator(FunctionsDirective.Directive),
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("functions").Accepts(AcceptedCharactersInternal.None),
-                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None),
-                Factory.Code(Environment.NewLine + "foo").AsStatement()),
+            // Arrange
+            var chunkGenerator = new DirectiveChunkGenerator(FunctionsDirective.Directive);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
                     new RazorError(
                         LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", "}", "{"),
                         new SourceLocation(10, 0, 10),
-                        length: 1));
+                        length: 1)));
+
+            // Act & Assert
+            ParseBlockTest(
+                "@functions{" + Environment.NewLine + "foo",
+                new[] { FunctionsDirective.Directive },
+                new DirectiveBlock(chunkGenerator,
+                    Factory.CodeTransition(),
+                    Factory.MetaCode("functions").Accepts(AcceptedCharactersInternal.None),
+                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None),
+                Factory.Code(Environment.NewLine + "foo").AsStatement()));
         }
 
         [Fact]
         public void SectionDirectiveAutoCompleteAtStartOfFile()
         {
-            ParseBlockTest("@section Header {" + Environment.NewLine
-                         + "<p>Foo</p>",
-                new[] { SectionDirective.Directive, },
-                new DirectiveBlock(new DirectiveChunkGenerator(SectionDirective.Directive),
+            // Arrange
+            var chunkGenerator = new DirectiveChunkGenerator(SectionDirective.Directive);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF("section", "}", "{"),
+                        new SourceLocation(16, 0, 16),
+                        length: 1)));
+
+            // Act & Assert
+            ParseBlockTest(
+                "@section Header {" + Environment.NewLine + "<p>Foo</p>",
+                new[] { SectionDirective.Directive },
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("section").Accepts(AcceptedCharactersInternal.None),
                     Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
@@ -101,37 +130,33 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             Factory.Markup("<p>")),
                         Factory.Markup("Foo"),
                         new MarkupTagBlock(
-                            Factory.Markup("</p>")))),
-                new RazorError(
-                    LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF("section", "}", "{"),
-                    new SourceLocation(16, 0, 16),
-                    length: 1));
+                            Factory.Markup("</p>")))));
         }
 
         [Fact]
         public void VerbatimBlockAutoCompleteAtStartOfFile()
         {
-            ParseBlockTest("@{" + Environment.NewLine
-                         + "<p></p>",
-                           new StatementBlock(
-                               Factory.CodeTransition(),
-                               Factory.MetaCode("{").Accepts(AcceptedCharactersInternal.None),
-                               Factory.Code(Environment.NewLine)
-                                   .AsStatement()
-                                   .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString) { AutoCompleteString = "}" }),
-                               new MarkupBlock(
-                                    new MarkupTagBlock(
-                                        Factory.Markup("<p>").Accepts(AcceptedCharactersInternal.None)),
-                                    new MarkupTagBlock(
-                                        Factory.Markup("</p>").Accepts(AcceptedCharactersInternal.None))),
-                               Factory.Span(SpanKindInternal.Code, new CSharpSymbol(string.Empty, CSharpSymbolType.Unknown))
-                                   .With(new StatementChunkGenerator())
-                               ),
-                           new RazorError(
-                               LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
-                                   LegacyResources.BlockName_Code, "}", "{"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1));
+            ParseBlockTest(
+                "@{" + Environment.NewLine + "<p></p>",
+                new StatementBlock(
+                    Factory.CodeTransition(),
+                    Factory.MetaCode("{").Accepts(AcceptedCharactersInternal.None),
+                    Factory.Code(Environment.NewLine)
+                        .AsStatement()
+                        .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString) { AutoCompleteString = "}" }),
+                    new MarkupBlock(
+                        new MarkupTagBlock(
+                            Factory.Markup("<p>").Accepts(AcceptedCharactersInternal.None)),
+                        new MarkupTagBlock(
+                            Factory.Markup("</p>").Accepts(AcceptedCharactersInternal.None))),
+                    Factory.Span(SpanKindInternal.Code, new CSharpSymbol(string.Empty, CSharpSymbolType.Unknown))
+                        .With(new StatementChunkGenerator())
+                    ),
+                new RazorError(
+                    LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF(
+                        LegacyResources.BlockName_Code, "}", "{"),
+                    new SourceLocation(1, 0, 1),
+                    length: 1));
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
@@ -12,6 +12,32 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
     public class CSharpDirectivesTest : CsHtmlCodeParserTestBase
     {
         [Fact]
+        public void DirectiveDescriptor_TokensMustBeSeparatedBySpace()
+        {
+            // Arrange
+            var descriptor = DirectiveDescriptor.CreateDirective(
+                "custom",
+                DirectiveKind.SingleLine,
+                b => b.AddStringToken().AddStringToken());
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        Resources.FormatDirectiveTokensMustBeSeparatedByWhitespace("custom"),
+                        17, 0, 17, 9)));
+
+            // Act & Assert
+            ParseCodeBlockTest(
+                "@custom \"string1\"\"string2\"",
+                new[] { descriptor },
+                new DirectiveBlock(chunkGenerator,
+                    Factory.CodeTransition(),
+                    Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
+                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
+                    Factory.Span(SpanKindInternal.Code, "\"string1\"", markup: false).AsDirectiveToken(descriptor.Tokens[0])));
+        }
+
+        [Fact]
         public void DirectiveDescriptor_CanHandleEOFIncompleteNamespaceTokens()
         {
             // Arrange
@@ -19,19 +45,21 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddNamespaceToken());
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatDirectiveExpectsNamespace("custom"),
+                        8, 0, 8, 7)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom System.",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
-                new RazorError(
-                    LegacyResources.FormatDirectiveExpectsNamespace("custom"),
-                    8, 0, 8, 7));
+                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
 
         [Fact]
@@ -42,19 +70,21 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddNamespaceToken());
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatDirectiveExpectsNamespace("custom"),
+                        8, 0, 8, 7)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom System<",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
-                new RazorError(
-                    LegacyResources.FormatDirectiveExpectsNamespace("custom"),
-                    8, 0, 8, 7));
+                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
         [Fact]
         public void DirectiveDescriptor_CanHandleIncompleteNamespaceTokens()
@@ -64,19 +94,21 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddNamespaceToken());
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatDirectiveExpectsNamespace("custom"),
+                        8, 0, 8, 7)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom System." + Environment.NewLine,
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
-                new RazorError(
-                    LegacyResources.FormatDirectiveExpectsNamespace("custom"),
-                    8, 0, 8, 7));
+                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
 
         [Fact]
@@ -87,19 +119,21 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddNamespaceToken());
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatDirectiveExpectsNamespace("custom"),
+                        8, 0, 8, 7)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom System<" + Environment.NewLine,
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
-                new RazorError(
-                    LegacyResources.FormatDirectiveExpectsNamespace("custom"),
-                    8, 0, 8, 7));
+                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
         
         [Fact]
@@ -154,13 +188,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                                .Accepts(AcceptedCharactersInternal.None),
                         Factory.Code("\"*, Foo\"")
-                            .AsAddTagHelper("\"*, Foo\"")),
+                            .AsAddTagHelper(
+                                "\"*, Foo\"", 
+                                new RazorError(Resources.FormatDirectiveMustAppearAtStartOfLine("addTagHelper"), new SourceLocation(4, 0, 4), 12))),
                     Factory.Code(Environment.NewLine).AsStatement(),
-                    Factory.MetaCode("}").Accepts(AcceptedCharactersInternal.None)),
-                new RazorError(
-                        Resources.FormatDirectiveMustAppearAtStartOfLine("addTagHelper"),
-                        new SourceLocation(4, 0, 4),
-                        12));
+                    Factory.MetaCode("}").Accepts(AcceptedCharactersInternal.None)));
         }
 
         [Fact]
@@ -171,6 +203,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddTypeToken());
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        Resources.FormatDirectiveMustAppearAtStartOfLine("custom"),
+                        new SourceLocation(4, 0, 4),
+                        6)));
 
             // Act & Assert
             ParseCodeBlockTest(
@@ -181,19 +220,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.Code("  ")
                         .AsStatement()
                         .AutoCompleteWith(autoCompleteString: null, atEndOfSpan: false),
-                    new DirectiveBlock(
-                        new DirectiveChunkGenerator(descriptor),
+                    new DirectiveBlock(chunkGenerator,
                         Factory.CodeTransition(),
                         Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                         Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                         Factory.Span(SpanKindInternal.Code, "System.Text.Encoding.ASCIIEncoding", markup: false).AsDirectiveToken(descriptor.Tokens[0]),
                         Factory.MetaCode(Environment.NewLine).Accepts(AcceptedCharactersInternal.WhiteSpace)),
                     Factory.EmptyCSharp().AsStatement(),
-                    Factory.MetaCode("}").Accepts(AcceptedCharactersInternal.None)),
-                new RazorError(
-                    Resources.FormatDirectiveMustAppearAtStartOfLine("custom"),
-                    new SourceLocation(4, 0, 4),
-                    6));
+                    Factory.MetaCode("}").Accepts(AcceptedCharactersInternal.None)));
         }
 
         [Fact]
@@ -309,21 +343,22 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddStringToken());
-
-            var expectedError = new RazorError(
-                LegacyResources.FormatDirectiveExpectsQuotedStringLiteral("custom"),
-                new SourceLocation(8, 0, 8),
-                length: 7);
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatDirectiveExpectsQuotedStringLiteral("custom"),
+                        new SourceLocation(8, 0, 8),
+                        length: 7)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom AString",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)), expectedError);
+                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
 
         [Fact]
@@ -334,21 +369,22 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddStringToken());
-
-            var expectedError = new RazorError(
-                LegacyResources.FormatDirectiveExpectsQuotedStringLiteral("custom"),
-                new SourceLocation(8, 0, 8),
-                length: 1);
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatDirectiveExpectsQuotedStringLiteral("custom"),
+                        new SourceLocation(8, 0, 8),
+                        length: 1)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom {foo?}",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)), expectedError);
+                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
 
         [Fact]
@@ -359,21 +395,22 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddStringToken());
-
-            var expectedError = new RazorError(
-                LegacyResources.FormatDirectiveExpectsQuotedStringLiteral("custom"),
-                new SourceLocation(8, 0, 8),
-                length: 9);
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatDirectiveExpectsQuotedStringLiteral("custom"),
+                        new SourceLocation(8, 0, 8),
+                        length: 9)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom 'AString'",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)), expectedError);
+                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
 
         [Fact]
@@ -384,22 +421,22 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddStringToken());
-
-            var expectedError = new RazorError(
-                LegacyResources.FormatDirectiveExpectsQuotedStringLiteral("custom"),
-                new SourceLocation(8, 0, 8),
-                length: 7);
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatDirectiveExpectsQuotedStringLiteral("custom"),
+                        new SourceLocation(8, 0, 8),
+                        length: 7)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom AString\"",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
-                expectedError);
+                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
 
         [Fact]
@@ -526,22 +563,22 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddMemberToken());
-
-            var expectedErorr = new RazorError(
-                LegacyResources.FormatDirectiveExpectsIdentifier("custom"),
-                new SourceLocation(8, 0, 8),
-                length: 1);
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatDirectiveExpectsIdentifier("custom"),
+                        new SourceLocation(8, 0, 8),
+                        length: 1)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom -Some_Member",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
-                expectedErorr);
+                    Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
 
         [Fact]
@@ -574,25 +611,25 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.SingleLine,
                 b => b.AddStringToken());
-
-            var expectedErorr = new RazorError(
-                LegacyResources.FormatUnexpectedDirectiveLiteral("custom", "line break"),
-                new SourceLocation(16, 0, 16),
-                length: 7);
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatUnexpectedDirectiveLiteral("custom", "line break"),
+                        new SourceLocation(16, 0, 16),
+                        length: 7)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom \"hello\" \"world\"",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                     Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                     Factory.Span(SpanKindInternal.Code, "\"hello\"", markup: false).AsDirectiveToken(descriptor.Tokens[0]),
 
-                    Factory.MetaCode(" ").Accepts(AcceptedCharactersInternal.WhiteSpace)),
-                expectedErorr);
+                    Factory.MetaCode(" ").Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
 
         [Fact]
@@ -603,25 +640,25 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.CodeBlock,
                 b => b.AddStringToken());
-
-            var expectedErorr = new RazorError(
-                LegacyResources.FormatUnexpectedDirectiveLiteral("custom", "{"),
-                new SourceLocation(16, 0, 16),
-                length: 5);
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatUnexpectedDirectiveLiteral("custom", "{"),
+                        new SourceLocation(16, 0, 16),
+                        length: 5)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom \"Hello\" World { foo(); bar(); }",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                     Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                     Factory.Span(SpanKindInternal.Code, "\"Hello\"", markup: false).AsDirectiveToken(descriptor.Tokens[0]),
 
-                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.AllWhiteSpace)),
-                expectedErorr);
+                    Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.AllWhiteSpace)));
         }
 
         [Fact]
@@ -632,23 +669,23 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.CodeBlock,
                 b => b.AddStringToken());
-
-            var expectedErorr = new RazorError(
-                LegacyResources.FormatUnexpectedEOFAfterDirective("custom", "{"),
-                new SourceLocation(15, 0, 15),
-                length: 1);
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatUnexpectedEOFAfterDirective("custom", "{"),
+                        new SourceLocation(15, 0, 15),
+                        length: 1)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom \"Hello\"",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                     Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
-                    Factory.Span(SpanKindInternal.Code, "\"Hello\"", markup: false).AsDirectiveToken(descriptor.Tokens[0])),
-                expectedErorr);
+                    Factory.Span(SpanKindInternal.Code, "\"Hello\"", markup: false).AsDirectiveToken(descriptor.Tokens[0])));
         }
 
         [Fact]
@@ -659,18 +696,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 "custom",
                 DirectiveKind.CodeBlock,
                 b => b.AddStringToken());
-
-            var expectedErorr = new RazorError(
-                LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF("custom", "}", "{"),
-                new SourceLocation(16, 0, 16),
-                length: 1);
+            var chunkGenerator = new DirectiveChunkGenerator(descriptor);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF("custom", "}", "{"),
+                        new SourceLocation(16, 0, 16),
+                        length: 1)));
 
             // Act & Assert
             ParseCodeBlockTest(
                 "@custom \"Hello\" {",
                 new[] { descriptor },
-                new DirectiveBlock(
-                    new DirectiveChunkGenerator(descriptor),
+                new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                     Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
@@ -678,8 +716,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.AllWhiteSpace),
                     Factory.MetaCode("{")
                         .AutoCompleteWith("}", atEndOfSpan: true)
-                        .Accepts(AcceptedCharactersInternal.None)),
-                expectedErorr);
+                        .Accepts(AcceptedCharactersInternal.None)));
         }
 
         [Fact]
@@ -724,6 +761,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         [Fact]
         public void TagHelperPrefixDirective_RequiresValue()
         {
+            // Arrange 
+            var expectedError = new RazorError(
+                LegacyResources.FormatParseError_DirectiveMustHaveValue(SyntaxConstants.CSharp.TagHelperPrefixKeyword),
+                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 15);
+
+            // Act & Assert
             ParseBlockTest("@tagHelperPrefix ",
                 new DirectiveBlock(
                     Factory.CodeTransition(),
@@ -731,17 +774,25 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharactersInternal.None),
                     Factory.EmptyCSharp()
-                        .AsTagHelperPrefixDirective(string.Empty)
-                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)),
-                 new RazorError(
-                    LegacyResources.FormatParseError_DirectiveMustHaveValue(
-                        SyntaxConstants.CSharp.TagHelperPrefixKeyword),
-                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 15));
+                        .AsTagHelperPrefixDirective(string.Empty, expectedError)
+                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)));
         }
 
         [Fact]
         public void TagHelperPrefixDirective_StartQuoteRequiresDoubleQuotesAroundValue()
         {
+            // Arrange
+            var expectedErrors = new[]
+            {
+                new RazorError(
+                    LegacyResources.ParseError_Unterminated_String_Literal,
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
+                new RazorError(
+                    LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(SyntaxConstants.CSharp.TagHelperPrefixKeyword),
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 4)
+            };
+
+            // Act & Assert
             ParseBlockTest("@tagHelperPrefix \"Foo",
                 new DirectiveBlock(
                     Factory.CodeTransition(),
@@ -749,19 +800,24 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharactersInternal.None),
                     Factory.Code("\"Foo")
-                        .AsTagHelperPrefixDirective("\"Foo")),
-                new RazorError(
-                    LegacyResources.ParseError_Unterminated_String_Literal,
-                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
-                new RazorError(
-                    LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(
-                        SyntaxConstants.CSharp.TagHelperPrefixKeyword),
-                        absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 4));
+                        .AsTagHelperPrefixDirective("\"Foo", expectedErrors)));
         }
 
         [Fact]
         public void TagHelperPrefixDirective_EndQuoteRequiresDoubleQuotesAroundValue()
         {
+            // Arrange
+            var expectedErrors = new[]
+            {
+                new RazorError(
+                    LegacyResources.ParseError_Unterminated_String_Literal,
+                    absoluteIndex: 23, lineIndex: 0, columnIndex: 23, length: 1),
+                new RazorError(
+                    LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(SyntaxConstants.CSharp.TagHelperPrefixKeyword),
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 7)
+            };
+
+            // Act & Assert
             ParseBlockTest("@tagHelperPrefix Foo   \"",
                 new DirectiveBlock(
                     Factory.CodeTransition(),
@@ -769,14 +825,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .MetaCode(SyntaxConstants.CSharp.TagHelperPrefixKeyword + " ")
                         .Accepts(AcceptedCharactersInternal.None),
                     Factory.Code("Foo   \"")
-                        .AsTagHelperPrefixDirective("Foo   \"")),
-                new RazorError(
-                    LegacyResources.ParseError_Unterminated_String_Literal,
-                    absoluteIndex: 23, lineIndex: 0, columnIndex: 23, length: 1),
-                new RazorError(
-                    LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(
-                        SyntaxConstants.CSharp.TagHelperPrefixKeyword),
-                        absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 7));
+                        .AsTagHelperPrefixDirective("Foo   \"", expectedErrors)));
         }
 
         [Fact]
@@ -831,57 +880,69 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         [Fact]
         public void RemoveTagHelperDirective_RequiresValue()
         {
+            // Arrange
+            var expectedError = new RazorError(
+                LegacyResources.FormatParseError_DirectiveMustHaveValue(SyntaxConstants.CSharp.RemoveTagHelperKeyword),
+                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 15);
+
+            // Act & Assert
             ParseBlockTest("@removeTagHelper ",
                 new DirectiveBlock(
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharactersInternal.None),
                     Factory.EmptyCSharp()
-                        .AsRemoveTagHelper(string.Empty)
-                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)),
-                 new RazorError(
-                    LegacyResources.FormatParseError_DirectiveMustHaveValue(
-                        SyntaxConstants.CSharp.RemoveTagHelperKeyword),
-                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 15));
+                        .AsRemoveTagHelper(string.Empty, expectedError)
+                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)));
         }
 
         [Fact]
         public void RemoveTagHelperDirective_StartQuoteRequiresDoubleQuotesAroundValue()
         {
+            // Arrange
+            var expectedErrors = new[]
+            {
+                new RazorError(
+                    LegacyResources.ParseError_Unterminated_String_Literal,
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
+                new RazorError(
+                    LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(SyntaxConstants.CSharp.RemoveTagHelperKeyword),
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 4)
+            };
+
+            // Act & Assert
             ParseBlockTest("@removeTagHelper \"Foo",
                 new DirectiveBlock(
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharactersInternal.None),
                     Factory.Code("\"Foo")
-                        .AsRemoveTagHelper("\"Foo")),
-                 new RazorError(
-                     LegacyResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
-                 new RazorError(
-                     LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(
-                        SyntaxConstants.CSharp.RemoveTagHelperKeyword),
-                        absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 4));
+                        .AsRemoveTagHelper("\"Foo", expectedErrors)));
         }
 
         [Fact]
         public void RemoveTagHelperDirective_EndQuoteRequiresDoubleQuotesAroundValue()
         {
+            // Arrange
+            var expectedErrors = new[]
+            {
+                new RazorError(
+                    LegacyResources.ParseError_Unterminated_String_Literal,
+                    absoluteIndex: 20, lineIndex: 0, columnIndex: 20, length: 1),
+                new RazorError(
+                    LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(SyntaxConstants.CSharp.RemoveTagHelperKeyword),
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 4)
+            };
+
+            // Act & Assert
             ParseBlockTest("@removeTagHelper Foo\"",
                 new DirectiveBlock(
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword + " ")
                            .Accepts(AcceptedCharactersInternal.None),
                     Factory.Code("Foo\"")
-                        .AsRemoveTagHelper("Foo\"")
-                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)),
-                 new RazorError(
-                     LegacyResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 20, lineIndex: 0, columnIndex: 20, length: 1),
-                 new RazorError(
-                     LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(
-                        SyntaxConstants.CSharp.RemoveTagHelperKeyword),
-                        absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 4));
+                        .AsRemoveTagHelper("Foo\"", expectedErrors)
+                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)));
         }
 
         [Fact]
@@ -935,56 +996,69 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         [Fact]
         public void AddTagHelperDirectiveRequiresValue()
         {
+            // Arrange
+            var expectedError = new RazorError(
+                LegacyResources.FormatParseError_DirectiveMustHaveValue(SyntaxConstants.CSharp.AddTagHelperKeyword),
+                absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 12);
+
+            // Act & Assert
             ParseBlockTest("@addTagHelper ",
                 new DirectiveBlock(
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharactersInternal.None),
                     Factory.EmptyCSharp()
-                        .AsAddTagHelper(string.Empty)
-                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)),
-                 new RazorError(
-                    LegacyResources.FormatParseError_DirectiveMustHaveValue(SyntaxConstants.CSharp.AddTagHelperKeyword),
-                    absoluteIndex: 1, lineIndex: 0, columnIndex: 1, length: 12));
+                        .AsAddTagHelper(string.Empty, expectedError)
+                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)));
         }
 
         [Fact]
         public void AddTagHelperDirective_StartQuoteRequiresDoubleQuotesAroundValue()
         {
+            // Arrange
+            var expectedErrors = new[]
+            {
+                new RazorError(
+                    LegacyResources.ParseError_Unterminated_String_Literal,
+                    absoluteIndex: 14, lineIndex: 0, columnIndex: 14, length: 1),
+                new RazorError(
+                    LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(SyntaxConstants.CSharp.AddTagHelperKeyword),
+                    absoluteIndex: 14, lineIndex: 0, columnIndex: 14, length: 4)
+            };
+
+            // Act & Assert
             ParseBlockTest("@addTagHelper \"Foo",
                 new DirectiveBlock(
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharactersInternal.None),
                     Factory.Code("\"Foo")
-                        .AsAddTagHelper("\"Foo")),
-                 new RazorError(
-                     LegacyResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 14, lineIndex: 0, columnIndex: 14, length: 1),
-                 new RazorError(
-                     LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(
-                        SyntaxConstants.CSharp.AddTagHelperKeyword),
-                        absoluteIndex: 14, lineIndex: 0, columnIndex: 14, length: 4));
+                        .AsAddTagHelper("\"Foo", expectedErrors)));
         }
 
         [Fact]
         public void AddTagHelperDirective_EndQuoteRequiresDoubleQuotesAroundValue()
         {
+            // Arrange
+            var expectedErrors = new[]
+            {
+                new RazorError(
+                    LegacyResources.ParseError_Unterminated_String_Literal,
+                    absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
+                new RazorError(
+                    LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(SyntaxConstants.CSharp.AddTagHelperKeyword),
+                    absoluteIndex: 14, lineIndex: 0, columnIndex: 14, length: 4)
+            };
+
+            // Act & Assert
             ParseBlockTest("@addTagHelper Foo\"",
                 new DirectiveBlock(
                     Factory.CodeTransition(),
                     Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword + " ")
                            .Accepts(AcceptedCharactersInternal.None),
                     Factory.Code("Foo\"")
-                        .AsAddTagHelper("Foo\"")
-                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)),
-                 new RazorError(
-                     LegacyResources.ParseError_Unterminated_String_Literal,
-                     absoluteIndex: 17, lineIndex: 0, columnIndex: 17, length: 1),
-                 new RazorError(
-                     LegacyResources.FormatParseError_IncompleteQuotesAroundDirective(
-                        SyntaxConstants.CSharp.AddTagHelperKeyword),
-                        absoluteIndex: 14, lineIndex: 0, columnIndex: 14, length: 4));
+                        .AsAddTagHelper("Foo\"", expectedErrors)
+                        .Accepts(AcceptedCharactersInternal.AnyExceptNewline)));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpErrorTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpErrorTest.cs
@@ -299,18 +299,24 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         [Fact]
         public void ParseBlockReportsErrorIfClassBlockUnterminatedAtEOF()
         {
+            // Arrange
+            var chunkGenerator = new DirectiveChunkGenerator(FunctionsDirective.Directive);
+            chunkGenerator.Diagnostics.Add(
+                RazorDiagnostic.Create(
+                    new RazorError(
+                        LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", '}', '{'),
+                        new SourceLocation(10, 0, 10),
+                        length: 1)));
+
+            // Act & Assert
             ParseBlockTest(
                 "functions { var foo = bar; if(foo != null) { bar(); } ",
-                new[] { FunctionsDirective.Directive, },
-                new DirectiveBlock(new DirectiveChunkGenerator(FunctionsDirective.Directive),
+                new[] { FunctionsDirective.Directive },
+                new DirectiveBlock(chunkGenerator,
                     Factory.MetaCode("functions").Accepts(AcceptedCharactersInternal.None),
                     Factory.Span(SpanKindInternal.Markup, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.AllWhiteSpace),
                     Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None),
-                    Factory.Code(" var foo = bar; if(foo != null) { bar(); } ").AsStatement()),
-                new RazorError(
-                    LegacyResources.FormatParseError_Expected_EndOfBlock_Before_EOF("functions", '}', '{'),
-                    new SourceLocation(10, 0, 10),
-                    length: 1));
+                    Factory.Code(" var foo = bar; if(foo != null) { bar(); } ").AsStatement()));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TestSpanBuilder.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TestSpanBuilder.cs
@@ -334,24 +334,27 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return _self.With(SpanChunkGenerator.Null);
         }
 
-        public SpanConstructor AsAddTagHelper(string lookupText)
+        public SpanConstructor AsAddTagHelper(string lookupText, params RazorError[] legacyErrors)
         {
+            var diagnostics = legacyErrors.Select(error => RazorDiagnostic.Create(error)).ToList();
             return _self
-                .With(new AddTagHelperChunkGenerator(lookupText))
+                .With(new AddTagHelperChunkGenerator(lookupText, diagnostics))
                 .Accepts(AcceptedCharactersInternal.AnyExceptNewline);
         }
 
-        public SpanConstructor AsRemoveTagHelper(string lookupText)
+        public SpanConstructor AsRemoveTagHelper(string lookupText, params RazorError[] legacyErrors)
         {
+            var diagnostics = legacyErrors.Select(error => RazorDiagnostic.Create(error)).ToList();
             return _self
-                .With(new RemoveTagHelperChunkGenerator(lookupText))
+                .With(new RemoveTagHelperChunkGenerator(lookupText, diagnostics))
                 .Accepts(AcceptedCharactersInternal.AnyExceptNewline);
         }
 
-        public SpanConstructor AsTagHelperPrefixDirective(string prefix)
+        public SpanConstructor AsTagHelperPrefixDirective(string prefix, params RazorError[] legacyErrors)
         {
+            var diagnostics = legacyErrors.Select(error => RazorDiagnostic.Create(error)).ToList();
             return _self
-                .With(new TagHelperPrefixDirectiveChunkGenerator(prefix))
+                .With(new TagHelperPrefixDirectiveChunkGenerator(prefix, diagnostics))
                 .Accepts(AcceptedCharactersInternal.AnyExceptNewline);
         }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -47,12 +47,6 @@ global::System.Object __typeHelper = ";
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            DefineSection("", async (__razor_section_writer) => {
-            });
-            DefineSection("", async (__razor_section_writer) => {
-            });
-            DefineSection("", async (__razor_section_writer) => {
-            });
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -16,43 +16,57 @@ Document -
             MethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                MalformedDirective - (100:2,13 [0] IncompleteDirectives.cshtml)
+                    DirectiveToken - (100:2,13 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (100:2,13 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (100:2,13 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (116:3,14 [0] IncompleteDirectives.cshtml)
+                    DirectiveToken - (116:3,14 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (116:3,14 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (116:3,14 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (132:4,14 [1] IncompleteDirectives.cshtml)
+                    DirectiveToken - (132:4,14 [1] IncompleteDirectives.cshtml) - "
                 HtmlContent - (133:4,15 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (133:4,15 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                MalformedDirective - (153:6,16 [0] IncompleteDirectives.cshtml)
+                    DirectiveToken - (153:6,16 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (153:6,16 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (153:6,16 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (172:7,17 [0] IncompleteDirectives.cshtml)
+                    DirectiveToken - (172:7,17 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (172:7,17 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (172:7,17 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (191:8,17 [1] IncompleteDirectives.cshtml)
+                    DirectiveToken - (191:8,17 [1] IncompleteDirectives.cshtml) - "
                 HtmlContent - (192:8,18 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (192:8,18 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                MalformedDirective - (212:10,16 [0] IncompleteDirectives.cshtml)
+                    DirectiveToken - (212:10,16 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (212:10,16 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (212:10,16 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (231:11,17 [0] IncompleteDirectives.cshtml)
+                    DirectiveToken - (231:11,17 [0] IncompleteDirectives.cshtml) - 
                 HtmlContent - (231:11,17 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (231:11,17 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (250:12,17 [1] IncompleteDirectives.cshtml)
+                    DirectiveToken - (250:12,17 [1] IncompleteDirectives.cshtml) - "
                 HtmlContent - (251:12,18 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (251:12,18 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                MalformedDirective - (255:14,0 [9] IncompleteDirectives.cshtml)
                 HtmlContent - (264:14,9 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (264:14,9 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (266:15,0 [10] IncompleteDirectives.cshtml)
                 HtmlContent - (276:15,10 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (276:15,10 [4] IncompleteDirectives.cshtml) - Html - \n\n
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - DefineSection("", async (__razor_section_writer) => {
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - });
+                MalformedDirective - (280:17,0 [12] IncompleteDirectives.cshtml)
+                MalformedDirective - (292:18,0 [15] IncompleteDirectives.cshtml)
+                MalformedDirective - (307:20,0 [8] IncompleteDirectives.cshtml)
                 HtmlContent - (315:20,8 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (315:20,8 [2] IncompleteDirectives.cshtml) - Html - \n
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - DefineSection("", async (__razor_section_writer) => {
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - });
+                MalformedDirective - (317:21,0 [9] IncompleteDirectives.cshtml)
                 HtmlContent - (326:21,9 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (326:21,9 [4] IncompleteDirectives.cshtml) - Html - \n\n
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - DefineSection("", async (__razor_section_writer) => {
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - });
+                MalformedDirective - (330:23,0 [9] IncompleteDirectives.cshtml)
                 HtmlContent - (339:23,9 [3] IncompleteDirectives.cshtml)
                     RazorIRToken - (339:23,9 [3] IncompleteDirectives.cshtml) - Html - {\n
+                MalformedDirective - (342:24,0 [12] IncompleteDirectives.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.codegen.cs
@@ -13,14 +13,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             WriteLiteral("\r\n");
             WriteLiteral("\r\n");
             WriteLiteral("\r\n\r\n");
-            DefineSection("", async () => {
-            });
             WriteLiteral("\r\n");
-            DefineSection("", async () => {
-            });
             WriteLiteral("\r\n\r\n");
-            DefineSection("", async () => {
-            });
             WriteLiteral("{\r\n");
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -4,31 +4,45 @@ Document -
             MethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                MalformedDirective - (100:2,13 [2] IncompleteDirectives.cshtml)
+                    DirectiveToken - (100:2,13 [2] IncompleteDirectives.cshtml) - 
+                MalformedDirective - (116:3,14 [2] IncompleteDirectives.cshtml)
+                    DirectiveToken - (116:3,14 [2] IncompleteDirectives.cshtml) - 
+                MalformedDirective - (132:4,14 [3] IncompleteDirectives.cshtml)
+                    DirectiveToken - (132:4,14 [3] IncompleteDirectives.cshtml) - "
                 HtmlContent - (135:5,0 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (135:5,0 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (153:6,16 [2] IncompleteDirectives.cshtml)
+                    DirectiveToken - (153:6,16 [2] IncompleteDirectives.cshtml) - 
+                MalformedDirective - (172:7,17 [2] IncompleteDirectives.cshtml)
+                    DirectiveToken - (172:7,17 [2] IncompleteDirectives.cshtml) - 
+                MalformedDirective - (191:8,17 [3] IncompleteDirectives.cshtml)
+                    DirectiveToken - (191:8,17 [3] IncompleteDirectives.cshtml) - "
                 HtmlContent - (194:9,0 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (194:9,0 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (212:10,16 [2] IncompleteDirectives.cshtml)
+                    DirectiveToken - (212:10,16 [2] IncompleteDirectives.cshtml) - 
+                MalformedDirective - (231:11,17 [2] IncompleteDirectives.cshtml)
+                    DirectiveToken - (231:11,17 [2] IncompleteDirectives.cshtml) - 
+                MalformedDirective - (250:12,17 [3] IncompleteDirectives.cshtml)
+                    DirectiveToken - (250:12,17 [3] IncompleteDirectives.cshtml) - "
                 HtmlContent - (253:13,0 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (253:13,0 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (255:14,0 [9] IncompleteDirectives.cshtml)
                 HtmlContent - (264:14,9 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (264:14,9 [2] IncompleteDirectives.cshtml) - Html - \n
+                MalformedDirective - (266:15,0 [10] IncompleteDirectives.cshtml)
                 HtmlContent - (276:15,10 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (276:15,10 [4] IncompleteDirectives.cshtml) - Html - \n\n
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - DefineSection("", async () => {
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - });
+                MalformedDirective - (280:17,0 [12] IncompleteDirectives.cshtml)
+                MalformedDirective - (292:18,0 [15] IncompleteDirectives.cshtml)
+                MalformedDirective - (307:20,0 [8] IncompleteDirectives.cshtml)
                 HtmlContent - (315:20,8 [2] IncompleteDirectives.cshtml)
                     RazorIRToken - (315:20,8 [2] IncompleteDirectives.cshtml) - Html - \n
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - DefineSection("", async () => {
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - });
+                MalformedDirective - (317:21,0 [9] IncompleteDirectives.cshtml)
                 HtmlContent - (326:21,9 [4] IncompleteDirectives.cshtml)
                     RazorIRToken - (326:21,9 [4] IncompleteDirectives.cshtml) - Html - \n\n
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - DefineSection("", async () => {
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - });
+                MalformedDirective - (330:23,0 [9] IncompleteDirectives.cshtml)
                 HtmlContent - (339:23,9 [3] IncompleteDirectives.cshtml)
                     RazorIRToken - (339:23,9 [3] IncompleteDirectives.cshtml) - Html - {\n
+                MalformedDirective - (342:24,0 [12] IncompleteDirectives.cshtml)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
@@ -15,8 +15,6 @@ global::System.Object Link = null;
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            DefineSection("Link", async (__razor_section_writer) => {
-            });
 #line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml"
               if(link != null) { 
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.ir.txt
@@ -6,10 +6,8 @@ Document -
             CSharpCode - 
                 RazorIRToken -  - CSharp - private static System.Object __o = null;
             MethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - DefineSection("Link", async (__razor_section_writer) => {
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - });
+                MalformedDirective - (0:0,0 [13] InlineBlocks.cshtml)
+                    DirectiveToken - (9:0,9 [4] InlineBlocks.cshtml) - Link
                 HtmlContent - (13:0,13 [23] InlineBlocks.cshtml)
                     RazorIRToken - (13:0,13 [21] InlineBlocks.cshtml) - Html - (string link) {\n    
                     RazorIRToken - (34:1,4 [2] InlineBlocks.cshtml) - Html - <a

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (351:8,22 [4] )
 
 Source Location: (44:1,14 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |if(link != null) { |
-Generated Location: (793:20,14 [19] )
+Generated Location: (705:18,14 [19] )
 |if(link != null) { |
 
 Source Location: (64:1,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |link|
-Generated Location: (967:25,34 [4] )
+Generated Location: (879:23,34 [4] )
 |link|
 
 Source Location: (68:1,38 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | } else { |
-Generated Location: (1131:30,38 [10] )
+Generated Location: (1043:28,38 [10] )
 | } else { |
 
 Source Location: (92:1,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | }|
-Generated Location: (1324:35,62 [2] )
+Generated Location: (1236:33,62 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.codegen.cs
@@ -7,8 +7,6 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-            DefineSection("Link", async () => {
-            });
             WriteLiteral("(string link) {\r\n    <a");
             BeginWriteAttribute("href", " href=\"", 36, "\"", 94, 1);
             WriteAttributeValue("", 43, new Microsoft.AspNetCore.Mvc.Razor.HelperResult(async(__razor_attribute_value_writer) => {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_Runtime.ir.txt
@@ -2,10 +2,8 @@ Document -
     NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_InlineBlocks_Runtime -  - 
             MethodDeclaration -  - public - async - System.Threading.Tasks.Task - ExecuteAsync
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - DefineSection("Link", async () => {
-                CSharpCode - 
-                    RazorIRToken -  - CSharp - });
+                MalformedDirective - (0:0,0 [13] InlineBlocks.cshtml)
+                    DirectiveToken - (9:0,9 [4] InlineBlocks.cshtml) - Link
                 HtmlContent - (13:0,13 [23] InlineBlocks.cshtml)
                     RazorIRToken - (13:0,13 [21] InlineBlocks.cshtml) - Html - (string link) {\n    
                     RazorIRToken - (34:1,4 [2] InlineBlocks.cshtml) - Html - <a


### PR DESCRIPTION
## Basics of what's in this PR
- Enforce whitespace inbetween directive tokens
- Re-write malformed directives into `MalformedDirectiveIRNode`s via a `MalformedDirectiveIRPass`
- Raise directive errors to the IR layer.

## Goals for extensible directive error handling
Tried to encompass 3 primary goals when coming up with a design for our directive error story.

### Consistency
When we  encounter a malformed token when parsing an extensible directive we don't consume the token; instead, we bail out and log an appropriate error that's raised to the `DirectiveIRNode`. Therefore, a user will never have to deal with a malformed directive token state unless they're purposefully consuming `MalformedDirectiveIRNode`s.

### Default simple approach for malformed directives
If a user writes a malformed directive an extensible directive author will not see it represented as a `DirectiveIRNode` as long as their pass operates after the `MalformedDirectiveIRPass`. This means for malformed directives Razor will provide IntelliSense until they have fully satisfied all tokens of a directive, at which point the directive will be valid and will make its way over to extensible directive IR pass code. 

Since a user never sees malformed directives, in the case of a block directive we flow the body of the malformed block directive to the execute method so that all contents continue to get IntelliSense/coloring.

Basically, I made it so extensible directive code is not called until its structure is 100% while maintaining the current editing experience; this should help us avoid VS explosions and make extensible directive IR consumption code simple.

### Opt-in customizable approach for malformed directive
If a user does not like how we handle malformed directives they can write an IR pass that consumes `MalformedDirectiveIRNode`s. They can have it log additional errors, modify code gen... basically whatever they want. A great example of when you'd want to do this is if you wish your malformed directive to still impact code gen to provide more verbose/specific errors (think `@model` where TModel was restricted with a `where` clause).

-----------------------------------------------

#1173 

@ajaybhargavb @rynowak 