### PR TITLE
Added convenience properties to TagHelperIntermediateNode

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperIntermediateNode.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 {
@@ -48,6 +49,24 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
         public TagMode TagMode { get; set; }
 
         public ICollection<TagHelperDescriptor> TagHelpers { get; } = new List<TagHelperDescriptor>();
+
+        public TagHelperBodyIntermediateNode Body => Children.OfType<TagHelperBodyIntermediateNode>().SingleOrDefault();
+
+        public IEnumerable<SetTagHelperPropertyIntermediateNode> SetTagHelperProperties
+        {
+            get
+            {
+                return Children.OfType<SetTagHelperPropertyIntermediateNode>();
+            }
+        }
+
+        public IEnumerable<AddTagHelperHtmlAttributeIntermediateNode> AddTagHelperHtmlAttributes
+        {
+            get
+            {
+                return Children.OfType<AddTagHelperHtmlAttributeIntermediateNode>();
+            }
+        }
 
         public override void Accept(IntermediateNodeVisitor visitor)
         {


### PR DESCRIPTION
#1329 

@NTaylorMullen @rynowak 

The reason behind doing this is to have all the parts of a tag helper tied to a single intermediate node. I have not made any changes to the code generation to use these properties. I will do that (if needed) after @rynowak's changes are in. 