### PR TITLE
Add ChildTagDescriptor.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/AllowedChildTagDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/AllowedChildTagDescriptor.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    [DebuggerDisplay("{DisplayName,nq}")]
+    public abstract class AllowedChildTagDescriptor : IEquatable<AllowedChildTagDescriptor>
+    {
+        public string Name { get; protected set; }
+
+        public string DisplayName { get; protected set; }
+
+        public IReadOnlyList<RazorDiagnostic> Diagnostics { get; protected set; }
+
+        public bool HasErrors
+        {
+            get
+            {
+                var errors = Diagnostics.Any(diagnostic => diagnostic.Severity == RazorDiagnosticSeverity.Error);
+
+                return errors;
+            }
+        }
+
+        public bool Equals(AllowedChildTagDescriptor other)
+        {
+            return AllowedChildTagDescriptorComparer.Default.Equals(this, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AllowedChildTagDescriptor);
+        }
+
+        public override int GetHashCode()
+        {
+            return AllowedChildTagDescriptorComparer.Default.GetHashCode(this);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/AllowedChildTagDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/AllowedChildTagDescriptorBuilder.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class AllowedChildTagDescriptorBuilder
+    {
+        public abstract string Name { get; set; }
+
+        public abstract string DisplayName { get; set; }
+
+        public abstract RazorDiagnosticCollection Diagnostics { get; }
+        
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/AllowedChildTagDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/AllowedChildTagDescriptorComparer.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class AllowedChildTagDescriptorComparer : IEqualityComparer<AllowedChildTagDescriptor>
+    {
+        /// <summary>
+        /// A default instance of the <see cref="AllowedChildTagDescriptorComparer"/>.
+        /// </summary>
+        public static readonly AllowedChildTagDescriptorComparer Default =
+            new AllowedChildTagDescriptorComparer();
+
+        /// <summary>
+        /// A default instance of the <see cref="AllowedChildTagDescriptorComparer"/> that does case-sensitive comparison.
+        /// </summary>
+        internal static readonly AllowedChildTagDescriptorComparer CaseSensitive =
+            new AllowedChildTagDescriptorComparer(caseSensitive: true);
+
+        private readonly StringComparer _stringComparer;
+        private readonly StringComparison _stringComparison;
+
+        private AllowedChildTagDescriptorComparer(bool caseSensitive = false)
+        {
+            if (caseSensitive)
+            {
+                _stringComparer = StringComparer.Ordinal;
+                _stringComparison = StringComparison.Ordinal;
+            }
+            else
+            {
+                _stringComparer = StringComparer.OrdinalIgnoreCase;
+                _stringComparison = StringComparison.OrdinalIgnoreCase;
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual bool Equals(
+            AllowedChildTagDescriptor descriptorX,
+            AllowedChildTagDescriptor descriptorY)
+        {
+            if (object.ReferenceEquals(descriptorX, descriptorY))
+            {
+                return true;
+            }
+
+            if (descriptorX == null ^ descriptorY == null)
+            {
+                return false;
+            }
+
+            return descriptorX != null &&
+                string.Equals(descriptorX.Name, descriptorY.Name, _stringComparison) &&
+                string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal) &&
+                Enumerable.SequenceEqual(descriptorX.Diagnostics, descriptorY.Diagnostics);
+        }
+
+        /// <inheritdoc />
+        public virtual int GetHashCode(AllowedChildTagDescriptor descriptor)
+        {
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(descriptor.Name, _stringComparer);
+            hashCodeCombiner.Add(descriptor.DisplayName, StringComparer.Ordinal);
+
+            return hashCodeCombiner.CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultAllowedChildTagDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultAllowedChildTagDescriptor.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultAllowedChildTagDescriptor : AllowedChildTagDescriptor
+    {
+        public DefaultAllowedChildTagDescriptor(string name, string displayName, RazorDiagnostic[] diagnostics)
+        {
+            Name = name;
+            DisplayName = displayName;
+            Diagnostics = diagnostics;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultAllowedChildTagDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultAllowedChildTagDescriptorBuilder.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultAllowedChildTagDescriptorBuilder : AllowedChildTagDescriptorBuilder
+    {
+        private readonly DefaultTagHelperDescriptorBuilder _parent;
+        private DefaultRazorDiagnosticCollection _diagnostics;
+
+        public DefaultAllowedChildTagDescriptorBuilder(DefaultTagHelperDescriptorBuilder parent)
+        {
+            _parent = parent;
+        }
+
+        public override string Name { get; set; }
+
+        public override string DisplayName { get; set; }
+
+        public override RazorDiagnosticCollection Diagnostics
+        {
+            get
+            {
+                if (_diagnostics == null)
+                {
+                    _diagnostics = new DefaultRazorDiagnosticCollection();
+                }
+
+                return _diagnostics;
+            }
+        }
+
+        public AllowedChildTagDescriptor Build()
+        {
+            var validationDiagnostics = Validate();
+            var diagnostics = new HashSet<RazorDiagnostic>(validationDiagnostics);
+            if (_diagnostics != null)
+            {
+                diagnostics.UnionWith(_diagnostics);
+            }
+
+            var displayName = DisplayName ?? Name;
+            var descriptor = new DefaultAllowedChildTagDescriptor(
+                Name,
+                displayName,
+                diagnostics?.ToArray() ?? Array.Empty<RazorDiagnostic>());
+
+            return descriptor;
+        }
+
+        private IEnumerable<RazorDiagnostic> Validate()
+        {
+            if (string.IsNullOrWhiteSpace(Name))
+            {
+                var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidRestrictedChildNullOrWhitespace(_parent.GetDisplayName());
+
+                yield return diagnostic;
+            }
+            else if (Name != TagHelperMatchingConventions.ElementCatchAllName)
+            {
+                foreach (var character in Name)
+                {
+                    if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
+                    {
+                        var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidRestrictedChild(_parent.GetDisplayName(), Name, character);
+
+                        yield return diagnostic;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultTagHelperDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultTagHelperDescriptor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             string tagOutputHint,
             TagMatchingRuleDescriptor[] tagMatchingRules,
             BoundAttributeDescriptor[] attributeDescriptors,
-            string[] allowedChildTags,
+            AllowedChildTagDescriptor[] allowedChildTags,
             Dictionary<string, string> metadata,
             RazorDiagnostic[] diagnostics) 
             : base(kind)

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -855,7 +855,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 {
                     AllowedChildren = Builder.BindingResult.Descriptors
                         .Where(descriptor => descriptor.AllowedChildTags != null)
-                        .SelectMany(descriptor => descriptor.AllowedChildTags)
+                        .SelectMany(descriptor => descriptor.AllowedChildTags.Select(childTag => childTag.Name))
                         .Distinct(StringComparer.OrdinalIgnoreCase)
                         .ToList();
                 }

--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptor.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public IEnumerable<BoundAttributeDescriptor> BoundAttributes { get; protected set; }
 
-        public IEnumerable<string> AllowedChildTags { get; protected set; }
+        public IEnumerable<AllowedChildTagDescriptor> AllowedChildTags { get; protected set; }
 
         public string Documentation { get; protected set; }
 
@@ -55,9 +55,13 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             if (_allDiagnostics == null)
             {
+                var allowedChildTagDiagnostics = AllowedChildTags.SelectMany(childTag => childTag.Diagnostics);
                 var attributeDiagnostics = BoundAttributes.SelectMany(attribute => attribute.Diagnostics);
                 var ruleDiagnostics = TagMatchingRules.SelectMany(rule => rule.GetAllDiagnostics());
-                var combinedDiagnostics = attributeDiagnostics.Concat(ruleDiagnostics).Concat(Diagnostics);
+                var combinedDiagnostics = allowedChildTagDiagnostics
+                    .Concat(attributeDiagnostics)
+                    .Concat(ruleDiagnostics)
+                    .Concat(Diagnostics);
                 _allDiagnostics = combinedDiagnostics.ToArray();
             }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptorBuilder.cs
@@ -54,15 +54,17 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public abstract string Documentation { get; set; }
 
-        public abstract ICollection<string> AllowedChildTags { get; }
-
         public abstract IDictionary<string, string> Metadata { get; }
 
         public abstract RazorDiagnosticCollection Diagnostics { get; }
 
+        public abstract IReadOnlyList<AllowedChildTagDescriptorBuilder> AllowedChildTags { get; }
+
         public abstract IReadOnlyList<BoundAttributeDescriptorBuilder> BoundAttributes { get; }
 
         public abstract IReadOnlyList<TagMatchingRuleDescriptorBuilder> TagMatchingRules { get; }
+
+        public abstract void AllowChildTag(Action<AllowedChildTagDescriptorBuilder> configure);
 
         public abstract void BindAttribute(Action<BoundAttributeDescriptorBuilder> configure);
 

--- a/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/DefaultTagHelperDescriptorFactory.cs
@@ -141,13 +141,13 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
-            builder.AllowedChildTags.Add((string)restrictChildrenAttribute.ConstructorArguments[0].Value);
+            builder.AllowChildTag(childTagBuilder => childTagBuilder.Name = (string)restrictChildrenAttribute.ConstructorArguments[0].Value);
 
             if (restrictChildrenAttribute.ConstructorArguments.Length == 2)
             {
                 foreach (var value in restrictChildrenAttribute.ConstructorArguments[1].Values)
                 {
-                    builder.AllowedChildTags.Add((string)value.Value);
+                    builder.AllowChildTag(childTagBuilder => childTagBuilder.Name = (string)value.Value);
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperCompletionService.cs
@@ -244,14 +244,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
             foreach (var descriptor in binding.Descriptors)
             {
-                if (descriptor.AllowedChildTags == null)
-                {
-                    continue;
-                }
-
                 foreach (var childTag in descriptor.AllowedChildTags)
                 {
-                    var prefixedName = string.Concat(prefix, childTag);
+                    var prefixedName = string.Concat(prefix, childTag.Name);
                     var descriptors = _tagHelperFactsService.GetTagHelpersGivenTag(
                         completionContext.DocumentContext,
                         prefixedName,

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperDescriptorJsonConverter.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/TagHelperDescriptorJsonConverter.cs
@@ -58,8 +58,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
             foreach (var childTag in childTags)
             {
-                var tagValue = childTag.Value<string>();
-                builder.AllowedChildTags.Add(tagValue);
+                var tag = childTag.Value<JObject>();
+                builder.AllowChildTag(childTagBuilder => ReadAllowedChildTag(childTagBuilder, tag, serializer));
             }
 
             foreach (var diagnostic in diagnostics)
@@ -124,6 +124,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             builder.NameComparisonMode = (RequiredAttributeDescriptor.NameComparisonMode)nameComparison;
             builder.Value = value;
             builder.ValueComparisonMode = (RequiredAttributeDescriptor.ValueComparisonMode)valueComparison;
+
+            foreach (var diagnostic in diagnostics)
+            {
+                var diagnosticReader = diagnostic.CreateReader();
+                var diagnosticObject = serializer.Deserialize<RazorDiagnostic>(diagnosticReader);
+                builder.Diagnostics.Add(diagnosticObject);
+            }
+        }
+
+        private void ReadAllowedChildTag(AllowedChildTagDescriptorBuilder builder, JObject childTag, JsonSerializer serializer)
+        {
+            var name = childTag[nameof(AllowedChildTagDescriptor.Name)].Value<string>();
+            var displayName = childTag[nameof(AllowedChildTagDescriptor.DisplayName)].Value<string>();
+            var diagnostics = childTag[nameof(AllowedChildTagDescriptor.Diagnostics)].Value<JArray>();
+
+            builder.Name = name;
+            builder.DisplayName = displayName;
 
             foreach (var diagnostic in diagnostics)
             {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultAllowedChildTagDescriptorBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultAllowedChildTagDescriptorBuilderTest.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class DefaultAllowedChildTagDescriptorBuilderTest
+    {
+        [Fact]
+        public void Build_DisplayNameIsName()
+        {
+            // Arrange
+            var builder = new DefaultAllowedChildTagDescriptorBuilder(null);
+            builder.Name = "foo";
+
+            // Act
+            var descriptor = builder.Build();
+
+            // Assert
+            Assert.Equal("foo", descriptor.DisplayName);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestTagHelperDescriptorBuilderExtensions.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestTagHelperDescriptorBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.AllowedChildTags.Add(allowedChild);
+            builder.AllowChildTag(childTagBuilder => childTagBuilder.Name = allowedChild);
 
             return builder;
         }

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Language/TestTagHelperDescriptorBuilderExtensions.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Language/TestTagHelperDescriptorBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.AllowedChildTags.Add(allowedChild);
+            builder.AllowChildTag(childTagBuilder => childTagBuilder.Name = allowedChild);
 
             return builder;
         }


### PR DESCRIPTION
- Changed the `AllowedChildTags` collection on `TagHelperDescriptor` to have a custom object type to represent child tags.
- Created comparers and builders to work with the child tag descriptor.
- Removed the validation methods on `TagHelperDescriptorBuilder` since there's no longer any bits to validate (they're contained within the sub-properties).
- Unit tested the `DisplayName`.

#1493 

/cc @rynowak @ajaybhargavb 