### PR TITLE
Make BraceSmartIndenterFactory VisualStudio agnostic.

### DIFF
--- a/src/Microsoft.VisualStudio.Editor.Razor/BraceSmartIndenterFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/BraceSmartIndenterFactory.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Host;
+
 namespace Microsoft.VisualStudio.Editor.Razor
 {
-    internal abstract class BraceSmartIndenterFactory
+    internal abstract class BraceSmartIndenterFactory : ILanguageService
     {
         public abstract BraceSmartIndenter Create(VisualStudioDocumentTracker documentTracker);
     }

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactory.cs
@@ -2,38 +2,32 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.ComponentModel.Composition;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Text.Operations;
 
-namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
+namespace Microsoft.VisualStudio.Editor.Razor
 {
-    [System.Composition.Shared]
-    [Export(typeof(BraceSmartIndenterFactory))]
     internal class DefaultBraceSmartIndenterFactory : BraceSmartIndenterFactory
     {
         private readonly IEditorOperationsFactoryService _editorOperationsFactory;
         private readonly ForegroundDispatcher _dispatcher;
 
-        [ImportingConstructor]
         public DefaultBraceSmartIndenterFactory(
-            IEditorOperationsFactoryService editorOperationsFactory,
-            [Import(typeof(VisualStudioWorkspace))] Workspace workspace)
+            ForegroundDispatcher dispatcher,
+            IEditorOperationsFactoryService editorOperationsFactory)
         {
+            if (dispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(dispatcher));
+            }
+
             if (editorOperationsFactory == null)
             {
                 throw new ArgumentNullException(nameof(editorOperationsFactory));
             }
 
-            if (workspace == null)
-            {
-                throw new ArgumentNullException(nameof(workspace));
-            }
-
+            _dispatcher = dispatcher;
             _editorOperationsFactory = editorOperationsFactory;
-            _dispatcher = workspace.Services.GetRequiredService<ForegroundDispatcher>();
         }
 
         public override BraceSmartIndenter Create(VisualStudioDocumentTracker documentTracker)

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactoryFactory.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.VisualStudio.Text.Operations;
+
+namespace Microsoft.VisualStudio.Editor.Razor
+{
+    [Shared]
+    [ExportLanguageServiceFactory(typeof(BraceSmartIndenterFactory), RazorLanguage.Name, ServiceLayer.Default)]
+    internal class DefaultBraceSmartIndenterFactoryFactory : ILanguageServiceFactory
+    {
+        private readonly IEditorOperationsFactoryService _editorOperationsFactory;
+
+        [ImportingConstructor]
+        public DefaultBraceSmartIndenterFactoryFactory(IEditorOperationsFactoryService editorOperationsFactory)
+        {
+            if (editorOperationsFactory == null)
+            {
+                throw new ArgumentNullException(nameof(editorOperationsFactory));
+            }
+
+            _editorOperationsFactory = editorOperationsFactory;
+        }
+
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            if (languageServices == null)
+            {
+                throw new ArgumentNullException(nameof(languageServices));
+            }
+
+            var dispatcher = languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>();
+            return new DefaultBraceSmartIndenterFactory(dispatcher, _editorOperationsFactory);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Editor/DefaultRazorEditorFactoryService.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Editor/DefaultRazorEditorFactoryService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Text;
 
@@ -21,6 +22,34 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
 
         [ImportingConstructor]
         public DefaultRazorEditorFactoryService(
+            VisualStudioDocumentTrackerFactory documentTrackerFactory,
+            VisualStudioRazorParserFactory parserFactory,
+            VisualStudioWorkspaceAccessor workspaceAccessor)
+        {
+            if (documentTrackerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(documentTrackerFactory));
+            }
+
+            if (parserFactory == null)
+            {
+                throw new ArgumentNullException(nameof(parserFactory));
+            }
+
+            if (workspaceAccessor == null)
+            {
+                throw new ArgumentNullException(nameof(workspaceAccessor));
+            }
+
+            _documentTrackerFactory = documentTrackerFactory;
+            _parserFactory = parserFactory;
+
+            var razorLanguageServices = workspaceAccessor.Workspace.Services.GetLanguageServices(RazorLanguage.Name);
+            _braceSmartIndenterFactory = razorLanguageServices.GetRequiredService<BraceSmartIndenterFactory>();
+        }
+
+        // Internal for testing
+        internal DefaultRazorEditorFactoryService(
             VisualStudioDocumentTrackerFactory documentTrackerFactory,
             VisualStudioRazorParserFactory parserFactory,
             BraceSmartIndenterFactory braceSmartIndenterFactory)


### PR DESCRIPTION
- Moved the `BraceSmartIndenterFactory` into the `Microsoft.VisualStudio.Editor.Razor` assembly so it can be used on Windows and Mac.
- Changed how the factory is exported since its only used internally. It now uses Roslyn services in the context of a Razor language service to be consistent with how the rest of Razor works.

#1789 

FYI @mkArtakMSFT 