### PR TITLE
Run DesignTimeDirectivePass later in the phase

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelDirective.cs
@@ -94,18 +94,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 }
 
                 var baseType = visitor.Class?.BaseType?.Replace("<TModel>", "<" + modelType + ">");
-                for (var i = visitor.InheritsDirectives.Count - 1; i >= 0; i--)
-                {
-                    var directive = visitor.InheritsDirectives[i];
-                    var tokens = directive.Tokens.ToArray();
-                    if (tokens.Length >= 1)
-                    {
-                        baseType = tokens[0].Content.Replace("<TModel>", "<" + modelType + ">");
-                        tokens[0].Content = baseType;
-                        break;
-                    }
-                }
-
                 visitor.Class.BaseType = baseType;
             }
         }
@@ -115,8 +103,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             public NamespaceDeclarationIntermediateNode Namespace { get; private set; }
 
             public ClassDeclarationIntermediateNode Class { get; private set; }
-
-            public IList<DirectiveIntermediateNode> InheritsDirectives { get; } = new List<DirectiveIntermediateNode>();
 
             public IList<DirectiveIntermediateNode> ModelDirectives { get; } = new List<DirectiveIntermediateNode>();
 
@@ -145,10 +131,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 if (node.Descriptor == Directive)
                 {
                     ModelDirectives.Add(node);
-                }
-                else if (node.Descriptor.Directive == "inherits")
-                {
-                    InheritsDirectives.Add(node);
                 }
             }
         }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectivePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectivePass.cs
@@ -9,8 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
     {
         internal const string DesignTimeVariable = "__o";
 
-        // This needs to run before other directive classifiers.
-        public override int Order => -10;
+        // This needs to run after other directive classifiers. Any DirectiveToken that is not removed 
+        // by the previous classifiers will have auto-generated design time support.
+        public override int Order => DefaultFeatureOrder;
 
         protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
         {

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/FunctionsDirectivePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/FunctionsDirectivePass.cs
@@ -17,8 +17,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             foreach (var functions in documentNode.FindDirectiveReferences(FunctionsDirective.Directive))
             {
-                functions.Remove();
-
                 for (var i = 0; i < functions.Node.Children.Count; i++)
                 {
                     @class.Children.Add(functions.Node.Children[i]);

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/InheritsDirectivePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/InheritsDirectivePass.cs
@@ -19,12 +19,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             foreach (var inherits in documentNode.FindDirectiveReferences(InheritsDirective.Directive))
             {
-                inherits.Remove();
-
                 var token = ((DirectiveIntermediateNode)inherits.Node).Tokens.FirstOrDefault();
                 if (token != null)
                 {
-                    
                     @class.BaseType = token.Content;
                     break;
                 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/SectionDirectivePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/SectionDirectivePass.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
                     section.Children.Add(directive.Node.Children[i]);
                 }
 
-                directive.Replace(section);
+                directive.InsertAfter(section);
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelDirectiveTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/ModelDirectiveTest.cs
@@ -259,6 +259,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 }
             }
 
+            // InheritsDirectivePass needs to run before ModelDirective.
+            var pass = new InheritsDirectivePass()
+            {
+                Engine = engine
+            };
+            pass.Execute(codeDocument, codeDocument.GetDocumentIntermediateNode());
+
             return codeDocument.GetDocumentIntermediateNode();
         }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/FunctionsDirectivePassTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/FunctionsDirectivePassTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
         }
 
         [Fact]
-        public void Execute_MovesStatementsToClassLevel()
+        public void Execute_AddsStatementsToClassLevel()
         {
             // Arrange
             var engine = CreateEngine();
@@ -68,8 +68,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
                 node => Assert.IsType<MethodDeclarationIntermediateNode>(node),
                 node => CSharpCode(" var value = true; ", node));
 
-            var method = (MethodDeclarationIntermediateNode)@class.Children[0];
-            Assert.Empty(method.Children);
+            var method = @class.Children[0];
+            Children(
+                method,
+                node => Assert.IsType<DirectiveIntermediateNode>(node));
         }
 
         private static RazorEngine CreateEngine()

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/SectionDirectivePassTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/SectionDirectivePassTest.cs
@@ -66,7 +66,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
             var @class = @namespace.Children[0];
             var method = SingleChild<MethodDeclarationIntermediateNode>(@class);
 
-            var section = SingleChild<SectionIntermediateNode>(method);
+            Children(
+                method,
+                node => Assert.IsType<DirectiveIntermediateNode>(node),
+                node => Assert.IsType<SectionIntermediateNode>(node));
+
+            var section = method.Children[1] as SectionIntermediateNode;
             Assert.Equal("Header", section.Name);
             Children(section, c => Html(" <p>Hello World</p> ", c));
         }


### PR DESCRIPTION
#1440 

- Running DesignTimeDirectivePass after all other DirectiveClassifier passes.
- Modified `Section`, `Functions` and `Inherits` directive passes to not remove themselves so that the DesignTimeDirectivePass has a chance to add design time support. They are then removed by the `DirectiveRemovalOptimizationPass`.
- Updated some unit tests to reflect the changes.