### PR TITLE
Moved TagHelperParseTreeRewriter out of LegacyRazorDiagnostic

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/ErrorSink.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/ErrorSink.cs
@@ -30,18 +30,5 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         /// </summary>
         /// <param name="error">The <see cref="RazorError"/> to track.</param>
         public void OnError(RazorDiagnostic error) =>_errors.Add(error);
-
-        /// <summary>
-        /// Creates and tracks a new <see cref="RazorDiagnostic"/>.
-        /// </summary>
-        /// <param name="location"><see cref="SourceLocation"/> of the error.</param>
-        /// <param name="message">A message describing the error.</param>
-        /// <param name="length">The length of the error.</param>
-        /// <remarks>This is temporary. It will be removed once we get rid of <see cref="LegacyRazorDiagnostic"/>.</remarks>
-        public void OnError(SourceLocation location, string message, int length)
-        {
-            var error = RazorDiagnostic.Create(new RazorError(message, location, length));
-            _errors.Add(error);
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -291,12 +291,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         {
                             // End tag TagHelper that states it shouldn't have an end tag.
                             errorSink.OnError(
-                                SourceLocationTracker.Advance(tagBlock.Start, "</"),
-                                LegacyResources.FormatTagHelperParseTreeRewriter_EndTagTagHelperMustNotHaveAnEndTag(
+                                RazorDiagnosticFactory.CreateParsing_TagHelperMustNotHaveAnEndTag(
+                                    new SourceSpan(SourceLocationTracker.Advance(tagBlock.Start, "</"), tagName.Length),
                                     tagName,
                                     descriptor.DisplayName,
-                                    invalidRule.TagStructure),
-                                tagName.Length);
+                                    invalidRule.TagStructure));
 
                             return false;
                         }
@@ -317,9 +316,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         // Could not recover, the end tag helper has no corresponding start tag, create
                         // an error based on the current childBlock.
                         errorSink.OnError(
-                            SourceLocationTracker.Advance(tagBlock.Start, "</"),
-                            LegacyResources.FormatTagHelpersParseTreeRewriter_FoundMalformedTagHelper(tagName),
-                            tagName.Length);
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(SourceLocationTracker.Advance(tagBlock.Start, "</"), tagName.Length), tagName));
 
                         return false;
                     }
@@ -502,11 +500,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     var allowedChildren = _currentTagHelperTracker.AllowedChildren;
                     var allowedChildrenString = string.Join(", ", allowedChildren);
                     errorSink.OnError(
-                        errorStart,
-                        LegacyResources.FormatTagHelperParseTreeRewriter_CannotHaveNonTagContent(
+                        RazorDiagnosticFactory.CreateTagHelper_CannotHaveNonTagContent(
+                            new SourceSpan(errorStart, length),
                             _currentTagHelperTracker.TagName,
-                            allowedChildrenString),
-                        length);
+                            allowedChildrenString));
                 }
             }
         }
@@ -559,13 +556,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             ErrorSink errorSink)
         {
             var allowedChildrenString = string.Join(", ", tracker.AllowedChildren);
-            var errorMessage = LegacyResources.FormatTagHelperParseTreeRewriter_InvalidNestedTag(
-                tagName,
-                tracker.TagName,
-                allowedChildrenString);
             var errorStart = GetTagDeclarationErrorStart(tagBlock);
 
-            errorSink.OnError(errorStart, errorMessage, tagName.Length);
+            errorSink.OnError(
+                RazorDiagnosticFactory.CreateTagHelper_InvalidNestedTag(
+                    new SourceSpan(errorStart, tagName.Length),
+                    tagName,
+                    tracker.TagName,
+                    allowedChildrenString));
         }
 
         private static void ValidateBinding(
@@ -589,13 +587,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         if (baseStructure.HasValue && baseStructure != rule.TagStructure)
                         {
                             errorSink.OnError(
-                                tagBlock.Start,
-                                LegacyResources.FormatTagHelperParseTreeRewriter_InconsistentTagStructure(
+                                RazorDiagnosticFactory.CreateTagHelper_InconsistentTagStructure(
+                                    new SourceSpan(tagBlock.Start, tagBlock.Length),
                                     baseDescriptor.DisplayName,
                                     descriptor.DisplayName,
-                                    tagName,
-                                    nameof(TagMatchingRuleDescriptor.TagStructure)),
-                                tagBlock.Length);
+                                    tagName));
                         }
 
                         baseDescriptor = descriptor;
