### PR TITLE
Skip building the VSIX if the Microsoft.VisualStudio.Component.VSSDK workload is not available

### DIFF
--- a/build/VSIX.targets
+++ b/build/VSIX.targets
@@ -12,25 +12,19 @@
     DependsOnTargets="RestoreVSIX;PackageVSIX"
     Condition="'$(OS)'=='Windows_NT'" />
 
-  <Target Name="_LocateMSBuildExe" Condition="Exists('$(MSBuildProgramFiles32)')">
-    <ItemGroup>
-      <MSBuild15ExePaths Include="$(MSBuildProgramFiles32)\Microsoft Visual Studio\**\MSBuild\15.0\Bin\MSBuild.exe" />
-    </ItemGroup>
-
-    <Warning
-      Text="Unable to locate MSBuild 15.0 under $(MSBuildProgramFiles32)\Microsoft Visual Studio"
-      Condition="'@(MSBuild15ExePaths)'==''"/>
-
-    <PropertyGroup Condition="'@(MSBuild15ExePaths)'!=''">
-      <MSBuildExePath>%(MSBuild15ExePaths.FullPath)</MSBuildExePath>
-    </PropertyGroup>
+  <!--
+    VisualStudioMSBuildx86Path is set by the GetToolsets target in KoreBuild if a version of VS matching the requirements in korebuild.json is found.
+   -->
+  <Target Name="RestoreVSIX" DependsOnTargets="GetToolsets">
+    <Exec Command="&quot;$(VisualStudioMSBuildx86Path)&quot; &quot;$(VSIXProject)&quot; /t:Restore /v:m /p:BuildNumber=$(BuildNumber)"
+      Condition="'$(VisualStudioMSBuildx86Path)' != ''" />
   </Target>
 
-  <Target Name="RestoreVSIX" DependsOnTargets="_LocateMSBuildExe">
-    <Exec Command="&quot;$(MSBuildExePath)&quot; &quot;$(VSIXProject)&quot; /t:Restore /v:m /p:BuildNumber=$(BuildNumber)" />
-  </Target>
+  <Target Name="PackageVSIX" DependsOnTargets="GetToolsets">
 
-  <Target Name="PackageVSIX" DependsOnTargets="_LocateMSBuildExe">
+    <Warning Text="Could not find a version of Visual Studio that has the Visual Studio SDK installed. This is required to build the Razor VSIX. Skipping."
+      Condition="'$(VisualStudioMSBuildx86Path)' == ''" />
+
     <PropertyGroup>
       <MSBuildArtifactsDir>$(ArtifactsDir)msbuild\</MSBuildArtifactsDir>
       <VSIXLogFilePath>$(MSBuildArtifactsDir)vsix.log</VSIXLogFilePath>
@@ -57,7 +51,8 @@
       Lines="@(MSBuildArguments)"
       Overwrite="true" />
 
-    <Exec Command="&quot;$(MSBuildExePath)&quot; @&quot;$(VSIXResponseFilePath)&quot;" />
+    <Exec Command="&quot;$(VisualStudioMSBuildx86Path)&quot; @&quot;$(VSIXResponseFilePath)&quot;"
+      Condition="'$(VisualStudioMSBuildx86Path)' != ''" />
   </Target>
 
 </Project>

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/dev/tools/korebuild.schema.json",
+  "channel": "dev",
+  "toolsets": {
+    "visualstudio": {
+      "required": false,
+      "includePrerelease": true,
+      "minVersion": "15.0.26730.03",
+      "requiredWorkloads": [
+        "Microsoft.VisualStudio.Component.VSSDK"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Uses the new "toolsets" section of korebuild.json to find a version of MSBuild in Visual Studio that has the required VSIX SDK.

Behavior: this currently warns if a version of VS with this workload could not be found and skips building the VSIX. We could change this to be made a fatal error if that would be better.

cc @jkotalik - you'll need something similar for ANCM.