### PR TITLE
Check for warnrings in tests taht compile

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -77,7 +77,6 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // The document should contain all errors that currently exist in the system. This involves
             // adding the errors from the primary and imported syntax trees.
-
             for (i = 0; i < syntaxTree.Diagnostics.Count; i++)
             {
                 document.Diagnostics.Add(syntaxTree.Diagnostics[i]);

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperTargetExtension.cs
@@ -437,11 +437,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
             {
                 context.CodeWriter.WriteLine("#line hidden");
 
-                // Need to disable the warning "X is assigned to but never used." for the value buffer since
+                // Need to disable the warning "X is never used." for the value buffer since
                 // whether it's used depends on how a TagHelper is used.
-                context.CodeWriter.WriteLine("#pragma warning disable 0414");
+                context.CodeWriter.WriteLine("#pragma warning disable 0169");
                 context.CodeWriter.WriteField(PrivateModifiers, "string", StringValueBufferVariableName);
-                context.CodeWriter.WriteLine("#pragma warning restore 0414");
+                context.CodeWriter.WriteLine("#pragma warning restore 0169");
 
                 context.CodeWriter.WriteField(PrivateModifiers, ExecutionContextTypeName, ExecutionContextVariableName);
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectivePass.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectivePass.cs
@@ -25,15 +25,39 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             public override void VisitClassDeclaration(ClassDeclarationIntermediateNode node)
             {
-                var designTimeHelperDeclaration = new CSharpCodeIntermediateNode();
-                IntermediateNodeBuilder.Create(designTimeHelperDeclaration)
-                    .Add(new IntermediateToken()
+                node.Children.Insert(0, new CSharpCodeIntermediateNode()
+                {
+                    Children =
                     {
-                        Kind = IntermediateToken.TokenKind.CSharp,
-                        Content = $"private static {typeof(object).FullName} {DesignTimeVariable} = null;"
-                    });
-
-                node.Children.Insert(0, designTimeHelperDeclaration);
+                        new IntermediateToken()
+                        {
+                            Kind = IntermediateToken.TokenKind.CSharp,
+                            Content = "#pragma warning disable 0414",
+                        }
+                    }
+                });
+                node.Children.Insert(1, new CSharpCodeIntermediateNode()
+                {
+                    Children =
+                    {
+                        new IntermediateToken()
+                        {
+                            Kind = IntermediateToken.TokenKind.CSharp,
+                            Content = $"private static {typeof(object).FullName} {DesignTimeVariable} = null;",
+                        }
+                    }
+                });
+                node.Children.Insert(2, new CSharpCodeIntermediateNode()
+                {
+                    Children =
+                    {
+                        new IntermediateToken()
+                        {
+                            Kind = IntermediateToken.TokenKind.CSharp,
+                            Content = "#pragma warning restore 0414",
+                        }
+                    }
+                });
 
                 _directiveNode = new DesignTimeDirectiveIntermediateNode();
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -109,8 +109,11 @@ public class MyModel
         [Fact]
         public void _ViewImports_Runtime()
         {
+            var error = "'TestFiles_IntegrationTests_CodeGenerationIntegrationTest__ViewImports_cshtml.Model' " + 
+                "hides inherited member 'RazorPage<dynamic>.Model'. Use the new keyword if hiding was intended.";
+
             var references = CreateCompilationReferences(CurrentMvcShim);
-            RunRuntimeTest(references);
+            RunRuntimeTest(references, new[] { error, });
         }
 
         [Fact]
@@ -344,8 +347,11 @@ public abstract class MyPageModel<T> : Page
         [Fact]
         public void _ViewImports_DesignTime()
         {
+            var error = "'TestFiles_IntegrationTests_CodeGenerationIntegrationTest__ViewImports_cshtml.Model' " +
+                "hides inherited member 'RazorPage<dynamic>.Model'. Use the new keyword if hiding was intended.";
+
             var references = CreateCompilationReferences(CurrentMvcShim);
-            RunDesignTimeTest(references);
+            RunDesignTimeTest(references, new[] { error, });
         }
 
         [Fact]
@@ -555,7 +561,7 @@ public class AllTagHelper : {typeof(TagHelper).FullName}
 
             var diagnostics = compilation.GetDiagnostics();
 
-            var errors = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
+            var errors = diagnostics.Where(d => d.Severity >= DiagnosticSeverity.Warning);
 
             if (expectedErrors == null)
             {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.codegen.cs
@@ -18,7 +18,9 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.ir.txt
@@ -26,7 +26,11 @@ Document -
                 DirectiveToken - (729:13,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [4] Basic.cshtml)
                     IntermediateToken - (0:0,0 [4] Basic.cshtml) - Html - <div

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_DesignTime.mappings.txt
@@ -1,34 +1,34 @@
 Source Location: (13:0,13 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml)
 |this.ToString()|
-Generated Location: (1139:25,13 [15] )
+Generated Location: (1215:27,13 [15] )
 |this.ToString()|
 
 Source Location: (54:2,5 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml)
 |string.Format("{0}", "Hello")|
-Generated Location: (1275:30,6 [29] )
+Generated Location: (1351:32,6 [29] )
 |string.Format("{0}", "Hello")|
 
 Source Location: (95:4,2 [25] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml)
 | 
     var cls = "foo";
 |
-Generated Location: (1421:35,2 [25] )
+Generated Location: (1497:37,2 [25] )
 | 
     var cls = "foo";
 |
 
 Source Location: (134:7,11 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml)
 |if(cls != null) { |
-Generated Location: (1569:41,11 [18] )
+Generated Location: (1645:43,11 [18] )
 |if(cls != null) { |
 
 Source Location: (153:7,30 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml)
 |cls|
-Generated Location: (1731:46,30 [3] )
+Generated Location: (1807:48,30 [3] )
 |cls|
 
 Source Location: (156:7,33 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml)
 | }|
-Generated Location: (1882:51,33 [2] )
+Generated Location: (1958:53,33 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -22,7 +22,9 @@ MyService<TModel> __typeHelper = default(MyService<TModel>);
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -27,7 +27,11 @@ Document -
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
@@ -26,7 +26,9 @@ MyModel __typeHelper = default(MyModel);
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.ir.txt
@@ -28,7 +28,11 @@ Document -
                 DirectiveToken - (10:0,10 [26] InheritsViewModel.cshtml) - MyBasePageForViews<TModel>
                 DirectiveToken - (45:1,7 [7] InheritsViewModel.cshtml) - MyModel
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
             Inject - 
             Inject - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
@@ -22,7 +22,9 @@ MyModel __typeHelper = default(MyModel);
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.ir.txt
@@ -28,7 +28,11 @@ Document -
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (14:1,7 [7] InheritsWithViewImports.cshtml) - MyModel
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
             Inject - 
             Inject - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
@@ -38,7 +38,9 @@ global::System.Object Html = null;
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.ir.txt
@@ -31,7 +31,11 @@ Document -
                 DirectiveToken - (54:2,8 [17] InjectWithModel.cshtml) - MyService<TModel>
                 DirectiveToken - (72:2,26 [4] InjectWithModel.cshtml) - Html
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
             Inject - 
             Inject - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
@@ -54,7 +54,9 @@ global::System.Object Html2 = null;
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.ir.txt
@@ -35,7 +35,11 @@ Document -
                 DirectiveToken - (129:4,8 [17] InjectWithSemicolon.cshtml) - MyService<TModel>
                 DirectiveToken - (147:4,26 [5] InjectWithSemicolon.cshtml) - Html2
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
             Inject - 
             Inject - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
@@ -26,7 +26,9 @@ global::System.Object MyPropertyName = null;
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.ir.txt
@@ -28,7 +28,11 @@ Document -
                 DirectiveToken - (8:0,8 [5] Inject.cshtml) - MyApp
                 DirectiveToken - (14:0,14 [14] Inject.cshtml) - MyPropertyName
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
             Inject - 
             Inject - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_DesignTime.codegen.cs
@@ -18,7 +18,9 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InvalidNamespaceAtEOF_DesignTime.ir.txt
@@ -26,7 +26,11 @@ Document -
                 DirectiveToken - (729:13,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 MalformedDirective - (0:0,0 [11] InvalidNamespaceAtEOF.cshtml) - namespace
                 HtmlContent - (11:0,11 [5] InvalidNamespaceAtEOF.cshtml)

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.codegen.cs
@@ -18,7 +18,9 @@ namespace AspNetCore
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.ir.txt
@@ -26,7 +26,11 @@ Document -
                 DirectiveToken - (729:13,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 MalformedDirective - (0:0,0 [6] MalformedPageDirective.cshtml) - page
                 HtmlContent - (6:0,6 [49] MalformedPageDirective.cshtml)

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -27,7 +27,9 @@ global::System.Object __typeHelper = "InputTestTagHelper, AppCode";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.ir.txt
@@ -30,7 +30,11 @@ Document -
                 DirectiveToken - (7:0,7 [8] ModelExpressionTagHelper.cshtml) - DateTime
                 DirectiveToken - (33:2,14 [29] ModelExpressionTagHelper.cshtml) - "InputTestTagHelper, AppCode"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (17:1,0 [2] ModelExpressionTagHelper.cshtml)
                     IntermediateToken - (17:1,0 [2] ModelExpressionTagHelper.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
@@ -10,11 +10,11 @@ Generated Location: (1096:24,37 [29] )
 
 Source Location: (83:4,17 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Date|
-Generated Location: (1668:35,102 [4] )
+Generated Location: (1744:37,102 [4] )
 |Date|
 
 Source Location: (111:5,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (1984:41,94 [5] )
+Generated Location: (2060:43,94 [5] )
 |Model|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_Runtime.codegen.cs
@@ -15,9 +15,9 @@ namespace AspNetCore
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ModelExpressionTagHelper_cshtml : global::Microsoft.AspNetCore.Mvc.Razor.RazorPage<DateTime>
     {
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
@@ -22,7 +22,9 @@ System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumer
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.ir.txt
@@ -27,7 +27,11 @@ Document -
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (7:0,7 [30] Model.cshtml) - System.Collections.IEnumerable
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
             Inject - 
             Inject - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -26,7 +26,9 @@ System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumer
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.ir.txt
@@ -28,7 +28,11 @@ Document -
                 DirectiveToken - (7:0,7 [21] MultipleModels.cshtml) - ThisShouldBeGenerated
                 DirectiveToken - (37:1,7 [30] MultipleModels.cshtml) - System.Collections.IEnumerable
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 MalformedDirective - (30:1,0 [39] MultipleModels.cshtml) - model
                     DirectiveToken - (37:1,7 [30] MultipleModels.cshtml) - System.Collections.IEnumerable

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.codegen.cs
@@ -22,7 +22,9 @@ global::System.Object __typeHelper = nameof(Test.Namespace);
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.ir.txt
@@ -27,7 +27,11 @@ Document -
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (18:1,11 [14] PageWithNamespace.cshtml) - Test.Namespace
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (34:2,0 [20] PageWithNamespace.cshtml)
                     IntermediateToken - (34:2,0 [4] PageWithNamespace.cshtml) - Html - <h1>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
@@ -28,7 +28,9 @@ global::System.Object __typeHelper = "*, AppCode";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.ir.txt
@@ -30,7 +30,11 @@ Document -
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (23:2,14 [12] RazorPagesWithoutModel.cshtml) - "*, AppCode"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (7:1,0 [2] RazorPagesWithoutModel.cshtml)
                     IntermediateToken - (7:1,0 [2] RazorPagesWithoutModel.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
@@ -10,7 +10,7 @@ Generated Location: (1153:25,37 [12] )
 
 Source Location: (566:24,47 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |Name|
-Generated Location: (1640:36,47 [4] )
+Generated Location: (1716:38,47 [4] )
 |Name|
 
 Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
@@ -28,7 +28,7 @@ Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegra
         public string Name { get; set; }
     }
 |
-Generated Location: (2121:47,12 [283] )
+Generated Location: (2197:49,12 [283] )
 |
     public IActionResult OnPost(Customer customer)
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_Runtime.codegen.cs
@@ -24,9 +24,9 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("form-group"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("col-md-offset-2 col-md-10"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -32,7 +32,9 @@ global::System.Object __typeHelper = "*, AppCode";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.ir.txt
@@ -31,7 +31,11 @@ Document -
                 DirectiveToken - (16:2,7 [8] RazorPages.cshtml) - NewModel
                 DirectiveToken - (40:3,14 [12] RazorPages.cshtml) - "*, AppCode"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (7:1,0 [2] RazorPages.cshtml)
                     IntermediateToken - (7:1,0 [2] RazorPages.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -15,7 +15,7 @@ Generated Location: (1221:29,37 [12] )
 
 Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |Model.Name|
-Generated Location: (1696:40,47 [10] )
+Generated Location: (1772:42,47 [10] )
 |Model.Name|
 
 Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegr
         public string Name { get; set; }
     }
 |
-Generated Location: (2171:51,12 [360] )
+Generated Location: (2247:53,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_Runtime.codegen.cs
@@ -24,9 +24,9 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("form-group"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("col-md-offset-2 col-md-10"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
@@ -24,7 +24,9 @@ global::System.Object __typeHelper = "*, AppCode";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.ir.txt
@@ -30,7 +30,11 @@ Document -
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (14:0,14 [12] ViewComponentTagHelper.cshtml) - "*, AppCode"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (26:0,26 [2] ViewComponentTagHelper.cshtml)
                     IntermediateToken - (26:0,26 [2] ViewComponentTagHelper.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
@@ -7,13 +7,13 @@ Source Location: (30:1,2 [26] TestFiles/IntegrationTests/CodeGenerationIntegrati
 |
     var foo = "Hello";
 |
-Generated Location: (1538:31,2 [26] )
+Generated Location: (1614:33,2 [26] )
 |
     var foo = "Hello";
 |
 
 Source Location: (83:5,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |foo|
-Generated Location: (1996:39,22 [3] )
+Generated Location: (2072:41,22 [3] )
 |foo|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_Runtime.codegen.cs
@@ -17,9 +17,9 @@ namespace AspNetCore
         private global::AspNetCore.TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ViewComponentTagHelper_cshtml.__Generated__TestViewComponentTagHelper __TestViewComponentTagHelper;
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("bar", " World", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.codegen.cs
@@ -22,7 +22,9 @@ global::System.Object __typeHelper = nameof(Test.Namespace);
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.ir.txt
@@ -27,7 +27,11 @@ Document -
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (11:0,11 [14] ViewWithNamespace.cshtml) - Test.Namespace
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (27:1,0 [20] ViewWithNamespace.cshtml)
                     IntermediateToken - (27:1,0 [4] ViewWithNamespace.cshtml) - Html - <h1>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
@@ -26,7 +26,9 @@ global::System.Object Model = null;
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.ir.txt
@@ -28,7 +28,11 @@ Document -
                 DirectiveToken - (8:0,8 [19] _ViewImports.cshtml) - IHtmlHelper<TModel>
                 DirectiveToken - (28:0,28 [5] _ViewImports.cshtml) - Model
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async override - global::System.Threading.Tasks.Task - ExecuteAsync
             Inject - 
             Inject - 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/InstrumentationPassIntegrationTest/BasicTest.codegen.cs
@@ -10,9 +10,9 @@ namespace Razor
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("foo"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/DefaultTagHelperTargetExtensionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/DefaultTagHelperTargetExtensionTest.cs
@@ -802,9 +802,9 @@ __tagHelperExecutionContext.AddTagHelperAttribute(""foo-bound"", __InputTagHelpe
             var csharp = context.CodeWriter.Builder.ToString();
             Assert.Equal(
 @"#line hidden
-#pragma warning disable 0414
+#pragma warning disable 0169
 private string __tagHelperStringValueBuffer;
-#pragma warning restore 0414
+#pragma warning restore 0169
 private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
 private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
 private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.codegen.cs
@@ -13,7 +13,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.ir.txt
@@ -4,7 +4,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] AddTagHelperDirective.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [2] AddTagHelperDirective.cshtml)
                     IntermediateToken - (31:0,31 [2] AddTagHelperDirective.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
@@ -17,7 +17,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.ir.txt
@@ -9,7 +9,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [15] AttributeTargetingTagHelpers.cshtml) - *, TestAssembly
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (29:0,29 [4] AttributeTargetingTagHelpers.cshtml)
                     IntermediateToken - (29:0,29 [4] AttributeTargetingTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (779:14,38 [15] )
 
 Source Location: (187:5,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (1651:29,42 [4] )
+Generated Location: (1727:31,42 [4] )
 |true|
 
 Source Location: (233:6,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (2304:39,42 [4] )
+Generated Location: (2380:41,42 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_Runtime.codegen.cs
@@ -10,9 +10,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("btn"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Await_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (89:5,1 [102] Await.cshtml)
                     IntermediateToken - (89:5,1 [4] Await.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await_DesignTime.mappings.txt
@@ -1,81 +1,81 @@
 Source Location: (192:9,39 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo()|
-Generated Location: (673:16,39 [11] )
+Generated Location: (749:18,39 [11] )
 |await Foo()|
 
 Source Location: (247:10,38 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo()|
-Generated Location: (838:21,38 [11] )
+Generated Location: (914:23,38 [11] )
 |await Foo()|
 
 Source Location: (304:11,39 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | await Foo(); |
-Generated Location: (1004:26,39 [14] )
+Generated Location: (1080:28,39 [14] )
 | await Foo(); |
 
 Source Location: (371:12,46 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | |
-Generated Location: (1109:30,58 [1] )
+Generated Location: (1185:32,58 [1] )
 | |
 
 Source Location: (376:12,51 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo()|
-Generated Location: (1245:32,51 [11] )
+Generated Location: (1321:34,51 [11] )
 |await Foo()|
 
 Source Location: (391:12,66 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | |
-Generated Location: (1368:36,78 [1] )
+Generated Location: (1444:38,78 [1] )
 | |
 
 Source Location: (448:13,49 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await|
-Generated Location: (1502:38,49 [5] )
+Generated Location: (1578:40,49 [5] )
 |await|
 
 Source Location: (578:18,42 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo(1, 2)|
-Generated Location: (1665:43,42 [15] )
+Generated Location: (1741:45,42 [15] )
 |await Foo(1, 2)|
 
 Source Location: (650:19,51 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo.Bar(1, 2)|
-Generated Location: (1847:48,51 [19] )
+Generated Location: (1923:50,51 [19] )
 |await Foo.Bar(1, 2)|
 
 Source Location: (716:20,41 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo("bob", true)|
-Generated Location: (2023:53,41 [22] )
+Generated Location: (2099:55,41 [22] )
 |await Foo("bob", true)|
 
 Source Location: (787:21,42 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | await Foo(something, hello: "world"); |
-Generated Location: (2203:58,42 [39] )
+Generated Location: (2279:60,42 [39] )
 | await Foo(something, hello: "world"); |
 
 Source Location: (884:22,51 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | await Foo.Bar(1, 2) |
-Generated Location: (2408:63,51 [21] )
+Generated Location: (2484:65,51 [21] )
 | await Foo.Bar(1, 2) |
 
 Source Location: (961:23,49 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | |
-Generated Location: (2523:67,61 [1] )
+Generated Location: (2599:69,61 [1] )
 | |
 
 Source Location: (966:23,54 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await Foo(boolValue: false)|
-Generated Location: (2662:69,54 [27] )
+Generated Location: (2738:71,54 [27] )
 |await Foo(boolValue: false)|
 
 Source Location: (997:23,85 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 | |
-Generated Location: (2820:73,97 [1] )
+Generated Location: (2896:75,97 [1] )
 | |
 
 Source Location: (1057:24,52 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
 |await ("wrrronggg")|
-Generated Location: (2957:75,52 [19] )
+Generated Location: (3033:77,52 [19] )
 |await ("wrrronggg")|
 
 Source Location: (12:0,12 [76] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Await.cshtml)
@@ -85,7 +85,7 @@ Source Location: (12:0,12 [76] TestFiles/IntegrationTests/CodeGenerationIntegrat
         return "Bar";
     }
 |
-Generated Location: (3152:82,12 [76] )
+Generated Location: (3228:84,12 [76] )
 |
     public async Task<string> Foo()
     {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.codegen.cs
@@ -24,7 +24,9 @@ using System.Text;
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicImports_DesignTime.ir.txt
@@ -7,7 +7,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (69:2,10 [5] BasicImports_Imports0.cshtml) - Hello
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] BasicImports.cshtml)
                     IntermediateToken - (0:0,0 [3] BasicImports.cshtml) - Html - <p>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
@@ -16,7 +16,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.ir.txt
@@ -8,7 +8,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] BasicTagHelpers.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [73] BasicTagHelpers.cshtml)
                     IntermediateToken - (31:0,31 [4] BasicTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (673:13,37 [17] )
 
 Source Location: (220:5,38 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1363:26,38 [23] )
+Generated Location: (1439:28,38 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (303:6,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |true|
-Generated Location: (2061:37,42 [4] )
+Generated Location: (2137:39,42 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
@@ -20,7 +20,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.ir.txt
@@ -9,7 +9,11 @@ Document -
                 DirectiveToken - (17:0,17 [5] BasicTagHelpers_Prefixed.cshtml) - "THS"
                 DirectiveToken - (38:1,14 [17] BasicTagHelpers_Prefixed.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (22:0,22 [2] BasicTagHelpers_Prefixed.cshtml)
                     IntermediateToken - (22:0,22 [2] BasicTagHelpers_Prefixed.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
@@ -10,6 +10,6 @@ Generated Location: (787:17,37 [17] )
 
 Source Location: (226:7,43 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |true|
-Generated Location: (1548:31,43 [4] )
+Generated Location: (1624:33,43 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_Runtime.codegen.cs
@@ -9,9 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_RemoveTagHelper_Runtime.codegen.cs
@@ -10,9 +10,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Runtime.codegen.cs
@@ -12,9 +12,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_3 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Blocks_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [18] Blocks.cshtml)
                     IntermediateToken - (2:0,2 [18] Blocks.cshtml) - CSharp - \n    int i = 1;\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks_DesignTime.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (2:0,2 [18] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |
     int i = 1;
 |
-Generated Location: (637:16,2 [18] )
+Generated Location: (713:18,2 [18] )
 |
     int i = 1;
 |
@@ -10,20 +10,20 @@ Generated Location: (637:16,2 [18] )
 Source Location: (26:4,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |while(i <= 10) {
     |
-Generated Location: (769:22,1 [22] )
+Generated Location: (845:24,1 [22] )
 |while(i <= 10) {
     |
 
 Source Location: (69:5,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |i|
-Generated Location: (931:28,25 [1] )
+Generated Location: (1007:30,25 [1] )
 |i|
 
 Source Location: (75:5,31 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
     i += 1;
 }|
-Generated Location: (1079:33,31 [16] )
+Generated Location: (1155:35,31 [16] )
 |
     i += 1;
 }|
@@ -31,14 +31,14 @@ Generated Location: (1079:33,31 [16] )
 Source Location: (96:9,1 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |if(i == 11) {
     |
-Generated Location: (1212:40,1 [19] )
+Generated Location: (1288:42,1 [19] )
 |if(i == 11) {
     |
 
 Source Location: (140:10,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
 }|
-Generated Location: (1376:46,29 [3] )
+Generated Location: (1452:48,29 [3] )
 |
 }|
 
@@ -46,7 +46,7 @@ Source Location: (148:13,1 [35] TestFiles/IntegrationTests/CodeGenerationIntegra
 |switch(i) {
     case 11:
         |
-Generated Location: (1496:52,1 [35] )
+Generated Location: (1572:54,1 [35] )
 |switch(i) {
     case 11:
         |
@@ -56,7 +56,7 @@ Source Location: (219:15,44 [40] TestFiles/IntegrationTests/CodeGenerationIntegr
         break;
     default:
         |
-Generated Location: (1691:59,44 [40] )
+Generated Location: (1767:61,44 [40] )
 |
         break;
     default:
@@ -66,7 +66,7 @@ Source Location: (288:18,37 [19] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
         break;
 }|
-Generated Location: (1884:67,37 [19] )
+Generated Location: (1960:69,37 [19] )
 |
         break;
 }|
@@ -74,26 +74,26 @@ Generated Location: (1884:67,37 [19] )
 Source Location: (312:22,1 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |for(int j = 1; j <= 10; j += 2) {
     |
-Generated Location: (2020:74,1 [39] )
+Generated Location: (2096:76,1 [39] )
 |for(int j = 1; j <= 10; j += 2) {
     |
 
 Source Location: (378:23,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |j|
-Generated Location: (2206:80,31 [1] )
+Generated Location: (2282:82,31 [1] )
 |j|
 
 Source Location: (384:23,37 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
 }|
-Generated Location: (2361:85,37 [3] )
+Generated Location: (2437:87,37 [3] )
 |
 }|
 
 Source Location: (392:26,1 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |try {
     |
-Generated Location: (2481:91,1 [11] )
+Generated Location: (2557:93,1 [11] )
 |try {
     |
 
@@ -101,39 +101,39 @@ Source Location: (438:27,39 [31] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
 } catch(Exception ex) {
     |
-Generated Location: (2647:97,39 [31] )
+Generated Location: (2723:99,39 [31] )
 |
 } catch(Exception ex) {
     |
 
 Source Location: (500:29,35 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |ex.Message|
-Generated Location: (2829:104,35 [10] )
+Generated Location: (2905:106,35 [10] )
 |ex.Message|
 
 Source Location: (515:29,50 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
 }|
-Generated Location: (3006:109,50 [3] )
+Generated Location: (3082:111,50 [3] )
 |
 }|
 
 Source Location: (535:32,13 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |i|
-Generated Location: (3138:115,13 [1] )
+Generated Location: (3214:117,13 [1] )
 |i|
 
 Source Location: (545:34,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |lock(new object()) {
     |
-Generated Location: (3257:120,1 [26] )
+Generated Location: (3333:122,1 [26] )
 |lock(new object()) {
     |
 
 Source Location: (618:35,51 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Blocks.cshtml)
 |
 }|
-Generated Location: (3450:126,51 [3] )
+Generated Location: (3526:128,51 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CSharp7_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [12] CSharp7.cshtml)
                     IntermediateToken - (0:0,0 [6] CSharp7.cshtml) - Html - <body>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7_DesignTime.mappings.txt
@@ -6,7 +6,7 @@ Source Location: (14:1,6 [187] TestFiles/IntegrationTests/CodeGenerationIntegrat
         };
 
         |
-Generated Location: (643:16,6 [187] )
+Generated Location: (719:18,6 [187] )
 |
         var nameLookup = new Dictionary<string, (string FirstName, string LastName, object Extra)>()
         {
@@ -23,7 +23,7 @@ Source Location: (246:7,53 [253] TestFiles/IntegrationTests/CodeGenerationIntegr
         double AvogadroConstant = 6.022_140_857_747_474e23;
         decimal GoldenRatio = 1.618_033_988_749_894_848_204_586_834_365_638_117_720_309_179M;
     |
-Generated Location: (999:27,53 [253] )
+Generated Location: (1075:29,53 [253] )
 |
 
         int Sixteen = 0b0001_0000;
@@ -40,7 +40,7 @@ Source Location: (509:15,5 [159] TestFiles/IntegrationTests/CodeGenerationIntegr
             // Do Something
         }
     }|
-Generated Location: (1374:38,5 [159] )
+Generated Location: (1450:40,5 [159] )
 |if (nameLookup.TryGetValue("John Doe", out var entry))
     {
         if (entry.Extra is bool alive)
@@ -51,12 +51,12 @@ Generated Location: (1374:38,5 [159] )
 
 Source Location: (718:23,39 [62] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7.cshtml)
 |1.618_033_988_749_894_848_204_586_834_365_638_117_720_309_179M|
-Generated Location: (1689:49,39 [62] )
+Generated Location: (1765:51,39 [62] )
 |1.618_033_988_749_894_848_204_586_834_365_638_117_720_309_179M|
 
 Source Location: (816:27,10 [34] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7.cshtml)
 |(First: "John", Last: "Doe").First|
-Generated Location: (1879:54,10 [34] )
+Generated Location: (1955:56,10 [34] )
 |(First: "John", Last: "Doe").First|
 
 Source Location: (891:30,5 [291] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CSharp7.cshtml)
@@ -72,7 +72,7 @@ Source Location: (891:30,5 [291] TestFiles/IntegrationTests/CodeGenerationIntegr
             // Do even more of something
             break;
     }|
-Generated Location: (2036:59,5 [291] )
+Generated Location: (2112:61,5 [291] )
 |switch (entry.Extra)
     {
         case int age:

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlockAtEOF_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [0] CodeBlockAtEOF.cshtml)
                     IntermediateToken - (2:0,2 [0] CodeBlockAtEOF.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (2:0,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockAtEOF.cshtml)
 ||
-Generated Location: (575:15,14 [0] )
+Generated Location: (651:17,14 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlockWithTextElement_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [17] CodeBlockWithTextElement.cshtml)
                     IntermediateToken - (2:0,2 [17] CodeBlockWithTextElement.cshtml) - CSharp - \n    var a = 1; 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement_DesignTime.mappings.txt
@@ -1,26 +1,26 @@
 Source Location: (2:0,2 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml)
 |
     var a = 1; |
-Generated Location: (673:16,2 [17] )
+Generated Location: (749:18,2 [17] )
 |
     var a = 1; |
 
 Source Location: (35:1,31 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml)
 | 		
     var b = 1;			|
-Generated Location: (854:22,31 [22] )
+Generated Location: (930:24,31 [22] )
 | 		
     var b = 1;			|
 
 Source Location: (69:2,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml)
 |a+b|
-Generated Location: (1047:28,38 [3] )
+Generated Location: (1123:30,38 [3] )
 |a+b|
 
 Source Location: (80:2,40 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlockWithTextElement.cshtml)
 |
 |
-Generated Location: (1145:32,61 [2] )
+Generated Location: (1221:34,61 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_CodeBlock_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [115] CodeBlock.cshtml)
                     IntermediateToken - (2:0,2 [115] CodeBlock.cshtml) - CSharp - \n    for(int i = 1; i <= 10; i++) {\n        Output.Write("<p>Hello from C#, #" + i.ToString() + "</p>");\n    }\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CodeBlock_DesignTime.mappings.txt
@@ -4,7 +4,7 @@ Source Location: (2:0,2 [115] TestFiles/IntegrationTests/CodeGenerationIntegrati
         Output.Write("<p>Hello from C#, #" + i.ToString() + "</p>");
     }
 |
-Generated Location: (643:16,2 [115] )
+Generated Location: (719:18,2 [115] )
 |
     for(int i = 1; i <= 10; i++) {
         Output.Write("<p>Hello from C#, #" + i.ToString() + "</p>");

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
@@ -16,7 +16,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.ir.txt
@@ -8,7 +8,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] ComplexTagHelpers.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] ComplexTagHelpers.cshtml)
                     IntermediateToken - (31:0,31 [4] ComplexTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
@@ -9,7 +9,7 @@ Source Location: (36:2,1 [52] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var checkbox = "checkbox";
 
     |
-Generated Location: (1027:23,1 [52] )
+Generated Location: (1103:25,1 [52] )
 |if (true)
 {
     var checkbox = "checkbox";
@@ -18,39 +18,39 @@ Generated Location: (1027:23,1 [52] )
 
 Source Location: (147:7,16 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (1333:33,33 [1] )
+Generated Location: (1409:35,33 [1] )
 |@|
 
 Source Location: (149:7,18 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 ||
-Generated Location: (1334:33,34 [0] )
+Generated Location: (1410:35,34 [0] )
 ||
 
 Source Location: (149:7,18 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (1334:33,34 [1] )
+Generated Location: (1410:35,34 [1] )
 |@|
 
 Source Location: (150:7,19 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (1335:33,35 [1] )
+Generated Location: (1411:35,35 [1] )
 |(|
 
 Source Location: (151:7,20 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |1+2|
-Generated Location: (1336:33,36 [3] )
+Generated Location: (1412:35,36 [3] )
 |1+2|
 
 Source Location: (154:7,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (1339:33,39 [1] )
+Generated Location: (1415:35,39 [1] )
 |)|
 
 Source Location: (273:10,13 [43] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if (false)
             {
                 |
-Generated Location: (1481:38,13 [43] )
+Generated Location: (1557:40,13 [43] )
 |if (false)
             {
                 |
@@ -61,7 +61,7 @@ Source Location: (399:12,99 [66] TestFiles/IntegrationTests/CodeGenerationIntegr
             else
             {
                 |
-Generated Location: (2201:50,99 [66] )
+Generated Location: (2277:52,99 [66] )
 |
             }
             else
@@ -70,224 +70,224 @@ Generated Location: (2201:50,99 [66] )
 
 Source Location: (495:16,46 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checkbox|
-Generated Location: (2648:61,46 [8] )
+Generated Location: (2724:63,46 [8] )
 |checkbox|
 
 Source Location: (512:16,63 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true|
-Generated Location: (3001:68,63 [4] )
+Generated Location: (3077:70,63 [4] )
 |true|
 
 Source Location: (523:16,74 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (3220:73,86 [18] )
+Generated Location: (3296:75,86 [18] )
 |
                 |
 
 Source Location: (556:17,31 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true ? "checkbox" : "anything"|
-Generated Location: (3573:78,31 [30] )
+Generated Location: (3649:80,31 [30] )
 |true ? "checkbox" : "anything"|
 
 Source Location: (591:17,66 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (3869:84,78 [18] )
+Generated Location: (3945:86,78 [18] )
 |
                 |
 
 Source Location: (623:18,30 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if(true) { |
-Generated Location: (4221:89,30 [11] )
+Generated Location: (4297:91,30 [11] )
 |if(true) { |
 
 Source Location: (655:18,62 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | } else { |
-Generated Location: (4421:94,62 [10] )
+Generated Location: (4497:96,62 [10] )
 | } else { |
 
 Source Location: (686:18,93 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | }|
-Generated Location: (4651:99,93 [2] )
+Generated Location: (4727:101,93 [2] )
 | }|
 
 Source Location: (690:18,97 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
             }|
-Generated Location: (5031:106,97 [15] )
+Generated Location: (5107:108,97 [15] )
 |
             }|
 
 Source Location: (212:8,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (5299:113,32 [12] )
+Generated Location: (5375:115,32 [12] )
 |DateTime.Now|
 
 Source Location: (832:22,14 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | var @object = false;|
-Generated Location: (5453:118,14 [21] )
+Generated Location: (5529:120,14 [21] )
 | var @object = false;|
 
 Source Location: (885:23,29 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (5851:125,42 [1] )
+Generated Location: (5927:127,42 [1] )
 |(|
 
 Source Location: (886:23,30 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@object|
-Generated Location: (5852:125,43 [7] )
+Generated Location: (5928:127,43 [7] )
 |@object|
 
 Source Location: (893:23,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (5859:125,50 [1] )
+Generated Location: (5935:127,50 [1] )
 |)|
 
 Source Location: (760:21,39 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (6121:131,38 [23] )
+Generated Location: (6197:133,38 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (783:21,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | -|
-Generated Location: (6144:131,61 [2] )
+Generated Location: (6220:133,61 [2] )
 | -|
 
 Source Location: (785:21,64 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 1970|
-Generated Location: (6146:131,63 [5] )
+Generated Location: (6222:133,63 [5] )
 | 1970|
 
 Source Location: (1025:26,61 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (6547:138,60 [1] )
+Generated Location: (6623:140,60 [1] )
 |(|
 
 Source Location: (1026:26,62 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (6548:138,61 [30] )
+Generated Location: (6624:140,61 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1056:26,92 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (6578:138,91 [1] )
+Generated Location: (6654:140,91 [1] )
 |)|
 
 Source Location: (928:25,16 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |-1970|
-Generated Location: (6835:144,33 [5] )
+Generated Location: (6911:146,33 [5] )
 |-1970|
 
 Source Location: (933:25,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | +|
-Generated Location: (6840:144,38 [2] )
+Generated Location: (6916:146,38 [2] )
 | +|
 
 Source Location: (935:25,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | |
-Generated Location: (6842:144,40 [1] )
+Generated Location: (6918:146,40 [1] )
 | |
 
 Source Location: (936:25,24 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (6843:144,41 [1] )
+Generated Location: (6919:146,41 [1] )
 |@|
 
 Source Location: (937:25,25 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (6844:144,42 [23] )
+Generated Location: (6920:146,42 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (1155:29,28 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (7245:151,42 [30] )
+Generated Location: (7321:153,42 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1093:28,16 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year - 1970|
-Generated Location: (7531:157,33 [30] )
+Generated Location: (7607:159,33 [30] )
 |DateTimeOffset.Now.Year - 1970|
 
 Source Location: (1283:32,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (7939:164,42 [3] )
+Generated Location: (8015:166,42 [3] )
 |   |
 
 Source Location: (1286:32,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (7942:164,45 [1] )
+Generated Location: (8018:166,45 [1] )
 |@|
 
 Source Location: (1287:32,32 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (7943:164,46 [1] )
+Generated Location: (8019:166,46 [1] )
 |(|
 
 Source Location: (1288:32,33 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |  DateTimeOffset.Now.Year  |
-Generated Location: (7944:164,47 [27] )
+Generated Location: (8020:166,47 [27] )
 |  DateTimeOffset.Now.Year  |
 
 Source Location: (1315:32,60 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (7971:164,74 [1] )
+Generated Location: (8047:166,74 [1] )
 |)|
 
 Source Location: (1316:32,61 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | >|
-Generated Location: (7972:164,75 [2] )
+Generated Location: (8048:166,75 [2] )
 | >|
 
 Source Location: (1318:32,63 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 2014|
-Generated Location: (7974:164,77 [5] )
+Generated Location: (8050:166,77 [5] )
 | 2014|
 
 Source Location: (1323:32,68 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (7979:164,82 [3] )
+Generated Location: (8055:166,82 [3] )
 |   |
 
 Source Location: (1220:31,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (8238:170,33 [1] )
+Generated Location: (8314:172,33 [1] )
 |(|
 
 Source Location: (1221:31,18 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"My age is this long.".Length|
-Generated Location: (8239:170,34 [29] )
+Generated Location: (8315:172,34 [29] )
 |"My age is this long.".Length|
 
 Source Location: (1250:31,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (8268:170,63 [1] )
+Generated Location: (8344:172,63 [1] )
 |)|
 
 Source Location: (1355:34,9 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |someMethod(|
-Generated Location: (8406:175,9 [11] )
+Generated Location: (8482:177,9 [11] )
 |someMethod(|
 
 Source Location: (1410:34,64 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checked|
-Generated Location: (8824:179,63 [7] )
+Generated Location: (8900:181,63 [7] )
 |checked|
 
 Source Location: (1375:34,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |123|
-Generated Location: (9079:185,33 [3] )
+Generated Location: (9155:187,33 [3] )
 |123|
 
 Source Location: (1424:34,78 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (9120:190,1 [1] )
+Generated Location: (9196:192,1 [1] )
 |)|
 
 Source Location: (1437:35,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
 }|
-Generated Location: (9259:195,10 [3] )
+Generated Location: (9335:197,10 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_Runtime.codegen.cs
@@ -15,9 +15,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("world"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("hello"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ConditionalAttributes_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [48] ConditionalAttributes.cshtml)
                     IntermediateToken - (2:0,2 [48] ConditionalAttributes.cshtml) - CSharp - \n    var ch = true;\n    var cls = "bar";\n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes_DesignTime.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (2:0,2 [48] TestFiles/IntegrationTests/CodeGenerationIntegratio
     var ch = true;
     var cls = "bar";
     |
-Generated Location: (667:16,2 [48] )
+Generated Location: (743:18,2 [48] )
 |
     var ch = true;
     var cls = "bar";
@@ -12,127 +12,127 @@ Generated Location: (667:16,2 [48] )
 Source Location: (66:3,20 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (780:23,32 [6] )
+Generated Location: (856:25,32 [6] )
 |
     |
 
 Source Location: (83:4,15 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (900:26,15 [3] )
+Generated Location: (976:28,15 [3] )
 |cls|
 
 Source Location: (90:4,22 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (971:30,34 [6] )
+Generated Location: (1047:32,34 [6] )
 |
     |
 
 Source Location: (111:5,19 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (1095:33,19 [3] )
+Generated Location: (1171:35,19 [3] )
 |cls|
 
 Source Location: (118:5,26 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (1170:37,38 [6] )
+Generated Location: (1246:39,38 [6] )
 |
     |
 
 Source Location: (135:6,15 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (1290:40,15 [3] )
+Generated Location: (1366:42,15 [3] )
 |cls|
 
 Source Location: (146:6,26 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (1365:44,38 [6] )
+Generated Location: (1441:46,38 [6] )
 |
     |
 
 Source Location: (185:7,37 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |ch|
-Generated Location: (1507:47,37 [2] )
+Generated Location: (1583:49,37 [2] )
 |ch|
 
 Source Location: (191:7,43 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (1598:51,55 [6] )
+Generated Location: (1674:53,55 [6] )
 |
     |
 
 Source Location: (234:8,41 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |ch|
-Generated Location: (1744:54,41 [2] )
+Generated Location: (1820:56,41 [2] )
 |ch|
 
 Source Location: (240:8,47 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (1839:58,59 [6] )
+Generated Location: (1915:60,59 [6] )
 |
     |
 
 Source Location: (257:9,15 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |if(cls != null) { |
-Generated Location: (1960:61,15 [18] )
+Generated Location: (2036:63,15 [18] )
 |if(cls != null) { |
 
 Source Location: (276:9,34 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |cls|
-Generated Location: (2143:66,34 [3] )
+Generated Location: (2219:68,34 [3] )
 |cls|
 
 Source Location: (279:9,37 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 | }|
-Generated Location: (2315:71,37 [2] )
+Generated Location: (2391:73,37 [2] )
 | }|
 
 Source Location: (285:9,43 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (2405:75,55 [6] )
+Generated Location: (2481:77,55 [6] )
 |
     |
 
 Source Location: (309:10,22 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (2447:77,34 [6] )
+Generated Location: (2523:79,34 [6] )
 |
     |
 
 Source Location: (329:11,18 [44] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |Url.Content("~/Scripts/jquery-1.6.2.min.js")|
-Generated Location: (2571:80,18 [44] )
+Generated Location: (2647:82,18 [44] )
 |Url.Content("~/Scripts/jquery-1.6.2.min.js")|
 
 Source Location: (407:11,96 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (2757:84,108 [6] )
+Generated Location: (2833:86,108 [6] )
 |
     |
 
 Source Location: (427:12,18 [60] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")|
-Generated Location: (2881:87,18 [60] )
+Generated Location: (2957:89,18 [60] )
 |Url.Content("~/Scripts/modernizr-2.0.6-development-only.js")|
 
 Source Location: (521:12,112 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
     |
-Generated Location: (3099:91,124 [6] )
+Generated Location: (3175:93,124 [6] )
 |
     |
 
 Source Location: (638:13,115 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ConditionalAttributes.cshtml)
 |
 |
-Generated Location: (3234:93,127 [2] )
+Generated Location: (3310:95,127 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/CssSelectorTagHelperAttributes_Runtime.codegen.cs
@@ -16,9 +16,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_8 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", new global::Microsoft.AspNetCore.Html.HtmlString("2 TagHelper"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
@@ -13,7 +13,9 @@ global::System.Object Footer = null;
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.ir.txt
@@ -4,7 +4,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (173:11,9 [6] DesignTime.cshtml) - Footer
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [19] DesignTime.cshtml)
                     IntermediateToken - (0:0,0 [5] DesignTime.cshtml) - Html - <div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
@@ -6,44 +6,44 @@ Generated Location: (401:10,22 [6] )
 Source Location: (20:1,13 [36] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |for(int i = 1; i <= 10; i++) {
     |
-Generated Location: (754:20,13 [36] )
+Generated Location: (830:22,13 [36] )
 |for(int i = 1; i <= 10; i++) {
     |
 
 Source Location: (74:2,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |i|
-Generated Location: (931:26,22 [1] )
+Generated Location: (1007:28,22 [1] )
 |i|
 
 Source Location: (79:2,27 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |
             }|
-Generated Location: (1079:31,27 [15] )
+Generated Location: (1155:33,27 [15] )
 |
             }|
 
 Source Location: (113:7,2 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(Bar.Baz)|
-Generated Location: (1219:37,6 [12] )
+Generated Location: (1295:39,6 [12] )
 |Foo(Bar.Baz)|
 
 Source Location: (129:8,1 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(|
-Generated Location: (1357:42,6 [4] )
+Generated Location: (1433:44,6 [4] )
 |Foo(|
 
 Source Location: (142:8,14 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |baz|
-Generated Location: (1519:44,14 [3] )
+Generated Location: (1595:46,14 [3] )
 |baz|
 
 Source Location: (153:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |)|
-Generated Location: (1560:49,1 [1] )
+Generated Location: (1636:51,1 [1] )
 |)|
 
 Source Location: (204:13,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |bar|
-Generated Location: (1760:55,6 [3] )
+Generated Location: (1836:57,6 [3] )
 |bar|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
@@ -16,7 +16,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.ir.txt
@@ -8,7 +8,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] DuplicateAttributeTagHelpers.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] DuplicateAttributeTagHelpers.cshtml)
                     IntermediateToken - (31:0,31 [4] DuplicateAttributeTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
@@ -5,16 +5,16 @@ Generated Location: (686:13,37 [17] )
 
 Source Location: (146:4,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (1806:31,42 [4] )
+Generated Location: (1882:33,42 [4] )
 |true|
 
 Source Location: (222:5,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (2348:40,42 [4] )
+Generated Location: (2424:42,42 [4] )
 |true|
 
 Source Location: (43:2,8 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |3|
-Generated Location: (2618:46,33 [1] )
+Generated Location: (2694:48,33 [1] )
 |3|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_Runtime.codegen.cs
@@ -16,9 +16,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("AGE", new global::Microsoft.AspNetCore.Html.HtmlString("40"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_8 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("Age", new global::Microsoft.AspNetCore.Html.HtmlString("500"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.codegen.cs
@@ -15,7 +15,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.ir.txt
@@ -7,7 +7,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] DuplicateTargetTagHelper.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] DuplicateTargetTagHelper.cshtml)
                     IntermediateToken - (31:0,31 [4] DuplicateTargetTagHelper.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (608:12,37 [17] )
 
 Source Location: (67:2,32 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper.cshtml)
 |true|
-Generated Location: (1373:26,41 [4] )
+Generated Location: (1449:28,41 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_Runtime.codegen.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "checkbox", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
@@ -14,7 +14,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.ir.txt
@@ -6,7 +6,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] DynamicAttributeTagHelpers.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] DynamicAttributeTagHelpers.cshtml)
                     IntermediateToken - (31:0,31 [4] DynamicAttributeTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
@@ -5,151 +5,151 @@ Generated Location: (518:11,37 [17] )
 
 Source Location: (59:2,24 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1005:22,24 [12] )
+Generated Location: (1081:24,24 [12] )
 |DateTime.Now|
 
 Source Location: (96:4,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (1273:28,17 [12] )
+Generated Location: (1349:30,17 [12] )
 |if (true) { |
 
 Source Location: (109:4,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (1450:33,30 [12] )
+Generated Location: (1526:35,30 [12] )
 |string.Empty|
 
 Source Location: (121:4,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (1640:38,42 [10] )
+Generated Location: (1716:40,42 [10] )
 | } else { |
 
 Source Location: (132:4,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (1838:43,53 [5] )
+Generated Location: (1914:45,53 [5] )
 |false|
 
 Source Location: (137:4,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (2037:48,58 [2] )
+Generated Location: (2113:50,58 [2] )
 | }|
 
 Source Location: (176:6,22 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (2299:54,22 [12] )
+Generated Location: (2375:56,22 [12] )
 |DateTime.Now|
 
 Source Location: (214:6,60 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (2573:60,60 [12] )
+Generated Location: (2649:62,60 [12] )
 |DateTime.Now|
 
 Source Location: (256:8,15 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (2839:66,15 [13] )
+Generated Location: (2915:68,15 [13] )
 |long.MinValue|
 
 Source Location: (271:8,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (3018:71,30 [12] )
+Generated Location: (3094:73,30 [12] )
 |if (true) { |
 
 Source Location: (284:8,43 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (3208:76,43 [12] )
+Generated Location: (3284:78,43 [12] )
 |string.Empty|
 
 Source Location: (296:8,55 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (3411:81,55 [10] )
+Generated Location: (3487:83,55 [10] )
 | } else { |
 
 Source Location: (307:8,66 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (3622:86,66 [5] )
+Generated Location: (3698:88,66 [5] )
 |false|
 
 Source Location: (312:8,71 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (3834:91,71 [2] )
+Generated Location: (3910:93,71 [2] )
 | }|
 
 Source Location: (316:8,75 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (4046:96,75 [12] )
+Generated Location: (4122:98,75 [12] )
 |int.MaxValue|
 
 Source Location: (348:9,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (4278:102,17 [13] )
+Generated Location: (4354:104,17 [13] )
 |long.MinValue|
 
 Source Location: (363:9,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (4460:107,32 [12] )
+Generated Location: (4536:109,32 [12] )
 |if (true) { |
 
 Source Location: (376:9,45 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (4653:112,45 [12] )
+Generated Location: (4729:114,45 [12] )
 |string.Empty|
 
 Source Location: (388:9,57 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (4859:117,57 [10] )
+Generated Location: (4935:119,57 [10] )
 | } else { |
 
 Source Location: (399:9,68 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (5073:122,68 [5] )
+Generated Location: (5149:124,68 [5] )
 |false|
 
 Source Location: (404:9,73 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (5288:127,73 [2] )
+Generated Location: (5364:129,73 [2] )
 | }|
 
 Source Location: (408:9,77 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (5503:132,77 [12] )
+Generated Location: (5579:134,77 [12] )
 |int.MaxValue|
 
 Source Location: (445:11,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (5772:138,17 [13] )
+Generated Location: (5848:140,17 [13] )
 |long.MinValue|
 
 Source Location: (460:11,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (5954:143,32 [12] )
+Generated Location: (6030:145,32 [12] )
 |DateTime.Now|
 
 Source Location: (492:11,64 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (6167:148,64 [12] )
+Generated Location: (6243:150,64 [12] )
 |int.MaxValue|
 
 Source Location: (529:13,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (6436:154,17 [12] )
+Generated Location: (6512:156,17 [12] )
 |if (true) { |
 
 Source Location: (542:13,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (6614:159,30 [12] )
+Generated Location: (6690:161,30 [12] )
 |string.Empty|
 
 Source Location: (554:13,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (6805:164,42 [10] )
+Generated Location: (6881:166,42 [10] )
 | } else { |
 
 Source Location: (565:13,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (7004:169,53 [5] )
+Generated Location: (7080:171,53 [5] )
 |false|
 
 Source Location: (570:13,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (7204:174,58 [2] )
+Generated Location: (7280:176,58 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_Runtime.codegen.cs
@@ -7,9 +7,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_DynamicAttributeTagHelpers_Runtime
     {
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
@@ -16,7 +16,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
@@ -8,7 +8,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [15] EmptyAttributeTagHelpers.cshtml) - *, TestAssembly
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (29:0,29 [15] EmptyAttributeTagHelpers.cshtml)
                     IntermediateToken - (29:0,29 [4] EmptyAttributeTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
@@ -5,16 +5,16 @@ Generated Location: (683:13,38 [15] )
 
 Source Location: (66:3,26 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (1434:27,42 [0] )
+Generated Location: (1510:29,42 [0] )
 ||
 
 Source Location: (126:5,30 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (1962:36,42 [0] )
+Generated Location: (2038:38,42 [0] )
 ||
 
 Source Location: (92:4,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (2224:42,33 [0] )
+Generated Location: (2300:44,33 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
@@ -9,9 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyCodeBlock_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] EmptyCodeBlock.cshtml)
                     IntermediateToken - (0:0,0 [18] EmptyCodeBlock.cshtml) - Html - This is markup\n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (20:2,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyCodeBlock.cshtml)
 ||
-Generated Location: (575:15,14 [0] )
+Generated Location: (651:17,14 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyExplicitExpression_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] EmptyExplicitExpression.cshtml)
                     IntermediateToken - (0:0,0 [18] EmptyExplicitExpression.cshtml) - Html - This is markup\n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (20:2,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyExplicitExpression.cshtml)
 ||
-Generated Location: (675:16,6 [0] )
+Generated Location: (751:18,6 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyImplicitExpressionInCode_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [6] EmptyImplicitExpressionInCode.cshtml)
                     IntermediateToken - (2:0,2 [6] EmptyImplicitExpressionInCode.cshtml) - CSharp - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
 |
     |
-Generated Location: (590:15,14 [6] )
+Generated Location: (666:17,14 [6] )
 |
     |
 
 Source Location: (9:1,5 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
 ||
-Generated Location: (709:18,6 [0] )
+Generated Location: (785:20,6 [0] )
 ||
 
 Source Location: (9:1,5 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpressionInCode.cshtml)
 |
 |
-Generated Location: (760:22,17 [2] )
+Generated Location: (836:24,17 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EmptyImplicitExpression_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] EmptyImplicitExpression.cshtml)
                     IntermediateToken - (0:0,0 [18] EmptyImplicitExpression.cshtml) - Html - This is markup\n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (19:2,1 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyImplicitExpression.cshtml)
 ||
-Generated Location: (675:16,6 [0] )
+Generated Location: (751:18,6 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
@@ -15,7 +15,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.ir.txt
@@ -7,7 +7,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] EnumTagHelpers.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] EnumTagHelpers.cshtml)
                     IntermediateToken - (31:0,31 [4] EnumTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
@@ -7,43 +7,43 @@ Source Location: (37:2,2 [39] TestFiles/IntegrationTests/CodeGenerationIntegrati
 |
     var enumValue = MyEnum.MyValue;
 |
-Generated Location: (948:22,2 [39] )
+Generated Location: (1024:24,2 [39] )
 |
     var enumValue = MyEnum.MyValue;
 |
 
 Source Location: (96:6,15 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MyValue|
-Generated Location: (1359:30,39 [14] )
+Generated Location: (1435:32,39 [14] )
 |MyEnum.MyValue|
 
 Source Location: (131:7,15 [20] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MySecondValue|
-Generated Location: (1724:37,15 [20] )
+Generated Location: (1800:39,15 [20] )
 |MyEnum.MySecondValue|
 
 Source Location: (171:8,14 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (2212:44,132 [7] )
+Generated Location: (2288:46,132 [7] )
 |MyValue|
 
 Source Location: (198:9,14 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MySecondValue|
-Generated Location: (2688:51,132 [13] )
+Generated Location: (2764:53,132 [13] )
 |MySecondValue|
 
 Source Location: (224:9,40 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (2964:56,138 [7] )
+Generated Location: (3040:58,138 [7] )
 |MyValue|
 
 Source Location: (251:10,15 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (3347:63,39 [9] )
+Generated Location: (3423:65,39 [9] )
 |enumValue|
 
 Source Location: (274:10,38 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (3526:68,45 [9] )
+Generated Location: (3602:70,45 [9] )
 |enumValue|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_Runtime.codegen.cs
@@ -7,9 +7,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EnumTagHelpers_Runtime
     {
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
@@ -15,7 +15,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.ir.txt
@@ -7,7 +7,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [15] EscapedTagHelpers.cshtml) - *, TestAssembly
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (29:0,29 [5] EscapedTagHelpers.cshtml)
                     IntermediateToken - (29:0,29 [4] EscapedTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
@@ -5,16 +5,16 @@ Generated Location: (598:12,38 [15] )
 
 Source Location: (106:3,29 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (977:22,29 [12] )
+Generated Location: (1053:24,29 [12] )
 |DateTime.Now|
 
 Source Location: (204:5,51 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1375:29,51 [12] )
+Generated Location: (1451:31,51 [12] )
 |DateTime.Now|
 
 Source Location: (227:5,74 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |true|
-Generated Location: (1742:36,74 [4] )
+Generated Location: (1818:38,74 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_Runtime.codegen.cs
@@ -7,9 +7,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_EscapedTagHelpers_Runtime
     {
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpressionAtEOF_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml)
                     IntermediateToken - (0:0,0 [18] ExplicitExpressionAtEOF.cshtml) - Html - This is markup\n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (20:2,2 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionAtEOF.cshtml)
 ||
-Generated Location: (675:16,6 [0] )
+Generated Location: (751:18,6 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpressionWithMarkup_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [5] ExplicitExpressionWithMarkup.cshtml)
                     IntermediateToken - (0:0,0 [5] ExplicitExpressionWithMarkup.cshtml) - Html - <div>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpressionWithMarkup.cshtml)
 ||
-Generated Location: (749:18,1 [0] )
+Generated Location: (825:20,1 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExplicitExpression_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [8] ExplicitExpression.cshtml)
                     IntermediateToken - (0:0,0 [8] ExplicitExpression.cshtml) - Html - 1 + 1 = 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (10:0,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExplicitExpression.cshtml)
 |1+1|
-Generated Location: (669:16,10 [3] )
+Generated Location: (745:18,10 [3] )
 |1+1|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ExpressionsInCode_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [51] ExpressionsInCode.cshtml)
                     IntermediateToken - (2:0,2 [51] ExpressionsInCode.cshtml) - CSharp - \n    object foo = null;\n    string bar = "Foo";\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode_DesignTime.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (2:0,2 [51] TestFiles/IntegrationTests/CodeGenerationIntegratio
     object foo = null;
     string bar = "Foo";
 |
-Generated Location: (659:16,2 [51] )
+Generated Location: (735:18,2 [51] )
 |
     object foo = null;
     string bar = "Foo";
@@ -12,20 +12,20 @@ Generated Location: (659:16,2 [51] )
 Source Location: (59:5,1 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |if(foo != null) {
     |
-Generated Location: (835:23,1 [23] )
+Generated Location: (911:25,1 [23] )
 |if(foo != null) {
     |
 
 Source Location: (83:6,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |foo|
-Generated Location: (990:29,6 [3] )
+Generated Location: (1066:31,6 [3] )
 |foo|
 
 Source Location: (86:6,8 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |
 } else {
     |
-Generated Location: (1128:34,8 [16] )
+Generated Location: (1204:36,8 [16] )
 |
 } else {
     |
@@ -33,26 +33,26 @@ Generated Location: (1128:34,8 [16] )
 Source Location: (121:8,23 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |
 }|
-Generated Location: (1293:41,23 [3] )
+Generated Location: (1369:43,23 [3] )
 |
 }|
 
 Source Location: (134:12,1 [38] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |if(!String.IsNullOrEmpty(bar)) {
     |
-Generated Location: (1424:47,1 [38] )
+Generated Location: (1500:49,1 [38] )
 |if(!String.IsNullOrEmpty(bar)) {
     |
 
 Source Location: (174:13,6 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |bar.Replace("F", "B")|
-Generated Location: (1595:53,6 [21] )
+Generated Location: (1671:55,6 [21] )
 |bar.Replace("F", "B")|
 
 Source Location: (196:13,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ExpressionsInCode.cshtml)
 |
 }|
-Generated Location: (1772:58,28 [3] )
+Generated Location: (1848:60,28 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_FunctionsBlockMinimal_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [5] FunctionsBlockMinimal.cshtml)
                     IntermediateToken - (0:0,0 [5] FunctionsBlockMinimal.cshtml) - Html - \n\n	

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlockMinimal_DesignTime.mappings.txt
@@ -4,7 +4,7 @@ string foo(string input) {
 	return input + "!";
 }
 |
-Generated Location: (729:18,15 [55] )
+Generated Location: (805:20,15 [55] )
 |
 string foo(string input) {
 	return input + "!";

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_FunctionsBlock_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (17:2,1 [4] FunctionsBlock.cshtml)
                     IntermediateToken - (17:2,1 [4] FunctionsBlock.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock_DesignTime.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (167:11,25 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock.cshtml)
 |RandomInt()|
-Generated Location: (677:16,25 [11] )
+Generated Location: (753:18,25 [11] )
 |RandomInt()|
 
 Source Location: (12:0,12 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock.cshtml)
 |
 
 |
-Generated Location: (791:22,20 [4] )
+Generated Location: (867:24,20 [4] )
 |
 
 |
@@ -19,7 +19,7 @@ Source Location: (33:4,12 [104] TestFiles/IntegrationTests/CodeGenerationIntegra
         return _rand.Next();
     }
 |
-Generated Location: (899:26,12 [104] )
+Generated Location: (975:28,12 [104] )
 |
     Random _rand = new Random();
     private int RandomInt() {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HiddenSpansInCode_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [6] HiddenSpansInCode.cshtml)
                     IntermediateToken - (2:0,2 [6] HiddenSpansInCode.cshtml) - CSharp - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode_DesignTime.mappings.txt
@@ -1,14 +1,14 @@
 Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode.cshtml)
 |
     |
-Generated Location: (578:15,14 [6] )
+Generated Location: (654:17,14 [6] )
 |
     |
 
 Source Location: (9:1,5 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HiddenSpansInCode.cshtml)
 |@Da
 |
-Generated Location: (684:18,5 [5] )
+Generated Location: (760:20,5 [5] )
 |@Da
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Double_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HtmlCommentWithQuote_Double_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Double.cshtml)
                     IntermediateToken - (0:0,0 [12] HtmlCommentWithQuote_Double.cshtml) - Html - <!-- " -->\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/HtmlCommentWithQuote_Single_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_HtmlCommentWithQuote_Single_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [45] HtmlCommentWithQuote_Single.cshtml)
                     IntermediateToken - (0:0,0 [12] HtmlCommentWithQuote_Single.cshtml) - Html - <!-- ' -->\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ImplicitExpressionAtEOF_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml)
                     IntermediateToken - (0:0,0 [18] ImplicitExpressionAtEOF.cshtml) - Html - This is markup\n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (19:2,1 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpressionAtEOF.cshtml)
 ||
-Generated Location: (675:16,6 [0] )
+Generated Location: (751:18,6 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ImplicitExpression_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (1:0,1 [36] ImplicitExpression.cshtml)
                     IntermediateToken - (1:0,1 [36] ImplicitExpression.cshtml) - CSharp - for(int i = 1; i <= 10; i++) {\n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (1:0,1 [36] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression.cshtml)
 |for(int i = 1; i <= 10; i++) {
     |
-Generated Location: (660:16,1 [36] )
+Generated Location: (736:18,1 [36] )
 |for(int i = 1; i <= 10; i++) {
     |
 
 Source Location: (55:1,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression.cshtml)
 |i|
-Generated Location: (845:22,22 [1] )
+Generated Location: (921:24,22 [1] )
 |i|
 
 Source Location: (60:1,27 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ImplicitExpression.cshtml)
 |
 }|
-Generated Location: (1001:27,27 [3] )
+Generated Location: (1077:29,27 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -45,7 +45,9 @@ global::System.Object __typeHelper = ";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -12,7 +12,11 @@ Document -
                 DirectiveToken - (231:11,17 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (250:12,17 [1] IncompleteDirectives.cshtml) - "
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (83:0,83 [4] IncompleteDirectives.cshtml)
                     IntermediateToken - (83:0,83 [4] IncompleteDirectives.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
@@ -14,7 +14,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.ir.txt
@@ -6,7 +6,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] IncompleteTagHelper.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] IncompleteTagHelper.cshtml)
                     IntermediateToken - (31:0,31 [4] IncompleteTagHelper.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.codegen.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString(""), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
@@ -13,7 +13,9 @@ foo.bar<baz<biz>>.boz __typeHelper = default(foo.bar<baz<biz>>.boz);
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.ir.txt
@@ -4,7 +4,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (10:0,10 [21] Inherits.cshtml) - foo.bar<baz<biz>>.boz
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (33:1,0 [2] Inherits.cshtml)
                     IntermediateToken - (33:1,0 [2] Inherits.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (401:10,0 [21] )
 
 Source Location: (36:2,1 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
 |foo()|
-Generated Location: (799:20,6 [5] )
+Generated Location: (875:22,6 [5] )
 |foo()|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
@@ -13,7 +13,9 @@ global::System.Object Link = null;
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.ir.txt
@@ -4,7 +4,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (9:0,9 [4] InlineBlocks.cshtml) - Link
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 MalformedDirective - (0:0,0 [13] InlineBlocks.cshtml) - section
                     DirectiveToken - (9:0,9 [4] InlineBlocks.cshtml) - Link

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (403:10,22 [4] )
 
 Source Location: (44:1,14 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |if(link != null) { |
-Generated Location: (757:20,14 [19] )
+Generated Location: (833:22,14 [19] )
 |if(link != null) { |
 
 Source Location: (64:1,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |link|
-Generated Location: (931:25,34 [4] )
+Generated Location: (1007:27,34 [4] )
 |link|
 
 Source Location: (68:1,38 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | } else { |
-Generated Location: (1095:30,38 [10] )
+Generated Location: (1171:32,38 [10] )
 | } else { |
 
 Source Location: (92:1,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | }|
-Generated Location: (1288:35,62 [2] )
+Generated Location: (1364:37,62 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Instrumented_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [32] Instrumented.cshtml)
                     IntermediateToken - (2:0,2 [32] Instrumented.cshtml) - CSharp - \n    int i = 1;\n    var foo = 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented_DesignTime.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (2:0,2 [32] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |
     int i = 1;
     var foo = |
-Generated Location: (649:16,2 [32] )
+Generated Location: (725:18,2 [32] )
 |
     int i = 1;
     var foo = |
@@ -10,39 +10,39 @@ Generated Location: (649:16,2 [32] )
 Source Location: (45:2,25 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |;
     |
-Generated Location: (927:26,25 [7] )
+Generated Location: (1003:28,25 [7] )
 |;
     |
 
 Source Location: (68:4,0 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |    |
-Generated Location: (967:31,0 [4] )
+Generated Location: (1043:33,0 [4] )
 |    |
 
 Source Location: (91:4,23 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 |
-Generated Location: (1020:32,35 [2] )
+Generated Location: (1096:34,35 [2] )
 |
 |
 
 Source Location: (99:7,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |while(i <= 10) {
     |
-Generated Location: (1113:35,1 [22] )
+Generated Location: (1189:37,1 [22] )
 |while(i <= 10) {
     |
 
 Source Location: (142:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |i|
-Generated Location: (1281:41,25 [1] )
+Generated Location: (1357:43,25 [1] )
 |i|
 
 Source Location: (148:8,31 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
     i += 1;
 }|
-Generated Location: (1435:46,31 [16] )
+Generated Location: (1511:48,31 [16] )
 |
     i += 1;
 }|
@@ -50,14 +50,14 @@ Generated Location: (1435:46,31 [16] )
 Source Location: (169:12,1 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |if(i == 11) {
     |
-Generated Location: (1574:53,1 [19] )
+Generated Location: (1650:55,1 [19] )
 |if(i == 11) {
     |
 
 Source Location: (213:13,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (1744:59,29 [3] )
+Generated Location: (1820:61,29 [3] )
 |
 }|
 
@@ -65,7 +65,7 @@ Source Location: (221:16,1 [35] TestFiles/IntegrationTests/CodeGenerationIntegra
 |switch(i) {
     case 11:
         |
-Generated Location: (1870:65,1 [35] )
+Generated Location: (1946:67,1 [35] )
 |switch(i) {
     case 11:
         |
@@ -75,7 +75,7 @@ Source Location: (292:18,44 [40] TestFiles/IntegrationTests/CodeGenerationIntegr
         break;
     default:
         |
-Generated Location: (2071:72,44 [40] )
+Generated Location: (2147:74,44 [40] )
 |
         break;
     default:
@@ -85,7 +85,7 @@ Source Location: (361:21,37 [19] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
         break;
 }|
-Generated Location: (2270:80,37 [19] )
+Generated Location: (2346:82,37 [19] )
 |
         break;
 }|
@@ -93,26 +93,26 @@ Generated Location: (2270:80,37 [19] )
 Source Location: (385:25,1 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |for(int j = 1; j <= 10; j += 2) {
     |
-Generated Location: (2412:87,1 [39] )
+Generated Location: (2488:89,1 [39] )
 |for(int j = 1; j <= 10; j += 2) {
     |
 
 Source Location: (451:26,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |j|
-Generated Location: (2604:93,31 [1] )
+Generated Location: (2680:95,31 [1] )
 |j|
 
 Source Location: (457:26,37 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (2765:98,37 [3] )
+Generated Location: (2841:100,37 [3] )
 |
 }|
 
 Source Location: (465:29,1 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |try {
     |
-Generated Location: (2891:104,1 [11] )
+Generated Location: (2967:106,1 [11] )
 |try {
     |
 
@@ -120,34 +120,34 @@ Source Location: (511:30,39 [31] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
 } catch(Exception ex) {
     |
-Generated Location: (3063:110,39 [31] )
+Generated Location: (3139:112,39 [31] )
 |
 } catch(Exception ex) {
     |
 
 Source Location: (573:32,35 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |ex.Message|
-Generated Location: (3251:117,35 [10] )
+Generated Location: (3327:119,35 [10] )
 |ex.Message|
 
 Source Location: (588:32,50 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (3434:122,50 [3] )
+Generated Location: (3510:124,50 [3] )
 |
 }|
 
 Source Location: (596:35,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |lock(new object()) {
     |
-Generated Location: (3560:128,1 [26] )
+Generated Location: (3636:130,1 [26] )
 |lock(new object()) {
     |
 
 Source Location: (669:36,51 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Instrumented.cshtml)
 |
 }|
-Generated Location: (3759:134,51 [3] )
+Generated Location: (3835:136,51 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_MarkupInCodeBlock_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [46] MarkupInCodeBlock.cshtml)
                     IntermediateToken - (2:0,2 [46] MarkupInCodeBlock.cshtml) - CSharp - \n    for(int i = 1; i <= 10; i++) {\n        

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock_DesignTime.mappings.txt
@@ -2,21 +2,21 @@ Source Location: (2:0,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |
     for(int i = 1; i <= 10; i++) {
         |
-Generated Location: (659:16,2 [46] )
+Generated Location: (735:18,2 [46] )
 |
     for(int i = 1; i <= 10; i++) {
         |
 
 Source Location: (69:2,29 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock.cshtml)
 |i.ToString()|
-Generated Location: (860:23,29 [12] )
+Generated Location: (936:25,29 [12] )
 |i.ToString()|
 
 Source Location: (86:2,46 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MarkupInCodeBlock.cshtml)
 |
     }
 |
-Generated Location: (1045:28,46 [9] )
+Generated Location: (1121:30,46 [9] )
 |
     }
 |

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
@@ -15,7 +15,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.ir.txt
@@ -7,7 +7,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] MinimizedTagHelpers.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] MinimizedTagHelpers.cshtml)
                     IntermediateToken - (31:0,31 [4] MinimizedTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_Runtime.codegen.cs
@@ -14,9 +14,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("input-unbound-required", new global::Microsoft.AspNetCore.Html.HtmlString("hello2"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("input-bound-required-string", "world", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedCSharp_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [6] NestedCSharp.cshtml)
                     IntermediateToken - (2:0,2 [6] NestedCSharp.cshtml) - CSharp - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp_DesignTime.mappings.txt
@@ -1,7 +1,7 @@
 Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |
     |
-Generated Location: (573:15,14 [6] )
+Generated Location: (649:17,14 [6] )
 |
     |
 
@@ -9,27 +9,27 @@ Source Location: (9:1,5 [53] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |foreach (var result in (dynamic)Url)
     {
         |
-Generated Location: (674:18,5 [53] )
+Generated Location: (750:20,5 [53] )
 |foreach (var result in (dynamic)Url)
     {
         |
 
 Source Location: (82:4,13 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |result.SomeValue|
-Generated Location: (861:25,13 [16] )
+Generated Location: (937:27,13 [16] )
 |result.SomeValue|
 
 Source Location: (115:5,14 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |
     }|
-Generated Location: (1013:30,14 [7] )
+Generated Location: (1089:32,14 [7] )
 |
     }|
 
 Source Location: (122:6,5 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCSharp.cshtml)
 |
 |
-Generated Location: (1070:35,17 [2] )
+Generated Location: (1146:37,17 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NestedCodeBlocks_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (1:0,1 [15] NestedCodeBlocks.cshtml)
                     IntermediateToken - (1:0,1 [15] NestedCodeBlocks.cshtml) - CSharp - if(foo) {\n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks_DesignTime.mappings.txt
@@ -1,21 +1,21 @@
 Source Location: (1:0,1 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks.cshtml)
 |if(foo) {
     |
-Generated Location: (656:16,1 [15] )
+Generated Location: (732:18,1 [15] )
 |if(foo) {
     |
 
 Source Location: (17:1,5 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks.cshtml)
 |if(bar) {
     }|
-Generated Location: (801:22,5 [16] )
+Generated Location: (877:24,5 [16] )
 |if(bar) {
     }|
 
 Source Location: (33:2,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedCodeBlocks.cshtml)
 |
 }|
-Generated Location: (947:28,5 [3] )
+Generated Location: (1023:30,5 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
@@ -16,7 +16,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.ir.txt
@@ -8,7 +8,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] NestedScriptTagTagHelpers.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [108] NestedScriptTagTagHelpers.cshtml)
                     IntermediateToken - (31:0,31 [4] NestedScriptTagTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
@@ -6,24 +6,24 @@ Generated Location: (683:13,37 [17] )
 Source Location: (195:5,13 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |for(var i = 0; i < 5; i++) {
                 |
-Generated Location: (1055:23,13 [46] )
+Generated Location: (1131:25,13 [46] )
 |for(var i = 0; i < 5; i++) {
                 |
 
 Source Location: (339:7,50 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1493:31,50 [23] )
+Generated Location: (1569:33,50 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (389:7,100 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |true|
-Generated Location: (1899:38,100 [4] )
+Generated Location: (1975:40,100 [4] )
 |true|
 
 Source Location: (422:8,25 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |
             }|
-Generated Location: (2063:43,25 [15] )
+Generated Location: (2139:45,25 [15] )
 |
             }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_Runtime.codegen.cs
@@ -10,9 +10,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-delay", new global::Microsoft.AspNetCore.Html.HtmlString("1000"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
@@ -16,7 +16,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.ir.txt
@@ -8,7 +8,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [15] NestedTagHelpers.cshtml) - *, TestAssembly
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (29:0,29 [2] NestedTagHelpers.cshtml)
                     IntermediateToken - (29:0,29 [2] NestedTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_Runtime.codegen.cs
@@ -10,9 +10,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("unbound", new global::Microsoft.AspNetCore.Html.HtmlString("foo"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NoLinePragmas_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [18] NoLinePragmas.cshtml)
                     IntermediateToken - (2:0,2 [18] NoLinePragmas.cshtml) - CSharp - \n    int i = 1;\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas_DesignTime.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (2:0,2 [18] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |
     int i = 1;
 |
-Generated Location: (651:16,2 [18] )
+Generated Location: (727:18,2 [18] )
 |
     int i = 1;
 |
@@ -10,20 +10,20 @@ Generated Location: (651:16,2 [18] )
 Source Location: (26:4,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |while(i <= 10) {
     |
-Generated Location: (790:22,1 [22] )
+Generated Location: (866:24,1 [22] )
 |while(i <= 10) {
     |
 
 Source Location: (69:5,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |i|
-Generated Location: (959:28,25 [1] )
+Generated Location: (1035:30,25 [1] )
 |i|
 
 Source Location: (75:5,31 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |
     i += 1;
 }|
-Generated Location: (1114:33,31 [16] )
+Generated Location: (1190:35,31 [16] )
 |
     i += 1;
 }|
@@ -31,14 +31,14 @@ Generated Location: (1114:33,31 [16] )
 Source Location: (96:9,1 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |if(i == 11) {
     |
-Generated Location: (1254:40,1 [19] )
+Generated Location: (1330:42,1 [19] )
 |if(i == 11) {
     |
 
 Source Location: (140:10,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |
 }|
-Generated Location: (1425:46,29 [3] )
+Generated Location: (1501:48,29 [3] )
 |
 }|
 
@@ -46,7 +46,7 @@ Source Location: (148:13,1 [35] TestFiles/IntegrationTests/CodeGenerationIntegra
 |switch(i) {
     case 11:
         |
-Generated Location: (1552:52,1 [35] )
+Generated Location: (1628:54,1 [35] )
 |switch(i) {
     case 11:
         |
@@ -56,7 +56,7 @@ Source Location: (219:15,44 [40] TestFiles/IntegrationTests/CodeGenerationIntegr
         break;
     default:
         |
-Generated Location: (1754:59,44 [40] )
+Generated Location: (1830:61,44 [40] )
 |
         break;
     default:
@@ -66,7 +66,7 @@ Source Location: (288:18,37 [19] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
         break;
 }|
-Generated Location: (1954:67,37 [19] )
+Generated Location: (2030:69,37 [19] )
 |
         break;
 }|
@@ -74,26 +74,26 @@ Generated Location: (1954:67,37 [19] )
 Source Location: (312:22,1 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |for(int j = 1; j <= 10; j += 2) {
     |
-Generated Location: (2097:74,1 [39] )
+Generated Location: (2173:76,1 [39] )
 |for(int j = 1; j <= 10; j += 2) {
     |
 
 Source Location: (378:23,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |j|
-Generated Location: (2290:80,31 [1] )
+Generated Location: (2366:82,31 [1] )
 |j|
 
 Source Location: (384:23,37 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |
 }|
-Generated Location: (2452:85,37 [3] )
+Generated Location: (2528:87,37 [3] )
 |
 }|
 
 Source Location: (392:26,1 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |try {
     |
-Generated Location: (2579:91,1 [11] )
+Generated Location: (2655:93,1 [11] )
 |try {
     |
 
@@ -101,14 +101,14 @@ Source Location: (438:27,39 [31] TestFiles/IntegrationTests/CodeGenerationIntegr
 |
 } catch(Exception ex) {
     |
-Generated Location: (2752:97,39 [31] )
+Generated Location: (2828:99,39 [31] )
 |
 } catch(Exception ex) {
     |
 
 Source Location: (500:29,35 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |ex.Message|
-Generated Location: (2941:104,35 [10] )
+Generated Location: (3017:106,35 [10] )
 |ex.Message|
 
 Source Location: (515:29,50 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
@@ -116,7 +116,7 @@ Source Location: (515:29,50 [7] TestFiles/IntegrationTests/CodeGenerationIntegra
 }
 
 |
-Generated Location: (3125:109,50 [7] )
+Generated Location: (3201:111,50 [7] )
 |
 }
 
@@ -124,25 +124,25 @@ Generated Location: (3125:109,50 [7] )
 
 Source Location: (556:32,34 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 ||
-Generated Location: (3209:115,46 [0] )
+Generated Location: (3285:117,46 [0] )
 ||
 
 Source Location: (571:33,13 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |i|
-Generated Location: (3314:117,13 [1] )
+Generated Location: (3390:119,13 [1] )
 |i|
 
 Source Location: (581:35,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |lock(new object()) {
     |
-Generated Location: (3440:122,1 [26] )
+Generated Location: (3516:124,1 [26] )
 |lock(new object()) {
     |
 
 Source Location: (654:36,51 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NoLinePragmas.cshtml)
 |
 }|
-Generated Location: (3640:128,51 [3] )
+Generated Location: (3716:130,51 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_NullConditionalExpressions_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [6] NullConditionalExpressions.cshtml)
                     IntermediateToken - (2:0,2 [6] NullConditionalExpressions.cshtml) - CSharp - \n    

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions_DesignTime.mappings.txt
@@ -1,75 +1,75 @@
 Source Location: (2:0,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
     |
-Generated Location: (587:15,14 [6] )
+Generated Location: (663:17,14 [6] )
 |
     |
 
 Source Location: (9:1,5 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Data|
-Generated Location: (703:18,6 [13] )
+Generated Location: (779:20,6 [13] )
 |ViewBag?.Data|
 
 Source Location: (22:1,18 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
     |
-Generated Location: (780:22,30 [6] )
+Generated Location: (856:24,30 [6] )
 |
     |
 
 Source Location: (29:2,5 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.IntIndexer?[0]|
-Generated Location: (896:25,6 [22] )
+Generated Location: (972:27,6 [22] )
 |ViewBag.IntIndexer?[0]|
 
 Source Location: (51:2,27 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
     |
-Generated Location: (991:29,39 [6] )
+Generated Location: (1067:31,39 [6] )
 |
     |
 
 Source Location: (58:3,5 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.StrIndexer?["key"]|
-Generated Location: (1107:32,6 [26] )
+Generated Location: (1183:34,6 [26] )
 |ViewBag.StrIndexer?["key"]|
 
 Source Location: (84:3,31 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
     |
-Generated Location: (1210:36,43 [6] )
+Generated Location: (1286:38,43 [6] )
 |
     |
 
 Source Location: (91:4,5 [41] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
-Generated Location: (1326:39,6 [41] )
+Generated Location: (1402:41,6 [41] )
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
 
 Source Location: (132:4,46 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |
 |
-Generated Location: (1459:43,58 [2] )
+Generated Location: (1535:45,58 [2] )
 |
 |
 
 Source Location: (140:7,1 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Data|
-Generated Location: (1571:46,6 [13] )
+Generated Location: (1647:48,6 [13] )
 |ViewBag?.Data|
 
 Source Location: (156:8,1 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.IntIndexer?[0]|
-Generated Location: (1726:51,6 [22] )
+Generated Location: (1802:53,6 [22] )
 |ViewBag.IntIndexer?[0]|
 
 Source Location: (181:9,1 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag.StrIndexer?["key"]|
-Generated Location: (1891:56,6 [26] )
+Generated Location: (1967:58,6 [26] )
 |ViewBag.StrIndexer?["key"]|
 
 Source Location: (210:10,1 [41] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NullConditionalExpressions.cshtml)
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
-Generated Location: (2060:61,6 [41] )
+Generated Location: (2136:63,6 [41] )
 |ViewBag?.Method(Value?[23]?.More)?["key"]|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_OpenedIf_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [16] OpenedIf.cshtml)
                     IntermediateToken - (0:0,0 [6] OpenedIf.cshtml) - Html - <html>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (17:2,1 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf.cshtml)
 |if (true) { 
 |
-Generated Location: (640:16,1 [14] )
+Generated Location: (716:18,1 [14] )
 |if (true) { 
 |
 
 Source Location: (38:3,7 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf.cshtml)
 |
 |
-Generated Location: (704:20,19 [2] )
+Generated Location: (780:22,19 [2] )
 |
 |
 
 Source Location: (47:4,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/OpenedIf.cshtml)
 ||
-Generated Location: (727:22,19 [0] )
+Generated Location: (803:24,19 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_ParserError_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [31] ParserError.cshtml)
                     IntermediateToken - (2:0,2 [31] ParserError.cshtml) - CSharp - \n/*\nint i =10;\nint j =20;\n}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ParserError_DesignTime.mappings.txt
@@ -4,7 +4,7 @@ Source Location: (2:0,2 [31] TestFiles/IntegrationTests/CodeGenerationIntegratio
 int i =10;
 int j =20;
 }|
-Generated Location: (647:16,2 [31] )
+Generated Location: (723:18,2 [31] )
 |
 /*
 int i =10;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
@@ -15,7 +15,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.ir.txt
@@ -7,7 +7,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] PrefixedAttributeTagHelpers.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] PrefixedAttributeTagHelpers.cshtml)
                     IntermediateToken - (31:0,31 [4] PrefixedAttributeTagHelpers.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
@@ -15,7 +15,7 @@ Source Location: (37:2,2 [242] TestFiles/IntegrationTests/CodeGenerationIntegrat
         { "name", "value" },
     };
 |
-Generated Location: (972:22,2 [242] )
+Generated Location: (1048:24,2 [242] )
 |
     var literate = "or illiterate";
     var intDictionary = new Dictionary<string, int>
@@ -30,51 +30,51 @@ Generated Location: (972:22,2 [242] )
 
 Source Location: (370:15,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (1615:38,56 [13] )
+Generated Location: (1691:40,56 [13] )
 |intDictionary|
 
 Source Location: (404:15,77 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |stringDictionary|
-Generated Location: (1967:44,77 [16] )
+Generated Location: (2043:46,77 [16] )
 |stringDictionary|
 
 Source Location: (468:16,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (2517:52,56 [13] )
+Generated Location: (2593:54,56 [13] )
 |intDictionary|
 
 Source Location: (502:16,77 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (2869:58,77 [2] )
+Generated Location: (2945:60,77 [2] )
 |37|
 
 Source Location: (526:16,101 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (3254:64,101 [2] )
+Generated Location: (3330:66,101 [2] )
 |42|
 
 Source Location: (590:18,31 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (3775:72,46 [2] )
+Generated Location: (3851:74,46 [2] )
 |42|
 
 Source Location: (611:18,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (4104:78,64 [2] )
+Generated Location: (4180:80,64 [2] )
 |37|
 
 Source Location: (634:18,75 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |98|
-Generated Location: (4459:84,75 [2] )
+Generated Location: (4535:86,75 [2] )
 |98|
 
 Source Location: (783:20,42 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |literate|
-Generated Location: (5241:94,42 [8] )
+Generated Location: (5317:96,42 [8] )
 |literate|
 
 Source Location: (826:21,29 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (5905:103,65 [2] )
+Generated Location: (5981:105,65 [2] )
 |37|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_Runtime.codegen.cs
@@ -14,9 +14,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("string-prefix-paprika", "another string", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("string-prefix-thyme", "string", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_RazorComments_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (36:0,36 [17] RazorComments.cshtml)
                     IntermediateToken - (36:0,36 [2] RazorComments.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments_DesignTime.mappings.txt
@@ -1,14 +1,14 @@
 Source Location: (81:3,2 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |
     |
-Generated Location: (574:15,14 [6] )
+Generated Location: (650:17,14 [6] )
 |
     |
 
 Source Location: (122:4,39 [22] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |
     Exception foo = |
-Generated Location: (710:18,39 [22] )
+Generated Location: (786:20,39 [22] )
 |
     Exception foo = |
 
@@ -18,7 +18,7 @@ Source Location: (173:5,49 [58] TestFiles/IntegrationTests/CodeGenerationIntegra
         throw foo;
     }
 |
-Generated Location: (903:24,49 [58] )
+Generated Location: (979:26,49 [58] )
 | null;
     if(foo != null) {
         throw foo;
@@ -27,21 +27,21 @@ Generated Location: (903:24,49 [58] )
 
 Source Location: (238:11,2 [24] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 | var bar = "@* bar *@"; |
-Generated Location: (1084:32,2 [24] )
+Generated Location: (1160:34,2 [24] )
 | var bar = "@* bar *@"; |
 
 Source Location: (310:12,45 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |bar|
-Generated Location: (1276:37,45 [3] )
+Generated Location: (1352:39,45 [3] )
 |bar|
 
 Source Location: (323:14,2 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |a|
-Generated Location: (1409:42,6 [1] )
+Generated Location: (1485:44,6 [1] )
 |a|
 
 Source Location: (328:14,7 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorComments.cshtml)
 |b|
-Generated Location: (1410:42,7 [1] )
+Generated Location: (1486:44,7 [1] )
 |b|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.codegen.cs
@@ -13,7 +13,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.ir.txt
@@ -4,7 +4,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (17:0,17 [15] RemoveTagHelperDirective.cshtml) - *, TestAssembly
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (32:0,32 [2] RemoveTagHelperDirective.cshtml)
                     IntermediateToken - (32:0,32 [2] RemoveTagHelperDirective.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -21,7 +21,9 @@ global::System.Object NestedDelegates = null;
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.ir.txt
@@ -6,7 +6,11 @@ Document -
                 DirectiveToken - (172:10,9 [8] Sections.cshtml) - Section1
                 DirectiveToken - (235:14,9 [15] Sections.cshtml) - NestedDelegates
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [44] Sections.cshtml)
                     IntermediateToken - (2:0,2 [44] Sections.cshtml) - CSharp - \n    Layout = "_SectionTestLayout.cshtml"\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -17,28 +17,28 @@ Source Location: (2:0,2 [44] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |
     Layout = "_SectionTestLayout.cshtml"
 |
-Generated Location: (948:28,2 [44] )
+Generated Location: (1024:30,2 [44] )
 |
     Layout = "_SectionTestLayout.cshtml"
 |
 
 Source Location: (123:7,22 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |thing|
-Generated Location: (1203:35,22 [5] )
+Generated Location: (1279:37,22 [5] )
 |thing|
 
 Source Location: (260:15,6 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | Func<dynamic, object> f = |
-Generated Location: (1550:46,6 [27] )
+Generated Location: (1626:48,6 [27] )
 | Func<dynamic, object> f = |
 
 Source Location: (295:15,41 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |item|
-Generated Location: (1810:52,41 [4] )
+Generated Location: (1886:54,41 [4] )
 |item|
 
 Source Location: (306:15,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |; |
-Generated Location: (2023:59,52 [2] )
+Generated Location: (2099:61,52 [2] )
 |; |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
@@ -14,7 +14,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.ir.txt
@@ -6,7 +6,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [15] SimpleTagHelpers.cshtml) - *, TestAssembly
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (29:0,29 [27] SimpleTagHelpers.cshtml)
                     IntermediateToken - (29:0,29 [2] SimpleTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_Runtime.codegen.cs
@@ -9,9 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("value", "Hello", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_SimpleUnspacedIf_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (1:0,1 [15] SimpleUnspacedIf.cshtml)
                     IntermediateToken - (1:0,1 [15] SimpleUnspacedIf.cshtml) - CSharp - if (true)\n{\n	

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf_DesignTime.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (1:0,1 [15] TestFiles/IntegrationTests/CodeGenerationIntegratio
 |if (true)
 {
 	|
-Generated Location: (656:16,1 [15] )
+Generated Location: (732:18,1 [15] )
 |if (true)
 {
 	|
@@ -10,7 +10,7 @@ Generated Location: (656:16,1 [15] )
 Source Location: (27:2,12 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleUnspacedIf.cshtml)
 |
 }|
-Generated Location: (811:23,15 [3] )
+Generated Location: (887:25,15 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
@@ -14,7 +14,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.ir.txt
@@ -6,7 +6,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml)
                     IntermediateToken - (31:0,31 [4] SingleTagHelperWithNewlineBeforeAttributes.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (526:11,37 [17] )
 
 Source Location: (67:3,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml)
 |1337|
-Generated Location: (1030:22,33 [4] )
+Generated Location: (1106:24,33 [4] )
 |1337|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_Runtime.codegen.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
@@ -14,7 +14,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.ir.txt
@@ -6,7 +6,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] SingleTagHelper.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] SingleTagHelper.cshtml)
                     IntermediateToken - (31:0,31 [4] SingleTagHelper.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (499:11,37 [17] )
 
 Source Location: (63:2,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml)
 |1337|
-Generated Location: (976:22,33 [4] )
+Generated Location: (1052:24,33 [4] )
 |1337|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_Runtime.codegen.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("Hello World"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.codegen.cs
@@ -17,7 +17,9 @@ global::System.Object WriteLiteralsToInHereAlso = null;
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.ir.txt
@@ -5,7 +5,11 @@ Document -
                 DirectiveToken - (2022:85,9 [21] StringLiterals.cshtml) - WriteLiteralsToInHere
                 DirectiveToken - (5701:205,9 [25] StringLiterals.cshtml) - WriteLiteralsToInHereAlso
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (0:0,0 [2013] StringLiterals.cshtml)
                     IntermediateToken - (0:0,0 [3] StringLiterals.cshtml) - Html - <p>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
@@ -14,7 +14,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.ir.txt
@@ -6,7 +6,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [15] SymbolBoundAttributes.cshtml) - *, TestAssembly
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (29:0,29 [255] SymbolBoundAttributes.cshtml)
                     IntermediateToken - (29:0,29 [4] SymbolBoundAttributes.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (520:11,38 [15] )
 
 Source Location: (302:11,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1030:22,46 [5] )
+Generated Location: (1106:24,46 [5] )
 |items|
 
 Source Location: (351:12,20 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1323:28,47 [5] )
+Generated Location: (1399:30,47 [5] )
 |items|
 
 Source Location: (405:13,23 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (1612:34,43 [13] )
+Generated Location: (1688:36,43 [13] )
 |doSomething()|
 
 Source Location: (487:14,24 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (1909:40,43 [13] )
+Generated Location: (1985:42,43 [13] )
 |doSomething()|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_Runtime.codegen.cs
@@ -15,9 +15,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_6 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("#local", "value", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_7 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("#local", new global::Microsoft.AspNetCore.Html.HtmlString("value"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersInSection_Runtime.codegen.cs
@@ -7,9 +7,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     public class TestFiles_IntegrationTests_CodeGenerationIntegrationTest_TagHelpersInSection_Runtime
     {
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
@@ -14,7 +14,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.ir.txt
@@ -6,7 +6,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [15] TagHelpersWithBoundAttributes.cshtml) - *, TestAssembly
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (29:0,29 [14] TagHelpersWithBoundAttributes.cshtml)
                     IntermediateToken - (29:0,29 [2] TagHelpersWithBoundAttributes.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (494:11,38 [15] )
 
 Source Location: (57:2,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml)
 |Hello|
-Generated Location: (949:22,18 [5] )
+Generated Location: (1025:24,18 [5] )
 |Hello|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_Runtime.codegen.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
@@ -18,7 +18,9 @@ global::System.Object __typeHelper = "cool:";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.ir.txt
@@ -7,7 +7,11 @@ Document -
                 DirectiveToken - (14:0,14 [15] TagHelpersWithPrefix.cshtml) - *, TestAssembly
                 DirectiveToken - (48:1,17 [5] TagHelpersWithPrefix.cshtml) - cool:
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (29:0,29 [2] TagHelpersWithPrefix.cshtml)
                     IntermediateToken - (29:0,29 [2] TagHelpersWithPrefix.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
@@ -10,6 +10,6 @@ Generated Location: (602:15,38 [5] )
 
 Source Location: (86:3,23 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |Hello|
-Generated Location: (1043:26,23 [5] )
+Generated Location: (1119:28,23 [5] )
 |Hello|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_Runtime.codegen.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", new global::Microsoft.AspNetCore.Html.HtmlString("text"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
@@ -15,7 +15,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.ir.txt
@@ -7,7 +7,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] TagHelpersWithTemplate.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] TagHelpersWithTemplate.cshtml)
                     IntermediateToken - (31:0,31 [4] TagHelpersWithTemplate.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
@@ -8,7 +8,7 @@ Source Location: (333:12,6 [66] TestFiles/IntegrationTests/CodeGenerationIntegra
         RenderTemplate(
             "Template: ",
             |
-Generated Location: (903:22,6 [66] )
+Generated Location: (979:24,6 [66] )
 |
         RenderTemplate(
             "Template: ",
@@ -16,13 +16,13 @@ Generated Location: (903:22,6 [66] )
 
 Source Location: (427:15,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |item|
-Generated Location: (1211:31,40 [4] )
+Generated Location: (1287:33,40 [4] )
 |item|
 
 Source Location: (482:15,95 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |);
     |
-Generated Location: (1627:40,95 [8] )
+Generated Location: (1703:42,95 [8] )
 |);
     |
 
@@ -35,7 +35,7 @@ Source Location: (47:2,12 [268] TestFiles/IntegrationTests/CodeGenerationIntegra
         helperResult.WriteTo(Output, HtmlEncoder);
     }
 |
-Generated Location: (1898:49,12 [268] )
+Generated Location: (1974:51,12 [268] )
 |
     public void RenderTemplate(string title, Func<string, HelperResult> template)
     {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_Runtime.codegen.cs
@@ -10,9 +10,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_1 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("checked", new global::Microsoft.AspNetCore.Html.HtmlString("true"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_2 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("condition", new global::Microsoft.AspNetCore.Html.HtmlString("true"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
@@ -16,7 +16,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.ir.txt
@@ -8,7 +8,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] TagHelpersWithWeirdlySpacedAttributes.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml)
                     IntermediateToken - (31:0,31 [4] TagHelpersWithWeirdlySpacedAttributes.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
@@ -5,16 +5,16 @@ Generated Location: (695:13,37 [17] )
 
 Source Location: (74:5,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1337|
-Generated Location: (1194:24,33 [4] )
+Generated Location: (1270:26,33 [4] )
 |1337|
 
 Source Location: (99:6,19 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |true|
-Generated Location: (1364:29,19 [4] )
+Generated Location: (1440:31,19 [4] )
 |true|
 
 Source Location: (186:10,11 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1234|
-Generated Location: (2000:39,33 [4] )
+Generated Location: (2076:41,33 [4] )
 |1234|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_Runtime.codegen.cs
@@ -13,9 +13,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_4 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("type", "password", global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_5 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("data-content", new global::Microsoft.AspNetCore.Html.HtmlString("blah"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.NoQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Templates_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (278:8,1 [4] Templates.cshtml)
                     IntermediateToken - (278:8,1 [4] Templates.cshtml) - Html - \n\n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates_DesignTime.mappings.txt
@@ -1,149 +1,149 @@
 Source Location: (284:10,2 [34] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |
     Func<dynamic, object> foo = |
-Generated Location: (644:16,2 [34] )
+Generated Location: (720:18,2 [34] )
 |
     Func<dynamic, object> foo = |
 
 Source Location: (337:11,51 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (918:23,51 [4] )
+Generated Location: (994:25,51 [4] )
 |item|
 
 Source Location: (349:11,63 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |;
     |
-Generated Location: (1135:30,63 [7] )
+Generated Location: (1211:32,63 [7] )
 |;
     |
 
 Source Location: (357:12,5 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |foo("")|
-Generated Location: (1267:36,6 [7] )
+Generated Location: (1343:38,6 [7] )
 |foo("")|
 
 Source Location: (364:12,12 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |
 |
-Generated Location: (1332:40,24 [2] )
+Generated Location: (1408:42,24 [2] )
 |
 |
 
 Source Location: (373:15,2 [35] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 | 
     Func<dynamic, object> bar = |
-Generated Location: (1424:43,2 [35] )
+Generated Location: (1500:45,2 [35] )
 | 
     Func<dynamic, object> bar = |
 
 Source Location: (420:16,44 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (1692:50,44 [4] )
+Generated Location: (1768:52,44 [4] )
 |item|
 
 Source Location: (435:16,59 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |;
     |
-Generated Location: (1905:57,59 [7] )
+Generated Location: (1981:59,59 [7] )
 |;
     |
 
 Source Location: (443:17,5 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |bar("myclass")|
-Generated Location: (2037:63,6 [14] )
+Generated Location: (2113:65,6 [14] )
 |bar("myclass")|
 
 Source Location: (457:17,19 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |
 |
-Generated Location: (2116:67,31 [2] )
+Generated Location: (2192:69,31 [2] )
 |
 |
 
 Source Location: (472:21,2 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10, |
-Generated Location: (2212:70,6 [11] )
+Generated Location: (2288:72,6 [11] )
 |Repeat(10, |
 
 Source Location: (495:21,25 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2392:72,25 [4] )
+Generated Location: (2468:74,25 [4] )
 |item|
 
 Source Location: (504:21,34 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2434:77,1 [1] )
+Generated Location: (2510:79,1 [1] )
 |)|
 
 Source Location: (523:25,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (2561:82,6 [16] )
+Generated Location: (2637:84,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (556:26,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (2742:85,21 [4] )
+Generated Location: (2818:87,21 [4] )
 |item|
 
 Source Location: (577:27,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (2784:90,1 [1] )
+Generated Location: (2860:92,1 [1] )
 |)|
 
 Source Location: (594:31,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (2911:95,6 [16] )
+Generated Location: (2987:97,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (628:32,22 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (3093:98,22 [4] )
+Generated Location: (3169:100,22 [4] )
 |item|
 
 Source Location: (650:33,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (3135:103,1 [1] )
+Generated Location: (3211:105,1 [1] )
 |)|
 
 Source Location: (667:37,1 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10,
     |
-Generated Location: (3262:108,6 [16] )
+Generated Location: (3338:110,6 [16] )
 |Repeat(10,
     |
 
 Source Location: (702:38,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (3445:111,23 [4] )
+Generated Location: (3521:113,23 [4] )
 |item|
 
 Source Location: (724:39,0 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (3487:116,1 [1] )
+Generated Location: (3563:118,1 [1] )
 |)|
 
 Source Location: (748:44,5 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |Repeat(10, |
-Generated Location: (3614:121,6 [11] )
+Generated Location: (3690:123,6 [11] )
 |Repeat(10, |
 
 Source Location: (781:45,15 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |item|
-Generated Location: (3784:123,15 [4] )
+Generated Location: (3860:125,15 [4] )
 |item|
 
 Source Location: (797:46,10 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |var parent = item;|
-Generated Location: (3918:128,10 [18] )
+Generated Location: (3994:130,10 [18] )
 |var parent = item;|
 
 Source Location: (956:51,9 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
 |)|
-Generated Location: (3973:133,1 [1] )
+Generated Location: (4049:135,1 [1] )
 |)|
 
 Source Location: (12:0,12 [265] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Templates.cshtml)
@@ -156,7 +156,7 @@ Source Location: (12:0,12 [265] TestFiles/IntegrationTests/CodeGenerationIntegra
         });
     }
 |
-Generated Location: (4154:140,12 [265] )
+Generated Location: (4230:142,12 [265] )
 |
     public HelperResult Repeat(int times, Func<int, object> template) {
         return new HelperResult((writer) => {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
@@ -14,7 +14,9 @@ global::System.Object __typeHelper = "*, TestAssembly";
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.ir.txt
@@ -6,7 +6,11 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [17] TransitionsInTagHelperAttributes.cshtml) - "*, TestAssembly"
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (31:0,31 [2] TransitionsInTagHelperAttributes.cshtml)
                     IntermediateToken - (31:0,31 [2] TransitionsInTagHelperAttributes.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
@@ -8,7 +8,7 @@ Source Location: (35:1,2 [59] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var @class = "container-fluid";
     var @int = 1;
 |
-Generated Location: (884:21,2 [59] )
+Generated Location: (960:23,2 [59] )
 | 
     var @class = "container-fluid";
     var @int = 1;
@@ -16,101 +16,101 @@ Generated Location: (884:21,2 [59] )
 
 Source Location: (122:6,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |1337|
-Generated Location: (1210:29,33 [4] )
+Generated Location: (1286:31,33 [4] )
 |1337|
 
 Source Location: (157:7,12 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (1463:35,12 [6] )
+Generated Location: (1539:37,12 [6] )
 |@class|
 
 Source Location: (171:7,26 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42|
-Generated Location: (1644:40,33 [2] )
+Generated Location: (1720:42,33 [2] )
 |42|
 
 Source Location: (202:8,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42|
-Generated Location: (1916:46,33 [2] )
+Generated Location: (1992:48,33 [2] )
 |42|
 
 Source Location: (204:8,23 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | +|
-Generated Location: (1918:46,35 [2] )
+Generated Location: (1994:48,35 [2] )
 | +|
 
 Source Location: (206:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | |
-Generated Location: (1920:46,37 [1] )
+Generated Location: (1996:48,37 [1] )
 | |
 
 Source Location: (207:8,26 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
-Generated Location: (1921:46,38 [1] )
+Generated Location: (1997:48,38 [1] )
 |@|
 
 Source Location: (208:8,27 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (1922:46,39 [3] )
+Generated Location: (1998:48,39 [3] )
 |int|
 
 Source Location: (241:9,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (2196:52,33 [3] )
+Generated Location: (2272:54,33 [3] )
 |int|
 
 Source Location: (274:10,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |(|
-Generated Location: (2470:58,33 [1] )
+Generated Location: (2546:60,33 [1] )
 |(|
 
 Source Location: (275:10,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int|
-Generated Location: (2471:58,34 [4] )
+Generated Location: (2547:60,34 [4] )
 |@int|
 
 Source Location: (279:10,27 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (2475:58,38 [1] )
+Generated Location: (2551:60,38 [1] )
 |)|
 
 Source Location: (307:11,19 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (2733:64,19 [6] )
+Generated Location: (2809:66,19 [6] )
 |@class|
 
 Source Location: (321:11,33 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |4|
-Generated Location: (2915:69,33 [1] )
+Generated Location: (2991:71,33 [1] )
 |4|
 
 Source Location: (322:11,34 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | *|
-Generated Location: (2916:69,34 [2] )
+Generated Location: (2992:71,34 [2] )
 | *|
 
 Source Location: (324:11,36 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | |
-Generated Location: (2918:69,36 [1] )
+Generated Location: (2994:71,36 [1] )
 | |
 
 Source Location: (325:11,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
-Generated Location: (2919:69,37 [1] )
+Generated Location: (2995:71,37 [1] )
 |@|
 
 Source Location: (326:11,38 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |(|
-Generated Location: (2920:69,38 [1] )
+Generated Location: (2996:71,38 [1] )
 |(|
 
 Source Location: (327:11,39 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int + 2|
-Generated Location: (2921:69,39 [8] )
+Generated Location: (2997:71,39 [8] )
 |@int + 2|
 
 Source Location: (335:11,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (2929:69,47 [1] )
+Generated Location: (3005:71,47 [1] )
 |)|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_Runtime.codegen.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
     {
         private static readonly global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute __tagHelperAttribute_0 = new global::Microsoft.AspNetCore.Razor.TagHelpers.TagHelperAttribute("class", new global::Microsoft.AspNetCore.Html.HtmlString("test"), global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
         #line hidden
-        #pragma warning disable 0414
+        #pragma warning disable 0169
         private string __tagHelperStringValueBuffer;
-        #pragma warning restore 0414
+        #pragma warning restore 0169
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperExecutionContext __tagHelperExecutionContext;
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner __tagHelperRunner = new global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperRunner();
         private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeManager __backed__tagHelperScopeManager = null;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.codegen.cs
@@ -9,7 +9,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.ir.txt
@@ -3,7 +3,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_UnfinishedExpressionInCode_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 CSharpCode - (2:0,2 [2] UnfinishedExpressionInCode.cshtml)
                     IntermediateToken - (2:0,2 [2] UnfinishedExpressionInCode.cshtml) - CSharp - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (2:0,2 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml)
 |
 |
-Generated Location: (587:15,14 [2] )
+Generated Location: (663:17,14 [2] )
 |
 |
 
 Source Location: (5:1,1 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml)
 |DateTime.|
-Generated Location: (699:18,6 [9] )
+Generated Location: (775:20,6 [9] )
 |DateTime.|
 
 Source Location: (14:1,10 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/UnfinishedExpressionInCode.cshtml)
 |
 |
-Generated Location: (764:22,22 [2] )
+Generated Location: (840:24,22 [2] )
 |
 |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.codegen.cs
@@ -39,7 +39,9 @@ using static global::System.Text.Encoding;
         private void __RazorDirectiveTokenHelpers__() {
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.ir.txt
@@ -9,7 +9,11 @@ Document -
         ClassDeclaration -  - public - TestFiles_IntegrationTests_CodeGenerationIntegrationTest_Usings_DesignTime -  - 
             DesignTimeDirective - 
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync
                 HtmlContent - (16:0,16 [2] Usings.cshtml)
                     IntermediateToken - (16:0,16 [2] Usings.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings_DesignTime.mappings.txt
@@ -30,11 +30,11 @@ Generated Location: (914:31,0 [41] )
 
 Source Location: (197:8,29 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
 |typeof(Path).FullName|
-Generated Location: (1506:46,29 [21] )
+Generated Location: (1582:48,29 [21] )
 |typeof(Path).FullName|
 
 Source Location: (259:9,35 [20] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Usings.cshtml)
 |typeof(Foo).FullName|
-Generated Location: (1679:51,35 [20] )
+Generated Location: (1755:53,35 [20] )
 |typeof(Foo).FullName|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.codegen.cs
@@ -13,7 +13,9 @@ global::System.Object __typeHelper = nameof(System.Globalization);
         ))();
         }
         #pragma warning restore 219
+        #pragma warning disable 0414
         private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.ir.txt
@@ -4,5 +4,9 @@ Document -
             DesignTimeDirective - 
                 DirectiveToken - (8:0,8 [20] NamespaceToken.cshtml) - System.Globalization
             CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
                 IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
             MethodDeclaration -  - public async - System.Threading.Tasks.Task - ExecuteAsync


### PR DESCRIPTION
This fixes and issue that snuck through and broke MVC as well as
preventing this from happening in the future.