### PR TITLE
Add file scoped extensible directives.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelDirective.cs
@@ -14,7 +14,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
         public static readonly DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
             "model",
             DirectiveKind.SingleLine,
-            builder => builder.AddTypeToken());
+            builder =>
+            {
+                builder.AddTypeToken();
+                builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
+            });
 
         public static IRazorEngineBuilder Register(IRazorEngineBuilder builder)
         {
@@ -55,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             }
             else
             {
-                return  "dynamic";
+                return "dynamic";
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/NamespaceDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/NamespaceDirective.cs
@@ -17,7 +17,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
         public static readonly DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
             "namespace",
             DirectiveKind.SingleLine,
-            builder => builder.AddNamespaceToken());
+            builder =>
+            {
+                builder.AddNamespaceToken();
+                builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
+            });
 
         public static void Register(IRazorEngineBuilder builder)
         {
@@ -58,7 +62,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                     // No namespace node. Skip.
                     return;
                 }
-                
+
                 if (TryComputeNamespace(codeDocument.Source.FilePath, directive, out var computedNamespace))
                 {
                     // Beautify the class name since we're using a hierarchy for namespaces.

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/PageDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/PageDirective.cs
@@ -14,7 +14,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
         public static readonly DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
             "page",
             DirectiveKind.SingleLine,
-            builder => builder.AddOptionalStringToken());
+            builder =>
+            {
+                builder.AddOptionalStringToken();
+                builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
+            });
 
         private PageDirective(string routeTemplate)
         {

--- a/src/Microsoft.AspNetCore.Razor.Language/DirectiveDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DirectiveDescriptor.cs
@@ -39,6 +39,11 @@ namespace Microsoft.AspNetCore.Razor.Language
         public abstract DirectiveKind Kind { get; }
 
         /// <summary>
+        /// Gets the way a directive can be used. The usage determines how many, and where directives can exist per document.
+        /// </summary>
+        public abstract DirectiveUsage Usage { get; }
+
+        /// <summary>
         /// Gets the list of directive tokens that can follow the directive keyword.
         /// </summary>
         public abstract IReadOnlyList<DirectiveTokenDescriptor> Tokens { get; }
@@ -189,6 +194,8 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             public DirectiveKind Kind { get; }
 
+            public DirectiveUsage Usage { get; set; }
+
             public IList<DirectiveTokenDescriptor> Tokens { get; }
 
             public DirectiveDescriptor Build()
@@ -218,7 +225,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                     }
                 }
 
-                return new DefaultDirectiveDescriptor(Directive, Kind, Tokens.ToArray(), DisplayName, Description);
+                return new DefaultDirectiveDescriptor(Directive, Kind, Usage, Tokens.ToArray(), DisplayName, Description);
             }
         }
 
@@ -227,12 +234,14 @@ namespace Microsoft.AspNetCore.Razor.Language
             public DefaultDirectiveDescriptor(
                 string directive, 
                 DirectiveKind kind, 
+                DirectiveUsage usage,
                 DirectiveTokenDescriptor[] tokens,
                 string displayName,
                 string description)
             {
                 Directive = directive;
                 Kind = kind;
+                Usage = usage;
                 Tokens = tokens;
                 DisplayName = displayName;
                 Description = description;
@@ -245,6 +254,8 @@ namespace Microsoft.AspNetCore.Razor.Language
             public override string DisplayName { get; }
 
             public override DirectiveKind Kind { get; }
+
+            public override DirectiveUsage Usage { get; }
 
             public override IReadOnlyList<DirectiveTokenDescriptor> Tokens { get; }
         }

