### PR TITLE
Make `RazorParserOptions` creation more like RazorEngine

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/RazorParserOptions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorParserOptions.cs
@@ -3,35 +3,42 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
     public abstract class RazorParserOptions
     {
-        public static RazorParserOptions Create(IEnumerable<DirectiveDescriptor> directives, bool designTime)
-        {
-            if (directives == null)
-            {
-                throw new ArgumentNullException(nameof(directives));
-            }
-
-            return new DefaultRazorParserOptions(directives.ToArray(), designTime, parseOnlyLeadingDirectives: false);
-        }
-
-        public static RazorParserOptions Create(IEnumerable<DirectiveDescriptor> directives, bool designTime, bool parseOnlyLeadingDirectives)
-        {
-            if (directives == null)
-            {
-                throw new ArgumentNullException(nameof(directives));
-            }
-
-            return new DefaultRazorParserOptions(directives.ToArray(), designTime, parseOnlyLeadingDirectives);
-        }
-
         public static RazorParserOptions CreateDefault()
         {
             return new DefaultRazorParserOptions(Array.Empty<DirectiveDescriptor>(), designTime: false, parseOnlyLeadingDirectives: false);
+        }
+
+        public static RazorParserOptions Create(Action<RazorParserOptionsBuilder> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var builder = new DefaultRazorParserOptionsBuilder(designTime: false);
+            configure(builder);
+            var options = builder.Build();
+
+            return options;
+        }
+
+        public static RazorParserOptions CreateDesignTime(Action<RazorParserOptionsBuilder> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var builder = new DefaultRazorParserOptionsBuilder(designTime: true);
+            configure(builder);
+            var options = builder.Build();
+
+            return options;
         }
 
         public abstract bool DesignTime { get; }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIntermediateNodeLoweringPhaseTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIntermediateNodeLoweringPhaseTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.Phases.Add(phase);
                 b.AddDirective(directive);
             });
-            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
             var importSource = TestRazorSourceDocument.Create("@custom \"hello\"", fileName: "import.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.Phases.Add(phase);
                 b.AddDirective(directive);
             });
-            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
             var importSource = TestRazorSourceDocument.Create("@custom \"hello\"", fileName: "import.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("@custom \"world\"");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.Phases.Add(phase);
                 b.AddDirective(directive);
             });
-            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
             var importSource1 = TestRazorSourceDocument.Create("@custom \"hello\"", fileName: "import1.cshtml");
             var importSource2 = TestRazorSourceDocument.Create("@custom \"world\"", fileName: "import2.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
@@ -127,7 +127,11 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.AddDirective(codeBlockDirective);
                 b.AddDirective(razorBlockDirective);
             });
-            var options = RazorParserOptions.Create(new[] { codeBlockDirective, razorBlockDirective }, designTime: false);
+            var options = RazorParserOptions.Create(builder =>
+            {
+                builder.Directives.Add(codeBlockDirective);
+                builder.Directives.Add(razorBlockDirective); 
+            });
             var importSource = TestRazorSourceDocument.Create(
 @"@code ""code block"" { }
 @razor ""razor block"" { }",
@@ -156,7 +160,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.Phases.Add(phase);
                 b.AddDirective(directive);
             });
-            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
             var importSource = TestRazorSourceDocument.Create("@custom { }", fileName: "import.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
@@ -185,7 +189,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.Phases.Add(phase);
                 b.AddDirective(directive);
             });
-            var options = RazorParserOptions.Create(new[] { directive }, designTime: false);
+            var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
             var importSource = TestRazorSourceDocument.Create("@custom { }", fileName: "import.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/ParserTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/ParserTestBase.cs
@@ -47,7 +47,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             directives = directives ?? Array.Empty<DirectiveDescriptor>();
 
             var source = TestRazorSourceDocument.Create(document, fileName: null);
-            var options = RazorParserOptions.Create(directives, designTime);
+
+            var options = CreateParserOptions(directives, designTime);
             var context = new ParserContext(source, options);
 
             var codeParser = new CSharpCodeParser(directives, context);
@@ -77,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             directives = directives ?? Array.Empty<DirectiveDescriptor>();
 
             var source = TestRazorSourceDocument.Create(document, fileName: null);
-            var options = RazorParserOptions.Create(directives, designTime);
+            var options = CreateParserOptions(directives, designTime);
             var context = new ParserContext(source, options);
 
             var parser = new HtmlMarkupParser(context);
@@ -107,7 +108,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             directives = directives ?? Array.Empty<DirectiveDescriptor>();
 
             var source = TestRazorSourceDocument.Create(document, fileName: null);
-            var options = RazorParserOptions.Create(directives, designTime);
+            var options = CreateParserOptions(directives, designTime);
             var context = new ParserContext(source, options);
 
             var parser = new CSharpCodeParser(directives, context);
@@ -601,6 +602,26 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
             block.Children.Add(span);
             return block.Build();
+        }
+
+        private static RazorParserOptions CreateParserOptions(IEnumerable<DirectiveDescriptor> directives, bool designTime)
+        {
+            if (designTime)
+            {
+                return RazorParserOptions.CreateDesignTime(ConfigureOptions);
+            }
+            else
+            {
+                return RazorParserOptions.Create(ConfigureOptions);
+            }
+
+            void ConfigureOptions(RazorParserOptionsBuilder builder)
+            {
+                foreach (var directive in directives)
+                {
+                    builder.Directives.Add(directive);
+                }
+            }
         }
 
         private class IgnoreOutputBlock : Block

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorSyntaxTreeTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorSyntaxTreeTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
         {
             // Arrange
             var source = TestRazorSourceDocument.Create("\r\n  \r\n    @*SomeComment*@ \r\n  @tagHelperPrefix \"SomePrefix\"\r\n<html>\r\n@if (true) {\r\n @if(false) { <div>@something.</div> } \r\n}");
-            var options = RazorParserOptions.Create(Array.Empty<DirectiveDescriptor>(), designTime: false, parseOnlyLeadingDirectives: true);
+            var options = RazorParserOptions.Create(builder => builder.ParseOnlyLeadingDirectives = true);
 
             // Act
             var syntaxTree = RazorSyntaxTree.Parse(source, options);


### PR DESCRIPTION
- Removed verbose `Create` methods in favor of the `RazorParserOptionsBuilder`. This is similar to how the `RazorEngine` functions.
- Added a `CreateDesignTime` method.
- Updated existing tests to use new Create syntax.

#1510