@@ -613,9 +609,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 var errorStart = GetTagDeclarationErrorStart(tag);
 
                 errorSink.OnError(
-                    errorStart,
-                    LegacyResources.FormatTagHelpersParseTreeRewriter_MissingCloseAngle(tagName),
-                    tagName.Length);
+                    RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                        new SourceSpan(errorStart, tagName.Length), tagName));
 
                 return false;
             }
@@ -771,10 +766,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 var malformedTagHelper = ((TagHelperBlockTracker)tracker).Builder;
 
                 errorSink.OnError(
-                    SourceLocationTracker.Advance(malformedTagHelper.Start, "<"),
-                    LegacyResources.FormatTagHelpersParseTreeRewriter_FoundMalformedTagHelper(
-                        malformedTagHelper.TagName),
-                    malformedTagHelper.TagName.Length);
+                    RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                        new SourceSpan(SourceLocationTracker.Advance(malformedTagHelper.Start, "<"), malformedTagHelper.TagName.Length),
+                        malformedTagHelper.TagName));
 
                 BuildCurrentlyTrackedTagHelperBlock(endTag: null);
             }

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticFactory.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorDiagnosticFactory.cs
@@ -370,6 +370,53 @@ namespace Microsoft.AspNetCore.Razor.Language
             return RazorDiagnostic.Create(Parsing_TagHelperAttributesMustHaveAName, location, tagName);
         }
 
+        internal static readonly RazorDiagnosticDescriptor Parsing_TagHelperMustNotHaveAnEndTag =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}1033",
+                () => LegacyResources.TagHelperParseTreeRewriter_EndTagTagHelperMustNotHaveAnEndTag,
+                RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateParsing_TagHelperMustNotHaveAnEndTag(SourceSpan location, string tagName, string displayName, TagStructure tagStructure)
+        {
+            var diagnostic = RazorDiagnostic.Create(
+                Parsing_TagHelperMustNotHaveAnEndTag,
+                location,
+                tagName,
+                displayName,
+                tagStructure);
+
+            return diagnostic;
+        }
+
+        internal static readonly RazorDiagnosticDescriptor Parsing_TagHelperFoundMalformedTagHelper =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}1034",
+                () => LegacyResources.TagHelpersParseTreeRewriter_FoundMalformedTagHelper,
+                RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateParsing_TagHelperFoundMalformedTagHelper(SourceSpan location, string tagName)
+        {
+            var diagnostic = RazorDiagnostic.Create(
+                Parsing_TagHelperFoundMalformedTagHelper,
+                location,
+                tagName);
+
+            return diagnostic;
+        }
+
+        internal static readonly RazorDiagnosticDescriptor Parsing_TagHelperMissingCloseAngle =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}1035",
+                () => LegacyResources.TagHelpersParseTreeRewriter_MissingCloseAngle,
+                RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateParsing_TagHelperMissingCloseAngle(SourceSpan location, string tagName)
+        {
+            var diagnostic = RazorDiagnostic.Create(
+                Parsing_TagHelperMissingCloseAngle,
+                location,
+                tagName);
+
+            return diagnostic;
+        }
+
         #endregion
 
         #region Semantic Errors