--- a/src/Microsoft.AspNetCore.Razor.Language/DirectiveUsage.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DirectiveUsage.cs
@@ -1,0 +1,11 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public enum DirectiveUsage
+    {
+        Unrestricted,
+        FileScopedSinglyOccurring,
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/InheritsDirective.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/InheritsDirective.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
         public static readonly DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
             SyntaxConstants.CSharp.InheritsKeyword,
             DirectiveKind.SingleLine,
-            builder => builder.AddTypeToken());
+            builder =>
+            {
+                builder.AddTypeToken();
+                builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
+            });
 
         public static void Register(IRazorEngineBuilder builder)
         {

--- a/src/Microsoft.AspNetCore.Razor.Language/IDirectiveDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IDirectiveDescriptorBuilder.cs
@@ -31,6 +31,11 @@ namespace Microsoft.AspNetCore.Razor.Language
         DirectiveKind Kind { get; }
 
         /// <summary>
+        /// Gets or sets the directive usage. The usage determines how many, and where directives can exist per document.
+        /// </summary>
+        DirectiveUsage Usage { get; set; }
+
+        /// <summary>
         /// Gets a list of the directive tokens.
         /// </summary>
         IList<DirectiveTokenDescriptor> Tokens { get; }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/BlockKindInternal.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/BlockKindInternal.cs
@@ -8,13 +8,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         // Code
         Statement,
         Directive,
-        Functions,
         Expression,
-        Helper,
 
         // Markup
         Markup,
-        Section,
         Template,
 
         // Special

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/SyntaxTreeBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/SyntaxTreeBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             _endBlock = EndBlock;
         }
 
-        public IEnumerable<BlockBuilder> ActiveBlocks => _blockStack;
+        public IReadOnlyCollection<BlockBuilder> ActiveBlocks => _blockStack;
 
         public BlockBuilder CurrentBlock => _blockStack.Peek();
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -514,6 +514,34 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static string FormatIntermediateNodeReference_CollectionIsReadOnly(object p0)
             => string.Format(CultureInfo.CurrentCulture, GetString("IntermediateNodeReference_CollectionIsReadOnly"), p0);
 
+        /// <summary>
+        /// The '{0}' directive may only occur once per document.
+        /// </summary>
+        internal static string DuplicateDirective
+        {
+            get => GetString("DuplicateDirective");
+        }
+
+        /// <summary>
+        /// The '{0}' directive may only occur once per document.
+        /// </summary>
+        internal static string FormatDuplicateDirective(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("DuplicateDirective"), p0);
+
+        /// <summary>
+        /// The '{0}' directive must exist prior to markup or code.
+        /// </summary>
+        internal static string DirectiveMustExistBeforeMarkupOrCode
+        {
+            get => GetString("DirectiveMustExistBeforeMarkupOrCode");
+        }
+
+        /// <summary>
+        /// The '{0}' directive must exist prior to markup or code.
+        /// </summary>
+        internal static string FormatDirectiveMustExistBeforeMarkupOrCode(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("DirectiveMustExistBeforeMarkupOrCode"), p0);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -225,4 +225,10 @@
   <data name="IntermediateNodeReference_CollectionIsReadOnly" xml:space="preserve">
     <value>The node '{0}' has a read-only child collection and cannot be modified.</value>
   </data>
