### PR TITLE
Stop generating invalid code for empty non-string bound attributes

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -684,6 +684,14 @@ namespace Microsoft.AspNetCore.Razor.Language
                                 return TagHelperMatchingConventions.CanSatisfyBoundAttribute(attribute.Name, a);
                             });
 
+                            if (!associatedAttributeDescriptor.IsStringProperty &&
+                                TagHelperBlockRewriter.IsNullOrWhitespaceAttributeValue(attributeValueNode))
+                            {
+                                // TagHelperBlockRewriter has already logged an error for this. We don't want to generate
+                                // invalid code for this attribute which might produce misleading errors.
+                                continue;
+                            }
+
                             var setTagHelperProperty = new TagHelperPropertyIntermediateNode()
                             {
                                 AttributeName = attribute.Name,

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -684,14 +684,6 @@ namespace Microsoft.AspNetCore.Razor.Language
                                 return TagHelperMatchingConventions.CanSatisfyBoundAttribute(attribute.Name, a);
                             });
 
-                            if (!associatedAttributeDescriptor.IsStringProperty &&
-                                TagHelperBlockRewriter.IsNullOrWhitespaceAttributeValue(attributeValueNode))
-                            {
-                                // TagHelperBlockRewriter has already logged an error for this. We don't want to generate
-                                // invalid code for this attribute which might produce misleading errors.
-                                continue;
-                            }
-
                             var setTagHelperProperty = new TagHelperPropertyIntermediateNode()
                             {
                                 AttributeName = attribute.Name,
@@ -703,7 +695,26 @@ namespace Microsoft.AspNetCore.Razor.Language
                             };
 
                             _builder.Push(setTagHelperProperty);
-                            attributeValueNode.Accept(this);
+
+                            if (!associatedAttributeDescriptor.IsStringProperty &&
+                                TagHelperBlockRewriter.IsNullOrWhitespaceAttributeValue(attributeValueNode))
+                            {
+                                // TagHelperBlockRewriter has already logged an error for this. We don't want to generate
+                                // invalid code for this attribute which might produce misleading errors.
+                                _builder.Push(new CSharpExpressionIntermediateNode());
+                                _builder.Add(new IntermediateToken()
+                                {
+                                    Content = $"default({associatedAttributeDescriptor.TypeName})",
+                                    Source = BuildSourceSpanFromNode(attributeValueNode),
+                                    Kind = TokenKind.CSharp
+                                });
+                                _builder.Pop();
+                            }
+                            else
+                            {
+                                attributeValueNode.Accept(this);
+                            }
+
                             _builder.Pop();
                         }
                     }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
@@ -646,7 +646,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return builder.Build();
         }
 
-        internal static bool IsNullOrWhitespaceAttributeValue(SyntaxTreeNode attributeValue)
+        private static bool IsNullOrWhitespaceAttributeValue(SyntaxTreeNode attributeValue)
         {
             if (attributeValue.IsBlock)
             {

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperBlockRewriter.cs
@@ -646,7 +646,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return builder.Build();
         }
 
-        private static bool IsNullOrWhitespaceAttributeValue(SyntaxTreeNode attributeValue)
+        internal static bool IsNullOrWhitespaceAttributeValue(SyntaxTreeNode attributeValue)
         {
             if (attributeValue.IsBlock)
             {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
@@ -26,26 +26,11 @@ global::System.Object __typeHelper = "*, TestAssembly";
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
-#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
-__TestNamespace_InputTagHelper2.Checked = ;
-
-#line default
-#line hidden
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
-#line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
-__TestNamespace_InputTagHelper2.Checked = ;
-
-#line default
-#line hidden
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
-#line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
-__TestNamespace_PTagHelper.Age = ;
-
-#line default
-#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
@@ -26,11 +26,26 @@ global::System.Object __typeHelper = "*, TestAssembly";
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
+__TestNamespace_InputTagHelper2.Checked = default(System.Boolean);
+
+#line default
+#line hidden
             __TestNamespace_InputTagHelper = CreateTagHelper<global::TestNamespace.InputTagHelper>();
             __TestNamespace_InputTagHelper2 = CreateTagHelper<global::TestNamespace.InputTagHelper2>();
             __TestNamespace_InputTagHelper.Type = "";
             __TestNamespace_InputTagHelper2.Type = __TestNamespace_InputTagHelper.Type;
+#line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
+__TestNamespace_InputTagHelper2.Checked = default(System.Boolean);
+
+#line default
+#line hidden
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
+#line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
+__TestNamespace_PTagHelper.Age = default(System.Int32);
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
@@ -28,6 +28,9 @@ Document -
                     DefaultTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - type - string TestNamespace.InputTagHelper2.Type - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml)
                             IntermediateToken - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
+                    DefaultTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - bool TestNamespace.InputTagHelper2.Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - 
+                            IntermediateToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - default(System.Boolean)
                     DefaultTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml)
                             IntermediateToken - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
@@ -48,6 +51,9 @@ Document -
                             DefaultTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - type - string TestNamespace.InputTagHelper2.Type - HtmlAttributeValueStyle.DoubleQuotes
                                 HtmlContent - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml)
                                     IntermediateToken - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
