### PR TITLE
Add `RazorLanguage.CoreContentType`.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor/RazorLanguage.cs
+++ b/src/Microsoft.CodeAnalysis.Razor/RazorLanguage.cs
@@ -8,5 +8,7 @@ namespace Microsoft.CodeAnalysis.Razor
         public const string Name = "Razor";
 
         public const string ContentType = "RazorCSharp";
+
+        public const string CoreContentType = "RazorCoreCSharp";
     }
 }

--- a/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionProvider.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionProvider.cs
@@ -205,7 +205,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 }
 
                 var mappedPoints = projectionSnapshot.MapToSourceSnapshots(context.CompletionListSpan.Start);
-                var htmlSnapshotPoints = mappedPoints.Where(p => p.Snapshot.TextBuffer.ContentType.IsOfType(RazorLanguage.ContentType));
+                var htmlSnapshotPoints = mappedPoints.Where(p => p.Snapshot.TextBuffer.IsRazorBuffer());
 
                 if (!htmlSnapshotPoints.Any())
                 {

--- a/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {
-    [ContentType(RazorLanguage.ContentType)]
+    [ContentType(RazorLanguage.CoreContentType)]
     [TextViewRole(PredefinedTextViewRoles.Document)]
     [Export(typeof(ITextViewConnectionListener))]
     internal class RazorTextViewConnectionListener : ITextViewConnectionListener

--- a/src/Microsoft.VisualStudio.Editor.Razor/TextBufferExtensions.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/TextBufferExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Text
                 throw new ArgumentNullException(nameof(textBuffer));
             }
 
-            return textBuffer.ContentType.IsOfType(RazorLanguage.ContentType);
+            return textBuffer.ContentType.IsOfType(RazorLanguage.CoreContentType);
         }
     }
 }

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorDocumentManagerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorDocumentManagerTest.cs
@@ -17,9 +17,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
 {
     public class DefaultRazorDocumentManagerTest : ForegroundDispatcherTestBase
     {
-        private IContentType RazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) == true);
+        private IContentType RazorCoreContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.CoreContentType) == true);
 
-        private IContentType NonRazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(It.IsAny<string>()) == false);
+        private IContentType NonRazorCoreContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(It.IsAny<string>()) == false);
 
         private string FilePath => "C:/Some/Path/TestDocumentTracker.cshtml";
 
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var textView = Mock.Of<ITextView>();
             var buffers = new Collection<ITextBuffer>()
             {
-                Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection()),
             };
 
             // Act & Assert
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var textView = Mock.Of<ITextView>();
             var buffers = new Collection<ITextBuffer>()
             {
-                Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorCoreContentType && b.Properties == new PropertyCollection()),
             };
 
             // Act & Assert
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var textView = Mock.Of<ITextView>();
             var buffers = new Collection<ITextBuffer>()
             {
-                Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection()),
             };
             var documentTracker = new DefaultVisualStudioDocumentTracker(Dispatcher, FilePath, ProjectPath, ProjectManager, EditorSettingsManager, Workspace, buffers[0], ImportDocumentManager) as VisualStudioDocumentTracker;
             var editorFactoryService = Mock.Of<RazorEditorFactoryService>(factoryService => factoryService.TryGetDocumentTracker(It.IsAny<ITextBuffer>(), out documentTracker) == true);
@@ -99,8 +99,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var textView = Mock.Of<ITextView>();
             var buffers = new Collection<ITextBuffer>()
             {
-                Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection()),
-                Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorCoreContentType && b.Properties == new PropertyCollection()),
             };
             var documentTracker = new DefaultVisualStudioDocumentTracker(Dispatcher, FilePath, ProjectPath, ProjectManager, EditorSettingsManager, Workspace, buffers[0], ImportDocumentManager) as VisualStudioDocumentTracker;
             var editorFactoryService = Mock.Of<RazorEditorFactoryService>(f => f.TryGetDocumentTracker(It.IsAny<ITextBuffer>(), out documentTracker) == true);
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var textView = Mock.Of<ITextView>();
             var buffers = new Collection<ITextBuffer>()
             {
-                Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection()),
             };
 
             // Act
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var textView = Mock.Of<ITextView>();
             var buffers = new Collection<ITextBuffer>()
             {
-                Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection()),
             };
 
             // Act
@@ -160,8 +160,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var textView2 = Mock.Of<ITextView>();
             var buffers = new Collection<ITextBuffer>()
             {
-                Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection()),
-                Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorCoreContentType && b.Properties == new PropertyCollection()),
             };
 
             // Preload the buffer's properties with a tracker, so it's like we've already tracked this one.
@@ -197,8 +197,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var textView2 = Mock.Of<ITextView>();
             var buffers = new Collection<ITextBuffer>()
             {
-                Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection()),
-                Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection()),
+                Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorCoreContentType && b.Properties == new PropertyCollection()),
             };
             var documentTracker = new DefaultVisualStudioDocumentTracker(Dispatcher, FilePath, ProjectPath, ProjectManager, EditorSettingsManager, Workspace, buffers[0], ImportDocumentManager);
             buffers[0].Properties.AddProperty(typeof(VisualStudioDocumentTracker), documentTracker);

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorEditorFactoryServiceTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorEditorFactoryServiceTest.cs
@@ -11,9 +11,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
 {
     public class DefaultRazorEditorFactoryServiceTest
     {
-        private IContentType RazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) == true);
+        private IContentType RazorCoreContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.CoreContentType) == true);
 
