### PR TITLE
Make `RazorParserOptions.DesignTime` getter only.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorDirectiveFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorDirectiveFeature.cs
@@ -6,13 +6,13 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    internal class DefaultRazorDirectiveFeature : RazorEngineFeatureBase, IRazorDirectiveFeature, IRazorParserOptionsFeature
+    internal class DefaultRazorDirectiveFeature : RazorEngineFeatureBase, IRazorDirectiveFeature, IConfigureRazorParserOptionsFeature
     {
         public ICollection<DirectiveDescriptor> Directives { get; } = new List<DirectiveDescriptor>();
 
         public int Order => 100;
 
-        void IRazorParserOptionsFeature.Configure(RazorParserOptionsBuilder options)
+        void IConfigureRazorParserOptionsFeature.Configure(RazorParserOptionsBuilder options)
         {
             if (options == null)
             {

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParserOptionsBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParserOptionsBuilder.cs
@@ -8,7 +8,12 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     internal class DefaultRazorParserOptionsBuilder : RazorParserOptionsBuilder
     {
-        public override bool DesignTime { get; set; }
+        public DefaultRazorParserOptionsBuilder(bool designTime)
+        {
+            DesignTime = designTime;
+        }
+
+        public override bool DesignTime { get; }
 
         public override ICollection<DirectiveDescriptor> Directives { get; } = new List<DirectiveDescriptor>();
 

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParserOptionsFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParserOptionsFeature.cs
@@ -1,0 +1,36 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorParserOptionsFeature : RazorEngineFeatureBase, IRazorParserOptionsFeature
+    {
+        private readonly bool _designTime;
+        private IConfigureRazorParserOptionsFeature[] _configureOptions;
+
+        public DefaultRazorParserOptionsFeature(bool designTime)
+        {
+            _designTime = designTime;
+        }
+
+        protected override void OnInitialized()
+        {
+            _configureOptions = Engine.Features.OfType<IConfigureRazorParserOptionsFeature>().ToArray();
+        }
+
+        public RazorParserOptions GetOptions()
+        {
+            var builder = new DefaultRazorParserOptionsBuilder(_designTime);
+            for (var i = 0; i < _configureOptions.Length; i++)
+            {
+                _configureOptions[i].Configure(builder);
+            }
+
+            var options = builder.Build();
+
+            return options;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParsingPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParsingPhase.cs
@@ -1,29 +1,20 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
-
 namespace Microsoft.AspNetCore.Razor.Language
 {
     internal class DefaultRazorParsingPhase : RazorEnginePhaseBase, IRazorParsingPhase
     {
-        private IRazorParserOptionsFeature[] _parserOptionsCallbacks;
+        private IRazorParserOptionsFeature _optionsFeature;
 
         protected override void OnIntialized()
         {
-            _parserOptionsCallbacks = Engine.Features.OfType<IRazorParserOptionsFeature>().ToArray();
+            _optionsFeature = GetRequiredFeature<IRazorParserOptionsFeature>();
         }
 
         protected override void ExecuteCore(RazorCodeDocument codeDocument)
         {
-            var builder = new DefaultRazorParserOptionsBuilder();
-            for (var i = 0; i < _parserOptionsCallbacks.Length; i++)
-            {
-                _parserOptionsCallbacks[i].Configure(builder);
-            }
-
-            var options = builder.Build();
-
+            var options = _optionsFeature.GetOptions();
             var syntaxTree = RazorSyntaxTree.Parse(codeDocument.Source, options);
             codeDocument.SetSyntaxTree(syntaxTree);
 

--- a/src/Microsoft.AspNetCore.Razor.Language/DesignTimeOptionsFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DesignTimeOptionsFeature.cs
@@ -5,19 +5,9 @@ using System;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    internal class DesignTimeOptionsFeature : RazorEngineFeatureBase, IRazorParserOptionsFeature, IRazorCodeGenerationOptionsFeature
+    internal class DesignTimeOptionsFeature : RazorEngineFeatureBase, IRazorCodeGenerationOptionsFeature
     {
         public int Order { get; set; }
-
-        public void Configure(RazorParserOptionsBuilder options)
-        {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
-            options.DesignTime = true;
-        }
 
         public void Configure(RazorCodeGenerationOptionsBuilder options)
         {

--- a/src/Microsoft.AspNetCore.Razor.Language/IConfigureRazorParserOptionsFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IConfigureRazorParserOptionsFeature.cs
@@ -3,8 +3,10 @@
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public interface IRazorParserOptionsFeature : IRazorEngineFeature
+    public interface IConfigureRazorParserOptionsFeature : IRazorEngineFeature
     {
-        RazorParserOptions GetOptions();
+        int Order { get; }
+
+        void Configure(RazorParserOptionsBuilder options);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 
 namespace Microsoft.AspNetCore.Razor.Language
@@ -105,6 +104,9 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         internal static void AddRuntimeDefaults(IRazorEngineBuilder builder)
         {
+            // Configure options
+            builder.Features.Add(new DefaultRazorParserOptionsFeature(designTime: false));
+
             // Intermediate Node Passes
             builder.Features.Add(new PreallocatedTagHelperAttributeOptimizationPass());
 
@@ -116,6 +118,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static void AddDesignTimeDefaults(IRazorEngineBuilder builder)
         {
             // Configure options
+            builder.Features.Add(new DefaultRazorParserOptionsFeature(designTime: true));
             builder.Features.Add(new DesignTimeOptionsFeature());
 
             // Intermediate Node Passes

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorParserOptionsBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorParserOptionsBuilder.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public abstract class RazorParserOptionsBuilder
     {
-        public abstract bool DesignTime { get; set; }
+        public abstract bool DesignTime { get; }
 
         public abstract ICollection<DirectiveDescriptor> Directives { get; }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorParsingPhaseTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorParsingPhaseTest.cs
@@ -12,7 +12,11 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var phase = new DefaultRazorParsingPhase();
-            var engine = RazorEngine.CreateEmpty(b => b.Phases.Add(phase));
+            var engine = RazorEngine.CreateEmpty(builder =>
+            {
+                builder.Phases.Add(phase);
+                builder.Features.Add(new DefaultRazorParserOptionsFeature(designTime: false));
+            });
 
             var codeDocument = TestRazorCodeDocument.CreateEmpty();
 
@@ -28,10 +32,11 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var phase = new DefaultRazorParsingPhase();
-            var engine = RazorEngine.CreateEmpty((b) =>
+            var engine = RazorEngine.CreateEmpty((builder) =>
             {
-                b.Phases.Add(phase);
-                b.Features.Add(new MyParserOptionsFeature());
+                builder.Phases.Add(phase);
+                builder.Features.Add(new DefaultRazorParserOptionsFeature(designTime: false));
+                builder.Features.Add(new MyParserOptionsFeature());
             });
 
             var codeDocument = TestRazorCodeDocument.CreateEmpty();
@@ -50,10 +55,12 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var phase = new DefaultRazorParsingPhase();
-            var engine = RazorEngine.CreateEmpty((b) =>
+            var engine = RazorEngine.CreateEmpty((builder) =>
             {
-                b.Phases.Add(phase);
-                b.Features.Add(new MyParserOptionsFeature());
+                builder.Phases.Add(phase);
+                builder.Features.Add(new DefaultRazorParserOptionsFeature(designTime: false));
+                builder.Features.Add(new MyParserOptionsFeature());
+
             });
 
             var imports = new[]
@@ -74,7 +81,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 t => { Assert.Same(t.Source, imports[1]); Assert.Equal("test", Assert.Single(t.Options.Directives).Directive); });
         }
 
-        private class MyParserOptionsFeature : RazorEngineFeatureBase, IRazorParserOptionsFeature
+        private class MyParserOptionsFeature : RazorEngineFeatureBase, IConfigureRazorParserOptionsFeature
         {
             public int Order { get; }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorEngineTest.cs
@@ -160,6 +160,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 feature => Assert.IsType<DirectiveRemovalOptimizationPass>(feature),
                 feature => Assert.IsType<DefaultTagHelperOptimizationPass>(feature),
                 feature => Assert.IsType<DefaultDocumentClassifierPassFeature>(feature),
+                feature => Assert.IsType<DefaultRazorParserOptionsFeature>(feature),
                 feature => Assert.IsType<PreallocatedTagHelperAttributeOptimizationPass>(feature));
         }
 
@@ -200,6 +201,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 feature => Assert.IsType<DirectiveRemovalOptimizationPass>(feature),
                 feature => Assert.IsType<DefaultTagHelperOptimizationPass>(feature),
                 feature => Assert.IsType<DefaultDocumentClassifierPassFeature>(feature),
+                feature => Assert.IsType<DefaultRazorParserOptionsFeature>(feature),
                 feature => Assert.IsType<DesignTimeOptionsFeature>(feature),
                 feature => Assert.IsType<DesignTimeDirectivePass>(feature));
         }


### PR DESCRIPTION
- Renamed `IRazorParserOptionsFeature` to `IConfigureRazorParserOptionsFeature`, the original interface was re-purposed to get the options rather than configure them.
- This involved re-designing how we set design time on the `RazorParserOptions` object. The indicator of `DesignTime` is now configured at the RazorEngine level via a parser options provider feature.
- Moved options construction from the phase into an `IRazorParserOptionsFeature` type.

#1510 

This required a design change so looking for feedback.