### PR TITLE
Include the VSIX and MPack files in the bill of materials

### DIFF
--- a/build/MPack.targets
+++ b/build/MPack.targets
@@ -1,11 +1,36 @@
 ﻿<Project>
   <PropertyGroup>
     <PackageDependsOn Condition="'$(OS)'=='Windows_NT'">$(PackageDependsOn);GenerateMPack</PackageDependsOn>
+    <GetArtifactInfoDependsOn Condition="'$(OS)'=='Windows_NT'">$(GetArtifactInfoDependsOn);GetMPackArtifactInfo</GetArtifactInfoDependsOn>
     <AddinName>Microsoft.VisualStudio.Mac.RazorAddin</AddinName>
     <AddinDirectory>$(RepositoryRoot)tooling\$(AddinName)\</AddinDirectory>
+    <MPackArtifactCategory>shipoob</MPackArtifactCategory>
+
+    <MPackIntermediateOutputPath>$(IntermediateDir)mpack\</MPackIntermediateOutputPath>
+    <AddinOutputPath>$(AddinDirectory)bin\$(Configuration)\net461\</AddinOutputPath>
+    <LanguageServiceName>Microsoft.VisualStudio.Mac.LanguageServices.Razor</LanguageServiceName>
+    <LanguageServiceOutputPath>$(RepositoryRoot)src\$(LanguageServiceName)\bin\$(Configuration)\net461\</LanguageServiceOutputPath>
+    <MPackName>$(AddinName)_$(AddinVersion)</MPackName>
+    <MPackFileName>$(MPackName).mpack</MPackFileName>
+    <MPackOutputPath>$(BuildDir)$(MPackFileName)</MPackOutputPath>
+    <MPackZipFile>$(BuildDir)$(MPackName).zip</MPackZipFile>
+    <MPackManifest>$(AddinDirectory)Properties\_Manifest.addin.xml</MPackManifest>
+    <AddinInfoFilePath>$(MPackIntermediateOutputPath)addin.info</AddinInfoFilePath>
   </PropertyGroup>
 
   <Import Project="$(AddinDirectory)AddinMetadata.props" />
+
+  <!-- This target is required so KoreBuild can generate a bill of materials with relevant information about the .mpack files. -->
+  <Target Name="GetMPackArtifactInfo">
+    <ItemGroup>
+      <ArtifactInfo Include="$(MPackOutputPath)">
+        <ArtifactType>MPackFile</ArtifactType>
+        <PackageId>$(AddinName)</PackageId>
+        <Version>$(AddinVersion)</Version>
+        <Category>$(MPackArtifactCategory)</Category>
+      </ArtifactInfo>
+    </ItemGroup>
+  </Target>
 
   <Target
     Name="GenerateMPack"
@@ -19,21 +44,8 @@
       3. All language service binaries
     -->
 
-    <PropertyGroup>
-      <MSBuildArtifactsDir>$(ArtifactsDir)msbuild\</MSBuildArtifactsDir>
-      <MPackSourcesDir>$(MSBuildArtifactsDir)sources\</MPackSourcesDir>
-      <AddinOutputPath>$(AddinDirectory)bin\$(Configuration)\net461\</AddinOutputPath>
-      <LanguageServiceName>Microsoft.VisualStudio.Mac.LanguageServices.Razor</LanguageServiceName>
-      <LanguageServiceOutputPath>$(RepositoryRoot)src\$(LanguageServiceName)\bin\$(Configuration)\net461\</LanguageServiceOutputPath>
-      <MPackName>$(AddinName)_$(AddinVersion)</MPackName>
-      <MPackFileName>$(MPackName).mpack</MPackFileName>
-      <MPackOutputPath>$(BuildDir)$(MPackFileName)</MPackOutputPath>
-      <MPackZipFile>$(BuildDir)$(MPackName).zip</MPackZipFile>
-      <MPackManifest>$(AddinDirectory)Properties\_Manifest.addin.xml</MPackManifest>
-      <AddinInfoFilePath>$(MPackSourcesDir)addin.info</AddinInfoFilePath>
-    </PropertyGroup>
-    
-    <MakeDir Directories="$(MPackSourcesDir)" Condition="!Exists('$(MPackSourcesDir)')" />
+  
+    <MakeDir Directories="$(MPackIntermediateOutputPath)" Condition="!Exists('$(MPackIntermediateOutputPath)')" />
     <Delete Files="$(MPackOutputPath)" Condition="Exists('$(MPackOutputPath)')" />
 
     <!-- We need to resolve the language service assemblies to generate an addin.info for the mpack -->
