### PR TITLE
Make single line single file scoped directives automatically import.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CommonAnnotations.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CommonAnnotations.cs
@@ -5,6 +5,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 {
     internal static class CommonAnnotations
     {
+        public static readonly object Imported = "Imported";
+
         public static readonly object PrimaryClass = "PrimaryClass";
 
         public static readonly object PrimaryMethod = "PrimaryMethod";

--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -542,6 +542,34 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static string FormatDirectiveMustExistBeforeMarkupOrCode(object p0)
             => string.Format(CultureInfo.CurrentCulture, GetString("DirectiveMustExistBeforeMarkupOrCode"), p0);
 
+        /// <summary>
+        /// Block directive '{0}' cannot be imported.
+        /// </summary>
+        internal static string BlockDirectiveCannotBeImported
+        {
+            get => GetString("BlockDirectiveCannotBeImported");
+        }
+
+        /// <summary>
+        /// Block directive '{0}' cannot be imported.
+        /// </summary>
+        internal static string FormatBlockDirectiveCannotBeImported(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("BlockDirectiveCannotBeImported"), p0);
+
+        /// <summary>
+        /// Unreachable code. This can happen when a new {0} is introduced.
+        /// </summary>
+        internal static string UnexpectedDirectiveKind
+        {
+            get => GetString("UnexpectedDirectiveKind");
+        }
+
+        /// <summary>
+        /// Unreachable code. This can happen when a new {0} is introduced.
+        /// </summary>
+        internal static string FormatUnexpectedDirectiveKind(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("UnexpectedDirectiveKind"), p0);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticFactory.cs
@@ -13,6 +13,16 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         // General Errors ID Offset = 0
 
+        public static readonly RazorDiagnosticDescriptor Directive_BlockDirectiveCannotBeImported =
+        new RazorDiagnosticDescriptor(
+            $"{DiagnosticPrefix}0000",
+            () => Resources.BlockDirectiveCannotBeImported,
+            RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateDirective_BlockDirectiveCannotBeImported(string directive)
+        {
+            return RazorDiagnostic.Create(Directive_BlockDirectiveCannotBeImported, SourceSpan.Undefined, directive);
+        }
+
         #endregion
 
         #region Language Errors

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -231,4 +231,10 @@
   <data name="DirectiveMustExistBeforeMarkupOrCode" xml:space="preserve">
     <value>The '{0}' directive must exist prior to markup or code.</value>
   </data>
+  <data name="BlockDirectiveCannotBeImported" xml:space="preserve">
+    <value>Block directive '{0}' cannot be imported.</value>
+  </data>
+  <data name="UnexpectedDirectiveKind" xml:space="preserve">
+    <value>Unreachable code. This can happen when a new {0} is introduced.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIntermediateNodeLoweringPhaseIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIntermediateNodeLoweringPhaseIntegrationTest.cs
@@ -380,7 +380,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         }
 
         [Fact]
-        public void Lower_WithImports_Directive()
+        public void Lower_WithMultipleImports_SingleLineFileScopedSinglyOccurring()
         {
             // Arrange
             var source = TestRazorSourceDocument.Create("<p>Hi!</p>");
@@ -395,13 +395,19 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var documentNode = Lower(codeDocument, b =>
             {
-                b.AddDirective(DirectiveDescriptor.CreateDirective("test", DirectiveKind.SingleLine, d => d.AddMemberToken()));
+                b.AddDirective(DirectiveDescriptor.CreateDirective(
+                    "test", 
+                    DirectiveKind.SingleLine, 
+                    builder =>
+                    {
+                        builder.AddMemberToken();
+                        builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
+                    }));
             });
 
             // Assert
             Children(
                 documentNode,
-                n => Directive("test", n, c => DirectiveToken(DirectiveTokenKind.Member, "value1", c)),
                 n => Directive("test", n, c => DirectiveToken(DirectiveTokenKind.Member, "value2", c)),
                 n => Html("<p>Hi!</p>", n));
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIntermediateNodeLoweringPhaseTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIntermediateNodeLoweringPhaseTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
@@ -9,6 +11,198 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public class DefaultRazorIntermediateNodeLoweringPhaseTest
     {
+        [Fact]
+        public void Execute_AutomaticallyImportsSingleLineSinglyOccurringDirective()
+        {
+            // Arrange
+            var directive = DirectiveDescriptor.CreateSingleLineDirective(
+                "custom",
+                builder =>
+                {
+                    builder.AddStringToken();
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
+                });
+            var phase = new DefaultRazorIntermediateNodeLoweringPhase();
+            var engine = RazorEngine.CreateEmpty(b =>
+            {
+                b.Phases.Add(phase);
+                b.AddDirective(directive);
+            });
+            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var importSource = TestRazorSourceDocument.Create("@custom \"hello\"", fileName: "import.cshtml");
+            var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
+            codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
+            codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });
+
+            // Act
+            phase.Execute(codeDocument);
+
+            // Assert
+            var documentNode = codeDocument.GetDocumentIntermediateNode();
+            var customDirectives = documentNode.FindDirectiveReferences(directive);
+            var customDirective = (DirectiveIntermediateNode)Assert.Single(customDirectives).Node;
+            var stringToken = Assert.Single(customDirective.Tokens);
+            Assert.Equal("\"hello\"", stringToken.Content);
+        }
+
+        [Fact]
+        public void Execute_AutomaticallyOverridesImportedSingleLineSinglyOccurringDirective_MainDocument()
+        {
+            // Arrange
+            var directive = DirectiveDescriptor.CreateSingleLineDirective(
+                "custom",
+                builder =>
+                {
+                    builder.AddStringToken();
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
+                });
+            var phase = new DefaultRazorIntermediateNodeLoweringPhase();
+            var engine = RazorEngine.CreateEmpty(b =>
+            {
+                b.Phases.Add(phase);
+                b.AddDirective(directive);
+            });
+            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var importSource = TestRazorSourceDocument.Create("@custom \"hello\"", fileName: "import.cshtml");
+            var codeDocument = TestRazorCodeDocument.Create("@custom \"world\"");
+            codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
+            codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });
+
+            // Act
+            phase.Execute(codeDocument);
+
+            // Assert
+            var documentNode = codeDocument.GetDocumentIntermediateNode();
+            var customDirectives = documentNode.FindDirectiveReferences(directive);
+            var customDirective = (DirectiveIntermediateNode)Assert.Single(customDirectives).Node;
+            var stringToken = Assert.Single(customDirective.Tokens);
+            Assert.Equal("\"world\"", stringToken.Content);
+        }
+
+        [Fact]
+        public void Execute_AutomaticallyOverridesImportedSingleLineSinglyOccurringDirective_MultipleImports()
+        {
+            // Arrange
+            var directive = DirectiveDescriptor.CreateSingleLineDirective(
+                "custom",
+                builder =>
+                {
+                    builder.AddStringToken();
+                    builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
+                });
+            var phase = new DefaultRazorIntermediateNodeLoweringPhase();
+            var engine = RazorEngine.CreateEmpty(b =>
+            {
+                b.Phases.Add(phase);
+                b.AddDirective(directive);
+            });
+            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var importSource1 = TestRazorSourceDocument.Create("@custom \"hello\"", fileName: "import1.cshtml");
+            var importSource2 = TestRazorSourceDocument.Create("@custom \"world\"", fileName: "import2.cshtml");
+            var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
+            codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
+            codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource1, options), RazorSyntaxTree.Parse(importSource2, options) });
+
+            // Act
+            phase.Execute(codeDocument);
+
+            // Assert
+            var documentNode = codeDocument.GetDocumentIntermediateNode();
+            var customDirectives = documentNode.FindDirectiveReferences(directive);
+            var customDirective = (DirectiveIntermediateNode)Assert.Single(customDirectives).Node;
+            var stringToken = Assert.Single(customDirective.Tokens);
+            Assert.Equal("\"world\"", stringToken.Content);
+        }
+
+        [Fact]
+        public void Execute_DoesNotImportNonFileScopedSinglyOccurringDirectives_Block()
+        {
+            // Arrange
+            var codeBlockDirective = DirectiveDescriptor.CreateCodeBlockDirective("code", b => b.AddStringToken());
+            var razorBlockDirective = DirectiveDescriptor.CreateRazorBlockDirective("razor", b => b.AddStringToken());
+            var phase = new DefaultRazorIntermediateNodeLoweringPhase();
+            var engine = RazorEngine.CreateEmpty(b =>
+            {
+                b.Phases.Add(phase);
+                b.AddDirective(codeBlockDirective);
+                b.AddDirective(razorBlockDirective);
+            });
+            var options = RazorParserOptions.Create(new[] { codeBlockDirective, razorBlockDirective }, designTime: false);
+            var importSource = TestRazorSourceDocument.Create(
+@"@code ""code block"" { }
+@razor ""razor block"" { }",
+                fileName: "testImports.cshtml");
+            var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
+            codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
+            codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });
+
+            // Act
+            phase.Execute(codeDocument);
+
+            // Assert
+            var documentNode = codeDocument.GetDocumentIntermediateNode();
+            var directives = documentNode.Children.OfType<DirectiveIntermediateNode>();
+            Assert.Empty(directives);
+        }
+
+        [Fact]
+        public void Execute_ErrorsForCodeBlockFileScopedSinglyOccurringDirectives()
+        {
+            // Arrange
+            var directive = DirectiveDescriptor.CreateCodeBlockDirective("custom", b => b.Usage = DirectiveUsage.FileScopedSinglyOccurring);
+            var phase = new DefaultRazorIntermediateNodeLoweringPhase();
+            var engine = RazorEngine.CreateEmpty(b =>
+            {
+                b.Phases.Add(phase);
+                b.AddDirective(directive);
+            });
+            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var importSource = TestRazorSourceDocument.Create("@custom { }", fileName: "import.cshtml");
+            var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
+            codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
+            codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });
+            var expectedDiagnostic = RazorDiagnosticFactory.CreateDirective_BlockDirectiveCannotBeImported("custom");
+
+            // Act
+            phase.Execute(codeDocument);
+
+            // Assert
+            var documentNode = codeDocument.GetDocumentIntermediateNode();
+            var directives = documentNode.Children.OfType<DirectiveIntermediateNode>();
+            Assert.Empty(directives);
+            var diagnostic = Assert.Single(documentNode.GetAllDiagnostics());
+            Assert.Equal(expectedDiagnostic, diagnostic);
+        }
+
+        [Fact]
+        public void Execute_ErrorsForRazorBlockFileScopedSinglyOccurringDirectives()
+        {
+            // Arrange
+            var directive = DirectiveDescriptor.CreateRazorBlockDirective("custom", b => b.Usage = DirectiveUsage.FileScopedSinglyOccurring);
+            var phase = new DefaultRazorIntermediateNodeLoweringPhase();
+            var engine = RazorEngine.CreateEmpty(b =>
+            {
+                b.Phases.Add(phase);
+                b.AddDirective(directive);
+            });
+            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var importSource = TestRazorSourceDocument.Create("@custom { }", fileName: "import.cshtml");
+            var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
+            codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
+            codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });
+            var expectedDiagnostic = RazorDiagnosticFactory.CreateDirective_BlockDirectiveCannotBeImported("custom");
+
+            // Act
+            phase.Execute(codeDocument);
+
+            // Assert
+            var documentNode = codeDocument.GetDocumentIntermediateNode();
+            var directives = documentNode.Children.OfType<DirectiveIntermediateNode>();
+            Assert.Empty(directives);
+            var diagnostic = Assert.Single(documentNode.GetAllDiagnostics());
+            Assert.Equal(expectedDiagnostic, diagnostic);
+        }
+
         [Fact]
         public void Execute_ThrowsForMissingDependency_SyntaxTree()
         {
@@ -34,7 +228,6 @@ namespace Microsoft.AspNetCore.Razor.Language
             var engine = RazorEngine.CreateEmpty(b => b.Phases.Add(phase));
             var codeDocument = TestRazorCodeDocument.Create("<p class=@(");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source));
