### PR TITLE
Move some stuff to .Extensions

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeBasicWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DesignTimeBasicWriter.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/AddPreallocatedTagHelperHtmlAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/AddPreallocatedTagHelperHtmlAttributeIntermediateNode.cs
@@ -3,10 +3,11 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
-    internal sealed class DeclarePreallocatedTagHelperAttributeIntermediateNode : ExtensionIntermediateNode
+    internal sealed class AddPreallocatedTagHelperHtmlAttributeIntermediateNode : ExtensionIntermediateNode
     {
         public override RazorDiagnosticCollection Diagnostics { get; } = ReadOnlyDiagnosticCollection.Instance;
         
@@ -16,12 +17,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
         public string VariableName { get; set; }
 
-        public string Name { get; set; }
-
-        public string Value { get; set; }
-
-        public AttributeStructure AttributeStructure { get; set; }
-
         public override void Accept(IntermediateNodeVisitor visitor)
         {
             if (visitor == null)
@@ -29,7 +24,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
                 throw new ArgumentNullException(nameof(visitor));
             }
 
-            AcceptExtensionNode<DeclarePreallocatedTagHelperAttributeIntermediateNode>(this, visitor);
+            AcceptExtensionNode<AddPreallocatedTagHelperHtmlAttributeIntermediateNode>(this, visitor);
         }
 
         public override void WriteNode(CodeTarget target, CSharpRenderingContext context)
@@ -51,7 +46,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
                 return;
             }
 
-            extension.WriteDeclarePreallocatedTagHelperAttribute(context, this);
+            extension.WriteAddPreallocatedTagHelperHtmlAttribute(context, this);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DeclarePreallocatedTagHelperAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DeclarePreallocatedTagHelperAttributeIntermediateNode.cs
@@ -3,10 +3,11 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
-    internal sealed class AddPreallocatedTagHelperHtmlAttributeIntermediateNode : ExtensionIntermediateNode
+    internal sealed class DeclarePreallocatedTagHelperAttributeIntermediateNode : ExtensionIntermediateNode
     {
         public override RazorDiagnosticCollection Diagnostics { get; } = ReadOnlyDiagnosticCollection.Instance;
         
@@ -16,6 +17,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
         public string VariableName { get; set; }
 
+        public string Name { get; set; }
+
+        public string Value { get; set; }
+
+        public AttributeStructure AttributeStructure { get; set; }
+
         public override void Accept(IntermediateNodeVisitor visitor)
         {
             if (visitor == null)
@@ -23,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
                 throw new ArgumentNullException(nameof(visitor));
             }
 
-            AcceptExtensionNode<AddPreallocatedTagHelperHtmlAttributeIntermediateNode>(this, visitor);
+            AcceptExtensionNode<DeclarePreallocatedTagHelperAttributeIntermediateNode>(this, visitor);
         }
 
         public override void WriteNode(CodeTarget target, CSharpRenderingContext context)
@@ -45,7 +52,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
                 return;
             }
 
-            extension.WriteAddPreallocatedTagHelperHtmlAttribute(context, this);
+            extension.WriteDeclarePreallocatedTagHelperAttribute(context, this);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DeclarePreallocatedTagHelperHtmlAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DeclarePreallocatedTagHelperHtmlAttributeIntermediateNode.cs
@@ -3,8 +3,9 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     internal sealed class DeclarePreallocatedTagHelperHtmlAttributeIntermediateNode : ExtensionIntermediateNode
     {

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveIntermediateNode.cs
@@ -3,8 +3,9 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     internal sealed class DesignTimeDirectiveIntermediateNode : ExtensionIntermediateNode
     {

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectivePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectivePass.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     internal class DesignTimeDirectivePass : IntermediateNodePassBase, IRazorDirectiveClassifierPass
     {

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -2,9 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     internal class DesignTimeDirectiveTargetExtension : IDesignTimeDirectiveTargetExtension
     {

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/IDesignTimeDirectiveTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/IDesignTimeDirectiveTargetExtension.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     internal interface IDesignTimeDirectiveTargetExtension : ICodeTargetExtension
     {

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/IPreallocatedAttributeTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/IPreallocatedAttributeTargetExtension.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 
-namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     internal interface IPreallocatedAttributeTargetExtension : ICodeTargetExtension
     {

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedAttributeTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedAttributeTargetExtension.cs
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 
-namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     internal class PreallocatedAttributeTargetExtension : IPreallocatedAttributeTargetExtension
     {

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperAttributeOptimizationPass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperAttributeOptimizationPass.cs
@@ -6,9 +6,9 @@ using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
-    internal class RazorPreallocatedTagHelperAttributeOptimizationPass : IntermediateNodePassBase, IRazorOptimizationPass
+    internal class PreallocatedTagHelperAttributeOptimizationPass : IntermediateNodePassBase, IRazorOptimizationPass
     {
         public override int Order => DefaultFeatureOrder;
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/SetPreallocatedTagHelperPropertyIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/SetPreallocatedTagHelperPropertyIntermediateNode.cs
@@ -3,8 +3,9 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
-namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     internal sealed class SetPreallocatedTagHelperPropertyIntermediateNode : ExtensionIntermediateNode
     {

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -103,7 +104,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         internal static void AddRuntimeDefaults(IRazorEngineBuilder builder)
         {
-            builder.Features.Add(new RazorPreallocatedTagHelperAttributeOptimizationPass());
+            builder.Features.Add(new PreallocatedTagHelperAttributeOptimizationPass());
         }
 
         internal static void AddDesignTimeDefaults(IRazorEngineBuilder builder)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/DesignTimeDirectiveTargetExtensionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/DesignTimeDirectiveTargetExtensionTest.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     public class DesignTimeDirectiveTargetExtensionTest
     {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/PreallocatedAttributeTargetExtensionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/PreallocatedAttributeTargetExtensionTest.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
 {
     public class PreallocatedAttributeTargetExtensionTest
     {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorEngineTest.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Moq;
 using Xunit;
 
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 feature => Assert.IsType<DefaultDocumentClassifierPass>(feature),
                 feature => Assert.IsType<DirectiveRemovalOptimizationPass>(feature),
                 feature => Assert.IsType<DefaultDocumentClassifierPassFeature>(feature),
-                feature => Assert.IsType<RazorPreallocatedTagHelperAttributeOptimizationPass>(feature));
+                feature => Assert.IsType<PreallocatedTagHelperAttributeOptimizationPass>(feature));
         }
 
         private static void AssertDefaultRuntimePhases(IReadOnlyList<IRazorEnginePhase> phases)

--- a/test/Microsoft.AspNetCore.Razor.Test.Common/Langauge/Intermediate/IntermediateNodeAssert.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/Langauge/Intermediate/IntermediateNodeAssert.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Xunit;
 using Xunit.Sdk;


### PR DESCRIPTION
Moved design time directives and tag helper attribute preallocation to
.Extensions.

Just mechanical namespace changes here.