### PR TITLE
Make RazorEditorFactoryService VS agnostic.

### DIFF
--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorEditorFactoryService.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorEditorFactoryService.cs
@@ -5,10 +5,9 @@ using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Text;
 
-namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
+namespace Microsoft.VisualStudio.Editor.Razor
 {
     [System.Composition.Shared]
     [Export(typeof(RazorEditorFactoryService))]
@@ -74,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
             }
 
             EnsureTextBufferInitialized(textBuffer);
-            
+
             if (!textBuffer.Properties.TryGetProperty(typeof(VisualStudioDocumentTracker), out documentTracker))
             {
                 Debug.Fail("Document tracker should have been stored on the text buffer during initialization.");

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorEditorFactoryServiceTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorEditorFactoryServiceTest.cs
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Moq;
 using Xunit;
 
-namespace Microsoft.VisualStudio.LanguageServices.Razor.Editor
+namespace Microsoft.VisualStudio.Editor.Razor
 {
     public class DefaultRazorEditorFactoryServiceTest
     {


### PR DESCRIPTION
- Moved the editor factory service into the Editor dll. It did not have any windows specific functionality within it.
- Supppper complex PR 😉 

#1789 

FYI @mkArtakMSFT 