-            var options = RazorCodeGenerationOptions.CreateDefault();
 
             // Act
             phase.Execute(codeDocument);


### PR DESCRIPTION
### Gist of the PR
- Single line directives in imports always flow to the main document. This is to enable directives like `@inject` (a non-file scoped singly occurring directive) to provide its own import behavior.
- Single line directives that are `DirectiveUsage.FileScopedSinglyOccurring` only import if they're the first of their kind. Basically implementing overriding behavior (like what we have with `@model`) today.
- Block directives that are `DirectiveUsage.FileScopedSinglyOccurring` and exist in an import do not import AND have an error logged. 

*The third bullet point I'm unsure about, it seems too specific. Despite what's in this PR I think i'm leaning towards not having an error at all and just not flowing them* @rynowak / @ajaybhargavb please share your thoughts on this.

---------------------------------------
- Added an inner pass inside of the intermediate lowering phase to determine which directives get flowed to the final document. There were many ways to accomplish this but in order to keep the last wins mechanic for non-auto imported directives I had to let the directives get created and then removed based on if they were inherited.
- Added error case if a user attempts to import a block directive with a `FileScopedSinglyOccurring` directive usage.
- Added test cases that validate directives are properly inherietd at the intermediate lowering phase.
- Updated a few tests that had incorrect assumptions.
- Left the default directive passes alone in regards to determining the "imported" directive to enable users to add their own model, inherits, etc. directives that take precedence.
- Normalized the passes in the intermediate lowering phase to handle directives identically (we don't conditionally lower anymore).

#1376 

/cc @rynowak @ajaybhargavb 