### PR TITLE
Resolve conflicts

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -11,9 +11,9 @@
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
     <RoslynVersion>2.3.0-beta1</RoslynVersion>
     <RoslynDevVersion>2.3.0-beta3-61731-06</RoslynDevVersion>
-    <StreamJsonRpcVersion>1.0.2-rc</StreamJsonRpcVersion>
+    <StreamJsonRpcVersion>1.1.73</StreamJsonRpcVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
-    <VsShellVersion>15.0.26201</VsShellVersion>
+    <VsShellVersion>15.0.26606</VsShellVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/tooling/Microsoft.VisualStudio.RazorExtension/project.json
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/project.json
@@ -3,7 +3,7 @@
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.ComponentModelHost": "15.0.26201",
-        "Microsoft.VisualStudio.Shell.15.0": "15.0.26201",
+        "Microsoft.VisualStudio.Shell.15.0": "15.0.26606",
         "Microsoft.VSSDK.BuildTools": "15.0.26201"
       }
     }


### PR DESCRIPTION
Fixing updating both of these reduces dependency conflicts to just `Newtonsoft.Json`, which for now seems intentional.

@rynowak are there any problems with updating these dependencies?