### PR TITLE
Add relative path to source document

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorSourceLineCollection.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorSourceLineCollection.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 // We have an exact match for the start of a line.
                 Debug.Assert(_lineStarts[index] == position);
 
-                return new SourceLocation(_document.FilePath, position, index, characterIndex: 0);
+                return new SourceLocation(_document.GetFilePathForDisplay(), position, index, characterIndex: 0);
             }
 
 
@@ -59,12 +59,12 @@ namespace Microsoft.AspNetCore.Razor.Language
             if (index == -1)
             {
                 // There's no preceding line, so it's based on the start of the string
-                return new SourceLocation(_document.FilePath, position, 0, position);
+                return new SourceLocation(_document.GetFilePathForDisplay(), position, 0, position);
             }
             else
             {
                 var characterIndex = position - _lineStarts[index];
-                return new SourceLocation(_document.FilePath, position, index, characterIndex);
+                return new SourceLocation(_document.GetFilePathForDisplay(), position, index, characterIndex);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/LargeTextSourceDocument.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/LargeTextSourceDocument.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         private readonly int _length;
         private byte[] _checksum;
 
-        public LargeTextSourceDocument(StreamReader reader, int chunkMaxLength, Encoding encoding, string fileName)
+        public LargeTextSourceDocument(StreamReader reader, int chunkMaxLength, Encoding encoding, RazorSourceDocumentProperties properties)
         {
             if (reader == null)
             {
@@ -32,9 +32,15 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(encoding));
             }
 
+            if (properties == null)
+            {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
             _chunkMaxLength = chunkMaxLength;
             Encoding = encoding;
-            FilePath = fileName;
+            FilePath = properties.FilePath;
+            RelativePath = properties.RelativePath;
 
             ReadChunks(reader, _chunkMaxLength, out _length, out _chunks);
             _lines = new DefaultRazorSourceLineCollection(this);
@@ -58,6 +64,8 @@ namespace Microsoft.AspNetCore.Razor.Language
         public override int Length => _length;
 
         public override RazorSourceLineCollection Lines => _lines;
+
+        public override string RelativePath { get; }
 
         public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
         {

--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -1842,6 +1842,20 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static string FormatUnsupportedChecksumAlgorithm(object p0, object p1, object p2, object p3)
             => string.Format(CultureInfo.CurrentCulture, GetString("UnsupportedChecksumAlgorithm"), p0, p1, p2, p3);
 
+        /// <summary>
+        /// The '{0}.{1}' property must not be null.
+        /// </summary>
+        internal static string PropertyMustNotBeNull
+        {
+            get => GetString("PropertyMustNotBeNull");
+        }
+
+        /// <summary>
+        /// The '{0}.{1}' property must not be null.
+        /// </summary>
+        internal static string FormatPropertyMustNotBeNull(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("PropertyMustNotBeNull"), p0, p1);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorSourceDocumentProperties.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorSourceDocumentProperties.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    /// <summary>
+    /// Use to configure optional properties for creating a <see cref="RazorSourceDocument"/>.
+    /// </summary>
+    public sealed class RazorSourceDocumentProperties
+    {
+        /// <summary>
+        /// A <see cref="RazorSourceDocumentProperties"/> with default values.
+        /// </summary>
+        internal static readonly RazorSourceDocumentProperties Default = new RazorSourceDocumentProperties();
+
+        /// <summary>
+        /// Creates a new <see cref="RazorSourceDocumentProperties"/>.
+        /// </summary>
+        public RazorSourceDocumentProperties()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="RazorSourceDocumentProperties"/>.
+        /// </summary>
+        /// <param name="filePath">
+        /// The path to the source file. Provide an rooted path if possible. May be <c>null</c>.
+        /// </param>
+        /// <param name="relativePath">
+        /// The project-relative path to the source file. May be <c>null</c>. Must be a non-rooted path.
+        /// </param>
+        public RazorSourceDocumentProperties(string filePath, string relativePath)
+        {
+            // We don't do any magic or validation here since we don't need to do any I/O or interation
+            // with the file system. We didn't validate anything in 2.0 so we don't want any compat risk.
+            FilePath = filePath;
+            RelativePath = relativePath;
+        }
+
+        /// <summary>
+        /// Gets the path to the source file. May be an absolute or project-relative path. May be <c>null</c>.
+        /// </summary>
+        /// <remarks>
+        /// An absolute path must be provided to generate debuggable assemblies.
+        /// </remarks>
+        public string FilePath { get; }
+
+        /// <summary>
+        /// Gets the project-relative path to the source file. May be <c>null</c>.
+        /// </summary>
+        /// <remarks>
+        /// The relative path (if provided) is used for display (error messages). The project-relative path may also
+        /// be used to embed checksums of the original source documents to support runtime recompilation of Razor code.
+        /// </remarks>
+        public string RelativePath { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -530,4 +530,7 @@ Instead, wrap the contents of the block in "{{}}":
   <data name="UnsupportedChecksumAlgorithm" xml:space="preserve">
     <value>The hash algorithm '{0}' is not supported for checksum generation. Supported algorithms are: '{1}'. Set '{2}' to '{3}' to suppress automatic checksum generation.</value>
   </data>
+  <data name="PropertyMustNotBeNull" xml:space="preserve">
+    <value>The '{0}.{1}' property must not be null.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Razor.Language/StringSourceDocument.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/StringSourceDocument.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         private readonly RazorSourceLineCollection _lines;
         private byte[] _checksum;
 
-        public StringSourceDocument(string content, Encoding encoding, string filePath)
+        public StringSourceDocument(string content, Encoding encoding, RazorSourceDocumentProperties properties)
         {
             if (content == null)
             {
@@ -25,9 +25,15 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(encoding));
             }
 
+            if (properties == null)
+            {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
             _content = content;
             Encoding = encoding;
-            FilePath = filePath;
+            FilePath = properties.FilePath;
+            RelativePath = properties.RelativePath;
 
             _lines = new DefaultRazorSourceLineCollection(this);
         }
@@ -37,10 +43,12 @@ namespace Microsoft.AspNetCore.Razor.Language
         public override Encoding Encoding { get; }
 
         public override string FilePath { get; }
-
+        
         public override int Length => _content.Length;
 
         public override RazorSourceLineCollection Lines => _lines;
+
+        public override string RelativePath { get; }
 
         public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
         {

--- a/src/Microsoft.VisualStudio.Editor.Razor/TextSnapshotSourceDocument.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/TextSnapshotSourceDocument.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public override RazorSourceLineCollection Lines => _lines;
 
         public override string FilePath { get; }
-
+        
         public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
         {
             if (destination == null)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIntermediateNodeLoweringPhaseTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorIntermediateNodeLoweringPhaseTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.AddDirective(directive);
             });
             var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
-            var importSource = TestRazorSourceDocument.Create("@custom \"hello\"", fileName: "import.cshtml");
+            var importSource = TestRazorSourceDocument.Create("@custom \"hello\"", filePath: "import.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
             codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.AddDirective(directive);
             });
             var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
-            var importSource = TestRazorSourceDocument.Create("@custom \"hello\"", fileName: "import.cshtml");
+            var importSource = TestRazorSourceDocument.Create("@custom \"hello\"", filePath: "import.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("@custom \"world\"");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
             codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });
@@ -100,8 +100,8 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.AddDirective(directive);
             });
             var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