@@ -470,6 +517,36 @@ namespace Microsoft.AspNetCore.Razor.Language
         public static RazorDiagnostic CreateTagHelper_EmptyBoundAttribute(SourceSpan location, string attributeName, string tagName, string propertyTypeName)
         {
             return RazorDiagnostic.Create(TagHelper_EmptyBoundAttribute, location, attributeName, tagName, propertyTypeName);
+        }
+
+        internal static readonly RazorDiagnosticDescriptor TagHelper_CannotHaveNonTagContent =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}2009",
+                () => LegacyResources.TagHelperParseTreeRewriter_CannotHaveNonTagContent,
+                RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateTagHelper_CannotHaveNonTagContent(SourceSpan location, string tagName, string allowedChildren)
+        {
+            return RazorDiagnostic.Create(TagHelper_CannotHaveNonTagContent, location, tagName, allowedChildren);
+        }
+
+        internal static readonly RazorDiagnosticDescriptor TagHelper_InvalidNestedTag =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}2010",
+                () => LegacyResources.TagHelperParseTreeRewriter_InvalidNestedTag,
+                RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateTagHelper_InvalidNestedTag(SourceSpan location, string tagName, string parent, string allowedChildren)
+        {
+            return RazorDiagnostic.Create(TagHelper_InvalidNestedTag, location, tagName, parent, allowedChildren);
+        }
+
+        internal static readonly RazorDiagnosticDescriptor TagHelper_InconsistentTagStructure =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}2011",
+                () => LegacyResources.TagHelperParseTreeRewriter_InconsistentTagStructure,
+                RazorDiagnosticSeverity.Error);
+        public static RazorDiagnostic CreateTagHelper_InconsistentTagStructure(SourceSpan location, string firstDescriptor, string secondDescriptor, string tagName)
+        {
+            return RazorDiagnostic.Create(TagHelper_InconsistentTagStructure, location, firstDescriptor, secondDescriptor, tagName, nameof(TagMatchingRuleDescriptor.TagStructure));
         }
 
         #endregion

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -419,11 +419,8 @@ namespace Microsoft.AspNetCore.Razor.Language
             var originalTree = RazorSyntaxTree.Parse(sourceDocument);
 
             var initialError = RazorDiagnostic.Create(new RazorError("Initial test error", SourceLocation.Zero, length: 1));
-            var expectedRewritingError = RazorDiagnostic.Create(
-                new RazorError(
-                    LegacyResources.FormatTagHelpersParseTreeRewriter_FoundMalformedTagHelper("form"),
-                    new SourceLocation(Environment.NewLine.Length * 2 + 30, 2, 1),
-                    length: 4));
+            var expectedRewritingError = RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                new SourceSpan(new SourceLocation(Environment.NewLine.Length * 2 + 30, 2, 1), contentLength: 4), "form");
 
             var erroredOriginalTree = RazorSyntaxTree.Create(originalTree.Root, originalTree.Source, new[] { initialError }, originalTree.Options);
             codeDocument.SetSyntaxTree(erroredOriginalTree);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
@@ -343,9 +343,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             {
                 var factory = new SpanFactory();
                 var blockFactory = new BlockFactory(factory);
-                var errorFormatUnclosed = "Found a malformed '{0}' tag helper. Tag helpers must have a start and " +
-                                          "end tag or be self closing.";
-                var errorFormatNoCloseAngle = "Missing close angle for tag helper '{0}'.";
                 Func<string, Block> createInvalidDoBlock = extraCode =>
                 {
                     return new MarkupBlock(
@@ -375,14 +372,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -395,10 +388,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -414,14 +405,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -439,14 +426,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -462,15 +445,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnosticFactory.CreateParsing_TagHelperAttributeListMustBeWellFormed(new SourceSpan(12, 0, 12, 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperAttributeListMustBeWellFormed(
+                                new SourceSpan(12, 0, 12, 1))
                         }
                     },
                     {
@@ -485,14 +465,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -509,14 +485,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -531,18 +503,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 new MarkupTagHelperBlock("strong"))),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                new SourceLocation(11, 0, 11),
-                                length: 6))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(11, 0, 11), contentLength: 6), "strong"),
                         }
                     },
                     {
@@ -555,10 +521,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -571,10 +535,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -591,18 +553,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 new MarkupTagHelperBlock("strong"))),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                new SourceLocation(24, 0, 24),
-                                length: 6))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(24, 0, 24), contentLength: 6), "strong")
                         }
                     },
                     {
@@ -660,10 +616,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -678,14 +632,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
                             RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
                                 new SourceSpan(new SourceLocation(11, 0, 11), contentLength: 1), "do", "}", "{"),
                         }
