### PR TITLE
Add a VS for Mac compatible Razor addin

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
     <DebugType Condition="'$(OS)'=='Windows_NT' AND '$(TargetFramework)'=='net46'">full</DebugType>
     
     <RoslynDevVersion>2.6.0-beta1-62023-02</RoslynDevVersion>
+    <MonoDevelopAddinsVersion>0.3.18</MonoDevelopAddinsVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Razor.sln
+++ b/Razor.sln
@@ -71,6 +71,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Edit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Editor.Razor.Test.Common", "test\Microsoft.VisualStudio.Editor.Razor.Test.Common\Microsoft.VisualStudio.Editor.Razor.Test.Common.csproj", "{FC684D4F-D23C-407C-9C68-E10EF3B38560}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Mac.RazorAddin", "tooling\Microsoft.VisualStudio.Mac.RazorAddin\Microsoft.VisualStudio.Mac.RazorAddin.csproj", "{FAF9986F-E086-4513-9D52-F7BF5FFCF31D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Mac.LanguageServices.Razor", "src\Microsoft.VisualStudio.Mac.LanguageServices.Razor\Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj", "{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -285,6 +289,22 @@ Global
 		{FC684D4F-D23C-407C-9C68-E10EF3B38560}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FC684D4F-D23C-407C-9C68-E10EF3B38560}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
 		{FC684D4F-D23C-407C-9C68-E10EF3B38560}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
+		{FAF9986F-E086-4513-9D52-F7BF5FFCF31D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAF9986F-E086-4513-9D52-F7BF5FFCF31D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAF9986F-E086-4513-9D52-F7BF5FFCF31D}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAF9986F-E086-4513-9D52-F7BF5FFCF31D}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+		{FAF9986F-E086-4513-9D52-F7BF5FFCF31D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAF9986F-E086-4513-9D52-F7BF5FFCF31D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAF9986F-E086-4513-9D52-F7BF5FFCF31D}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{FAF9986F-E086-4513-9D52-F7BF5FFCF31D}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
+		{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+		{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -316,6 +336,8 @@ Global
 		{0BCDE75A-A438-46C7-95E9-391F029D07C5} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 		{AA888DB9-340E-4E06-A2A4-25BFEE1AC2B7} = {92463391-81BE-462B-AC3C-78C6C760741F}
 		{FC684D4F-D23C-407C-9C68-E10EF3B38560} = {92463391-81BE-462B-AC3C-78C6C760741F}
+		{FAF9986F-E086-4513-9D52-F7BF5FFCF31D} = {C0CC1E1F-1559-44DE-93A8-63259CEA2AAB}
+		{95B18DEE-8B45-4CF0-B9F8-CCBAF3B5251A} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0035341D-175A-4D05-95E6-F1C2785A1E26}

--- a/build/MPack.targets
+++ b/build/MPack.targets
@@ -1,0 +1,64 @@
+<Project>
+  <PropertyGroup>
+    <PackageDependsOn Condition="'$(OS)'=='Windows_NT'">$(PackageDependsOn);GenerateMPack</PackageDependsOn>
+    <AddinName>Microsoft.VisualStudio.Mac.RazorAddin</AddinName>
+    <AddinDirectory>$(RepositoryRoot)tooling\$(AddinName)\</AddinDirectory>
+  </PropertyGroup>
+
+  <Import Project="$(AddinDirectory)AddinMetadata.props" />
+
+  <Target
+    Name="GenerateMPack"
+    Condition="'$(OS)'=='Windows_NT'">
+    <!--
+      In our case the mpack archive requires the following:
+      1. An addin.info
+      2. An addin binary (Microsoft.VisualStudio.Mac.RazorAddin.dll)
+        a. _Manifest.addin.xml embedded
+        b. Addin assembly attributes for metadata 
+      3. All language service binaries
+    -->
+
+    <PropertyGroup>
+      <MSBuildArtifactsDir>$(ArtifactsDir)msbuild\</MSBuildArtifactsDir>
+      <MPackSourcesDir>$(MSBuildArtifactsDir)sources\</MPackSourcesDir>
+      <AddinOutputPath>$(AddinDirectory)bin\$(Configuration)\net461\</AddinOutputPath>
+      <LanguageServiceName>Microsoft.VisualStudio.Mac.LanguageServices.Razor</LanguageServiceName>
+      <LanguageServiceOutputPath>$(RepositoryRoot)src\$(LanguageServiceName)\bin\$(Configuration)\net46\</LanguageServiceOutputPath>
+      <MPackName>$(AddinName)_$(AddinVersion)</MPackName>
+      <MPackFileName>$(MPackName).mpack</MPackFileName>
+      <MPackOutputPath>$(BuildDir)$(MPackFileName)</MPackOutputPath>
+      <MPackZipFile>$(BuildDir)$(MPackName).zip</MPackZipFile>
+      <MPackManifest>$(AddinDirectory)Properties\_Manifest.addin.xml</MPackManifest>
+      <AddinInfoFilePath>$(MPackSourcesDir)addin.info</AddinInfoFilePath>
+    </PropertyGroup>
+    
+    <MakeDir Directories="$(MPackSourcesDir)" Condition="!Exists('$(MPackSourcesDir)')" />
+
+    <!-- We need to resolve the language service assemblies to generate an addin.info for the mpack -->
+    <XmlPeek XmlInputPath="$(MPackManifest)" Query="/ExtensionModel/Runtime/Import/@assembly">
+      <Output TaskParameter="Result" ItemName="LanguageServiceAssemblies" />
+    </XmlPeek>
+
+    <ItemGroup>
+      <AddinInfoLines Include="&lt;Addin id=&quot;$(AddinId)&quot; namespace=&quot;$(AddinNamespace)&quot; version=&quot;$(AddinVersion)&quot; name=&quot;$(AddinDetailedName)&quot; author=&quot;$(Authors)&quot; description=&quot;$(Description)&quot; category=&quot;$(AddinCategory)&quot;&gt;" />
+      <AddinInfoLines Include="  &lt;Runtime&gt;" />
+      <AddinInfoLines Include="    &lt;Import assembly=&quot;%(LanguageServiceAssemblies.Identity)&quot; /&gt;" />
+      <AddinInfoLines Include="    &lt;Import assembly=&quot;$(AddinName).dll&quot; /&gt;" />
+      <AddinInfoLines Include="  &lt;/Runtime&gt;" />
+      <AddinInfoLines Include="  &lt;Dependencies&gt;" />
+      <AddinInfoLines Include="  &lt;/Dependencies&gt;" />
+      <AddinInfoLines Include="&lt;/Addin&gt;" />
+    </ItemGroup>
+
+    <!-- Generate the addin.info and gather sources for mpack zipping-->
+    <WriteLinesToFile File="$(AddinInfoFilePath)" Lines="@(AddinInfoLines)" Overwrite="true" />
+    <Copy SourceFiles="$(LanguageServiceOutputPath)\%(LanguageServiceAssemblies.Identity)" DestinationFolder="$(MPackSourcesDir)" />
+    <Copy SourceFiles="$(AddinOutputPath)$(AddinName).dll" DestinationFolder="$(MPackSourcesDir)" />
+
+    <!-- We cannot use the ZipArchive task due to how it functions in CoreCLR. The archive it generates is unreadable by Visual Studio for Mac. -->
+    <Exec Command="powershell.exe -NonInteractive -command &quot;&amp; { Compress-Archive -Path $(MPackSourcesDir)* -DestinationPath $(MPackZipFile) -Force; } &quot;" />
+    <Move SourceFiles="$(MPackZipFile)" DestinationFiles="$(MPackOutputPath)" />
+  </Target>
+
+</Project>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="VSIX.targets" />
+  <Import Project="MPack.targets" />
   <ItemGroup>
     <Solutions Update="..\Razor.sln">
       <!-- the 'DebugNoVSIX' and 'ReleaseNoVSIX' configurations exclude the VSIX project, which doesn't build with Microsoft.NET.Sdk yet. -->

--- a/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj
+++ b/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net46</TargetFrameworks>
+    <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor design-time infrastructure for Visual Studio for Mac.</Description>
+    <EnableApiCheck>false</EnableApiCheck>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.Editor.Razor\Microsoft.VisualStudio.Editor.Razor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tooling/Microsoft.VisualStudio.Mac.RazorAddin/AddinMetadata.props
+++ b/tooling/Microsoft.VisualStudio.Mac.RazorAddin/AddinMetadata.props
@@ -1,0 +1,12 @@
+﻿<Project>
+  <PropertyGroup>
+    <VSForMacVersion>7.0</VSForMacVersion>
+    <AddinVersion Condition="'$(BuildNumber)'!=''">$(VSForMacVersion).$(BuildNumber)</AddinVersion>
+    <AddinVersion Condition="'$(BuildNumber)'==''">$(VSForMacVersion).999999</AddinVersion>
+    <AddinId>RazorAddin</AddinId>
+    <AddinNamespace>Microsoft.VisualStudio.Mac</AddinNamespace>
+    <AddinDetailedName>Razor Language Services</AddinDetailedName>
+    <AddinCategory>Web Development</AddinCategory>
+    <Description>Language services for ASP.NET Core Razor</Description>
+  </PropertyGroup>
+</Project>

--- a/tooling/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/tooling/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -1,0 +1,72 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="AddinMetadata.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Properties\_Manifest.addin.xml" LogicalName="_Manifest.addin.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- 
+      By default the MonoDevelop.Addins package has restore tasks that depend on monodevelop existing on the machine. 
+      We can avoid this requirement by not letting it auto-restore monodevelop dependencies because we know which ones
+      we depend on and can bring them in manually.
+    -->
+    <PackageReference Include="MonoDevelop.Addins" Version="$(MonoDevelopAddinsVersion)" NoWarn="KRB4002" ExcludeAssets="build" />
+    <Reference Include="Mono.Addins">
+      <HintPath>$(NuGetPackageRoot)monodevelop.addins\$(MonoDevelopAddinsVersion)\build\Mono.Addins.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- 
+      The extension project can not have a direct reference to its language service pieces. They are included via the manifest above.
+      This piece ensures that transitive builds/restores occurr for this project.
+    -->
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.Mac.LanguageServices.Razor\Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <PrivateAssets>true</PrivateAssets>
+      <OutputItemType>Content</OutputItemType>
+      <Targets>Build</Targets>
+    </ProjectReference>
+  </ItemGroup>
+
+  <!-- We need to generate assembly attributes with build time information to let MonoDevelop know RazorAddins metadata at runtime. -->
+  <Target Name="GenerateAddinAssemblyAttributes" BeforeTargets="PreBuildEvent">
+    <PropertyGroup>
+      <GeneratedAddinAssemblyInfo>$(IntermediateOutputPath)$(MSBuildProjectFile).AddinInfo.cs</GeneratedAddinAssemblyInfo>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <RazorAssemblyAttribute Include="Mono.Addins.AddinAttribute">
+        <_Parameter1>$(AddinId)</_Parameter1>
+        <Namespace>$(AddinNamespace)</Namespace>
+        <Version>$(AddinVersion)</Version>
+      </RazorAssemblyAttribute>
+      <RazorAssemblyAttribute Include="Mono.Addins.AddinNameAttribute">
+        <_Parameter1>$(AddinDetailedName)</_Parameter1>
+      </RazorAssemblyAttribute>
+      <RazorAssemblyAttribute Include="Mono.Addins.AddinCategoryAttribute">
+        <_Parameter1>$(AddinCategory)</_Parameter1>
+      </RazorAssemblyAttribute>
+      <RazorAssemblyAttribute Include="Mono.Addins.AddinDescriptionAttribute">
+        <_Parameter1>$(Description)</_Parameter1>
+      </RazorAssemblyAttribute>
+      <RazorAssemblyAttribute Include="Mono.Addins.AddinAuthorAttribute">
+        <_Parameter1>$(Authors)</_Parameter1>
+      </RazorAssemblyAttribute>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Ensure generated file is not already in compile sources -->
+      <Compile Remove="$(GeneratedAddinAssemblyInfo)" />
+    </ItemGroup>
+
+    <WriteCodeFragment Language="C#" OutputFile="$(GeneratedAddinAssemblyInfo)" AssemblyAttributes="@(RazorAssemblyAttribute)">
+      <Output TaskParameter="OutputFile" ItemName="Compile" />
+    </WriteCodeFragment>
+  </Target>
+</Project>

--- a/tooling/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/tooling/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ExtensionModel>
+  <Runtime>
+    <Import assembly="Microsoft.VisualStudio.Editor.Razor.dll" />
+    <Import assembly="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
+    <Import assembly="Microsoft.AspNetCore.Razor.Language.dll" />
+    <Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
+    <Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
+    <Import assembly="Microsoft.CodeAnalysis.Razor.dll" />
+    <Import assembly="Microsoft.CodeAnalysis.CSharp.dll" />
+    <Import assembly="Microsoft.VisualStudio.Mac.LanguageServices.Razor.dll" />
+  </Runtime>
+  <Dependencies>
+  </Dependencies>
+</ExtensionModel>


### PR DESCRIPTION
- Add Microsoft.MonoDevelop.RazorAddin.
- As part of this work I also added `Microsoft.MonoDevelop.LanguageServices.Razor` to be the monodevelop specific Razor code.
- Added MSBuild infrastructure to automate creation of MonoDevelop addins (MPacks). This work enables us to not have a dependency on a specific version of monodevelop and does not require us to have tool-prerequisites on the box. Every build outputs the mpacks into the artifacts/build directory.
- Built in build-level metadata pieces to workaround how addins are typically developed. They are usually authored C# first and then config files are generated after the fact; with this changeset we auto-generate the addin.info and its corresponding assembly attributes. Both of these take information directly from the build system.

#1696 

/cc @ToddGrun @KirillOsenkov 