### PR TITLE
[2.0.x] Ensure the VSIX project is skipped when executing restore and build

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="VSIX.targets" />
   <ItemGroup>
-    <Solutions Update="..\Razor.sln">
+    <Solutions Update="$(RepositoryRoot)Razor.sln">
       <!-- the 'DebugNoVSIX' and 'ReleaseNoVSIX' configurations exclude the VSIX project, which doesn't build with Microsoft.NET.Sdk yet. -->
       <AdditionalProperties>Configuration=$(Configuration)NoVSIX</AdditionalProperties>
     </Solutions>


### PR DESCRIPTION
The syntax of the Update in repo.targets was not actually matching Razor.sln. Something either changed in MSBuild or this never worked. Either way, this ensures we don't actually execute build and restore on the VSIX csproj when building patches.