### PR TITLE
Add error for using single quotes in add/remove taghelper directive

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -2032,7 +2032,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             // Ensure that we have valid lookupStrings to work with. The valid format is "typeName, assemblyName"
             if (lookupStrings == null ||
                 lookupStrings.Any(string.IsNullOrWhiteSpace) ||
-                lookupStrings.Length != 2)
+                lookupStrings.Length != 2 ||
+                text.StartsWith("'") ||
+                text.EndsWith("'"))
             {
                 errors.Add(
                     RazorDiagnostic.Create(

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
@@ -1204,6 +1204,31 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
+        public void RemoveTagHelperDirective_SingleQuotes_AddsError()
+        {
+            var expectedErrors = new[]
+            {
+                new RazorError(
+                    Resources.FormatInvalidTagHelperLookupText("'*, Foo'"),
+                    new SourceLocation(17, 0, 17),
+                    length: 8)
+            };
+
+            ParseBlockTest("@removeTagHelper '*, Foo'",
+                new DirectiveBlock(
+                    Factory.CodeTransition(),
+                    Factory.MetaCode(SyntaxConstants.CSharp.RemoveTagHelperKeyword)
+                           .Accepts(AcceptedCharactersInternal.None),
+                    Factory.Span(SpanKindInternal.Markup, " ", markup: false)
+                           .Accepts(AcceptedCharactersInternal.None),
+                    Factory.Code("'*, Foo'")
+                        .AsRemoveTagHelper(
+                            "'*, Foo'",
+                            "'*, Foo'",
+                            legacyErrors: expectedErrors)));
+        }
+
+        [Fact]
         public void RemoveTagHelperDirective_WithQuotes_InvalidLookupText_AddsError()
         {
             var expectedErrors = new[]
@@ -1418,6 +1443,31 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         .AsAddTagHelper(
                             "\"Foo\"",
                             "Foo",
+                            legacyErrors: expectedErrors)));
+        }
+
+        [Fact]
+        public void AddTagHelperDirective_SingleQuotes_AddsError()
+        {
+            var expectedErrors = new[]
+            {
+                new RazorError(
+                    Resources.FormatInvalidTagHelperLookupText("'*, Foo'"),
+                    new SourceLocation(14, 0, 14),
+                    length: 8)
+            };
+
+            ParseBlockTest("@addTagHelper '*, Foo'",
+                new DirectiveBlock(
+                    Factory.CodeTransition(),
+                    Factory.MetaCode(SyntaxConstants.CSharp.AddTagHelperKeyword)
+                           .Accepts(AcceptedCharactersInternal.None),
+                    Factory.Span(SpanKindInternal.Markup, " ", markup: false)
+                           .Accepts(AcceptedCharactersInternal.None),
+                    Factory.Code("'*, Foo'")
+                        .AsAddTagHelper(
+                            "'*, Foo'",
+                            "'*, Foo'",
                             legacyErrors: expectedErrors)));
         }
 


### PR DESCRIPTION
A simple fix for #1561. Just handles single quotes around the lookup text.

After discussing with @NTaylorMullen and @rynowak, we decided there is no good way to determining the validity of the assembly name at design time. It is good to have but it is a separate issue. (Worth filing an issue for it?)

Also, I chose not to handle cases like `@addTagHelper "WebApplication1.TagHelpers.MyTagHelper, WebApplication" + "1"` as it's very obscure and rare.