### PR TITLE
Add file scoped multiple occurring extensible directives.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/InjectDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/InjectDirective.cs
@@ -14,7 +14,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
         public static readonly DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
             "inject",
             DirectiveKind.SingleLine,
-            builder => builder.AddTypeToken().AddMemberToken());
+            builder =>
+            {
+                builder.AddTypeToken().AddMemberToken();
+                builder.Usage = DirectiveUsage.FileScopedMultipleOccurring;
+            });
 
         public static IRazorEngineBuilder Register(IRazorEngineBuilder builder)
         {

--- a/src/Microsoft.AspNetCore.Razor.Language/DirectiveUsage.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DirectiveUsage.cs
@@ -18,5 +18,10 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// <see cref="DirectiveKind.SingleLine"/>, the last occurrence of the directive is imported.
         /// </summary>
         FileScopedSinglyOccurring,
+
+        /// <summary>
+        /// Directive must exist prior to any HTML or code.
+        /// </summary>
+        FileScopedMultipleOccurring,
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -1785,7 +1785,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     UsageError(Resources.FormatDuplicateDirective(descriptor.Directive));
                     return;
                 }
+            }
 
+            if (descriptor.Usage == DirectiveUsage.FileScopedSinglyOccurring ||
+                descriptor.Usage == DirectiveUsage.FileScopedMultipleOccurring)
+            {
                 var root = Context.Builder.ActiveBlocks.Last();
                 for (var i = 0; i < root.Children.Count; i++)
                 {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
@@ -5,8 +5,11 @@ TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cs
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,7): Error RZ9999: The 'model' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,1): Error RZ9999: The 'model' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,8): Error RZ9999: The 'model' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(10,1): Error RZ9999: The 'inject' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(10,8): Error RZ9999: The 'inject' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(11,1): Error RZ9999: The 'inject' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(11,9): Error RZ9999: The 'inject' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(12,1): Error RZ9999: The 'inject' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(12,26): Error RZ9999: The 'inject' directive expects an identifier.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(14,1): Error RZ9999: The 'namespace' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(14,11): Error RZ9999: The 'namespace' directive expects a namespace name.

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
@@ -5,8 +5,11 @@ TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cs
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,7): Error RZ9999: The 'model' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,1): Error RZ9999: The 'model' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,8): Error RZ9999: The 'model' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(10,1): Error RZ9999: The 'inject' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(10,8): Error RZ9999: The 'inject' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(11,1): Error RZ9999: The 'inject' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(11,9): Error RZ9999: The 'inject' directive expects a type name.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(12,1): Error RZ9999: The 'inject' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(12,26): Error RZ9999: The 'inject' directive expects an identifier.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(14,1): Error RZ9999: The 'namespace' directive must exist prior to markup or code.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(14,11): Error RZ9999: The 'namespace' directive expects a namespace name.


### PR DESCRIPTION
- Updated existing singly occurring tests that verified that the directives must occur prior to any content to be theories that tested the joint "file scoped" behavior of the usage.
- Added tests that validate `FileScopedMultipleOccurring` can have duplicate directives without erroring.
- Update inject directive to utilize DirectiveUsage. 
- The `@inject` directive must now occur prior to any markup or code due to its `DirectiveUsage.FileScopedMultipleOccurring` usage.

#1377

/cc @ajaybhargavb @rynowak 