### PR TITLE
Enables the Razor Document Tracker

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTextViewRazorDocumentTrackerService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTextViewRazorDocumentTrackerService.cs
@@ -16,8 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
     [ContentType(RazorLanguage.ContentType)]
     [TextViewRole(PredefinedTextViewRoles.Editable)]
-    //[Export(typeof(IWpfTextViewConnectionListener))] - we're not exporting this interface because we only want it to be hooked up
-    // in developer mode.
+    [Export(typeof(IWpfTextViewConnectionListener))]
     [Export(typeof(TextViewRazorDocumentTrackerService))]
     internal class DefaultTextViewRazorDocumentTrackerService : TextViewRazorDocumentTrackerService, IWpfTextViewConnectionListener
     {

--- a/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindow.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/DocumentInfo/RazorDocumentInfoWindow.cs
@@ -63,6 +63,10 @@ namespace Microsoft.VisualStudio.RazorExtension.DocumentInfo
         private void OnBeforeDocumentWindowShow(IVsWindowFrame frame)
         {
             var vsTextView = VsShellUtilities.GetTextView(frame);
+            if (vsTextView == null)
+            {
+                return;
+            }
 
             var textView = _adapterFactory.GetWpfTextView(vsTextView);
             if (textView != null && textView != _textView)


### PR DESCRIPTION
This enables the tracking of events that change the 'razor' state of a
document that's open in the editor.

Also fixed a crash that can occur when creating a new project with the
Razor Info window open.