### PR TITLE
Add a background listener for notifications

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTemplateEngineFactoryService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTemplateEngineFactoryService.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Mvc1_X = Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X;
 using MvcLatest = Microsoft.AspNetCore.Mvc.Razor.Extensions;
 
@@ -14,14 +12,21 @@ namespace Microsoft.CodeAnalysis.Razor
 {
     internal class DefaultTemplateEngineFactoryService : RazorTemplateEngineFactoryService
     {
-        private const string MvcAssemblyName = "Microsoft.AspNetCore.Mvc.Razor";
-        private static readonly Version LatestSupportedMvc = new Version(2, 1, 0);
+        private readonly static ProjectExtensibilityConfiguration DefaultConfiguration = new MvcExtensibilityConfiguration(
+            ProjectExtensibilityConfigurationKind.Fallback,
+            new ProjectExtensibilityAssembly(new AssemblyIdentity("Microsoft.AspNetCore.Razor.Language", new Version("2.0.0.0"))),
+            new ProjectExtensibilityAssembly(new AssemblyIdentity("Microsoft.AspNetCore.Mvc.Razor", new Version("2.0.0.0"))));
 
-        private readonly HostLanguageServices _services;
+        private readonly ProjectSnapshotManager _projectManager;
 
-        public DefaultTemplateEngineFactoryService(HostLanguageServices services)
+        public DefaultTemplateEngineFactoryService(ProjectSnapshotManager projectManager)
         {
-            _services = services;
+            if (projectManager == null)
+            {
+                throw new ArgumentNullException(nameof(projectManager));
+            }
+
+            _projectManager = projectManager;
         }
 
         public override RazorTemplateEngine Create(string projectPath, Action<IRazorEngineBuilder> configure)
@@ -31,9 +36,12 @@ namespace Microsoft.CodeAnalysis.Razor
                 throw new ArgumentNullException(nameof(projectPath));
             }
 
+            // In 15.5 we expect projectPath to be a directory, NOT the path to the csproj.
+            var project = FindProject(projectPath);
+            var configuration = project?.Configuration ?? DefaultConfiguration;
+
             RazorEngine engine;
-            var mvcVersion = GetMvcVersion(projectPath);
-            if (mvcVersion?.Major == 1)
+            if (configuration.RazorAssembly.Identity.Version.Major == 1)
             {
                 engine = RazorEngine.CreateDesignTime(b =>
                 {
@@ -41,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Razor
 
                     Mvc1_X.RazorExtensions.Register(b);
 
-                    if (mvcVersion?.Minor >= 1)
+                    if (configuration.RazorAssembly.Identity.Version.Minor >= 1)
                     {
                         Mvc1_X.RazorExtensions.RegisterViewComponentTagHelpers(b);
                     }
@@ -53,12 +61,6 @@ namespace Microsoft.CodeAnalysis.Razor
             }
             else
             {
-                if (mvcVersion?.Major != LatestSupportedMvc.Major)
-                {
-                    // TODO: Log unknown Mvc version. Something like
-                    // Could not construct Razor engine for Mvc version '{mvcVersion}'. Falling back to Razor engine for Mvc '{LatestSupportedMvc}'.
-                }
-
                 engine = RazorEngine.CreateDesignTime(b =>
                 {
                     configure?.Invoke(b);
@@ -72,28 +74,20 @@ namespace Microsoft.CodeAnalysis.Razor
             }
         }
 
-        private Version GetMvcVersion(string projectPath)
+        private ProjectSnapshot FindProject(string directory)
         {
-            var workspace = _services.WorkspaceServices.Workspace;
+            directory = NormalizeDirectoryPath(directory);
 
-            var project = workspace.CurrentSolution.Projects.FirstOrDefault(p =>
+            var projects = _projectManager.Projects;
+            for (var i = 0; i < projects.Count; i++)
             {
-                var directory = Path.GetDirectoryName(p.FilePath);
-                return string.Equals(
-                    NormalizeDirectoryPath(directory),
-                    NormalizeDirectoryPath(projectPath),
-                    StringComparison.OrdinalIgnoreCase);
-            });
-
-            if (project != null)
-            {
-                var compilation = CSharpCompilation.Create(project.AssemblyName).AddReferences(project.MetadataReferences);
-
-                foreach (var identity in compilation.ReferencedAssemblyNames)
+                var project = projects[i];
+                if (project.UnderlyingProject.FilePath != null)
                 {
-                    if (identity.Name == MvcAssemblyName)
+                    Path.GetDirectoryName(project.UnderlyingProject.FilePath);
+                    if (string.Equals(directory, NormalizeDirectoryPath(Path.GetDirectoryName(project.UnderlyingProject.FilePath)), StringComparison.OrdinalIgnoreCase))
                     {
-                        return identity.Version;
+                        return project;
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTemplateEngineFactoryServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultTemplateEngineFactoryServiceFactory.cs
@@ -4,6 +4,7 @@
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
@@ -12,7 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
     {
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
-            return new DefaultTemplateEngineFactoryService(languageServices);
+            return new DefaultTemplateEngineFactoryService(languageServices.GetRequiredService<ProjectSnapshotManager>());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Legacy/LegacyTemplateEngineFactoryService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Legacy/LegacyTemplateEngineFactoryService.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Inner = Microsoft.CodeAnalysis.Razor.RazorTemplateEngineFactoryService;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
@@ -15,6 +17,38 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
     [Export(typeof(RazorTemplateEngineFactoryService))]
     internal class LegacyTemplateEngineFactoryService : RazorTemplateEngineFactoryService
     {
+        private readonly Inner _inner;
+        private readonly Workspace _workspace;
+
+        [ImportingConstructor]
+        public LegacyTemplateEngineFactoryService([Import(typeof(VisualStudioWorkspace))] Workspace workspace)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            _workspace = workspace;
+            _inner = workspace.Services.GetLanguageServices(RazorLanguage.Name).GetRequiredService<Inner>();
+        }
+
+        // internal for testing
+        internal LegacyTemplateEngineFactoryService(Workspace workspace, Inner inner)
+        {
+            if (workspace == null)
+            {
+                throw new ArgumentNullException(nameof(workspace));
+            }
+
+            if (inner == null)
+            {
+                throw new ArgumentNullException(nameof(inner));
+            }
+
+            _workspace = workspace;
+            _inner = workspace.Services.GetLanguageServices(RazorLanguage.Name).GetRequiredService<Inner>();
+        }
+
         public override RazorTemplateEngine Create(string projectPath, Action<IRazorEngineBuilder> configure)
         {
             if (projectPath == null)
@@ -22,17 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 throw new ArgumentNullException(nameof(projectPath));
             }
 
-            var engine = RazorEngine.CreateDesignTime(b =>
-            {
-                configure?.Invoke(b);
-
-                // For now we're hardcoded to use MVC's extensibility.
-                RazorExtensions.Register(b);
-            });
-
-            var templateEngine = new MvcRazorTemplateEngine(engine, RazorProject.Create(projectPath));
-            templateEngine.Options.ImportsFileName = "_ViewImports.cshtml";
-            return templateEngine;
+            return _inner.Create(projectPath, configure);
         }
     }
 }


### PR DESCRIPTION
This change adds an actual background worker for listening to project
change notifications and starts sending updates when the project's razor
dependencies change.

I had to do a litle surgery to get things working. There were plenty of
small bug fixes.

Additionally I got rid of the WeakReferences for tracking listeners. I
was seeing TextBuffers hanging around in VS longer than I expected and
the WeakReferences weren't getting cleaned up. I think it's better that
we just track the lifetime.