### PR TITLE
Make RequiredAttributeDescriptor IEquatable.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/RequiredAttributeDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RequiredAttributeDescriptor.cs
@@ -9,7 +9,7 @@ using System.Linq;
 namespace Microsoft.AspNetCore.Razor.Language
 {
     [DebuggerDisplay("{DisplayName,nq}")]
-    public abstract class RequiredAttributeDescriptor
+    public abstract class RequiredAttributeDescriptor : IEquatable<RequiredAttributeDescriptor>
     {
         public string Name { get; protected set; }
 
@@ -31,6 +31,21 @@ namespace Microsoft.AspNetCore.Razor.Language
 
                 return errors;
             }
+        }
+        
+        public bool Equals(RequiredAttributeDescriptor other)
+        {
+            return RequiredAttributeDescriptorComparer.Default.Equals(this, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RequiredAttributeDescriptor);
+        }
+
+        public override int GetHashCode()
+        {
+            return RequiredAttributeDescriptorComparer.Default.GetHashCode(this);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Razor.Language/RequiredAttributeDescriptorComparer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RequiredAttributeDescriptorComparer.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Internal;
 
-namespace Microsoft.AspNetCore.Razor.Language.Legacy
+namespace Microsoft.AspNetCore.Razor.Language
 {
     /// <summary>
     /// An <see cref="IEqualityComparer{TagHelperRequiredAttributeDescriptor}"/> used to check equality between


### PR DESCRIPTION
- All the other descriptors are already `IEquatable` this should be as well.
- Moved the required attribute descriptor comparer from Legacy => Language. It wasn't in the Legacy folder to begin with so this made sense given that it's already internal.

#1495 

FYI