### PR TITLE
Add EditorSettings management to workspaces.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/DefaultEditorSettingsManager.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/DefaultEditorSettingsManager.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor.Editor
+{
+    internal class DefaultEditorSettingsManager : EditorSettingsManager
+    {
+        public override event EventHandler<EditorSettingsChangedEventArgs> Changed;
+
+        private readonly object SettingsAccessorLock = new object();
+        private EditorSettings _settings;
+
+        public DefaultEditorSettingsManager()
+        {
+            _settings = EditorSettings.Default;
+        }
+
+        public override EditorSettings Current
+        {
+            get
+            {
+                lock (SettingsAccessorLock)
+                {
+                    return _settings;
+                }
+            }
+        }
+
+        public override void Update(EditorSettings updatedSettings)
+        {
+            if (updatedSettings == null)
+            {
+                throw new ArgumentNullException(nameof(updatedSettings));
+            }
+
+            lock (SettingsAccessorLock)
+            {
+                if (!_settings.Equals(updatedSettings))
+                {
+                    _settings = updatedSettings;
+                    OnChanged();
+                }
+            }
+        }
+
+        private void OnChanged()
+        {
+            var args = new EditorSettingsChangedEventArgs(Current);
+            Changed?.Invoke(this, args);
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/DefaultEditorSettingsManagerFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/DefaultEditorSettingsManagerFactory.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Razor.Editor
+{
+    [Shared]
+    [ExportLanguageServiceFactory(typeof(EditorSettingsManager), RazorLanguage.Name)]
+    internal class DefaultEditorSettingsManagerFactory : ILanguageServiceFactory
+    {
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            if (languageServices == null)
+            {
+                throw new ArgumentNullException(nameof(languageServices));
+            }
+
+            return new DefaultEditorSettingsManager();
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/EditorSettings.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/EditorSettings.cs
@@ -1,0 +1,53 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.CodeAnalysis.Razor.Editor
+{
+    public sealed class EditorSettings : IEquatable<EditorSettings>
+    {
+        public static readonly EditorSettings Default = new EditorSettings(indentWithTabs: false, indentSize: 4);
+
+        public EditorSettings(bool indentWithTabs, int indentSize)
+        {
+            if (indentSize < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(indentSize));
+            }
+
+            IndentWithTabs = indentWithTabs;
+            IndentSize = indentSize;
+        }
+
+        public bool IndentWithTabs { get; }
+
+        public int IndentSize { get; }
+
+        public bool Equals(EditorSettings other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return IndentWithTabs == other.IndentWithTabs &&
+                IndentSize == other.IndentSize;
+        }
+
+        public override bool Equals(object other)
+        {
+            return Equals(other as EditorSettings);
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(IndentWithTabs);
+            combiner.Add(IndentSize);
+
+            return combiner.CombinedHash;
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/EditorSettingsChangedEventArgs.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/EditorSettingsChangedEventArgs.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor.Editor
+{
+    public sealed class EditorSettingsChangedEventArgs : EventArgs
+    {
+        public EditorSettingsChangedEventArgs(EditorSettings settings)
+        {
+            Settings = settings;
+        }
+
+        public EditorSettings Settings { get; }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/EditorSettingsManager.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/EditorSettingsManager.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Razor.Editor
+{
+    public abstract class EditorSettingsManager : ILanguageService
+    {
+        public abstract event EventHandler<EditorSettingsChangedEventArgs> Changed;
+
+        public abstract EditorSettings Current { get; }
+
+        public abstract void Update(EditorSettings updateSettings);
+    }
+}

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Editor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using ITextBuffer = Microsoft.VisualStudio.Text.ITextBuffer;
@@ -376,21 +378,25 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         private void ConfigureTemplateEngine(IRazorEngineBuilder builder)
         {
-            builder.Features.Add(new VisualStudioParserOptionsFeature());
+            builder.Features.Add(new VisualStudioParserOptionsFeature(_documentTracker.EditorSettings));
             builder.Features.Add(new VisualStudioTagHelperFeature(TextBuffer));
         }
 
-        /// <summary>
-        /// This class will cease to be useful once we harvest/monitor settings from the editor.
-        /// </summary>
         private class VisualStudioParserOptionsFeature : RazorEngineFeatureBase, IConfigureRazorCodeGenerationOptionsFeature
         {
+            private readonly EditorSettings _settings;
+
+            public VisualStudioParserOptionsFeature(EditorSettings settings)
+            {
+                _settings = settings;
+            }
+
             public int Order { get; set; }
 
             public void Configure(RazorCodeGenerationOptionsBuilder options)
             {
-                options.IndentSize = 4;
-                options.IndentWithTabs = false;
+                options.IndentSize = _settings.IndentSize;
+                options.IndentWithTabs = _settings.IndentWithTabs;
             }
         }
 

--- a/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioDocumentTracker.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioDocumentTracker.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.Editor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -15,6 +16,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public abstract event EventHandler ContextChanged;
 
         internal abstract ProjectExtensibilityConfiguration Configuration { get; }
+
+        public abstract EditorSettings EditorSettings { get; }
 
         public abstract bool IsSupportedProject { get; }
 

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Editor/DefaultVisualStudioDocumentTrackerFactory.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Editor/DefaultVisualStudioDocumentTrackerFactory.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Editor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Text;
@@ -21,6 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
         private readonly Workspace _workspace;
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly ProjectSnapshotManager _projectManager;
+        private readonly EditorSettingsManager _editorSettingsManager;
 
         [ImportingConstructor]
         public DefaultVisualStudioDocumentTrackerFactory(
@@ -48,7 +50,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
             _workspace = workspace;
 
             _foregroundDispatcher = workspace.Services.GetRequiredService<ForegroundDispatcher>();
-            _projectManager = workspace.Services.GetLanguageServices(RazorLanguage.Name).GetRequiredService<ProjectSnapshotManager>();
+            var razorLanguageServices = workspace.Services.GetLanguageServices(RazorLanguage.Name);
+            _projectManager = razorLanguageServices.GetRequiredService<ProjectSnapshotManager>();
+            _editorSettingsManager = razorLanguageServices.GetRequiredService<EditorSettingsManager>();
         }
 
         public override VisualStudioDocumentTracker Create(ITextBuffer textBuffer)
@@ -65,7 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
             }
 
             var filePath = textDocument.FilePath;
-            var tracker = new DefaultVisualStudioDocumentTracker(filePath, _projectManager, _projectService, _workspace, textBuffer);
+            var tracker = new DefaultVisualStudioDocumentTracker(filePath, _projectManager, _projectService, _editorSettingsManager, _workspace, textBuffer);
 
             return tracker;
         }

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Editor/DefaultEditorSettingsManagerTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Editor/DefaultEditorSettingsManagerTest.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor.Editor
+{
+    public class DefaultEditorSettingsManagerTest
+    {
+        [Fact]
+        public void InitialSettingsAreDefault()
+        {
+            // Act
+            var manager = new DefaultEditorSettingsManager();
+
+            // Assert
+            Assert.Equal(EditorSettings.Default, manager.Current);
+        }
+
+        [Fact]
+        public void Update_TriggersChangedIfEditorSettingsAreDifferent()
+        {
+            // Arrange
+            var manager = new DefaultEditorSettingsManager();
+            var called = false;
+            manager.Changed += (caller, args) =>
+            {
+                called = true;
+            };
+            var settings = new EditorSettings(indentWithTabs: true, indentSize: 7);
+
+            // Act
+            manager.Update(settings);
+
+            // Assert
+            Assert.True(called);
+            Assert.Equal(settings, manager.Current);
+        }
+
+        [Fact]
+        public void Update_DoesNotTriggerChangedIfEditorSettingsAreSame()
+        {
+            // Arrange
+            var manager = new DefaultEditorSettingsManager();
+            var called = false;
+            manager.Changed += (caller, args) =>
+            {
+                called = true;
+            };
+            var originalSettings = manager.Current;
+
+            // Act
+            manager.Update(EditorSettings.Default);
+
+            // Assert
+            Assert.False(called);
+            Assert.Same(originalSettings, manager.Current);
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Editor/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Editor/DefaultVisualStudioDocumentTrackerTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Editor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
@@ -29,13 +30,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
                 s.IsSupportedProject(It.IsAny<IVsHierarchy>()) == true &&
                 s.GetProjectPath(It.IsAny<IVsHierarchy>()) == "C:/Some/Path/TestProject.csproj");
 
+        private EditorSettingsManager EditorSettingsManager => new DefaultEditorSettingsManager();
+
         private Workspace Workspace => new AdhocWorkspace();
+
+        [Fact]
+        public void EditorSettingsManager_Changed_TriggersContextChanged()
+        {
+            // Arrange
+            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, EditorSettingsManager, Workspace, TextBuffer);
+            var called = false;
+            documentTracker.ContextChanged += (sender, args) =>
+            {
+                called = true;
+            };
+
+            // Act
+            documentTracker.EditorSettingsManager_Changed(null, null);
+
+            // Assert
+            Assert.True(called);
+        }
 
         [Fact]
         public void AddTextView_AddsToTextViewCollection()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, Workspace, TextBuffer);
+            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, EditorSettingsManager, Workspace, TextBuffer);
             var textView = Mock.Of<ITextView>();
 
             // Act
@@ -49,7 +70,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
         public void AddTextView_SubscribesAfterFirstTextViewAdded()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, Workspace, TextBuffer);
+            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, EditorSettingsManager, Workspace, TextBuffer);
             var textView = Mock.Of<ITextView>();
 
             // Assert - 1
@@ -66,7 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
         public void AddTextView_DoesNotAddDuplicateTextViews()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, Workspace, TextBuffer);
+            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, EditorSettingsManager, Workspace, TextBuffer);
             var textView = Mock.Of<ITextView>();
 
             // Act
@@ -81,7 +102,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
         public void AddTextView_AddsMultipleTextViewsToCollection()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, Workspace, TextBuffer);
+            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, EditorSettingsManager, Workspace, TextBuffer);
             var textView1 = Mock.Of<ITextView>();
             var textView2 = Mock.Of<ITextView>();
 
