### PR TITLE
Add MonoDevelop.Core and MonoDevelop.Ide addin dependencies.

### DIFF
--- a/build/MPack.targets
+++ b/build/MPack.targets
@@ -24,7 +24,7 @@
       <MPackSourcesDir>$(MSBuildArtifactsDir)sources\</MPackSourcesDir>
       <AddinOutputPath>$(AddinDirectory)bin\$(Configuration)\net461\</AddinOutputPath>
       <LanguageServiceName>Microsoft.VisualStudio.Mac.LanguageServices.Razor</LanguageServiceName>
-      <LanguageServiceOutputPath>$(RepositoryRoot)src\$(LanguageServiceName)\bin\$(Configuration)\net46\</LanguageServiceOutputPath>
+      <LanguageServiceOutputPath>$(RepositoryRoot)src\$(LanguageServiceName)\bin\$(Configuration)\net461\</LanguageServiceOutputPath>
       <MPackName>$(AddinName)_$(AddinVersion)</MPackName>
       <MPackFileName>$(MPackName).mpack</MPackFileName>
       <MPackOutputPath>$(BuildDir)$(MPackFileName)</MPackOutputPath>
@@ -40,6 +40,11 @@
       <Output TaskParameter="Result" ItemName="LanguageServiceAssemblies" />
     </XmlPeek>
 
+    <!-- We need to resolve the addin dependencies to generate an addin.info for the mpack -->
+    <XmlPeek XmlInputPath="$(MPackManifest)" Query="/ExtensionModel/Dependencies/Addin">
+      <Output TaskParameter="Result" ItemName="AddinDependencies" />
+    </XmlPeek>
+
     <ItemGroup>
       <AddinInfoLines Include="&lt;Addin id=&quot;$(AddinId)&quot; namespace=&quot;$(AddinNamespace)&quot; version=&quot;$(AddinVersion)&quot; name=&quot;$(AddinDetailedName)&quot; author=&quot;$(Authors)&quot; description=&quot;$(Description)&quot; category=&quot;$(AddinCategory)&quot;&gt;" />
       <AddinInfoLines Include="  &lt;Runtime&gt;" />
@@ -47,6 +52,7 @@
       <AddinInfoLines Include="    &lt;Import assembly=&quot;$(AddinName).dll&quot; /&gt;" />
       <AddinInfoLines Include="  &lt;/Runtime&gt;" />
       <AddinInfoLines Include="  &lt;Dependencies&gt;" />
+      <AddinInfoLines Include="    %(AddinDependencies.Identity)" />
       <AddinInfoLines Include="  &lt;/Dependencies&gt;" />
       <AddinInfoLines Include="&lt;/Addin&gt;" />
     </ItemGroup>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -28,11 +28,13 @@
     <MicrosoftVisualStudioShellInterop90PackageVersion>9.0.30729</MicrosoftVisualStudioShellInterop90PackageVersion>
     <MicrosoftVisualStudioShellInteropPackageVersion>7.10.6071</MicrosoftVisualStudioShellInteropPackageVersion>
     <MonoAddinsPackageVersion>1.3.7</MonoAddinsPackageVersion>
+    <MonoDevelopSdkPackageVersion>1.0.0</MonoDevelopSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <NETStandard20PackageVersion>2.0.0</NETStandard20PackageVersion>
     <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
     <StreamJsonRpcPackageVersion>1.1.92</StreamJsonRpcPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.0-preview1-25914-04</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemValueTuplePackageVersion>4.5.0-preview1-25914-04</SystemValueTuplePackageVersion>
     <VisualStudio_NewtonsoftJsonPackageVersion>9.0.1</VisualStudio_NewtonsoftJsonPackageVersion>
     <VSIX_MicrosoftCodeAnalysisCommonPackageVersion>2.6.0-beta1-62023-02</VSIX_MicrosoftCodeAnalysisCommonPackageVersion>
     <VSIX_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>2.6.0-beta1-62023-02</VSIX_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>

--- a/build/sources.props
+++ b/build/sources.props
@@ -8,7 +8,8 @@
       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
       https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
-      https://vside.myget.org/F/vssdk/api/v3/index.json
+      https://vside.myget.org/F/vssdk/api/v3/index.json;
+      https://vside.myget.org/F/vsmac/api/v3/index.json
     </RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       $(RestoreSources);

--- a/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj
+++ b/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Microsoft.VisualStudio.Mac.LanguageServices.Razor.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor design-time infrastructure for Visual Studio for Mac.</Description>
     <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MonoDevelop.Sdk" Version="$(MonoDevelopSdkPackageVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(SystemValueTuplePackageVersion)" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.Editor.Razor\Microsoft.VisualStudio.Editor.Razor.csproj" />

--- a/tooling/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/tooling/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -23,6 +23,14 @@
     <AssemblyAttribute Include="Mono.Addins.AddinAuthorAttribute">
       <_Parameter1>$(Authors)</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="Mono.Addins.AddinDependencyAttribute">
+      <_Parameter1>::MonoDevelop.Ide</_Parameter1>
+      <_Parameter2>7.4</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Mono.Addins.AddinDependencyAttribute">
+      <_Parameter1>::MonoDevelop.Core</_Parameter1>
+      <_Parameter2>7.4</_Parameter2>
+    </AssemblyAttribute>
     </ItemGroup>
 
   <ItemGroup>

--- a/tooling/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/tooling/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -7,9 +7,17 @@
     <Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
     <Import assembly="Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
     <Import assembly="Microsoft.CodeAnalysis.Razor.dll" />
-    <Import assembly="Microsoft.CodeAnalysis.CSharp.dll" />
     <Import assembly="Microsoft.VisualStudio.Mac.LanguageServices.Razor.dll" />
   </Runtime>
   <Dependencies>
+    <Addin id="::MonoDevelop.Core" version="7.4" />
+    <Addin id="::MonoDevelop.Ide" version="7.4" />
   </Dependencies>
+  
+  <!-- MEF catalog -->
+  <Extension path="/MonoDevelop/Ide/Composition">
+    <Assembly file="Microsoft.VisualStudio.Editor.Razor.dll" />
+    <Assembly file="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
+    <Assembly file="Microsoft.VisualStudio.Mac.LanguageServices.Razor.dll" />
+  </Extension> 
 </ExtensionModel>

--- a/version.props
+++ b/version.props
@@ -6,10 +6,13 @@
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
+    <!-- VS for Mac does not like letters in package versions -->
+    <AddinBuildNumber Condition="'$(BuildNumber)' == 't000'">99999</AddinBuildNumber>
+    <AddinBuildNumber Condition="'$(AddinBuildNumber)' == ''">$(BuildNumber)</AddinBuildNumber>
+    
     
     <!-- Properties for VS for Mac addin -->
     <VSForMacVersion>7.0</VSForMacVersion>
-    <AddinVersion Condition="'$(BuildNumber)'!=''">$(VSForMacVersion).$(BuildNumber)</AddinVersion>
-    <AddinVersion Condition="'$(BuildNumber)'==''">$(VSForMacVersion).999999</AddinVersion>
+    <AddinVersion>$(VSForMacVersion).$(AddinBuildNumber)</AddinVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Added the runtime package dependency to allow for proper assembly building.
- Added a new external package source for the MonoDevelop.Sdk.
- Had to change the MPack version to be compliant with VS for mac versioning support.
- Exposed VS for mac compatible binaries to the MEF catalog.

#1789 

@ToddGrun @KirillOsenkov would appreciate if you guys could review since you have more monodevelop knowledge.

FYI @mkArtakMSFT