+  <data name="DuplicateDirective" xml:space="preserve">
+    <value>The '{0}' directive may only occur once per document.</value>
+  </data>
+  <data name="DirectiveMustExistBeforeMarkupOrCode" xml:space="preserve">
+    <value>The '{0}' directive must exist prior to markup or code.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelDirectiveTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelDirectiveTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
     public class ModelDirectiveTest
     {
         [Fact]
-        public void ModelDirective_GetModelType_GetsTypeFromLastWellFormedDirective()
+        public void ModelDirective_GetModelType_GetsTypeFromFirstWellFormedDirective()
         {
             // Arrange
             var codeDocument = CreateDocument(@"
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             var result = ModelDirective.GetModelType(irDocument);
 
             // Assert
-            Assert.Equal("Type2", result);
+            Assert.Equal("Type1", result);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             // Assert
             var @class = FindClassNode(irDocument);
             Assert.NotNull(@class);
-            Assert.Equal("BaseType<Type2>", @class.BaseType);
+            Assert.Equal("BaseType<Type1>", @class.BaseType);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
@@ -1,8 +1,14 @@
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(4,1): Error RZ9999: The 'page' directive may only occur once per document.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,1): Error RZ9999: The 'page' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ9999: The 'page' directive expects a string surrounded by double quotes.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,1): Error RZ9999: The 'model' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,7): Error RZ9999: The 'model' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,1): Error RZ9999: The 'model' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,8): Error RZ9999: The 'model' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(10,8): Error RZ9999: The 'inject' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(11,9): Error RZ9999: The 'inject' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(12,26): Error RZ9999: The 'inject' directive expects an identifier.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(14,1): Error RZ9999: The 'namespace' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(14,11): Error RZ9999: The 'namespace' directive expects a namespace name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(15,1): Error RZ9999: The 'namespace' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(15,12): Error RZ9999: The 'namespace' directive expects a namespace name.

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -31,6 +31,7 @@ Document -
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
+                MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml)
                 MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml)
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     IntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
@@ -1,8 +1,14 @@
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(4,1): Error RZ9999: The 'page' directive may only occur once per document.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,1): Error RZ9999: The 'page' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ9999: The 'page' directive expects a string surrounded by double quotes.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,1): Error RZ9999: The 'model' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,7): Error RZ9999: The 'model' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,1): Error RZ9999: The 'model' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,8): Error RZ9999: The 'model' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(10,8): Error RZ9999: The 'inject' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(11,9): Error RZ9999: The 'inject' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(12,26): Error RZ9999: The 'inject' directive expects an identifier.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(14,1): Error RZ9999: The 'namespace' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(14,11): Error RZ9999: The 'namespace' directive expects a namespace name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(15,1): Error RZ9999: The 'namespace' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(15,12): Error RZ9999: The 'namespace' directive expects a namespace name.

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -17,6 +17,7 @@ Document -
                     IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 CSharpCode - 
                     IntermediateToken -  - CSharp - EndContext();
