### PR TITLE
Attempt to fix travis

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Design/Microsoft.AspNetCore.Razor.Design.csproj
+++ b/src/Microsoft.AspNetCore.Razor.Design/Microsoft.AspNetCore.Razor.Design.csproj
@@ -110,7 +110,10 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Include="@(_RazorTool)" PackagePath="tools\" Pack="true"/>      
+      <None Include="@(_RazorTool)">
+        <PackagePath>tools\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+        <Pack>true</Pack>
+      </None>
     </ItemGroup>
 
     <Error Text="_RazorTool is empty. This is a bug" Condition="'@(_RazorTool)'==''"/>


### PR DESCRIPTION
I think our .nuspec is ending up with paths like:
tools//Microsoft.CodeAnalysis.CSharp.dll

Note the double-slash. This is an attempt to avoid double-slashing.