-            var importSource1 = TestRazorSourceDocument.Create("@custom \"hello\"", fileName: "import1.cshtml");
-            var importSource2 = TestRazorSourceDocument.Create("@custom \"world\"", fileName: "import2.cshtml");
+            var importSource1 = TestRazorSourceDocument.Create("@custom \"hello\"", filePath: "import1.cshtml");
+            var importSource2 = TestRazorSourceDocument.Create("@custom \"world\"", filePath: "import2.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
             codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource1, options), RazorSyntaxTree.Parse(importSource2, options) });
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var importSource = TestRazorSourceDocument.Create(
 @"@code ""code block"" { }
 @razor ""razor block"" { }",
-                fileName: "testImports.cshtml");
+                filePath: "testImports.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
             codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.AddDirective(directive);
             });
             var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
-            var importSource = TestRazorSourceDocument.Create("@custom { }", fileName: "import.cshtml");
+            var importSource = TestRazorSourceDocument.Create("@custom { }", filePath: "import.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
             codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });
@@ -196,7 +196,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 b.AddDirective(directive);
             });
             var options = RazorParserOptions.Create(builder => builder.Directives.Add(directive));
-            var importSource = TestRazorSourceDocument.Create("@custom { }", fileName: "import.cshtml");
+            var importSource = TestRazorSourceDocument.Create("@custom { }", filePath: "import.cshtml");
             var codeDocument = TestRazorCodeDocument.Create("<p>NonDirective</p>");
             codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(codeDocument.Source, options));
             codeDocument.SetImportSyntaxTrees(new[] { RazorSyntaxTree.Parse(importSource, options) });

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var content =
             @"
 @addTagHelper """;
-            var sourceDocument = TestRazorSourceDocument.Create(content, fileName: null);
+            var sourceDocument = TestRazorSourceDocument.Create(content, filePath: null);
             var codeDocument = RazorCodeDocument.Create(sourceDocument);
             var originalTree = RazorSyntaxTree.Parse(sourceDocument);
             codeDocument.SetSyntaxTree(originalTree);
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var content =
             @"
 @removeTagHelper """;