@@ -700,14 +650,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
                             RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
                                 new SourceSpan(new SourceLocation(11, 0, 11), contentLength: 1), "do", "}", "{"),
                             RazorDiagnosticFactory.CreateParsing_UnterminatedStringLiteral(
@@ -720,14 +666,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             new MarkupTagHelperBlock("p")),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
                             RazorDiagnosticFactory.CreateParsing_TagHelpersCannotHaveCSharpInTagDeclaration(new SourceSpan(3, 0, 3, 30), "p"),
                             RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
                                 new SourceSpan(new SourceLocation(4, 0, 4), contentLength: 1), "do", "}", "{"),
@@ -768,9 +710,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             {
                 var factory = new SpanFactory();
                 var blockFactory = new BlockFactory(factory);
-                var errorFormatUnclosed = "Found a malformed '{0}' tag helper. Tag helpers must have a start and " +
-                                          "end tag or be self closing.";
-                var errorFormatNoCloseAngle = "Missing close angle for tag helper '{0}'.";
 
                 return new TheoryData<string, MarkupBlock, RazorDiagnostic[]>
                 {
@@ -780,14 +719,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             new MarkupTagHelperBlock("p")),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                         }
                     },
                     {
@@ -796,9 +731,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             new MarkupTagHelperBlock("p")),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "p"),
-                                absoluteIndex: 5, lineIndex: 0, columnIndex: 5, length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(absoluteIndex: 5, lineIndex: 0, characterIndex: 5, length: 1), "p")
                         }
                     },
                     {
@@ -808,18 +742,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 new MarkupTagHelperBlock("strong"))),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "strong"),
-                                new SourceLocation(4, 0, 4),
-                                length: 6)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                new SourceLocation(4, 0, 4),
-                                length: 6))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(4, 0, 4), contentLength: 6), "strong"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(4, 0, 4), contentLength: 6), "strong")
                         }
                     },
                     {
@@ -829,18 +757,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 new MarkupTagHelperBlock("p"))),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "strong"),
-                                new SourceLocation(1, 0, 1),
-                                length: 6)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                new SourceLocation(1, 0, 1),
-                                length: 6)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(9, 0, 9),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 6), "strong"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 6), "strong"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(9, 0, 9), contentLength: 1), "p")
                         }
                     },
                     {
@@ -849,14 +771,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             new MarkupTagHelperBlock("strong")),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "strong"),
-                                new SourceLocation(1, 0, 1),
-                                length: 6)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatNoCloseAngle, "strong"),
-                                new SourceLocation(10, 0, 10),
-                                length: 6))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 6), "strong"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(10, 0, 10), contentLength: 6), "strong")
                         }
                     },
                     {
@@ -870,14 +788,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             new MarkupTagHelperBlock("p")),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                new SourceLocation(4, 0, 4),
-                                length: 6)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(14, 0, 14),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(4, 0, 4), contentLength: 6), "strong"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(14, 0, 14), contentLength: 1), "p")
                         }
                     },
                     {
@@ -892,10 +806,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 factory.Markup(">"))),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "strong"),
-                                new SourceLocation(3, 0, 3),
-                                length: 6))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(3, 0, 3), contentLength: 6), "strong")
                         }
                     },
                     {
@@ -906,10 +818,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 blockFactory.MarkupTagBlock("</p>"))),
                         new []
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(CultureInfo.InvariantCulture, errorFormatUnclosed, "p"),
-                                new SourceLocation(14, 0, 14),
-                                length: 1))
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(14, 0, 14), contentLength: 1), "p")
                         }
                     }
                 };