+                MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml)
                 MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml)
                 CSharpCode - 
                     IntermediateToken -  - CSharp - BeginContext(108, 5, true);

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -10,7 +10,7 @@ namespace AspNetCore
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Rendering;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
-    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MultipleModels_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<System.Collections.IEnumerable>
+    public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MultipleModels_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<ThisShouldBeGenerated>
     {
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -39,6 +39,6 @@ System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumer
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
         public global::Microsoft.AspNetCore.Mvc.Rendering.IJsonHelper Json { get; private set; }
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
-        public global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<System.Collections.IEnumerable> Html { get; private set; }
+        public global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<ThisShouldBeGenerated> Html { get; private set; }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.diagnostics.txt
@@ -1,0 +1,1 @@
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml(2,1): Error RZ9999: The 'model' directive may only occur once per document.

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.ir.txt
@@ -10,7 +10,7 @@ Document -
         UsingDirective - (102:4,1 [30] ) - Microsoft.AspNetCore.Mvc
         UsingDirective - (135:5,1 [40] ) - Microsoft.AspNetCore.Mvc.Rendering
         UsingDirective - (178:6,1 [43] ) - Microsoft.AspNetCore.Mvc.ViewFeatures
-        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MultipleModels_cshtml - global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<System.Collections.IEnumerable> - 
+        ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MultipleModels_cshtml - global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<ThisShouldBeGenerated> - 
             DesignTimeDirective - 
                 DirectiveToken - (231:7,8 [62] ) - global::Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper<TModel>
                 DirectiveToken - (294:7,71 [4] ) - Html
@@ -30,6 +30,8 @@ Document -
             CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
+                MalformedDirective - (30:1,0 [39] MultipleModels.cshtml)
+                    DirectiveToken - (37:1,7 [30] MultipleModels.cshtml) - System.Collections.IEnumerable
             Inject - 
             Inject - 
             Inject - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (7:0,7 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |ThisShouldBeGenerated|
-Generated Location: (839:17,0 [21] )
+Generated Location: (830:17,0 [21] )
 |ThisShouldBeGenerated|
 
 Source Location: (37:1,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (969:21,0 [30] )
+Generated Location: (960:21,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/BlockTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/BlockTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             var expected = new ExpressionChunkGenerator();
             var builder = new BlockBuilder()
             {
-                Type = BlockKindInternal.Helper,
+                Type = BlockKindInternal.Statement,
                 ChunkGenerator = expected
             };
 
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             var expected = new SpanBuilder(SourceLocation.Undefined) { Kind = SpanKindInternal.Code }.Build();
             var builder = new BlockBuilder()
             {
-                Type = BlockKindInternal.Functions
+                Type = BlockKindInternal.Statement
             };
             builder.Children.Add(expected);
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
     public class CSharpDirectivesTest : CsHtmlCodeParserTestBase
     {
         [Fact]
-        public void DirectiveDescriptor_SinglePreContent_ErrorsIfNestedInCode()
+        public void DirectiveDescriptor_FileScopedSinglyOccurring_ErrorsIfNestedInCode()
         {
             // Arrange
             var descriptor = DirectiveDescriptor.CreateDirective(
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 DirectiveKind.SingleLine,
                 builder =>
                 {
-                    builder.Usage = DirectiveUsage.SinglePreContent;
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
                     builder.AddTypeToken();
                 });
             var chunkGenerator = new DirectiveChunkGenerator(descriptor);
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void DirectiveDescriptor_SinglePreContent_ErrorsIfNestedInHtml()
+        public void DirectiveDescriptor_FileScopedSinglyOccurring_ErrorsIfNestedInHtml()
         {
             // Arrange
             var descriptor = DirectiveDescriptor.CreateDirective(
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 DirectiveKind.SingleLine,
                 builder =>
                 {
-                    builder.Usage = DirectiveUsage.SinglePreContent;
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
                     builder.AddTypeToken();
                 });
             var chunkGenerator = new DirectiveChunkGenerator(descriptor);
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void DirectiveDescriptor_SinglePreContent_ErrorsIfDuplicate()
+        public void DirectiveDescriptor_FileScopedSinglyOccurring_ErrorsIfDuplicate()
         {
             // Arrange
             var descriptor = DirectiveDescriptor.CreateDirective(
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 DirectiveKind.SingleLine,
                 builder =>
                 {
-                    builder.Usage = DirectiveUsage.SinglePreContent;
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
                     builder.AddTypeToken();
                 });
             var chunkGenerator = new DirectiveChunkGenerator(descriptor);
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void DirectiveDescriptor_SinglePreContent_CanBeBeneathOtherDirectives()
+        public void DirectiveDescriptor_FileScopedSinglyOccurring_CanBeBeneathOtherDirectives()
         {
             // Arrange
             var customDescriptor = DirectiveDescriptor.CreateDirective(
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 DirectiveKind.SingleLine,
                 builder =>
                 {
-                    builder.Usage = DirectiveUsage.SinglePreContent;
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
                     builder.AddTypeToken();
                 });
             var somethingDescriptor = DirectiveDescriptor.CreateDirective(
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 DirectiveKind.SingleLine,
                 builder =>
                 {
-                    builder.Usage = DirectiveUsage.SinglePreContent;
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
                     builder.AddMemberToken();
                 });
 
@@ -173,7 +173,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void DirectiveDescriptor_SinglePreContent_CanBeBeneathOtherWhiteSpaceCommentsAndDirectives()
+        public void DirectiveDescriptor_FileScopedSinglyOccurring_CanBeBeneathOtherWhiteSpaceCommentsAndDirectives()
         {
             // Arrange
             var customDescriptor = DirectiveDescriptor.CreateDirective(
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 DirectiveKind.SingleLine,
                 builder =>
                 {
-                    builder.Usage = DirectiveUsage.SinglePreContent;
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
                     builder.AddTypeToken();
                 });
             var somethingDescriptor = DirectiveDescriptor.CreateDirective(
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 DirectiveKind.SingleLine,
                 builder =>
                 {
-                    builder.Usage = DirectiveUsage.SinglePreContent;
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
                     builder.AddMemberToken();
                 });
 
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void DirectiveDescriptor_SinglePreContent_MixedContentErrors()
+        public void DirectiveDescriptor_FileScopedSinglyOccurring_MixedContentErrors()
         {
             // Arrange
             var customDescriptor = DirectiveDescriptor.CreateDirective(
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 DirectiveKind.SingleLine,
                 builder =>
                 {
-                    builder.Usage = DirectiveUsage.SinglePreContent;
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
                     builder.AddTypeToken();
                 });
             var somethingDescriptor = DirectiveDescriptor.CreateDirective(
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 DirectiveKind.SingleLine,
                 builder =>
                 {
-                    builder.Usage = DirectiveUsage.SinglePreContent;
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
                     builder.AddMemberToken();
                 });
             var chunkGenerator = new DirectiveChunkGenerator(somethingDescriptor);
@@ -1351,57 +1351,53 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void ParseBlock_InheritsDirective()
-        {
-            ParseCodeBlockTest(
-                "@inherits System.Web.WebPages.WebPage",
-                new[] { InheritsDirective.Directive, },
-                new DirectiveBlock(new DirectiveChunkGenerator(InheritsDirective.Directive),
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
-                    Factory.Span(SpanKindInternal.Code, "System.Web.WebPages.WebPage", markup: false).AsDirectiveToken(InheritsDirective.Directive.Tokens.First())));
-        }
-
-        [Fact]
         public void InheritsDirectiveSupportsArrays()
         {
-            ParseCodeBlockTest(
+            ParseDocumentTest(
                 "@inherits string[[]][]",
                 new[] { InheritsDirective.Directive, },
-                new DirectiveBlock(new DirectiveChunkGenerator(InheritsDirective.Directive),
+                new MarkupBlock(
+                    Factory.EmptyHtml(),
+                    new DirectiveBlock(new DirectiveChunkGenerator(InheritsDirective.Directive),
                     Factory.CodeTransition(),
                     Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
                     Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
-                    Factory.Span(SpanKindInternal.Code, "string[[]][]", markup: false).AsDirectiveToken(InheritsDirective.Directive.Tokens.First())));
+                    Factory.Span(SpanKindInternal.Code, "string[[]][]", markup: false).AsDirectiveToken(InheritsDirective.Directive.Tokens.First())),
+                    Factory.EmptyHtml()));
         }
 
         [Fact]
         public void InheritsDirectiveSupportsNestedGenerics()
         {
-            ParseCodeBlockTest(
+            ParseDocumentTest(
                 "@inherits System.Web.Mvc.WebViewPage<IEnumerable<MvcApplication2.Models.RegisterModel>>",
                 new[] { InheritsDirective.Directive, },
-                new DirectiveBlock(new DirectiveChunkGenerator(InheritsDirective.Directive),
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
-                    Factory.Span(SpanKindInternal.Code, "System.Web.Mvc.WebViewPage<IEnumerable<MvcApplication2.Models.RegisterModel>>", markup: false)
-                        .AsDirectiveToken(InheritsDirective.Directive.Tokens.First())));
+                new MarkupBlock(
+                    Factory.EmptyHtml(),
+                    new DirectiveBlock(new DirectiveChunkGenerator(InheritsDirective.Directive),
+                        Factory.CodeTransition(),
+                        Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
+                        Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
+                        Factory.Span(SpanKindInternal.Code, "System.Web.Mvc.WebViewPage<IEnumerable<MvcApplication2.Models.RegisterModel>>", markup: false)
+                            .AsDirectiveToken(InheritsDirective.Directive.Tokens.First())),
+                    Factory.EmptyHtml()));
         }
 
         [Fact]
         public void InheritsDirectiveSupportsTypeKeywords()
         {
-            ParseCodeBlockTest(
+            ParseDocumentTest(
                 "@inherits string",
                 new[] { InheritsDirective.Directive, },
-                new DirectiveBlock(new DirectiveChunkGenerator(InheritsDirective.Directive),
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
-                    Factory.Span(SpanKindInternal.Code, "string", markup: false)
-                        .AsDirectiveToken(InheritsDirective.Directive.Tokens.First())));
+                new MarkupBlock(
+                    Factory.EmptyHtml(),
+                    new DirectiveBlock(new DirectiveChunkGenerator(InheritsDirective.Directive),
+                        Factory.CodeTransition(),
+                        Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
+                        Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
+                        Factory.Span(SpanKindInternal.Code, "string", markup: false)
+                            .AsDirectiveToken(InheritsDirective.Directive.Tokens.First())),
+                    Factory.EmptyHtml()));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpSpecialBlockTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpSpecialBlockTest.cs
@@ -19,26 +19,34 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 RazorDiagnostic.Create(
                     new RazorError(
                         LegacyResources.FormatUnexpectedEOFAfterDirective(InheritsDirective.Directive.Directive, "type"),
-                        new SourceLocation(8, 0, 8), 1)));
+                        new SourceLocation(9, 0, 9), 1)));
 
             // Act & Assert
-            ParseBlockTest(
-                "inherits",
+            ParseDocumentTest(
+                "@inherits",
                 new[] { InheritsDirective.Directive },
-                new DirectiveBlock(chunkGenerator,
-                    Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None)));
+                new MarkupBlock(
+                    Factory.EmptyHtml(),
+                    new DirectiveBlock(chunkGenerator,
+                        Factory.CodeTransition(),
+                        Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None)),
+                    Factory.EmptyHtml()));
         }
 
         [Fact]
         public void InheritsBlockAcceptsMultipleGenericArguments()
         {
-            ParseBlockTest(
-                "inherits Foo.Bar<Biz<Qux>, string, int>.Baz",
+            ParseDocumentTest(
+                "@inherits Foo.Bar<Biz<Qux>, string, int>.Baz",
                 new[] { InheritsDirective.Directive },
-                new DirectiveBlock(new DirectiveChunkGenerator(InheritsDirective.Directive),
-                    Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
-                    Factory.Span(SpanKindInternal.Code, "Foo.Bar<Biz<Qux>, string, int>.Baz", markup: false).AsDirectiveToken(InheritsDirective.Directive.Tokens[0])));
+                new MarkupBlock(
+                    Factory.EmptyHtml(),
+                    new DirectiveBlock(new DirectiveChunkGenerator(InheritsDirective.Directive),
+                        Factory.CodeTransition(),
+                        Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
+                        Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
+                        Factory.Span(SpanKindInternal.Code, "Foo.Bar<Biz<Qux>, string, int>.Baz", markup: false).AsDirectiveToken(InheritsDirective.Directive.Tokens[0])),
+                    Factory.EmptyHtml()));
         }
 
         [Fact]
@@ -50,15 +58,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 RazorDiagnostic.Create(
                     new RazorError(
                         LegacyResources.FormatDirectiveExpectsTypeName(InheritsDirective.Directive.Directive),
-                        24, 0, 24, Environment.NewLine.Length)));
+                        25, 0, 25, Environment.NewLine.Length)));
 
             // Act & Assert
-            ParseBlockTest(
-                "inherits                " + Environment.NewLine + "foo",
+            ParseDocumentTest(
+                "@inherits                " + Environment.NewLine + "foo",
                 new[] { InheritsDirective.Directive },
-                new DirectiveBlock(chunkGenerator,
-                    Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, "                ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace)));
+                new MarkupBlock(
+                    Factory.EmptyHtml(),
+                    new DirectiveBlock(chunkGenerator,
+                        Factory.CodeTransition(),
+                        Factory.MetaCode("inherits").Accepts(AcceptedCharactersInternal.None),
+                        Factory.Span(SpanKindInternal.Code, "                ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace)),
+                    Factory.Markup(Environment.NewLine + "foo")));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.codegen.cs
@@ -1,12 +1,12 @@
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 {
     #line hidden
-#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml"
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml"
 using System.Globalization;
 
 #line default
 #line hidden
-#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml"
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml"
 using System.ComponentModel;
 
 #line default

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.ir.txt
@@ -1,11 +1,11 @@
 Document - 
     NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
-        UsingDirective - (31:1,1 [26] BasicImports_Imports0.cshtml) - System.Globalization
-        UsingDirective - (80:3,1 [27] BasicImports_Imports0.cshtml) - System.ComponentModel
+        UsingDirective - (1:0,1 [26] BasicImports_Imports0.cshtml) - System.Globalization
+        UsingDirective - (30:1,1 [27] BasicImports_Imports0.cshtml) - System.ComponentModel
         UsingDirective - (23:1,1 [18] BasicImports_Imports1.cshtml) - System.Text
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicImports_DesignTime - Hello - 
             DesignTimeDirective - 
-                DirectiveToken - (119:4,10 [5] BasicImports_Imports0.cshtml) - Hello
+                DirectiveToken - (69:2,10 [5] BasicImports_Imports0.cshtml) - Hello
             CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml
@@ -1,5 +1,5 @@
-﻿<p>This will get ignored</p>
-@using System.Globalization
-@("And also this")
+﻿@using System.Globalization
 @using System.ComponentModel
 @inherits Hello
+@("And also this")
+<p>This will get ignored</p>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.codegen.cs
@@ -2,12 +2,12 @@
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 {
     #line hidden
-#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml"
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml"
 using System.Globalization;
 
 #line default
 #line hidden
-#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml"
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Imports0.cshtml"
 using System.ComponentModel;
 
 #line default

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_Runtime.ir.txt
@@ -1,7 +1,7 @@
 Document - 
     NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
-        UsingDirective - (31:1,1 [28] BasicImports_Imports0.cshtml) - System.Globalization
-        UsingDirective - (80:3,1 [29] BasicImports_Imports0.cshtml) - System.ComponentModel
+        UsingDirective - (1:0,1 [28] BasicImports_Imports0.cshtml) - System.Globalization
+        UsingDirective - (30:1,1 [29] BasicImports_Imports0.cshtml) - System.ComponentModel
         UsingDirective - (23:1,1 [20] BasicImports_Imports1.cshtml) - System.Text
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_BasicImports_Runtime - Hello - 
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
@@ -8,6 +8,7 @@ TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cs
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(12,2): Error RZ9999: Directive 'tagHelperPrefix' must have a value.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(13,18): Error RZ9999: Unterminated string literal.  Strings that start with a quotation mark (") must be terminated before the end of the line.  However, strings that start with @ and a quotation mark (@") can span multiple lines.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(15,10): Error RZ9999: The 'inherits' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(16,1): Error RZ9999: The 'inherits' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(16,11): Error RZ9999: The 'inherits' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(19,1): Error RZ9999: Unexpected literal following the 'functions' directive. Expected '{'.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(21,1): Error RZ9999: Unexpected literal following the 'functions' directive. Expected '{'.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
@@ -8,6 +8,7 @@ TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cs
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(12,2): Error RZ9999: Directive 'tagHelperPrefix' must have a value.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(13,18): Error RZ9999: Unterminated string literal.  Strings that start with a quotation mark (") must be terminated before the end of the line.  However, strings that start with @ and a quotation mark (@") can span multiple lines.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(15,10): Error RZ9999: The 'inherits' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(16,1): Error RZ9999: The 'inherits' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(16,11): Error RZ9999: The 'inherits' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(19,1): Error RZ9999: Unexpected literal following the 'functions' directive. Expected '{'.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(21,1): Error RZ9999: Unexpected literal following the 'functions' directive. Expected '{'.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml
@@ -1,3 +1,3 @@
-﻿@foo()
+﻿@inherits foo.bar<baz<biz>>.boz
 
-@inherits foo.bar<baz<biz>>.boz
+@foo()

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
@@ -15,7 +15,7 @@ foo.bar<baz<biz>>.boz __typeHelper = default(foo.bar<baz<biz>>.boz);
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml"
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml"
 __o = foo();
 
 #line default

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.ir.txt
@@ -2,11 +2,11 @@ Document -
     NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Inherits_DesignTime - foo.bar<baz<biz>>.boz - 
             DesignTimeDirective - 
-                DirectiveToken - (20:2,10 [21] Inherits.cshtml) - foo.bar<baz<biz>>.boz
+                DirectiveToken - (10:0,10 [21] Inherits.cshtml) - foo.bar<baz<biz>>.boz
             CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
-                CSharpExpression - (1:0,1 [5] Inherits.cshtml)
-                    IntermediateToken - (1:0,1 [5] Inherits.cshtml) - CSharp - foo()
-                HtmlContent - (6:0,6 [4] Inherits.cshtml)
-                    IntermediateToken - (6:0,6 [4] Inherits.cshtml) - Html - \n\n
+                HtmlContent - (33:1,0 [2] Inherits.cshtml)
+                    IntermediateToken - (33:1,0 [2] Inherits.cshtml) - Html - \n
+                CSharpExpression - (36:2,1 [5] Inherits.cshtml)
+                    IntermediateToken - (36:2,1 [5] Inherits.cshtml) - CSharp - foo()

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
@@ -1,9 +1,9 @@
-Source Location: (20:2,10 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
+Source Location: (10:0,10 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
 |foo.bar<baz<biz>>.boz|
 Generated Location: (349:8,0 [21] )
 |foo.bar<baz<biz>>.boz|
 
-Source Location: (1:0,1 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
+Source Location: (36:2,1 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
 |foo()|
 Generated Location: (747:18,6 [5] )
 |foo()|

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.codegen.cs
@@ -1,4 +1,4 @@
-#pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "081d0c0715ffeacf3f97a2f3a8443e1e47346419"
+#pragma checksum "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml" "{ff1816ec-aa5e-4d10-87f7-6f4963833460}" "d5c565b0bb468550fca15010c0addc84e79c5297"
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
 {
     #line hidden
@@ -7,12 +7,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
-#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml"
+            WriteLiteral("\r\n");
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml"
 Write(foo());
 
 #line default
 #line hidden
-            WriteLiteral("\r\n\r\n");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_Runtime.ir.txt
@@ -2,7 +2,7 @@ Document -
     NamespaceDeclaration -  - Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Inherits_Runtime - foo.bar<baz<biz>>.boz - 
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
-                CSharpExpression - (1:0,1 [5] Inherits.cshtml)
-                    IntermediateToken - (1:0,1 [5] Inherits.cshtml) - CSharp - foo()
-                HtmlContent - (6:0,6 [4] Inherits.cshtml)
-                    IntermediateToken - (6:0,6 [4] Inherits.cshtml) - Html - \n\n
+                HtmlContent - (33:1,0 [2] Inherits.cshtml)
+                    IntermediateToken - (33:1,0 [2] Inherits.cshtml) - Html - \n
+                CSharpExpression - (36:2,1 [5] Inherits.cshtml)
+                    IntermediateToken - (36:2,1 [5] Inherits.cshtml) - CSharp - foo()


### PR DESCRIPTION
### What's in the PR
Introduced a new `DirectiveUsage` `enum` that enables directive authors to specify if they want their directives be have a specific usage. The default (what exists today) is `DirectiveUsage.Unrestricted`. The new one that was introduced in this PR (file scoped) is labeled as `SinglePreContent`. It's a semi-verbose name but I think it's important that when a user sees the enum they have a clear indication as to what it entails; this of course is further elaborated in doc comments.

For a `SinglePreContent` directive there is the following restrictions:
1. Must exist prior to any statements or expressions
1. Must exist prior to any HTML (including TagHelpers)
1. Must not have any duplicates

With these restrictions in mind these are the high level pieces that this enables
- Directives sitting next to other directives
- Directives sitting indiscriminately next to any number of whitespace
- Directives being decorated with comments

### Inheriting Directives
This PR does not contain the code to automatically inherit directives that are labeled as `SinglePreContent`. I thought about making this automatic but felt that it could go in a follow up if deemed important. The primary reason for it not being in this PR is due to it requiring a change in design on how we inherit directives. Today we append imported IR to the bottom of our IR document; this isn't sufficient if you have a default importing story. If we start specifying how directives are inherited we then need to start marking `DirectiveIntermediateNode`s (in a way that stops overridden directives from flowing into extensibility) as inherited or not inherited and enable ways on how to change that.

--------------------------------------------------------------

- Added `DirectiveUsage` to enable extensible directive authors to indicate how their directives should be used. Currently support `Unrestricted` (how section directives have always worked and a single pre-content based directive.
- Added directive parsing tests.
- Removed no longer used `BlockKindInternal` items.
- Update built-in directives to use DirectiveUsage.
- Updated integration code gen and IR bits to reflect new directive usage.
- Updated existing unit tests that happened to test directives in code blocks to now test what happens when they exist at the document level. Being inside of a code block is now invalid and we have separate tests for that scenario.

#1376 

/cc @rynowak @ajaybhargavb 