-            var sourceDocument = TestRazorSourceDocument.Create(content, fileName: null);
+            var sourceDocument = TestRazorSourceDocument.Create(content, filePath: null);
             var codeDocument = RazorCodeDocument.Create(sourceDocument);
             var originalTree = RazorSyntaxTree.Parse(sourceDocument);
             codeDocument.SetSyntaxTree(originalTree);
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var content =
             @"
 @tagHelperPrefix """;
-            var sourceDocument = TestRazorSourceDocument.Create(content, fileName: null);
+            var sourceDocument = TestRazorSourceDocument.Create(content, filePath: null);
             var codeDocument = RazorCodeDocument.Create(sourceDocument);
             var originalTree = RazorSyntaxTree.Parse(sourceDocument);
             codeDocument.SetSyntaxTree(originalTree);
@@ -413,7 +413,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 @addTagHelper *, TestAssembly
 <form>
     <input value='Hello' type='text' />";
-            var sourceDocument = TestRazorSourceDocument.Create(content, fileName: null);
+            var sourceDocument = TestRazorSourceDocument.Create(content, filePath: null);
             var codeDocument = RazorCodeDocument.Create(sourceDocument);
 
             var originalTree = RazorSyntaxTree.Parse(sourceDocument);
@@ -540,7 +540,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             string expectedPrefix)
         {
             // Arrange
-            var sourceDocument = TestRazorSourceDocument.Create(source, fileName: "TestFile");
+            var sourceDocument = TestRazorSourceDocument.Create(source, filePath: "TestFile");
             var parser = new RazorParser();
             var syntaxTree = parser.Parse(sourceDocument);
             var visitor = new DefaultRazorTagHelperBinderPhase.DirectiveVisitor(tagHelpers: new List<TagHelperDescriptor>());
@@ -706,7 +706,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var expected = (TagHelperDescriptor[])expectedDescriptors;
-            var sourceDocument = TestRazorSourceDocument.Create(source, fileName: "TestFile");
+            var sourceDocument = TestRazorSourceDocument.Create(source, filePath: "TestFile");
             var parser = new RazorParser();
             var syntaxTree = parser.Parse(sourceDocument);
             var visitor = new DefaultRazorTagHelperBinderPhase.DirectiveVisitor((TagHelperDescriptor[])tagHelpers);
@@ -850,7 +850,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             object tagHelpers)
         {
             // Arrange
-            var sourceDocument = TestRazorSourceDocument.Create(source, fileName: "TestFile");
+            var sourceDocument = TestRazorSourceDocument.Create(source, filePath: "TestFile");
             var parser = new RazorParser();
             var syntaxTree = parser.Parse(sourceDocument);
             var visitor = new DefaultRazorTagHelperBinderPhase.DirectiveVisitor((TagHelperDescriptor[])tagHelpers);
@@ -885,7 +885,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 <form>
     <input value='Hello' type='text' />
 </form>";
-            var sourceDocument = TestRazorSourceDocument.Create(content, fileName: null);
+            var sourceDocument = TestRazorSourceDocument.Create(content, filePath: null);
             return sourceDocument;
         }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/BasicIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/BasicIntegrationTest.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             // Arrange
             var engine = RazorEngine.Create();
 
-            var document = RazorCodeDocument.Create(TestRazorSourceDocument.Create("@!!!", fileName: "test.cshtml"));
+            var document = RazorCodeDocument.Create(TestRazorSourceDocument.Create("@!!!", filePath: "test.cshtml"));
 
             var expected = RazorDiagnosticFactory.CreateParsing_UnexpectedCharacterAtStartOfCodeBlock(
                                 new SourceSpan(new SourceLocation("test.cshtml", 1, 0, 1), contentLength: 1),
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             // Arrange
             var engine = RazorEngine.CreateDesignTime();
 
-            var document = RazorCodeDocument.Create(TestRazorSourceDocument.Create("@{", fileName: "test.cshtml"));
+            var document = RazorCodeDocument.Create(TestRazorSourceDocument.Create("@{", filePath: "test.cshtml"));
 
             var expected = RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
                 new SourceSpan(new SourceLocation("test.cshtml", 1, 0, 1), contentLength: 1), Resources.BlockName_Code, "}", "{");

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/LargeTextSourceDocumentTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/LargeTextSourceDocumentTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
             var contentString = "Hello World";
             var stream = TestRazorSourceDocument.CreateStreamContent(contentString);
             var reader = new StreamReader(stream, detectEncodingFromByteOrderMarks: true);
-            var document = new LargeTextSourceDocument(reader, 5, Encoding.UTF8, "file.cshtml");
+            var document = new LargeTextSourceDocument(reader, 5, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var firstChecksum = document.GetChecksum();
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
             var contentString = "Hello World";
             var stream = TestRazorSourceDocument.CreateStreamContent(contentString);
             var reader = new StreamReader(stream, detectEncodingFromByteOrderMarks: true);
-            var document = new LargeTextSourceDocument(reader, 5, Encoding.UTF8, "file.cshtml");
+            var document = new LargeTextSourceDocument(reader, 5, Encoding.UTF8, RazorSourceDocumentProperties.Default);
             var expectedChecksum = new byte[] { 10, 77, 85, 168, 215, 120, 229, 2, 47, 171, 112, 25, 119, 197, 216, 64, 187, 196, 134, 208 };
 
             // Act
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
             var contentString = "Hello World";
             var stream = TestRazorSourceDocument.CreateStreamContent(contentString, Encoding.UTF32);
             var reader = new StreamReader(stream, detectEncodingFromByteOrderMarks: true);
-            var document = new LargeTextSourceDocument(reader, 5, Encoding.UTF32, "file.cshtml");
+            var document = new LargeTextSourceDocument(reader, 5, Encoding.UTF32, RazorSourceDocumentProperties.Default);
             var expectedChecksum = new byte[] { 108, 172, 130, 171, 42, 19, 155, 176, 211, 80, 224, 121, 169, 133, 25, 134, 48, 228, 199, 141 };
 
             // Act
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
 
             var stream = TestRazorSourceDocument.CreateStreamContent(new string(content));
             var reader = new StreamReader(stream, true);
-            var document = new LargeTextSourceDocument(reader, ChunkTestLength, Encoding.UTF8, "file.cshtml");
+            var document = new LargeTextSourceDocument(reader, ChunkTestLength, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var output = new char[contentLength];
@@ -106,10 +106,26 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
             var reader = new StreamReader(stream, true);
 
             // Act
-            var document = new LargeTextSourceDocument(reader, ChunkTestLength, Encoding.UTF8, filePath);
+            var document = new LargeTextSourceDocument(reader, ChunkTestLength, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: filePath, relativePath: null));
 
             // Assert
             Assert.Equal(filePath, document.FilePath);
+        }
+
+        [Theory]
+        [InlineData("test.cshtml")]
+        [InlineData(null)]
+        public void RelativePath(string relativePath)
+        {
+            // Arrange
+            var stream = TestRazorSourceDocument.CreateStreamContent("abc");
+            var reader = new StreamReader(stream, true);
+
+            // Act
+            var document = new LargeTextSourceDocument(reader, ChunkTestLength, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: null, relativePath: relativePath));
+
+            // Assert
+            Assert.Equal(relativePath, document.RelativePath);
         }
 
         [Fact]
@@ -120,7 +136,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
             var reader = new StreamReader(stream, true);
 
             // Act
-            var document = new LargeTextSourceDocument(reader, ChunkTestLength, Encoding.UTF8, "file.cshtml");
+            var document = new LargeTextSourceDocument(reader, ChunkTestLength, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Assert
             Assert.Equal(3, document.Lines.Count);
@@ -142,7 +158,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
             var stream = TestRazorSourceDocument.CreateStreamContent("abcdefghijklmnopqrstuvwxyz");
 
             var reader = new StreamReader(stream, true);
-            var document = new LargeTextSourceDocument(reader, ChunkTestLength, Encoding.UTF8, "file.cshtml");
+            var document = new LargeTextSourceDocument(reader, ChunkTestLength, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var destination = new char[1000];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorSourceDocumentTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorSourceDocumentTest.cs
@@ -38,6 +38,22 @@ namespace Microsoft.AspNetCore.Razor.Language
         }
 
         [Fact]
+        public void ReadFrom_WithProperties()
+        {
+            // Arrange
+            var content = TestRazorSourceDocument.CreateStreamContent(encoding: Encoding.UTF32);
+            var properties = new RazorSourceDocumentProperties("c:\\myapp\\filePath.cshtml", "filePath.cshtml");
+
+            // Act
+            var document = RazorSourceDocument.ReadFrom(content, Encoding.UTF32, properties);
+
+            // Assert
+            Assert.Equal("c:\\myapp\\filePath.cshtml", document.FilePath);
+            Assert.Equal("filePath.cshtml", document.RelativePath);
+            Assert.Same(Encoding.UTF32, Assert.IsType<StreamSourceDocument>(document).Encoding);
+        }
+
+        [Fact]
         public void ReadFrom_EmptyStream_WithEncoding()
         {
             // Arrange
@@ -52,30 +68,17 @@ namespace Microsoft.AspNetCore.Razor.Language
         }
 
         [Fact]
-        public void ReadFrom_UsesProjectItemPhysicalPath()
-        {
-            // Arrange
-            var projectItem = new TestRazorProjectItem("/test-path", "some-physical-path");
-
-            // Act
-            var document = RazorSourceDocument.ReadFrom(projectItem);
-
-            // Assert
-            Assert.Equal(projectItem.PhysicalPath, document.FilePath);
-            Assert.Equal(projectItem.Content, ReadContent(document));
-        }
-
-        [Fact]
         public void ReadFrom_ProjectItem()
         {
             // Arrange
-            var projectItem = new TestRazorProjectItem("/test-path");
+            var projectItem = new TestRazorProjectItem("filePath.cshtml", "c:\\myapp\\filePath.cshtml", "c:\\myapp\\");
 
             // Act
             var document = RazorSourceDocument.ReadFrom(projectItem);
 
             // Assert
-            Assert.Equal(projectItem.FilePath, document.FilePath);
+            Assert.Equal("c:\\myapp\\filePath.cshtml", document.FilePath);
+            Assert.Equal("filePath.cshtml", document.RelativePath);
             Assert.Equal(projectItem.Content, ReadContent(document));
         }
 
@@ -110,6 +113,23 @@ namespace Microsoft.AspNetCore.Razor.Language
             Assert.Equal(fileName, document.FilePath);
             Assert.Equal(content, ReadContent(document));
             Assert.Same(encoding, document.Encoding);
+        }
+
+        [Fact]
+        public void Create_WithProperties()
+        {
+            // Arrange
+            var content = "Hello world";
+            var properties = new RazorSourceDocumentProperties("c:\\myapp\\filePath.cshtml", "filePath.cshtml");
+
+            // Act
+            var document = RazorSourceDocument.Create(content, Encoding.UTF32, properties);
+
+            // Assert
+            Assert.Equal("c:\\myapp\\filePath.cshtml", document.FilePath);
+            Assert.Equal("filePath.cshtml", document.RelativePath);
+            Assert.Equal(content, ReadContent(document));
+            Assert.Same(Encoding.UTF32, Assert.IsType<StringSourceDocument>(document).Encoding);
         }
 
         private static string ReadContent(RazorSourceDocument razorSourceDocument)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorSyntaxTreeTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorSyntaxTreeTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
         {
             // Arrange
             var filePath = "test.cshtml";
-            var source = TestRazorSourceDocument.Create("@if (true) { @if(false) { <div>@something.</div> } }", fileName: filePath);
+            var source = TestRazorSourceDocument.Create("@if (true) { @if(false) { <div>@something.</div> } }", filePath: filePath);
 
             // Act
             var syntaxTree = RazorSyntaxTree.Parse(source);

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/StreamSourceDocumentTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/StreamSourceDocumentTest.cs
@@ -11,12 +11,68 @@ namespace Microsoft.AspNetCore.Razor.Language
     public class StreamSourceDocumentTest
     {
         [Fact]
+        public void FilePath()
+        {
+            // Arrange
+            var content = "Hello World!";
+            var stream = CreateBOMStream(content, Encoding.UTF8);
+
+            // Act
+            var document = new StreamSourceDocument(stream, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: "file.cshtml", relativePath: null));
+
+            // Assert
+            Assert.Equal("file.cshtml", document.FilePath);
+        }
+
+        [Fact]
+        public void FilePath_Null()
+        {
+            // Arrange
+            var content = "Hello World!";
+            var stream = CreateBOMStream(content, Encoding.UTF8);
+
+            // Act
+            var document = new StreamSourceDocument(stream, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: null, relativePath: null));
+
+            // Assert
+            Assert.Null(document.FilePath);
+        }
+
+        [Fact]
+        public void RelativePath()
+        {
+            // Arrange
+            var content = "Hello World!";
+            var stream = CreateBOMStream(content, Encoding.UTF8);
+
+            // Act
+            var document = new StreamSourceDocument(stream, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: null, relativePath: "file.cshtml"));
+
+            // Assert
+            Assert.Equal("file.cshtml", document.RelativePath);
+        }
+
+        [Fact]
+        public void RelativePath_Null()
+        {
+            // Arrange
+            var content = "Hello World!";
+            var stream = CreateBOMStream(content, Encoding.UTF8);
+
+            // Act
+            var document = new StreamSourceDocument(stream, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: null, relativePath: null));
+
+            // Assert
+            Assert.Null(document.RelativePath);
+        }
+
+        [Fact]
         public void GetChecksum_ReturnsCopiedChecksum()
         {
             // Arrange
             var content = "Hello World!";
             var stream = CreateBOMStream(content, Encoding.UTF8);
-            var document = new StreamSourceDocument(stream, Encoding.UTF8, "file.cshtml");
+            var document = new StreamSourceDocument(stream, null, RazorSourceDocumentProperties.Default);
 
             // Act
             var firstChecksum = document.GetChecksum();
@@ -33,7 +89,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello World!";
             var stream = CreateBOMStream(content, Encoding.UTF8);
-            var document = new StreamSourceDocument(stream, Encoding.UTF8, "file.cshtml");
+            var document = new StreamSourceDocument(stream, Encoding.UTF8, RazorSourceDocumentProperties.Default);
             var expectedChecksum = new byte[] { 70, 180, 84, 105, 70, 79, 152, 31, 71, 157, 46, 159, 50, 83, 1, 243, 222, 48, 90, 18 };
 
             // Act
@@ -49,7 +105,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello World!";
             var stream = CreateBOMStream(content, Encoding.UTF32);
-            var document = new StreamSourceDocument(stream, encoding: null, fileName: "file.cshtml");
+            var document = new StreamSourceDocument(stream, null, RazorSourceDocumentProperties.Default);
             var expectedChecksum = new byte[] { 159, 154, 109, 89, 250, 163, 165, 108, 2, 112, 34, 4, 247, 161, 82, 168, 77, 213, 107, 71 };
 
             // Act
@@ -66,11 +122,10 @@ namespace Microsoft.AspNetCore.Razor.Language
             var content = TestRazorSourceDocument.CreateStreamContent(encoding: Encoding.UTF32);
 
             // Act
-            var document = new StreamSourceDocument(content, encoding: null, fileName: "file.cshtml");
+            var document = new StreamSourceDocument(content, null, RazorSourceDocumentProperties.Default);
 
             // Assert
             Assert.IsType<StreamSourceDocument>(document);
-            Assert.Equal("file.cshtml", document.FilePath);
             Assert.Equal(Encoding.UTF32, document.Encoding);
         }
 
@@ -81,11 +136,10 @@ namespace Microsoft.AspNetCore.Razor.Language
             var content = TestRazorSourceDocument.CreateStreamContent(content: string.Empty, encoding: Encoding.UTF32);
 
             // Act
-            var document = new StreamSourceDocument(content, encoding: null, fileName: "file.cshtml");
+            var document = new StreamSourceDocument(content, null, RazorSourceDocumentProperties.Default);
 
             // Assert
             Assert.IsType<StreamSourceDocument>(document);
-            Assert.Equal("file.cshtml", document.FilePath);
             Assert.Equal(Encoding.UTF32, document.Encoding);
         }
 
@@ -98,7 +152,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(
-                () => new StreamSourceDocument(content, Encoding.UTF8, "file.cshtml"));
+                () => new StreamSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default));
             Assert.Equal(expectedMessage, exception.Message);
         }
 
@@ -115,12 +169,11 @@ namespace Microsoft.AspNetCore.Razor.Language
             var stream = TestRazorSourceDocument.CreateStreamContent(content);
 
             // Act
-            var document = new StreamSourceDocument(stream, encoding: null, fileName: "file.cshtml");
+            var document = new StreamSourceDocument(stream, null, RazorSourceDocumentProperties.Default);
 
             // Assert
             var streamDocument = Assert.IsType<StreamSourceDocument>(document);
             Assert.IsType<LargeTextSourceDocument>(streamDocument._innerSourceDocument);
-            Assert.Equal("file.cshtml", document.FilePath);
             Assert.Same(Encoding.UTF8, document.Encoding);
             Assert.Equal(content, ReadContent(document));
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/StringSourceDocumentTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/StringSourceDocumentTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = "Hello World!";
-            var document = new StringSourceDocument(content, Encoding.UTF8, "file.cshtml");
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var firstChecksum = document.GetChecksum();
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = "Hello World!";
-            var document = new StringSourceDocument(content, Encoding.UTF8, "file.cshtml");
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
             var expectedChecksum = new byte[] { 46, 247, 189, 230, 8, 206, 84, 4, 233, 125, 95, 4, 47, 149, 248, 159, 28, 35, 40, 113 };
 
             // Act
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = "Hello World!";
-            var document = new StringSourceDocument(content, Encoding.UTF32, "file.cshtml");
+            var document = new StringSourceDocument(content, Encoding.UTF32, RazorSourceDocumentProperties.Default);
             var expectedChecksum = new byte[] { 8, 149, 159, 15, 242, 255, 115, 227, 219, 78, 61, 53, 127, 239, 77, 239, 215, 140, 248, 44 };
 
             // Act
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var expectedContent = "Hello, World!";
             var indexerBuffer = new char[expectedContent.Length];
-            var document = new StringSourceDocument(expectedContent, Encoding.UTF8, filePath: "file.cshtml");
+            var document = new StringSourceDocument(expectedContent, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             for (var i = 0; i < document.Length; i++)
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var expectedContent = "Hello, World!";
-            var document = new StringSourceDocument(expectedContent, Encoding.UTF8, filePath: "file.cshtml");
+            var document = new StringSourceDocument(expectedContent, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act & Assert
             Assert.Equal(expectedContent.Length, document.Length);
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             var content = "Hello, World!";
 
             // Act
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: "file.cshtml");
+            var document = new StringSourceDocument(content, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: "file.cshtml", relativePath: null));
 
             // Assert
             Assert.Equal("file.cshtml", document.FilePath);
@@ -104,10 +104,36 @@ namespace Microsoft.AspNetCore.Razor.Language
             var content = "Hello, World!";
 
             // Act
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: null, relativePath: null));
 
             // Assert
             Assert.Null(document.FilePath);
+        }
+
+        [Fact]
+        public void RelativePath()
+        {
+            // Arrange
+            var content = "Hello, World!";
+
+            // Act
+            var document = new StringSourceDocument(content, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: null, relativePath: "file.cshtml"));
+
+            // Assert
+            Assert.Equal("file.cshtml", document.RelativePath);
+        }
+
+        [Fact]
+        public void RelativePath_Null()
+        {
+            // Arrange
+            var content = "Hello, World!";
+
+            // Act
+            var document = new StringSourceDocument(content, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: null, relativePath: null));
+
+            // Assert
+            Assert.Null(document.RelativePath);
         }
 
         [Fact]
@@ -115,7 +141,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = "Hello, World!";
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
             var expectedContent = "Hello";
             var charBuffer = new char[expectedContent.Length];
 
@@ -132,7 +158,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = "Hello, World!";
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
             var expectedContent = "$Hello";
             var charBuffer = new char[expectedContent.Length];
             charBuffer[0] = '$';
@@ -150,7 +176,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = "Hello, World!";
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
             var expectedContent = "World";
             var charBuffer = new char[expectedContent.Length];
 
@@ -163,27 +189,11 @@ namespace Microsoft.AspNetCore.Razor.Language
         }
 
         [Fact]
-        public void CopyTo_WithEncoding()
-        {
-            // Arrange
-            var content = "Hi";
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
-            var charBuffer = new char[2];
-
-            // Act
-            document.CopyTo(0, charBuffer, 0, 2);
-
-            // Assert
-            var copiedContent = new string(charBuffer);
-            Assert.Equal("Hi", copiedContent);
-        }
-
-        [Fact]
         public void CopyTo_CanCopyMultipleTimes()
         {
             // Arrange
             var content = "Hi";
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act & Assert
             //
@@ -202,7 +212,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = string.Empty;
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = document.Lines.Count;
@@ -216,7 +226,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = string.Empty;
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = document.Lines.GetLineLength(0);
@@ -230,7 +240,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = "hello\n";
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = document.Lines.GetLineLength(0);
@@ -244,7 +254,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var content = "hello\r\n";
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = document.Lines.GetLineLength(0);
@@ -263,7 +273,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 .Append("jumps over the lazy dog.")
                 .ToString();
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = GetAllSourceMappings(document);
@@ -278,7 +288,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\r\nWorld!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = GetAllSourceMappings(document);
@@ -293,7 +303,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\rWorld!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = GetAllSourceMappings(document);
@@ -309,7 +319,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\rBig\r\nWorld!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = GetAllSourceMappings(document);
@@ -324,7 +334,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\nWorld!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = GetAllSourceMappings(document);
@@ -339,7 +349,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\u0085World!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = GetAllSourceMappings(document);
@@ -354,7 +364,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\u2028World!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = GetAllSourceMappings(document);
@@ -369,7 +379,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\u2029World!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = GetAllSourceMappings(document);
@@ -384,13 +394,29 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello, World!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: "Hi.cshtml");
+            var document = new StringSourceDocument(content, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: "Hi.cshtml", relativePath: null));
 
             // Act
             var actual = document.Lines.GetLocation(1);
 
             // Assert
             Assert.Equal("Hi.cshtml", actual.FilePath);
+            Assert.Equal(1, actual.AbsoluteIndex);
+        }
+
+        [Fact]
+        public void Lines_GetLocation_PrefersRelativePath()
+        {
+            // Arrange
+            var content = "Hello, World!";
+
+            var document = new StringSourceDocument(content, Encoding.UTF8, new RazorSourceDocumentProperties(filePath: "Hi.cshtml", relativePath: "Bye.cshtml"));
+
+            // Act
+            var actual = document.Lines.GetLocation(1);
+
+            // Assert
+            Assert.Equal("Bye.cshtml", actual.FilePath);
             Assert.Equal(1, actual.AbsoluteIndex);
         }
 
@@ -402,7 +428,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\nBig\r\nWorld!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = document.Lines.GetLocation(0);
@@ -418,7 +444,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\nBig\r\nWorld!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = document.Lines.GetLocation(5);
@@ -434,7 +460,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\nBig\r\nWorld!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = document.Lines.GetLocation(7);
@@ -450,7 +476,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\nBig\r\nWorld!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = document.Lines.GetLocation(11);
@@ -466,7 +492,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var content = "Hello\nBig\r\nWorld!";
 
-            var document = new StringSourceDocument(content, Encoding.UTF8, filePath: null);
+            var document = new StringSourceDocument(content, Encoding.UTF8, RazorSourceDocumentProperties.Default);
 
             // Act
             var actual = document.Lines.GetLocation(16);

--- a/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/ParserTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/ParserTestBase.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             directives = directives ?? Array.Empty<DirectiveDescriptor>();
 
-            var source = TestRazorSourceDocument.Create(document, fileName: null);
+            var source = TestRazorSourceDocument.Create(document, filePath: null);
 
             var options = CreateParserOptions(directives, designTime);
             var context = new ParserContext(source, options);
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             directives = directives ?? Array.Empty<DirectiveDescriptor>();
 
-            var source = TestRazorSourceDocument.Create(document, fileName: null);
+            var source = TestRazorSourceDocument.Create(document, filePath: null);
             var options = CreateParserOptions(directives, designTime);
             var context = new ParserContext(source, options);
 
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             directives = directives ?? Array.Empty<DirectiveDescriptor>();
 
-            var source = TestRazorSourceDocument.Create(document, fileName: null);
+            var source = TestRazorSourceDocument.Create(document, filePath: null);
             var options = CreateParserOptions(directives, designTime);
             var context = new ParserContext(source, options);
 

--- a/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRazorProjectItem.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRazorProjectItem.cs
@@ -9,11 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language
     public class TestRazorProjectItem : RazorProjectItem
     {
         public TestRazorProjectItem(
-            string path, 
+            string filePath, 
             string physicalPath = null,
             string basePath = "/")
         {
-            FilePath = path;
+            FilePath = filePath;
             PhysicalPath = physicalPath;
             BasePath = basePath;
         }


### PR DESCRIPTION
Adding this via a properties object that encompasses all of the optional
properties. This way if we need to add more items that are optional we
can continue to do so without overload explosion.