### PR TITLE
Update the TagHelperBinding API to use IReadOnlyList.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -256,7 +256,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 {
                     tagHelperBinding = _tagHelperBinder.GetBinding(
                         tagName,
-                        attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                        attributes: Array.Empty<KeyValuePair<string, string>>(),
                         parentTagName: _currentParentTagName);
 
                     // If there are not TagHelperDescriptors associated with the end tag block that also have no
@@ -314,7 +314,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         // Internal for testing
-        internal IEnumerable<KeyValuePair<string, string>> GetAttributeNameValuePairs(Block tagBlock)
+        internal IReadOnlyList<KeyValuePair<string, string>> GetAttributeNameValuePairs(Block tagBlock)
         {
             // Need to calculate how many children we should take that represent the attributes.
             var childrenOffset = IsPartialTag(tagBlock) ? 0 : 1;
@@ -322,7 +322,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
             if (childCount <= 1)
             {
-                return Enumerable.Empty<KeyValuePair<string, string>>();
+                return Array.Empty<KeyValuePair<string, string>>();
             }
 
             _htmlAttributeTracker.Clear();

--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinder.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// Will return <c>null</c> if no <see cref="TagHelperDescriptor"/>s are a match.</returns>
         public TagHelperBinding GetBinding(
             string tagName,
-            IEnumerable<KeyValuePair<string, string>> attributes,
+            IReadOnlyList<KeyValuePair<string, string>> attributes,
             string parentTagName)
         {
             if (!string.IsNullOrEmpty(_tagHelperPrefix) &&
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             }
 
             var tagNameWithoutPrefix = _tagHelperPrefix != null ? tagName.Substring(_tagHelperPrefix.Length) : tagName;
-            Dictionary<TagHelperDescriptor, IEnumerable<TagMatchingRuleDescriptor>> applicableDescriptorMappings = null;
+            Dictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>> applicableDescriptorMappings = null;
             foreach (var descriptor in descriptors)
             {
                 var applicableRules = descriptor.TagMatchingRules.Where(
@@ -84,10 +84,10 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     if (applicableDescriptorMappings == null)
                     {
-                        applicableDescriptorMappings = new Dictionary<TagHelperDescriptor, IEnumerable<TagMatchingRuleDescriptor>>();
+                        applicableDescriptorMappings = new Dictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>>();
                     }
 
-                    applicableDescriptorMappings[descriptor] = applicableRules;
+                    applicableDescriptorMappings[descriptor] = applicableRules.ToList();
                 }
             }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinding.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperBinding.cs
@@ -7,13 +7,13 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public sealed class TagHelperBinding
     {
-        private IReadOnlyDictionary<TagHelperDescriptor, IEnumerable<TagMatchingRuleDescriptor>> _mappings;
+        private IReadOnlyDictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>> _mappings;
 
         internal TagHelperBinding(
             string tagName,
-            IEnumerable<KeyValuePair<string, string>> attributes,
+            IReadOnlyList<KeyValuePair<string, string>> attributes,
             string parentTagName,
-            IReadOnlyDictionary<TagHelperDescriptor, IEnumerable<TagMatchingRuleDescriptor>> mappings,
+            IReadOnlyDictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>> mappings,
             string tagHelperPrefix)
         {
             TagName = tagName;
@@ -30,11 +30,11 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public string ParentTagName { get; }
 
-        public IEnumerable<KeyValuePair<string, string>> Attributes { get; }
+        public IReadOnlyList<KeyValuePair<string, string>> Attributes { get; }
 
         public string TagHelperPrefix { get; }
 
-        public IEnumerable<TagMatchingRuleDescriptor> GetBoundRules(TagHelperDescriptor descriptor)
+        public IReadOnlyList<TagMatchingRuleDescriptor> GetBoundRules(TagHelperDescriptor descriptor)
         {
             return _mappings[descriptor];
         }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTagHelperFactsService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 
@@ -41,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
             var prefix = documentContext.Prefix;
             var tagHelperBinder = new TagHelperBinder(prefix, descriptors);
-            var binding = tagHelperBinder.GetBinding(tagName, attributes, parentTag);
+            var binding = tagHelperBinder.GetBinding(tagName, attributes.ToList(), parentTag);
 
             return binding;
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TagHelperBinderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TagHelperBinderTest.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var bindingResult = tagHelperBinder.GetBinding(
                 tagName,
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: parentTagName);
 
             // Assert
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
                 return new TheoryData<
                     string, // tagName
-                    IEnumerable<KeyValuePair<string, string>>, // providedAttributes
+                    IReadOnlyList<KeyValuePair<string, string>>, // providedAttributes
                     IEnumerable<TagHelperDescriptor>, // availableDescriptors
                     IEnumerable<TagHelperDescriptor>> // expectedDescriptors
                 {
@@ -264,12 +264,12 @@ namespace Microsoft.AspNetCore.Razor.Language
         [MemberData(nameof(RequiredAttributeData))]
         public void GetBinding_ReturnsBindingResultDescriptorsWithRequiredAttributes(
             string tagName,
-            IEnumerable<KeyValuePair<string, string>> providedAttributes,
+            IReadOnlyList<KeyValuePair<string, string>> providedAttributes,
             object availableDescriptors,
             object expectedDescriptors)
         {
             // Arrange
-            var tagHelperBinder = new TagHelperBinder(null, (IEnumerable<TagHelperDescriptor>)availableDescriptors);
+            var tagHelperBinder = new TagHelperBinder(null, (IReadOnlyList<TagHelperDescriptor>)availableDescriptors);
 
             // Act
             var bindingResult = tagHelperBinder.GetBinding(tagName, providedAttributes, parentTagName: "p");
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var bindingResult = tagHelperBinder.GetBinding(
                 tagName: "th",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
 
             // Assert
@@ -311,11 +311,11 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var bindingResultDiv = tagHelperBinder.GetBinding(
                 tagName: "th:div",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
             var bindingResultSpan = tagHelperBinder.GetBinding(
                 tagName: "th:span",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
 
             // Assert
@@ -338,7 +338,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var bindingResult = tagHelperBinder.GetBinding(
                 tagName: "th:div",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
 
             // Assert
@@ -361,7 +361,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var bindingResult = tagHelperBinder.GetBinding(
                 tagName: "div",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
 
             // Assert
@@ -384,7 +384,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var tagHelperBinding = tagHelperBinder.GetBinding(
                 tagName: "foo",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
 
             // Assert
@@ -410,11 +410,11 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var divBinding = tagHelperBinder.GetBinding(
                 tagName: "div",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
             var spanBinding = tagHelperBinder.GetBinding(
                 tagName: "span",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
 
             // Assert
@@ -442,7 +442,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var bindingResult = tagHelperBinder.GetBinding(
                 tagName: "div",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
 
             // Assert
@@ -469,7 +469,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Act
             var binding = tagHelperBinder.GetBinding(
                 tagName: "div",
-                attributes: Enumerable.Empty<KeyValuePair<string, string>>(),
+                attributes: Array.Empty<KeyValuePair<string, string>>(),
                 parentTagName: "p");
 
             // Assert


### PR DESCRIPTION
- Changed `Attributes` to return `IReadOnlyList<KeyValuePair<string, string>>`.
- Changed `GetBoundRules` to return `IReadOnlyList<TagMatchingRuleDescriptor>`.
- Updated tests to react to new signature.

#1510 

FYI Only