+                            DefaultTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - bool TestNamespace.InputTagHelper2.Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - 
+                                    IntermediateToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - default(System.Boolean)
                             DefaultTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                                 HtmlContent - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml)
                                     IntermediateToken - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
@@ -55,6 +61,9 @@ Document -
                         HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml)
                             IntermediateToken - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                     DefaultTagHelperCreate -  - TestNamespace.PTagHelper
+                    DefaultTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - int TestNamespace.PTagHelper.Age - HtmlAttributeValueStyle.SingleQuotes
+                        CSharpExpression - 
+                            IntermediateToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - default(System.Int32)
                     DefaultTagHelperExecute - 
                 HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml)
                     IntermediateToken - (148:6,8 [2] EmptyAttributeTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.ir.txt
@@ -28,8 +28,6 @@ Document -
                     DefaultTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - type - string TestNamespace.InputTagHelper2.Type - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml)
                             IntermediateToken - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
-                    DefaultTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - bool TestNamespace.InputTagHelper2.Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        IntermediateToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                     DefaultTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                         HtmlContent - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml)
                             IntermediateToken - (74:3,34 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
@@ -50,8 +48,6 @@ Document -
                             DefaultTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - type - string TestNamespace.InputTagHelper2.Type - HtmlAttributeValueStyle.DoubleQuotes
                                 HtmlContent - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml)
                                     IntermediateToken - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
-                            DefaultTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - bool TestNamespace.InputTagHelper2.Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                IntermediateToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                             DefaultTagHelperHtmlAttribute -  - class - HtmlAttributeValueStyle.DoubleQuotes
                                 HtmlContent - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml)
                                     IntermediateToken - (134:5,38 [0] EmptyAttributeTagHelpers.cshtml) - Html - 
@@ -59,8 +55,6 @@ Document -
                         HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml)
                             IntermediateToken - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                     DefaultTagHelperCreate -  - TestNamespace.PTagHelper
