### PR TITLE
Dispatch DocumentStructureChanged event on foreground thread.

### DIFF
--- a/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
@@ -21,6 +21,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public abstract ITextBuffer TextBuffer { get; }
 
+        public abstract bool HasPendingChanges { get; }
+
         public abstract void QueueReparse();
     }
 }


### PR DESCRIPTION
- Had to add extra logic to track document structure changes so listeners could know if an event was on its way or not.
- Added and fixed some tests.

#1748