@@ -1209,8 +1119,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             {
                 var factory = new SpanFactory();
                 var blockFactory = new BlockFactory(factory);
-                var malformedErrorFormat = "Found a malformed '{0}' tag helper. Tag helpers must have a start and " +
-                                           "end tag or be self closing.";
 
                 yield return new object[]
                 {
@@ -1241,12 +1149,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             blockFactory.MarkupTagBlock("</strong>")),
                     new RazorDiagnostic[]
                     {
-                        RazorDiagnostic.Create(new RazorError(
-                            string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "strong"),
-                            absoluteIndex: 53, lineIndex: 0, columnIndex: 53, length: 6)),
-                        RazorDiagnostic.Create(new RazorError(
-                            string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "strong"),
-                            absoluteIndex: 66, lineIndex: 0, columnIndex: 66, length: 6))
+                        RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                            new SourceSpan(absoluteIndex: 53, lineIndex: 0, characterIndex: 53, length: 6), "strong"),
+                        RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                            new SourceSpan(absoluteIndex: 66, lineIndex: 0, characterIndex: 66, length: 6), "strong")
                     }
                 };
                 yield return new object[]
@@ -1261,9 +1167,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             blockFactory.MarkupTagBlock("</div>"))),
                     new RazorDiagnostic[]
                     {
-                        RazorDiagnostic.Create(new RazorError(
-                            string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "p"),
-                            absoluteIndex: 6, lineIndex: 0, columnIndex: 6, length: 1))
+                        RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                            new SourceSpan(absoluteIndex: 6, lineIndex: 0, characterIndex: 6, length: 1), "p")
                     }
                 };
                 yield return new object[]
@@ -1278,12 +1183,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 blockFactory.MarkupTagBlock("</div>")))),
                     new RazorDiagnostic[]
                     {
-                        RazorDiagnostic.Create(new RazorError(
-                            string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "p"),
-                            absoluteIndex: 6, lineIndex: 0, columnIndex: 6, length: 1)),
-                        RazorDiagnostic.Create(new RazorError(
-                            string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "strong"),
-                            absoluteIndex: 15, lineIndex: 0, columnIndex: 15, length: 6))
+                        RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                            new SourceSpan(absoluteIndex: 6, lineIndex: 0, characterIndex: 6, length: 1), "p"),
+                        RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                            new SourceSpan(absoluteIndex: 15, lineIndex: 0, characterIndex: 15, length: 6), "strong")
                     }
                 };
                 yield return new object[]
@@ -1304,10 +1207,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 factory.Markup("World")))),
                     new RazorDiagnostic[]
                     {
-                        RazorDiagnostic.Create(new RazorError(
-                            string.Format(CultureInfo.InvariantCulture, malformedErrorFormat, "p"),
-                            new SourceLocation(1, 0, 1),
-                            length: 1))
+                        RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                            new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p")
                     }
                 };
             }