-                    DefaultTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - int TestNamespace.PTagHelper.Age - HtmlAttributeValueStyle.SingleQuotes
-                        IntermediateToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                     DefaultTagHelperExecute - 
                 HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml)
                     IntermediateToken - (148:6,8 [2] EmptyAttributeTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
@@ -3,18 +3,3 @@ Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrat
 Generated Location: (683:13,38 [15] )
 |*, TestAssembly|
 
-Source Location: (66:3,26 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
-||
-Generated Location: (1510:29,42 [0] )
-||
-
-Source Location: (126:5,30 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
-||
-Generated Location: (2038:38,42 [0] )
-||
-
-Source Location: (92:4,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
-||
-Generated Location: (2300:44,33 [0] )
-||
-

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
@@ -3,3 +3,18 @@ Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrat
 Generated Location: (683:13,38 [15] )
 |*, TestAssembly|
 
+Source Location: (66:3,26 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
+||
+Generated Location: (1510:29,42 [0] )
+||
+
+Source Location: (126:5,30 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
+||
+Generated Location: (2061:38,42 [0] )
+||
+
+Source Location: (92:4,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
+||
+Generated Location: (2346:44,33 [0] )
+||
+

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
@@ -44,12 +44,6 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
             __TestNamespace_InputTagHelper2.Type = (string)__tagHelperAttribute_0.Value;
             __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
-#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
-__TestNamespace_InputTagHelper2.Checked = ;
-
-#line default
-#line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
@@ -72,12 +66,6 @@ __TestNamespace_InputTagHelper2.Checked = ;
                 __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
                 __TestNamespace_InputTagHelper2.Type = (string)__tagHelperAttribute_0.Value;
                 __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
-#line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
-__TestNamespace_InputTagHelper2.Checked = ;
-
-#line default
-#line hidden
-                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 if (!__tagHelperExecutionContext.Output.IsContentModified)
@@ -91,12 +79,6 @@ __TestNamespace_InputTagHelper2.Checked = ;
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
-#line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
-__TestNamespace_PTagHelper.Age = ;
-
-#line default
-#line hidden
-            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.codegen.cs
@@ -44,6 +44,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
             __TestNamespace_InputTagHelper2.Type = (string)__tagHelperAttribute_0.Value;
             __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
+__TestNamespace_InputTagHelper2.Checked = default(System.Boolean);
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
             __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
@@ -66,6 +72,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
                 __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
                 __TestNamespace_InputTagHelper2.Type = (string)__tagHelperAttribute_0.Value;
                 __tagHelperExecutionContext.AddTagHelperAttribute(__tagHelperAttribute_0);
+#line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
+__TestNamespace_InputTagHelper2.Checked = default(System.Boolean);
+
+#line default
+#line hidden
+                __tagHelperExecutionContext.AddTagHelperAttribute("checked", __TestNamespace_InputTagHelper2.Checked, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.DoubleQuotes);
                 __tagHelperExecutionContext.AddHtmlAttribute(__tagHelperAttribute_1);
                 await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
                 if (!__tagHelperExecutionContext.Output.IsContentModified)
@@ -79,6 +91,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
             );
             __TestNamespace_PTagHelper = CreateTagHelper<global::TestNamespace.PTagHelper>();
             __tagHelperExecutionContext.Add(__TestNamespace_PTagHelper);
+#line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
+__TestNamespace_PTagHelper.Age = default(System.Int32);
+
+#line default
+#line hidden
+            __tagHelperExecutionContext.AddTagHelperAttribute("age", __TestNamespace_PTagHelper.Age, global::Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeValueStyle.SingleQuotes);
             await __tagHelperRunner.RunAsync(__tagHelperExecutionContext);
             if (!__tagHelperExecutionContext.Output.IsContentModified)
             {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
@@ -18,6 +18,9 @@ Document -
                     DefaultTagHelperCreate -  - TestNamespace.InputTagHelper2
                     PreallocatedTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - __tagHelperAttribute_0 - type - Type
                     PreallocatedTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - __tagHelperAttribute_0 - type - Type
+                    DefaultTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - bool TestNamespace.InputTagHelper2.Checked - HtmlAttributeValueStyle.DoubleQuotes
+                        CSharpExpression - 
+                            IntermediateToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - default(System.Boolean)
                     PreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     DefaultTagHelperExecute - 
                 HtmlContent - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml)
@@ -32,11 +35,17 @@ Document -
                             DefaultTagHelperCreate -  - TestNamespace.InputTagHelper2
                             PreallocatedTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - __tagHelperAttribute_0 - type - Type
                             PreallocatedTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - __tagHelperAttribute_0 - type - Type
+                            DefaultTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - bool TestNamespace.InputTagHelper2.Checked - HtmlAttributeValueStyle.DoubleQuotes
+                                CSharpExpression - 
+                                    IntermediateToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - default(System.Boolean)
                             PreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                             DefaultTagHelperExecute - 
                         HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml)
                             IntermediateToken - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                     DefaultTagHelperCreate -  - TestNamespace.PTagHelper
+                    DefaultTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - int TestNamespace.PTagHelper.Age - HtmlAttributeValueStyle.SingleQuotes
+                        CSharpExpression - 
+                            IntermediateToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - default(System.Int32)
                     DefaultTagHelperExecute - 
                 HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml)
                     IntermediateToken - (148:6,8 [2] EmptyAttributeTagHelpers.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_Runtime.ir.txt
@@ -18,8 +18,6 @@ Document -
                     DefaultTagHelperCreate -  - TestNamespace.InputTagHelper2
                     PreallocatedTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - __tagHelperAttribute_0 - type - Type
                     PreallocatedTagHelperProperty - (56:3,16 [0] EmptyAttributeTagHelpers.cshtml) - __tagHelperAttribute_0 - type - Type
-                    DefaultTagHelperProperty - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - checked - bool TestNamespace.InputTagHelper2.Checked - HtmlAttributeValueStyle.DoubleQuotes
-                        IntermediateToken - (66:3,26 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                     PreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                     DefaultTagHelperExecute - 
                 HtmlContent - (78:3,38 [6] EmptyAttributeTagHelpers.cshtml)
@@ -34,15 +32,11 @@ Document -
                             DefaultTagHelperCreate -  - TestNamespace.InputTagHelper2
                             PreallocatedTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - __tagHelperAttribute_0 - type - Type
                             PreallocatedTagHelperProperty - (117:5,21 [0] EmptyAttributeTagHelpers.cshtml) - __tagHelperAttribute_0 - type - Type
-                            DefaultTagHelperProperty - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - checked - bool TestNamespace.InputTagHelper2.Checked - HtmlAttributeValueStyle.DoubleQuotes
-                                IntermediateToken - (126:5,30 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                             PreallocatedTagHelperHtmlAttribute -  - __tagHelperAttribute_1
                             DefaultTagHelperExecute - 
                         HtmlContent - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml)
                             IntermediateToken - (138:5,42 [6] EmptyAttributeTagHelpers.cshtml) - Html - \n    
                     DefaultTagHelperCreate -  - TestNamespace.PTagHelper
-                    DefaultTagHelperProperty - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - age - int TestNamespace.PTagHelper.Age - HtmlAttributeValueStyle.SingleQuotes
-                        IntermediateToken - (92:4,12 [0] EmptyAttributeTagHelpers.cshtml) - CSharp - 
                     DefaultTagHelperExecute - 
                 HtmlContent - (148:6,8 [8] EmptyAttributeTagHelpers.cshtml)
                     IntermediateToken - (148:6,8 [2] EmptyAttributeTagHelpers.cshtml) - Html - \n


### PR DESCRIPTION
#1565 

This seems like a straightforward enough fix.
Note: This is NOT a design PR.

@NTaylorMullen @rynowak 