### PR TITLE
Change TagHelperDescriptor APIs to use IReadOnlyList.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagHelperDescriptor.cs
@@ -22,13 +22,13 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public string Name { get; protected set; }
 
-        public IEnumerable<TagMatchingRuleDescriptor> TagMatchingRules { get; protected set; }
+        public IReadOnlyList<TagMatchingRuleDescriptor> TagMatchingRules { get; protected set; }
 
         public string AssemblyName { get; protected set; }
 
-        public IEnumerable<BoundAttributeDescriptor> BoundAttributes { get; protected set; }
+        public IReadOnlyList<BoundAttributeDescriptor> BoundAttributes { get; protected set; }
 
-        public IEnumerable<AllowedChildTagDescriptor> AllowedChildTags { get; protected set; }
+        public IReadOnlyList<AllowedChildTagDescriptor> AllowedChildTags { get; protected set; }
 
         public string Documentation { get; protected set; }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/TagMatchingRuleDescriptor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/TagMatchingRuleDescriptor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public string TagName { get; protected set; }
 
-        public IEnumerable<RequiredAttributeDescriptor> Attributes { get; protected set; }
+        public IReadOnlyList<RequiredAttributeDescriptor> Attributes { get; protected set; }
 
         public string ParentTag { get; protected set; }
 


### PR DESCRIPTION
- Change `TagHelperDescriptor.AllowedChildTags` to be `IReadOnlyList`.
- Change `TagHelperDescriptor.BoundAttributes` to be `IReadOnlyList`.
- Change `TagHelperDescriptor.TagMatchingRules` to be `IReadOnlyList`.
- Change `TagMatchingRuleDescriptor.Attributes` to be `IReadOnlyList`.

#1510 

FYI Only.