-        private IContentType NonRazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(It.IsAny<string>()) == false);
+        private IContentType NonRazorCoreContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(It.IsAny<string>()) == false);
 
         [Fact]
         public void TryGetDocumentTracker_ForRazorTextBuffer_ReturnsTrue()
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Arrange
             var expectedDocumentTracker = Mock.Of<VisualStudioDocumentTracker>();
             var factoryService = CreateFactoryService(expectedDocumentTracker);
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection());
 
             // Act
             var result = factoryService.TryGetDocumentTracker(textBuffer, out var documentTracker);
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var factoryService = CreateFactoryService();
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorCoreContentType && b.Properties == new PropertyCollection());
 
             // Act
             var result = factoryService.TryGetDocumentTracker(textBuffer, out var documentTracker);
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Arrange
             var expectedDocumentTracker = Mock.Of<VisualStudioDocumentTracker>();
             var factoryService = CreateFactoryService(expectedDocumentTracker);
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection());
 
             // Act
             factoryService.EnsureTextBufferInitialized(textBuffer);
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var factoryService = CreateFactoryService();
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection());
             factoryService.EnsureTextBufferInitialized(textBuffer);
             var expectedDocumentTracker = textBuffer.Properties[typeof(VisualStudioDocumentTracker)];
 
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Arrange
             var expectedParser = Mock.Of<VisualStudioRazorParser>();
             var factoryService = CreateFactoryService(parser: expectedParser);
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection());
 
             // Act
             var result = factoryService.TryGetParser(textBuffer, out var parser);
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var factoryService = CreateFactoryService();
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorCoreContentType && b.Properties == new PropertyCollection());
 
             // Act
             var result = factoryService.TryGetParser(textBuffer, out var parser);
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Arrange
             var expectedParser = Mock.Of<VisualStudioRazorParser>();
             var factoryService = CreateFactoryService(parser: expectedParser);
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection());
 
             // Act
             factoryService.EnsureTextBufferInitialized(textBuffer);
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var factoryService = CreateFactoryService();
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection());
             factoryService.EnsureTextBufferInitialized(textBuffer);
             var expectedParser = textBuffer.Properties[typeof(VisualStudioRazorParser)];
 
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Arrange
             var expectedSmartIndenter = Mock.Of<BraceSmartIndenter>();
             var factoryService = CreateFactoryService(smartIndenter: expectedSmartIndenter);
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection());
 
             // Act
             var result = factoryService.TryGetSmartIndenter(textBuffer, out var smartIndenter);
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var factoryService = CreateFactoryService();
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == NonRazorCoreContentType && b.Properties == new PropertyCollection());
 
             // Act
             var result = factoryService.TryGetSmartIndenter(textBuffer, out var smartIndenter);
@@ -186,7 +186,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Arrange
             var expectedSmartIndenter = Mock.Of<BraceSmartIndenter>();
             var factoryService = CreateFactoryService(smartIndenter: expectedSmartIndenter);
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection());
 
             // Act
             factoryService.EnsureTextBufferInitialized(textBuffer);
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var factoryService = CreateFactoryService();
-            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType && b.Properties == new PropertyCollection());
+            var textBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType && b.Properties == new PropertyCollection());
             factoryService.EnsureTextBufferInitialized(textBuffer);
             var expectedSmartIndenter = textBuffer.Properties[typeof(BraceSmartIndenter)];
 

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultTextBufferProviderTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultTextBufferProviderTest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             var contentType = new Mock<IContentType>();
             contentType.Setup(type => type.IsOfType(It.IsAny<string>()))
-                .Returns<string>(val => val == RazorLanguage.ContentType);
+                .Returns<string>(val => val == RazorLanguage.CoreContentType);
             textBuffer.Setup(buffer => buffer.ContentType)
                 .Returns(contentType.Object);
 

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
@@ -17,9 +17,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
 {
     public class DefaultVisualStudioDocumentTrackerTest : ForegroundDispatcherTestBase
     {
-        private IContentType RazorContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) == true);
+        private IContentType RazorCoreContentType { get; } = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.CoreContentType) == true);
 
-        private ITextBuffer TextBuffer => Mock.Of<ITextBuffer>(b => b.ContentType == RazorContentType);
+        private ITextBuffer TextBuffer => Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType);
 
         private string FilePath => "C:/Some/Path/TestDocumentTracker.cshtml";
 


### PR DESCRIPTION
- Going to wait to merge this until the web tooling side has the core content type changes in VS for mac. That way we can continue to test against VS for mac without changing content type. /cc @ToddGrun 

#1852 

FYI @mkArtakMSFT 