@@ -60,11 +72,11 @@
 
     <!-- Generate the addin.info and gather sources for mpack zipping-->
     <WriteLinesToFile File="$(AddinInfoFilePath)" Lines="@(AddinInfoLines)" Overwrite="true" />
-    <Copy SourceFiles="$(LanguageServiceOutputPath)\%(LanguageServiceAssemblies.Identity)" DestinationFolder="$(MPackSourcesDir)" />
-    <Copy SourceFiles="$(AddinOutputPath)$(AddinName).dll" DestinationFolder="$(MPackSourcesDir)" />
+    <Copy SourceFiles="$(LanguageServiceOutputPath)\%(LanguageServiceAssemblies.Identity)" DestinationFolder="$(MPackIntermediateOutputPath)" />
+    <Copy SourceFiles="$(AddinOutputPath)$(AddinName).dll" DestinationFolder="$(MPackIntermediateOutputPath)" />
 
     <!-- We cannot use the ZipArchive task due to how it functions in CoreCLR. The archive it generates is unreadable by Visual Studio for Mac. -->
-    <Exec Command="powershell.exe -NonInteractive -command &quot;&amp; { Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::CreateFromDirectory('$(MPackSourcesDir)', '$(MPackOutputPath)') } &quot;" />
+    <Exec Command="powershell.exe -NonInteractive -command &quot;&amp; { Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::CreateFromDirectory('$(MPackIntermediateOutputPath)', '$(MPackOutputPath)') } &quot;" />
   </Target>
 
 </Project>

--- a/build/VSIX.targets
+++ b/build/VSIX.targets
@@ -3,10 +3,12 @@
     <BuildVSIX Condition="'$(BuildVSIX)' ==''">true</BuildVSIX>
     <RestoreDependsOn Condition="'$(OS)'=='Windows_NT' AND '$(BuildVSIX)' == 'true'">$(RestoreDependsOn);RestoreVSIX</RestoreDependsOn>
     <PackageDependsOn Condition="'$(OS)'=='Windows_NT' AND '$(BuildVSIX)' == 'true'">$(PackageDependsOn);PackageVSIX</PackageDependsOn>
+    <GetArtifactInfoDependsOn Condition="'$(OS)'=='Windows_NT' AND '$(BuildVSIX)' == 'true'">$(GetArtifactInfoDependsOn);GetVSIXArtifactInfo</GetArtifactInfoDependsOn>
     <VSIXName>Microsoft.VisualStudio.RazorExtension</VSIXName>
     <VSIXOutputPath>$(BuildDir)$(VSIXName).vsix</VSIXOutputPath>
+    <VSIXManifestOutputPath>$(BuildDir)$(VSIXName).json</VSIXManifestOutputPath>
     <VSIXProject>$(RepositoryRoot)tooling\$(VSIXName)\$(VSIXName).csproj</VSIXProject>
-    <MSBuildArtifactsDir>$(ArtifactsDir)msbuild\</MSBuildArtifactsDir>
+    <VSIXArtifactCategory>shipoob</VSIXArtifactCategory>
   </PropertyGroup>
 
   <Target
@@ -14,13 +16,34 @@
     DependsOnTargets="RestoreVSIX;PackageVSIX"
     Condition="'$(OS)'=='Windows_NT'" />
 
