### PR TITLE
Rename ParseOnlyLeadingDirectives.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParserOptions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParserOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     internal class DefaultRazorParserOptions : RazorParserOptions
     {
-        public DefaultRazorParserOptions(DirectiveDescriptor[] directives, bool designTime, bool parseOnlyLeadingDirectives)
+        public DefaultRazorParserOptions(DirectiveDescriptor[] directives, bool designTime, bool parseLeadingDirectives)
         {
             if (directives == null)
             {
@@ -17,13 +17,13 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             Directives = directives;
             DesignTime = designTime;
-            ParseOnlyLeadingDirectives = parseOnlyLeadingDirectives;
+            ParseLeadingDirectives = parseLeadingDirectives;
         }
 
         public override bool DesignTime { get; }
 
         public override IReadOnlyCollection<DirectiveDescriptor> Directives { get; }
 
-        public override bool ParseOnlyLeadingDirectives { get; }
+        public override bool ParseLeadingDirectives { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParserOptionsBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorParserOptionsBuilder.cs
@@ -17,11 +17,11 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override ICollection<DirectiveDescriptor> Directives { get; } = new List<DirectiveDescriptor>();
 
-        public override bool ParseOnlyLeadingDirectives { get; set; }
+        public override bool ParseLeadingDirectives { get; set; }
 
         public override RazorParserOptions Build()
         {
-            return new DefaultRazorParserOptions(Directives.ToArray(), DesignTime, ParseOnlyLeadingDirectives);
+            return new DefaultRazorParserOptions(Directives.ToArray(), DesignTime, ParseLeadingDirectives);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         public CSharpCodeParser(IEnumerable<DirectiveDescriptor> directives, ParserContext context)
-            : base(context.ParseOnlyLeadingDirectives ? FirstDirectiveCSharpLanguageCharacteristics.Instance : CSharpLanguageCharacteristics.Instance, context)
+            : base(context.ParseLeadingDirectives ? FirstDirectiveCSharpLanguageCharacteristics.Instance : CSharpLanguageCharacteristics.Instance, context)
         {
             if (directives == null)
             {

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         };
 
         public HtmlMarkupParser(ParserContext context)
-            : base(context.ParseOnlyLeadingDirectives ? FirstDirectiveHtmlLanguageCharacteristics.Instance : HtmlLanguageCharacteristics.Instance, context)
+            : base(context.ParseLeadingDirectives ? FirstDirectiveHtmlLanguageCharacteristics.Instance : HtmlLanguageCharacteristics.Instance, context)
         {
         }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
             Source = new SeekableTextReader(chars, source.FilePath);
             DesignTimeMode = options.DesignTime;
-            ParseOnlyLeadingDirectives = options.ParseOnlyLeadingDirectives;
+            ParseLeadingDirectives = options.ParseLeadingDirectives;
             Builder = new SyntaxTreeBuilder();
             ErrorSink = new ErrorSink();
             SeenDirectives = new HashSet<string>(StringComparer.Ordinal);
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public bool DesignTimeMode { get; }
 
-        public bool ParseOnlyLeadingDirectives { get; }
+        public bool ParseLeadingDirectives { get; }
 
         public bool WhiteSpaceIsSignificantToAncestorBlock { get; set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorParserOptions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorParserOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Language
     {
         public static RazorParserOptions CreateDefault()
         {
-            return new DefaultRazorParserOptions(Array.Empty<DirectiveDescriptor>(), designTime: false, parseOnlyLeadingDirectives: false);
+            return new DefaultRazorParserOptions(Array.Empty<DirectiveDescriptor>(), designTime: false, parseLeadingDirectives: false);
         }
 
         public static RazorParserOptions Create(Action<RazorParserOptionsBuilder> configure)
@@ -53,6 +53,6 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// Currently setting this option to <c>true</c> will result in only the first line of directives being parsed.
         /// In a future release this may be updated to include all leading directive content.
         /// </remarks>
-        public abstract bool ParseOnlyLeadingDirectives { get; }
+        public abstract bool ParseLeadingDirectives { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorParserOptionsBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorParserOptionsBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public abstract ICollection<DirectiveDescriptor> Directives { get; }
 
-        public abstract bool ParseOnlyLeadingDirectives { get; set; }
+        public abstract bool ParseLeadingDirectives { get; set; }
 
         public abstract RazorParserOptions Build();
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorSyntaxTreeTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorSyntaxTreeTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
         {
             // Arrange
             var source = TestRazorSourceDocument.Create("\r\n  \r\n    @*SomeComment*@ \r\n  @tagHelperPrefix \"SomePrefix\"\r\n<html>\r\n@if (true) {\r\n @if(false) { <div>@something.</div> } \r\n}");
-            var options = RazorParserOptions.Create(builder => builder.ParseOnlyLeadingDirectives = true);
+            var options = RazorParserOptions.Create(builder => builder.ParseLeadingDirectives = true);
 
             // Act
             var syntaxTree = RazorSyntaxTree.Parse(source, options);


### PR DESCRIPTION
- Was renamed to `ParseLeadingDirectives`.

#1510 

FYI Only, but blocked by other PRs.