### PR TITLE
[Design] Add RazorProjectEngine abstractions to replace template engine.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/RazorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/RazorExtensions.cs
@@ -33,6 +33,19 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
             builder.Features.Add(new MvcViewDocumentClassifierPass());
         }
 
+        public static void Register(RazorProjectEngineBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.SetImportFileName("_ViewImports.cshtml");
+
+            builder.Features.Add(new MvcImportDiscoverer());
+            builder.Features.Add(new RelativePathCodeDocumentProcessor());
+        }
+
         public static void RegisterViewComponentTagHelpers(IRazorEngineBuilder builder)
         {
             EnsureDesignTime(builder);

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/RelativePathCodeDocumentProcessor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/RelativePathCodeDocumentProcessor.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
+{
+    internal class RelativePathCodeDocumentProcessor : RazorProjectEngineFeatureBase, IRazorCodeDocumentProcessor
+    {
+        public void Process(RazorCodeDocument codeDocument)
+        {
+            if (codeDocument == null)
+            {
+                throw new ArgumentNullException(nameof(codeDocument));
+            }
+
+            var projectItem = Engine.Project.GetItem(codeDocument.Source.FilePath);
+            codeDocument.SetRelativePath(projectItem.FilePath);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcImportDiscoverer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcImportDiscoverer.cs
@@ -6,41 +6,20 @@ using System.IO;
 using System.Text;
 using Microsoft.AspNetCore.Razor.Language;
 
-namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
+namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 {
-    /// <summary>
-    /// A <see cref="RazorTemplateEngine"/> for Mvc Razor views.
-    /// </summary>
-    [Obsolete("This class is obsolete and will be removed in a future version. Please use the " + nameof(RazorProjectEngine) +
-        " in conjunction with " + nameof(RazorExtensions) + "." + nameof(RazorExtensions.Register) + " instead.")]
-    public class MvcRazorTemplateEngine : RazorTemplateEngine
+    internal class MvcImportDiscoverer : RazorProjectEngineFeatureBase, IRazorImportDiscoverer
     {
-        /// <summary>
-        /// Initializes a new instance of <see cref="MvcRazorTemplateEngine"/>.
-        /// </summary>
-        /// <param name="engine">The <see cref="RazorEngine"/>.</param>
-        /// <param name="project">The <see cref="RazorProject"/>.</param>
-        public MvcRazorTemplateEngine(
-            RazorEngine engine,
-            RazorProject project)
-            : base(engine, project)
-        {
-            Options.ImportsFileName = "_ViewImports.cshtml";
-            Options.DefaultImports = GetDefaultImports();
-        }
+        // Need to run prior to the default import discoverers so these are overridden by any user imports.
+        public int Order => -10;
 
-        /// <inheritsdoc />
-        public override RazorCodeDocument CreateCodeDocument(RazorProjectItem projectItem)
+        public void Execute(ImportDiscoveryContext context)
         {
-            var codeDocument = base.CreateCodeDocument(projectItem);
-            codeDocument.SetRelativePath(projectItem.FilePath);
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
-            return codeDocument;
-        }
-
-        // Internal for testing.
-        internal static RazorSourceDocument GetDefaultImports()
-        {
             using (var stream = new MemoryStream())
             using (var writer = new StreamWriter(stream, Encoding.UTF8))
             {
@@ -57,10 +36,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
                 writer.WriteLine("@inject global::Microsoft.AspNetCore.Mvc.IUrlHelper Url");
                 writer.WriteLine("@inject global::Microsoft.AspNetCore.Mvc.ViewFeatures.IModelExpressionProvider ModelExpressionProvider");
                 writer.WriteLine("@addTagHelper Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper, Microsoft.AspNetCore.Mvc.Razor");
+                writer.WriteLine("@addTagHelper Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor");
+                writer.WriteLine("@addTagHelper Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor");
                 writer.Flush();
 
                 stream.Position = 0;
-                return RazorSourceDocument.ReadFrom(stream, fileName: null, encoding: Encoding.UTF8);
+                var defaultMvcImports = RazorSourceDocument.ReadFrom(stream, fileName: null, encoding: Encoding.UTF8);
+                context.Results.Add(defaultMvcImports);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcRazorTemplateEngine.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/MvcRazorTemplateEngine.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Text;
 using Microsoft.AspNetCore.Razor.Language;
@@ -10,6 +11,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
     /// <summary>
     /// A <see cref="RazorTemplateEngine"/> for Mvc Razor views.
     /// </summary>
+    [Obsolete("This class is obsolete and will be removed in a future version. Please use the " + nameof(RazorProjectEngine) +
+        " in conjunction with " + nameof(RazorExtensions) + "." + nameof(RazorExtensions.Register) + " instead.")]
     public class MvcRazorTemplateEngine : RazorTemplateEngine
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 
@@ -36,6 +37,19 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 builder.Features.Add(new AssemblyAttributeInjectionPass());
                 builder.Features.Add(new InstrumentationPass());
             }
+        }
+
+        public static void Register(RazorProjectEngineBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.SetImportFileName("_ViewImports.cshtml");
+
+            builder.Features.Add(new MvcImportDiscoverer());
+            builder.Features.Add(new RelativePathCodeDocumentProcessor());
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RelativePathCodeDocumentProcessor.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RelativePathCodeDocumentProcessor.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
+{
+    internal class RelativePathCodeDocumentProcessor : RazorProjectEngineFeatureBase, IRazorCodeDocumentProcessor
+    {
+        public void Process(RazorCodeDocument codeDocument)
+        {
+            if (codeDocument == null)
+            {
+                throw new ArgumentNullException(nameof(codeDocument));
+            }
+
+            var projectItem = Engine.Project.GetItem(codeDocument.Source.FilePath);
+            codeDocument.SetRelativePath(projectItem.FilePath);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.GenerateTool/RunCommand.cs
+++ b/src/Microsoft.AspNetCore.Razor.GenerateTool/RunCommand.cs
@@ -45,10 +45,10 @@ namespace Microsoft.AspNetCore.Razor.GenerateTool
                 b.Features.Add(new StaticTagHelperFeature() { TagHelpers = tagHelpers, });
             });
 
-            var templateEngine = new MvcRazorTemplateEngine(engine, RazorProject.Create(projectDirectory));
+            var projectEngine = RazorProjectEngine.Create(engine, RazorProject.Create(projectDirectory));
 
             var sourceItems = GetRazorFiles(projectDirectory, sources);
-            var results = GenerateCode(templateEngine, sourceItems);
+            var results = GenerateCode(projectEngine, sourceItems);
 
             var success = true;
 
@@ -107,14 +107,15 @@ namespace Microsoft.AspNetCore.Razor.GenerateTool
             return items;
         }
 
-        private OutputItem[] GenerateCode(RazorTemplateEngine templateEngine, IReadOnlyList<SourceItem> sources)
+        private OutputItem[] GenerateCode(RazorProjectEngine projectEngine, IReadOnlyList<SourceItem> sources)
         {
             var outputs = new OutputItem[sources.Count];
             Parallel.For(0, outputs.Length, new ParallelOptions() { MaxDegreeOfParallelism = 4 }, i =>
             {
                 var source = sources[i];
     
-                var csharpDocument = templateEngine.GenerateCode(source.ViewEnginePath);
+                var result = projectEngine.Process(source.ViewEnginePath);
+                var csharpDocument = result.CodeDocument.GetCSharpDocument();
                 outputs[i] = new OutputItem(source, csharpDocument);
             });
 

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultCodeDocumentFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultCodeDocumentFeature.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultCodeDocumentFeature : RazorProjectEngineFeatureBase, IRazorCodeDocumentFeature
+    {
+        private IEnumerable<IRazorCodeDocumentProcessor> _processors;
+
+        public RazorCodeDocument GetCodeDocument(RazorSourceDocument sourceDocument, IEnumerable<RazorSourceDocument> imports)
+        {
+            if (sourceDocument == null)
+            {
+                throw new ArgumentNullException(nameof(sourceDocument));
+            }
+
+            if (imports == null)
+            {
+                throw new ArgumentNullException(nameof(imports));
+            }
+
+            var codeDocument = RazorCodeDocument.Create(sourceDocument, imports);
+            foreach (var processor in _processors)
+            {
+                processor.Process(codeDocument);
+            }
+
+            return codeDocument;
+        }
+
+        protected override void OnInitialized()
+        {
+            _processors = Engine.Features.OfType<IRazorCodeDocumentProcessor>();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultImportDiscoverer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultImportDiscoverer.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultImportDiscoverer : RazorProjectEngineFeatureBase, IRazorImportDiscoverer
+    {
+        private IRazorImportItemFeature _importItemFeature;
+
+        public int Order { get; }
+
+        public void Execute(ImportDiscoveryContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var importProjectItems = _importItemFeature.GetAssociatedImportItems(context.SourceDocument.FilePath);
+
+            // We want items in descending order. GetAssociatedImportItems returns items in ascending order.
+            for (var i = importProjectItems.Count - 1; i >= 0; i--)
+            {
+                var importProjectItem = importProjectItems[i];
+                if (importProjectItem.Exists)
+                {
+                    var importSourceDocument = RazorSourceDocument.ReadFrom(importProjectItem);
+
+                    context.Results.Add(importSourceDocument);
+                }
+            }
+        }
+
+        protected override void OnInitialized()
+        {
+            _importItemFeature = GetRequiredFeature<IRazorImportItemFeature>();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultImportItemFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultImportItemFeature.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultImportItemFeature : RazorProjectEngineFeatureBase, IRazorImportItemFeature
+    {
+        private string _importsFileName;
+
+        public IReadOnlyList<RazorProjectItem> GetAssociatedImportItems(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(filePath));
+            }
+
+            var importProjectItems = Engine.Project.FindHierarchicalItems(filePath, _importsFileName).ToArray();
+            return importProjectItems;
+        }
+
+        protected override void OnInitialized()
+        {
+            var optionsFeature = GetRequiredFeature<IRazorProjectEngineOptionsFeature>();
+            _importsFileName = optionsFeature.Options.ImportsFileName;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorImportFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorImportFeature.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorImportFeature : RazorProjectEngineFeatureBase, IRazorImportFeature
+    {
+        private IEnumerable<IRazorImportDiscoverer> _discoverers;
+
+        public IReadOnlyList<RazorSourceDocument> GetImports(RazorSourceDocument sourceDocument)
+        {
+            if (sourceDocument == null)
+            {
+                throw new ArgumentNullException(nameof(sourceDocument));
+            }
+
+            if (!_discoverers.Any())
+            {
+                return Array.Empty<RazorSourceDocument>();
+            }
+
+            var importDiscoveryContext = new ImportDiscoveryContext(sourceDocument);
+            foreach (var discoverer in _discoverers)
+            {
+                discoverer.Execute(importDiscoveryContext);
+            }
+
+            return importDiscoveryContext.Results;
+        }
+
+        protected override void OnInitialized()
+        {
+            _discoverers = Engine.Features.OfType<IRazorImportDiscoverer>().OrderBy(discoverer => discoverer.Order);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorProjectEngine : RazorProjectEngine
+    {
+        private readonly RazorEngine _engine;
+
+        public DefaultRazorProjectEngine(
+            RazorEngine engine,
+            RazorProject project,
+            IReadOnlyList<IRazorProjectEngineFeature> features)
+        {
+            if (engine == null)
+            {
+                throw new ArgumentNullException(nameof(engine));
+            }
+
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            if (features == null)
+            {
+                throw new ArgumentNullException(nameof(features));
+            }
+
+            _engine = engine;
+            Project = project;
+            Features = features;
+
+            for (var i = 0; i < features.Count; i++)
+            {
+                features[i].Engine = this;
+            }
+        }
+
+        public override RazorProject Project { get; }
+
+        public override IReadOnlyList<IRazorProjectEngineFeature> Features { get; }
+
+        public override RazorProjectEngineResult Process(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(filePath));
+            }
+
+            var projectItem = Project.GetItem(filePath);
+            var sourceDocument = RazorSourceDocument.ReadFrom(projectItem);
+            var csharpDocument = Process(sourceDocument);
+
+            return csharpDocument;
+        }
+
+        public override RazorProjectEngineResult Process(RazorSourceDocument sourceDocument)
+        {
+            if (sourceDocument == null)
+            {
+                throw new ArgumentNullException(nameof(sourceDocument));
+            }
+
+            var importFeature = GetRequiredFeature<IRazorImportFeature>();
+            var imports = importFeature.GetImports(sourceDocument);
+
+            var codeDocumentFeature = GetRequiredFeature<IRazorCodeDocumentFeature>();
+            var codeDocument = codeDocumentFeature.GetCodeDocument(sourceDocument, imports);
+
+            _engine.Process(codeDocument);
+
+            var engineResult = RazorProjectEngineResult.Create(codeDocument);
+            return engineResult;
+        }
+
+        private TFeature GetRequiredFeature<TFeature>() where TFeature : IRazorProjectEngineFeature
+        {
+            var feature = Features.OfType<TFeature>().FirstOrDefault();
+            if (feature == null)
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatMissingFeatureDependency(
+                        typeof(RazorProjectEngine).FullName,
+                        typeof(TFeature).FullName));
+            }
+
+            return feature;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineBuilder.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorProjectEngineBuilder : RazorProjectEngineBuilder
+    {
+        private readonly RazorEngine _engine;
+
+        public DefaultRazorProjectEngineBuilder(RazorEngine engine, RazorProject project)
+        {
+            if (engine == null)
+            {
+                throw new ArgumentNullException(nameof(engine));
+            }
+
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            _engine = engine;
+            Project = project;
+            Features = new List<IRazorProjectEngineFeature>();
+        }
+
+        public override RazorProject Project { get; }
+
+        public override ICollection<IRazorProjectEngineFeature> Features { get; }
+
+        public override RazorProjectEngine Build()
+        {
+            var features = new IRazorProjectEngineFeature[Features.Count];
+            Features.CopyTo(features, arrayIndex: 0);
+
+            return new DefaultRazorProjectEngine(_engine, Project, features);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineOptionsFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineOptionsFeature.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorProjectEngineOptionsFeature : RazorProjectEngineFeatureBase, IRazorProjectEngineOptionsFeature
+    {
+        // REVIEWERS: This is least-designed as possible. Could take a similar approach to our syntax tree options but it felt like a heavy hammer
+        // to add all of that code for a single options property.
+        public RazorProjectEngineOptions Options { get; } = new RazorProjectEngineOptions();
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineResult.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineResult.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorProjectEngineResult : RazorProjectEngineResult
+    {
+        public DefaultRazorProjectEngineResult(RazorCodeDocument codeDocument)
+        {
+            if (codeDocument == null)
+            {
+                throw new ArgumentNullException(nameof(codeDocument));
+            }
+
+            CodeDocument = codeDocument;
+        }
+
+        public override RazorCodeDocument CodeDocument { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorCodeDocumentFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorCodeDocumentFeature.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal interface IRazorCodeDocumentFeature : IRazorProjectEngineFeature
+    {
+        RazorCodeDocument GetCodeDocument(RazorSourceDocument sourceDocument, IEnumerable<RazorSourceDocument> imports);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorCodeDocumentProcessor.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorCodeDocumentProcessor.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public interface IRazorCodeDocumentProcessor : IRazorProjectEngineFeature
+    {
+        void Process(RazorCodeDocument codeDocument);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorImportDiscoverer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorImportDiscoverer.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public interface IRazorImportDiscoverer : IRazorProjectEngineFeature
+    {
+        int Order { get; }
+
+        void Execute(ImportDiscoveryContext context);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorImportFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorImportFeature.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal interface IRazorImportFeature : IRazorProjectEngineFeature
+    {
+        IReadOnlyList<RazorSourceDocument> GetImports(RazorSourceDocument sourceDocument);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorImportItemFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorImportItemFeature.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public interface IRazorImportItemFeature : IRazorProjectEngineFeature
+    {
+        IReadOnlyList<RazorProjectItem> GetAssociatedImportItems(string filePath);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorProjectEngineFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorProjectEngineFeature.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public interface IRazorProjectEngineFeature
+    {
+        RazorProjectEngine Engine { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorProjectEngineOptionsFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorProjectEngineOptionsFeature.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public interface IRazorProjectEngineOptionsFeature : IRazorProjectEngineFeature
+    {
+        RazorProjectEngineOptions Options { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/ImportDiscoveryContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/ImportDiscoveryContext.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public sealed class ImportDiscoveryContext
+    {
+        public ImportDiscoveryContext(RazorSourceDocument sourceDocument)
+        {
+            if (sourceDocument == null)
+            {
+                throw new ArgumentNullException(nameof(sourceDocument));
+            }
+
+            SourceDocument = sourceDocument;
+            Results = new List<RazorSourceDocument>();
+        }
+
+        public RazorSourceDocument SourceDocument { get; }
+
+        public List<RazorSourceDocument> Results { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -1842,6 +1842,20 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static string FormatUnsupportedChecksumAlgorithm(object p0, object p1, object p2, object p3)
             => string.Format(CultureInfo.CurrentCulture, GetString("UnsupportedChecksumAlgorithm"), p0, p1, p2, p3);
 
+        /// <summary>
+        /// The '{0}' is missing feature '{1}'.
+        /// </summary>
+        internal static string MissingFeatureDependency
+        {
+            get => GetString("MissingFeatureDependency");
+        }
+
+        /// <summary>
+        /// The '{0}' is missing feature '{1}'.
+        /// </summary>
+        internal static string FormatMissingFeatureDependency(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("MissingFeatureDependency"), p0, p1);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectEngine
+    {
+        // REVIEWERS: Technically could do away with this because a user could construct each of the various features with the project that
+        // was passed to the RazorProjectEngine. However, it's super nice to have this available given the name of this class and the common
+        // need to have the project. Thoughts?
+        public abstract RazorProject Project { get; }
+
+        public abstract IReadOnlyList<IRazorProjectEngineFeature> Features { get; }
+
+        public abstract RazorProjectEngineResult Process(string filePath);
+
+        public abstract RazorProjectEngineResult Process(RazorSourceDocument sourceDocument);
+
+        public static RazorProjectEngine Create(RazorEngine engine, RazorProject project) => Create(engine, project, configure: null);
+
+        public static RazorProjectEngine Create(
+            RazorEngine engine,
+            RazorProject project,
+            Action<RazorProjectEngineBuilder> configure)
+        {
+            if (engine == null)
+            {
+                throw new ArgumentNullException(nameof(engine));
+            }
+
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(engine, project);
+
+            AddDefaults(builder);
+            configure?.Invoke(builder);
+
+            return builder.Build();
+        }
+
+        private static void AddDefaults(RazorProjectEngineBuilder builder)
+        {
+            builder.Features.Add(new DefaultRazorImportFeature());
+            builder.Features.Add(new DefaultImportDiscoverer());
+            builder.Features.Add(new DefaultCodeDocumentFeature());
+            builder.Features.Add(new DefaultImportItemFeature());
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilder.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectEngineBuilder
+    {
+        public abstract RazorProject Project { get; }
+
+        public abstract ICollection<IRazorProjectEngineFeature> Features { get; }
+
+        public abstract RazorProjectEngine Build();
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilderExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public static class RazorProjectEngineBuilderExtensions
+    {
+        // REVIEWERS: See DefaultRazorProjectEngineOptionsFeature for implications
+        public static void SetImportFileName(this RazorProjectEngineBuilder builder, string name)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(name));
+            }
+
+            var optionsFeature = builder.Features.OfType<IRazorProjectEngineOptionsFeature>().FirstOrDefault();
+            if (optionsFeature == null)
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatMissingFeatureDependency(
+                        typeof(RazorProjectEngineBuilder).FullName,
+                        typeof(IRazorProjectEngineOptionsFeature).FullName));
+            }
+
+            optionsFeature.Options.ImportsFileName = name;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineFeatureBase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineFeatureBase.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectEngineFeatureBase : IRazorProjectEngineFeature
+    {
+        private RazorProjectEngine _engine;
+
+        public RazorProjectEngine Engine
+        {
+            get { return _engine; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _engine = value;
+                OnInitialized();
+            }
+        }
+
+        protected TFeature GetRequiredFeature<TFeature>() where TFeature : IRazorProjectEngineFeature
+        {
+            if (Engine == null)
+            {
+                throw new InvalidOperationException(Resources.FormatFeatureMustBeInitialized(nameof(Engine)));
+            }
+
+            var feature = Engine.Features.OfType<TFeature>().FirstOrDefault();
+            ThrowForMissingFeatureDependency<TFeature>(feature);
+
+            return feature;
+        }
+
+        protected void ThrowForMissingFeatureDependency<TEngineDependency>(TEngineDependency value)
+        {
+            if (value == null)
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatFeatureDependencyMissing(
+                        GetType().Name,
+                        typeof(TEngineDependency).Name,
+                        typeof(RazorProjectEngine).Name));
+            }
+        }
+
+        protected virtual void OnInitialized()
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineOptions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineOptions.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public sealed class RazorProjectEngineOptions
+    {
+        public string ImportsFileName { get; internal set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineResult.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineResult.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectEngineResult
+    {
+        public abstract RazorCodeDocument CodeDocument { get; }
+
+        public static RazorProjectEngineResult Create(RazorCodeDocument codeDocument)
+        {
+            if (codeDocument == null)
+            {
+                throw new ArgumentNullException(nameof(codeDocument));
+            }
+
+            var result = new DefaultRazorProjectEngineResult(codeDocument);
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorTemplateEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorTemplateEngine.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Razor.Language
     /// <summary>
     /// Entry point to parse Razor files and generate code.
     /// </summary>
+    [Obsolete("This class is obsolete and will be removed in a future version. Please use the " + nameof(RazorProjectEngine) + " instead.")]
     public class RazorTemplateEngine
     {
         private RazorTemplateEngineOptions _options;

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorTemplateEngineOptions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorTemplateEngineOptions.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.AspNetCore.Razor.Language
 {
     /// <summary>
     /// Options for code generation in the <see cref="RazorTemplateEngine"/>.
     /// </summary>
+    [Obsolete("This class is obsolete and will be removed in a future version.")]
+
     public sealed class RazorTemplateEngineOptions
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -530,4 +530,7 @@ Instead, wrap the contents of the block in "{{}}":
   <data name="UnsupportedChecksumAlgorithm" xml:space="preserve">
     <value>The hash algorithm '{0}' is not supported for checksum generation. Supported algorithms are: '{1}'. Set '{2}' to '{3}' to suppress automatic checksum generation.</value>
   </data>
+  <data name="MissingFeatureDependency" xml:space="preserve">
+    <value>The '{0}' is missing feature '{1}'.</value>
+  </data>
 </root>

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorProjectEngineFactoryService.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorProjectEngineFactoryService.cs
@@ -7,8 +7,8 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
-    internal abstract class RazorTemplateEngineFactoryService : ILanguageService
+    internal abstract class RazorProjectEngineFactoryService : ILanguageService
     {
-        public abstract RazorTemplateEngine Create(string projectPath, Action<IRazorEngineBuilder> configure);
+        public abstract RazorProjectEngine Create(string projectPath, Action<IRazorEngineBuilder> configure);
     }
 }

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultImportDocumentManagerFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultImportDocumentManagerFactory.cs
@@ -23,13 +23,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var dispatcher = languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>();
             var errorReporter = languageServices.WorkspaceServices.GetRequiredService<ErrorReporter>();
             var fileChangeTrackerFactory = languageServices.GetRequiredService<FileChangeTrackerFactory>();
-            var templateEngineFactoryService = languageServices.GetRequiredService<RazorTemplateEngineFactoryService>();
+            var projectEngineFactoryService = languageServices.GetRequiredService<RazorProjectEngineFactoryService>();
 
             return new DefaultImportDocumentManager(
                 dispatcher,
                 errorReporter,
                 fileChangeTrackerFactory,
-                templateEngineFactoryService);
+                projectEngineFactoryService);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectEngineFactoryService.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectEngineFactoryService.cs
@@ -12,7 +12,7 @@ using MvcLatest = Microsoft.AspNetCore.Mvc.Razor.Extensions;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {
-    internal class DefaultTemplateEngineFactoryService : RazorTemplateEngineFactoryService
+    internal class DefaultProjectEngineFactoryService : RazorProjectEngineFactoryService
     {
         private readonly static MvcExtensibilityConfiguration DefaultConfiguration = new MvcExtensibilityConfiguration(
             ProjectExtensibilityConfigurationKind.Fallback,
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         private readonly ProjectSnapshotManager _projectManager;
 
-        public DefaultTemplateEngineFactoryService(ProjectSnapshotManager projectManager)
+        public DefaultProjectEngineFactoryService(ProjectSnapshotManager projectManager)
         {
             if (projectManager == null)
             {
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             _projectManager = projectManager;
         }
 
-        public override RazorTemplateEngine Create(string projectPath, Action<IRazorEngineBuilder> configure)
+        public override RazorProjectEngine Create(string projectPath, Action<IRazorEngineBuilder> configure)
         {
             if (projectPath == null)
             {
@@ -57,9 +57,11 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     }
                 });
 
-                var templateEngine = new Mvc1_X.MvcRazorTemplateEngine(engine, RazorProject.Create(projectPath));
-                templateEngine.Options.ImportsFileName = "_ViewImports.cshtml";
-                return templateEngine;
+                var projectEngine = RazorProjectEngine.Create(engine, RazorProject.Create(projectPath), b =>
+                {
+                    Mvc1_X.RazorExtensions.Register(b);
+                });
+                return projectEngine;
             }
             else
             {
@@ -70,9 +72,11 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     MvcLatest.RazorExtensions.Register(b);
                 });
 
-                var templateEngine = new MvcLatest.MvcRazorTemplateEngine(engine, RazorProject.Create(projectPath));
-                templateEngine.Options.ImportsFileName = "_ViewImports.cshtml";
-                return templateEngine;
+                var projectEngine = RazorProjectEngine.Create(engine, RazorProject.Create(projectPath), b =>
+                {
+                    MvcLatest.RazorExtensions.Register(b);
+                });
+                return projectEngine;
             }
         }
 

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectEngineFactoryServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultProjectEngineFactoryServiceFactory.cs
@@ -8,12 +8,12 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.VisualStudio.Editor.Razor
 {
-    [ExportLanguageServiceFactory(typeof(RazorTemplateEngineFactoryService), RazorLanguage.Name, ServiceLayer.Default)]
-    internal class DefaultTemplateEngineFactoryServiceFactory : ILanguageServiceFactory
+    [ExportLanguageServiceFactory(typeof(RazorProjectEngineFactoryService), RazorLanguage.Name, ServiceLayer.Default)]
+    internal class DefaultProjectEngineFactoryServiceFactory : ILanguageServiceFactory
     {
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
-            return new DefaultTemplateEngineFactoryService(languageServices.GetRequiredService<ProjectSnapshotManager>());
+            return new DefaultProjectEngineFactoryService(languageServices.GetRequiredService<ProjectSnapshotManager>());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -31,9 +31,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
         private readonly VisualStudioCompletionBroker _completionBroker;
         private readonly VisualStudioDocumentTracker _documentTracker;
         private readonly ForegroundDispatcher _dispatcher;
-        private readonly RazorTemplateEngineFactoryService _templateEngineFactory;
+        private readonly RazorProjectEngineFactoryService _projectEngineFactory;
         private readonly ErrorReporter _errorReporter;
-        private RazorTemplateEngine _templateEngine;
+        private RazorProjectEngine _projectEngine;
         private RazorCodeDocument _codeDocument;
         private ITextSnapshot _snapshot;
         private bool _disposed;
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public DefaultVisualStudioRazorParser(
             ForegroundDispatcher dispatcher,
             VisualStudioDocumentTracker documentTracker,
-            RazorTemplateEngineFactoryService templateEngineFactory,
+            RazorProjectEngineFactoryService projectEngineFactory,
             ErrorReporter errorReporter,
             VisualStudioCompletionBroker completionBroker)
         {
@@ -61,9 +61,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentNullException(nameof(documentTracker));
             }
 
-            if (templateEngineFactory == null)
+            if (projectEngineFactory == null)
             {
-                throw new ArgumentNullException(nameof(templateEngineFactory));
+                throw new ArgumentNullException(nameof(projectEngineFactory));
             }
 
             if (errorReporter == null)
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             }
 
             _dispatcher = dispatcher;
-            _templateEngineFactory = templateEngineFactory;
+            _projectEngineFactory = projectEngineFactory;
             _errorReporter = errorReporter;
             _completionBroker = completionBroker;
             _documentTracker = documentTracker;
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             _documentTracker.ContextChanged += DocumentTracker_ContextChanged;
         }
 
-        public override RazorTemplateEngine TemplateEngine => _templateEngine;
+        public override RazorProjectEngine ProjectEngine => _projectEngine;
 
         public override string FilePath => _documentTracker.FilePath;
 
@@ -170,8 +170,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             _dispatcher.AssertForegroundThread();
 
             var projectDirectory = Path.GetDirectoryName(_documentTracker.ProjectPath);
-            _templateEngine = _templateEngineFactory.Create(projectDirectory, ConfigureTemplateEngine);
-            _parser = new BackgroundParser(TemplateEngine, FilePath);
+            _projectEngine = _projectEngineFactory.Create(projectDirectory, ConfigureTemplateEngine);
+            _parser = new BackgroundParser(ProjectEngine, FilePath);
             _parser.ResultsReady += OnResultsReady;
             _parser.Start();
 

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParserFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParserFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
     internal class DefaultVisualStudioRazorParserFactory : VisualStudioRazorParserFactory
     {
         private readonly ForegroundDispatcher _dispatcher;
-        private readonly RazorTemplateEngineFactoryService _templateEngineFactoryService;
+        private readonly RazorProjectEngineFactoryService _projectEngineFactoryService;
         private readonly VisualStudioCompletionBroker _completionBroker;
         private readonly ErrorReporter _errorReporter;
 
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             ForegroundDispatcher dispatcher,
             ErrorReporter errorReporter,
             VisualStudioCompletionBroker completionBroker,
-            RazorTemplateEngineFactoryService templateEngineFactoryService)
+            RazorProjectEngineFactoryService projectEngineFactoryService)
         {
             if (dispatcher == null)
             {
@@ -34,15 +34,15 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentNullException(nameof(completionBroker));
             }
 
-            if (templateEngineFactoryService == null)
+            if (projectEngineFactoryService == null)
             {
-                throw new ArgumentNullException(nameof(templateEngineFactoryService));
+                throw new ArgumentNullException(nameof(projectEngineFactoryService));
             }
 
             _dispatcher = dispatcher;
             _errorReporter = errorReporter;
             _completionBroker = completionBroker;
-            _templateEngineFactoryService = templateEngineFactoryService;
+            _projectEngineFactoryService = projectEngineFactoryService;
         }
 
         public override VisualStudioRazorParser Create(VisualStudioDocumentTracker documentTracker)
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var parser = new DefaultVisualStudioRazorParser(
                 _dispatcher,
                 documentTracker,
-                _templateEngineFactoryService,
+                _projectEngineFactoryService,
                 _errorReporter,
                 _completionBroker);
             return parser;

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParserFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParserFactoryFactory.cs
@@ -24,13 +24,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var dispatcher = workspaceServices.GetRequiredService<ForegroundDispatcher>();
             var errorReporter = workspaceServices.GetRequiredService<ErrorReporter>();
             var completionBroker = languageServices.GetRequiredService<VisualStudioCompletionBroker>();
-            var templateEngineFactoryService = languageServices.GetRequiredService<RazorTemplateEngineFactoryService>();
+            var projectEngineFactoryService = languageServices.GetRequiredService<RazorProjectEngineFactoryService>();
 
             return new DefaultVisualStudioRazorParserFactory(
                 dispatcher,
                 errorReporter,
                 completionBroker,
-                templateEngineFactoryService);
+                projectEngineFactoryService);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioRazorParser.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         public abstract event EventHandler<DocumentStructureChangedEventArgs> DocumentStructureChanged;
 
-        public abstract RazorTemplateEngine TemplateEngine { get; }
+        public abstract RazorProjectEngine ProjectEngine { get; }
 
         public abstract string FilePath { get; }
 


### PR DESCRIPTION
- Added initial designs for a non-template engine project engine that owns the processing of a Razor view and allows external pieces to configure it.
- Updated existing usages to use the new RazorProjectEngine to flesh out requirements.

#1828 

FYI @mkArtakMSFT 