@@ -100,7 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
         public void RemoveTextView_RemovesTextViewFromCollection_SingleItem()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, Workspace, TextBuffer);
+            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, EditorSettingsManager, Workspace, TextBuffer);
             var textView = Mock.Of<ITextView>();
             documentTracker.AddTextView(textView);
 
@@ -115,7 +136,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
         public void RemoveTextView_RemovesTextViewFromCollection_MultipleItems()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, Workspace, TextBuffer);
+            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, EditorSettingsManager, Workspace, TextBuffer);
             var textView1 = Mock.Of<ITextView>();
             var textView2 = Mock.Of<ITextView>();
             var textView3 = Mock.Of<ITextView>();
@@ -137,7 +158,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
         public void RemoveTextView_NoopsWhenRemovingTextViewNotInCollection()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, Workspace, TextBuffer);
+            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, EditorSettingsManager, Workspace, TextBuffer);
             var textView1 = Mock.Of<ITextView>();
             documentTracker.AddTextView(textView1);
             var textView2 = Mock.Of<ITextView>();
@@ -153,7 +174,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
         public void RemoveTextView_UnsubscribesAfterLastTextViewRemoved()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, Workspace, TextBuffer);
+            var documentTracker = new DefaultVisualStudioDocumentTracker(FilePath, ProjectManager, ProjectService, EditorSettingsManager, Workspace, TextBuffer);
             var textView1 = Mock.Of<ITextView>();
             var textView2 = Mock.Of<ITextView>();
             documentTracker.AddTextView(textView1);


### PR DESCRIPTION
- Built a design where there's a singleton `EditorSettingsManager` that handles the "current" settings state in the world. When it detects that settings have changed via an update method being called it dispatches a `Changed` event.
- Exposed editor settings on the document tracker. When the editor settings change the document tracker dispatches to any listeners that its context has changed.
- Added tests to validate all the various settings management.

#1718