@@ -3694,9 +3595,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             {
                 var factory = new SpanFactory();
                 var noErrors = new RazorDiagnostic[0];
-                var errorFormatUnclosed = "Found a malformed '{0}' tag helper. Tag helpers must have a start and " +
-                    "end tag or be self closing.";
-                var errorFormatNoCloseAngle = "Missing close angle for tag helper '{0}'.";
                 var stringType = typeof(string).FullName;
                 var intType = typeof(int).FullName;
 
@@ -3715,14 +3613,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new[]
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatNoCloseAngle, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatUnclosed, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
                         }
                     },
                     {
@@ -3737,14 +3631,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new[]
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatNoCloseAngle, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatUnclosed, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
                             RazorDiagnosticFactory.CreateTagHelper_EmptyBoundAttribute(
                                 new SourceSpan(7, 0, 7, 21),
                                 "bound-required-string",
@@ -3764,14 +3654,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new[]
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatNoCloseAngle, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatUnclosed, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
                             RazorDiagnosticFactory.CreateTagHelper_EmptyBoundAttribute(
                                 new SourceSpan(7, 0, 7, 18),
                                 "bound-required-int",
@@ -3793,14 +3679,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new[]
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatNoCloseAngle, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatUnclosed, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
                             RazorDiagnosticFactory.CreateTagHelper_EmptyBoundAttribute(
                                 new SourceSpan(7, 0, 7, 18),
                                 "bound-required-int",
@@ -3825,14 +3707,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new[]
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
                             RazorDiagnosticFactory.CreateTagHelper_EmptyBoundAttribute(
                                 new SourceSpan(3, 0, 3, 12),
                                 "bound-string",
@@ -3852,14 +3730,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new[]
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
                             RazorDiagnosticFactory.CreateTagHelper_EmptyBoundAttribute(
                                 new SourceSpan(3, 0, 3, 9),
                                 "bound-int",
@@ -3880,14 +3754,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 })),
                         new[]
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatUnclosed, "p"),
-                                new SourceLocation(1, 0, 1),
-                                length: 1)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), "p"),
                             RazorDiagnosticFactory.CreateTagHelper_EmptyBoundAttribute(
                                 new SourceSpan(3, 0, 3, 9),
                                 "bound-int",
@@ -3922,14 +3792,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                     }))),
                         new[]
                         {
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatNoCloseAngle, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatUnclosed, "input"),
-                                new SourceLocation(1, 0, 1),
-                                length: 5)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 5), "input"),
                             RazorDiagnosticFactory.CreateTagHelper_EmptyBoundAttribute(
                                 new SourceSpan(7, 0, 7, 18),
                                 "bound-required-int",
@@ -3940,14 +3806,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                                 "bound-required-string",
                                 "input",
                                 stringType),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatNoCloseAngle, "p"),
-                                new SourceLocation(65, 0, 65),
-                                length: 1)),
-                            RazorDiagnostic.Create(new RazorError(
-                                string.Format(errorFormatUnclosed, "p"),
-                                new SourceLocation(65, 0, 65),
-                                length: 1)),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperMissingCloseAngle(
+                                new SourceSpan(new SourceLocation(65, 0, 65), contentLength: 1), "p"),
+                            RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
+                                new SourceSpan(new SourceLocation(65, 0, 65), contentLength: 1), "p"),
                             RazorDiagnosticFactory.CreateTagHelper_EmptyBoundAttribute(
                                 new SourceSpan(67, 0, 67, 9),
                                 "bound-int",

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.diagnostics.txt
@@ -1,2 +1,2 @@
-TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml(3,2): Error RZ9999: Missing close angle for tag helper 'p'.
-TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml(3,2): Error RZ9999: Found a malformed 'p' tag helper. Tag helpers must have a start and end tag or be self closing.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml(3,2): Error RZ1035: Missing close angle for tag helper 'p'.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml(3,2): Error RZ1034: Found a malformed 'p' tag helper. Tag helpers must have a start and end tag or be self closing.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_Runtime.diagnostics.txt
@@ -1,2 +1,2 @@
-TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml(3,2): Error RZ9999: Missing close angle for tag helper 'p'.
-TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml(3,2): Error RZ9999: Found a malformed 'p' tag helper. Tag helpers must have a start and end tag or be self closing.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml(3,2): Error RZ1035: Missing close angle for tag helper 'p'.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml(3,2): Error RZ1034: Found a malformed 'p' tag helper. Tag helpers must have a start and end tag or be self closing.


### PR DESCRIPTION
#1827 

- This should be the last set of errors to move out of `LegacyRazorDiagnostic`
- No more `RazorError` creation in src

FYI @mkArtakMSFT 