+  <!-- This target is required so KoreBuild can generate a bill of materials with relevant information about the VSIX. -->
+  <Target Name="GetVSIXArtifactInfo">
+    <ItemGroup>
+
+      <ArtifactInfo Include="$(VSIXOutputPath)">
+        <ArtifactType>VsixPackage</ArtifactType>
+        <Version>$(PackageVersion)</Version>
+        <Category>$(VSIXArtifactCategory)</Category>
+        <PackageId>$(VSIXName)</PackageId>
+      </ArtifactInfo>
+
+      <ArtifactInfo Include="$(VSIXManifestOutputPath)">
+        <ArtifactType>VsixPackageManifestFile</ArtifactType>
+        <Category>$(VSIXArtifactCategory)</Category>
+        <Dependencies>$(VSIXName).vsix</Dependencies>
+        <PackageId>$(VSIXName)</PackageId>
+      </ArtifactInfo>
+
+    </ItemGroup>
+  </Target>
+
   <!--
     VisualStudioMSBuildx86Path is set by the GetToolsets target in KoreBuild if a version of VS matching the requirements in korebuild.json is found.
    -->
   <Target Name="RestoreVSIX" DependsOnTargets="GetToolsets">
 
     <PropertyGroup>
-      <VSIXResponseFilePath>$(MSBuildArtifactsDir)vsix-restore.rsp</VSIXResponseFilePath>
+      <VSIXResponseFilePath>$(LogOutputDir)vsix-restore.rsp</VSIXResponseFilePath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -36,7 +59,7 @@
       <MSBuildArguments Include="/p:DotNetRestoreSourcePropsPath=$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''" />
     </ItemGroup>
 
-    <MakeDir Directories="$(MSBuildArtifactsDir)" />
+    <MakeDir Directories="$(LogOutputDir)" />
 
     <WriteLinesToFile
       File="$(VSIXResponseFilePath)"
@@ -53,8 +76,8 @@
       Condition="'$(VisualStudioMSBuildx86Path)' == ''" />
 
     <PropertyGroup>
-      <VSIXLogFilePath>$(MSBuildArtifactsDir)vsix.log</VSIXLogFilePath>
-      <VSIXResponseFilePath>$(MSBuildArtifactsDir)vsix-build.rsp</VSIXResponseFilePath>
+      <VSIXLogFilePath>$(LogOutputDir)vsix.log</VSIXLogFilePath>
+      <VSIXResponseFilePath>$(LogOutputDir)vsix-build.rsp</VSIXResponseFilePath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -70,7 +93,7 @@
         /p:Configuration=$(Configuration);" />
     </ItemGroup>
 
-    <MakeDir Directories="$(MSBuildArtifactsDir)" />
+    <MakeDir Directories="$(LogOutputDir)" />
 
     <WriteLinesToFile
       File="$(VSIXResponseFilePath)"

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview1-15626
-commithash:fd6410e9c90c428bc01238372303ad09cb9ec889
+version:2.1.0-preview1-15639
+commithash:231066d459f3c86a94b5bdcd197a3c2e4992a7ff

--- a/version.props
+++ b/version.props
@@ -10,7 +10,6 @@
     <AddinBuildNumber Condition="'$(BuildNumber)' == 't000'">99999</AddinBuildNumber>
     <AddinBuildNumber Condition="'$(AddinBuildNumber)' == ''">$(BuildNumber)</AddinBuildNumber>
     
-    
     <!-- Properties for VS for Mac addin -->
     <VSForMacVersion>7.0</VSForMacVersion>
     <AddinVersion>$(VSForMacVersion).$(AddinBuildNumber)</AddinVersion>


### PR DESCRIPTION
Part of https://github.com/aspnet/Universe/issues/679

Updates KoreBuild to generate the BOM (bill of materials). This includes metadata about the files produced in a build, and asserts that everything in `artifacts/` is accounted for in the BOM.

Note: you should probably run `build.cmd /t:Clean` after pulling this change