### PR TITLE
Upgrade to build tools 2.1.0-preview1-15651

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AssemblySigningCertName>Microsoft</AssemblySigningCertName>
 
     <!-- Generate full pdbs for desktop targeting projects on platforms that support generating full pdbs. -->
     <DebugType Condition="'$(OS)'=='Windows_NT' AND '$(TargetFramework)'=='net46'">full</DebugType>

--- a/build/MPack.targets
+++ b/build/MPack.targets
@@ -29,6 +29,8 @@
         <Version>$(AddinVersion)</Version>
         <Category>$(MPackArtifactCategory)</Category>
       </ArtifactInfo>
+
+      <FilesToExcludeFromSigning Include="$(MPackOutputPath)" />
     </ItemGroup>
   </Target>
 

--- a/build/VSIX.targets
+++ b/build/VSIX.targets
@@ -34,6 +34,9 @@
         <PackageId>$(VSIXName)</PackageId>
       </ArtifactInfo>
 
+      <FilesToSign Include="$(VSIXOutputPath)" Certificate="Vsix" />
+      <FilesToExcludeFromSigning Include="$(VSIXManifestOutputPath)" />
+
     </ItemGroup>
   </Target>
 

--- a/build/repo.props
+++ b/build/repo.props
@@ -12,12 +12,11 @@
     <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj" />
     <ExcludeSolutions Include="$(RepositoryRoot)Razor.Slim.sln" />
   </ItemGroup>
+
   <PropertyGroup>
     <!-- These properties are use by the automation that updates dependencies.props -->
     <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>
     <LineupPackageRestoreSource>https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</LineupPackageRestoreSource>
-
-    <GenerateSignRequest>false</GenerateSignRequest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview1-15650
-commithash:f85a36ecd070f8a83675a1464efd6e0fb630199d
+version:2.1.0-preview1-15651
+commithash:ebf2365121c2c6a6a0fbfa9b0f37bb5effc89323


### PR DESCRIPTION
Removes need for the workaround for the sign request generation not working correctly.

FYI - more info about sign requests + https://github.com/aspnet/BuildTools/blob/dev/docs/Signing.md

For now, the sign request isn't actually used to sign files. We're first make sure we can generate sign requests that match our expectations. For example, we need to also update the sign request to handle all the assemblies bundled in the \*.vsix files