### PR TITLE
Fix #1684 - CompletionProvider null ref

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Editor/RazorDirectiveCompletionProvider.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Editor/RazorDirectiveCompletionProvider.cs
@@ -77,7 +77,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (!context.Document.FilePath.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase))
+            // FilePath will be null when the editor is open for cases where we don't have a file on disk (C# interactive window and others).
+            if (context.Document?.FilePath == null ||
+                !context.Document.FilePath.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase))
             {
                 // Not a Razor file.
                 return Task.CompletedTask;


### PR DESCRIPTION
The CompletionProvider will be called in cases where the document
doesn't have a FilePath - such as the C# interactive window. This is
causing a null ref.