### PR TITLE
Unify how AdhocWorkspace is constructed.

### DIFF
--- a/Razor.sln
+++ b/Razor.sln
@@ -92,6 +92,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{C2C98051-0F39-47F2-80B6-E72B29159F2C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common", "test\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj", "{933101DA-C4CC-401A-AA01-2784E1025B7F}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.Tools", "src\Microsoft.AspNetCore.Razor.Tools\Microsoft.AspNetCore.Razor.Tools.csproj", "{3E7F2D49-3B45-45A8-9893-F73EC1EEBAAB}"
 EndProject
 Global
@@ -388,6 +390,14 @@ Global
 		{3E7F2D49-3B45-45A8-9893-F73EC1EEBAAB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3E7F2D49-3B45-45A8-9893-F73EC1EEBAAB}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
 		{3E7F2D49-3B45-45A8-9893-F73EC1EEBAAB}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
+		{933101DA-C4CC-401A-AA01-2784E1025B7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{933101DA-C4CC-401A-AA01-2784E1025B7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{933101DA-C4CC-401A-AA01-2784E1025B7F}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{933101DA-C4CC-401A-AA01-2784E1025B7F}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+		{933101DA-C4CC-401A-AA01-2784E1025B7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{933101DA-C4CC-401A-AA01-2784E1025B7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{933101DA-C4CC-401A-AA01-2784E1025B7F}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{933101DA-C4CC-401A-AA01-2784E1025B7F}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -429,6 +439,7 @@ Global
 		{323553F0-14AB-4FBD-9CF0-1CC0BE8056F8} = {92463391-81BE-462B-AC3C-78C6C760741F}
 		{6205467F-E381-4C42-AEEC-763BD62B3D5E} = {C2C98051-0F39-47F2-80B6-E72B29159F2C}
 		{3E7F2D49-3B45-45A8-9893-F73EC1EEBAAB} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
+		{933101DA-C4CC-401A-AA01-2784E1025B7F} = {92463391-81BE-462B-AC3C-78C6C760741F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0035341D-175A-4D05-95E6-F1C2785A1E26}

--- a/build/repo.props
+++ b/build/repo.props
@@ -10,6 +10,7 @@
     <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.VisualStudio.LanguageServices.Razor.Test\Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj" Condition="'$(OS)'!='Windows_NT'" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.VisualStudio.Editor.Razor.Test\Microsoft.VisualStudio.Editor.Razor.Test.csproj" Condition="'$(OS)'!='Windows_NT'" />
+    <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.VisualStudio.Editor.Razor.Test.Common\Microsoft.VisualStudio.Editor.Razor.Test.Common.csproj" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.AspNetCore.Razor.Performance\Microsoft.AspNetCore.Razor.Performance.csproj" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.AspNetCore.Razor.Test.MvcShim\Microsoft.AspNetCore.Razor.Test.MvcShim.csproj" />

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net46;$(StandardTestTfms)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(VSIX_MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestWorkspace.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestWorkspace.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis
+{
+    public static class TestWorkspace
+    {
+        private static readonly object WorkspaceLock = new object();
+
+        public static Workspace Create(Action<AdhocWorkspace> configure = null)
+        {
+            lock (WorkspaceLock)
+            {
+                var workspace = new AdhocWorkspace();
+                configure?.Invoke(workspace);
+
+                return workspace;
+            }
+        }
+    }
+}

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Razor.Workspaces\Microsoft.CodeAnalysis.Razor.Workspaces.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor.Runtime\Microsoft.AspNetCore.Razor.Runtime.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Razor\Microsoft.AspNetCore.Razor.csproj" />
-    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
+    <ProjectReference Include="..\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     {
         public DefaultProjectSnapshotManagerTest()
         {
-            Workspace = new AdhocWorkspace();
+            Workspace = TestWorkspace.Create();
             ProjectManager = new TestProjectSnapshotManager(Enumerable.Empty<ProjectSnapshotChangeTrigger>(), Workspace);
         }
 

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotTest.cs
@@ -102,7 +102,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private Project GetProject(string name)
         {
-            var project = new AdhocWorkspace().AddProject(name, LanguageNames.CSharp);
+            Project project = null;
+            TestWorkspace.Create(workspace =>
+            {
+                project = workspace.AddProject(name, LanguageNames.CSharp);
+            });
             return project;
         }
     }

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/WorkspaceProjectSnapshotChangeTriggerTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/WorkspaceProjectSnapshotChangeTriggerTest.cs
@@ -14,15 +14,31 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     {
         public WorkspaceProjectSnapshotChangeTriggerTest()
         {
-            Workspace = new AdhocWorkspace();
-            EmptySolution = Workspace.CurrentSolution.GetIsolatedSolution();
+            Solution emptySolution = null;
+            Project project1 = null;
+            Project project2 = null;
+            Project project3 = null;
+            Solution solutionWithTwoProjects = null;
+            Solution solutionWithOneProject = null;
 
-            ProjectNumberOne = Workspace.CurrentSolution.AddProject("One", "One", LanguageNames.CSharp);
-            ProjectNumberTwo = ProjectNumberOne.Solution.AddProject("Two", "Two", LanguageNames.CSharp);
-            SolutionWithTwoProjects = ProjectNumberTwo.Solution;
+            Workspace = TestWorkspace.Create(ws =>
+            {
+                emptySolution = ws.CurrentSolution.GetIsolatedSolution();
+                project1 = ws.CurrentSolution.AddProject("One", "One", LanguageNames.CSharp);
+                project2 = project1.Solution.AddProject("Two", "Two", LanguageNames.CSharp);
+                solutionWithTwoProjects = project2.Solution;
 
-            ProjectNumberThree = EmptySolution.GetIsolatedSolution().AddProject("Three", "Three", LanguageNames.CSharp);
-            SolutionWithOneProject = ProjectNumberThree.Solution;
+                project3 = emptySolution.GetIsolatedSolution().AddProject("Three", "Three", LanguageNames.CSharp);
+                solutionWithOneProject = project3.Solution;
+            });
+
+            EmptySolution = emptySolution;
+            ProjectNumberOne = project1;
+            ProjectNumberTwo = project2;
+            ProjectNumberThree = project3;
+            SolutionWithTwoProjects = solutionWithTwoProjects;
+            SolutionWithOneProject = solutionWithOneProject;
+
         }
 
         private Solution EmptySolution { get; }

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/Microsoft.VisualStudio.Editor.Razor.Test.Common.csproj
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/Microsoft.VisualStudio.Editor.Razor.Test.Common.csproj
@@ -9,15 +9,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
+    <ProjectReference Include="..\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common\Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.Editor.Razor\Microsoft.VisualStudio.Editor.Razor.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(VSIX_MicrosoftCodeAnalysisCommonPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorDocumentManagerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorDocumentManagerTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         private ImportDocumentManager ImportDocumentManager => Mock.Of<ImportDocumentManager>();
 
-        private Workspace Workspace => new AdhocWorkspace();
+        private Workspace Workspace => TestWorkspace.Create();
 
         private TextBufferProjectService SupportedProjectService { get; } = Mock.Of<TextBufferProjectService>(
             s => s.GetHostProject(It.IsAny<ITextBuffer>()) == Mock.Of<object>() &&

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultTemplateEngineFactoryServiceTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultTemplateEngineFactoryServiceTest.cs
@@ -18,10 +18,15 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         public DefaultTemplateEngineFactoryServiceTest()
         {
-            Workspace = new AdhocWorkspace();
+            Project project = null;
 
-            var info = ProjectInfo.Create(ProjectId.CreateNewId("Test"), VersionStamp.Default, "Test", "Test", LanguageNames.CSharp, filePath: "/TestPath/SomePath/Test.csproj");
-            Project = Workspace.CurrentSolution.AddProject(info).GetProject(info.Id);
+            Workspace = TestWorkspace.Create(workspace =>
+            {
+                var info = ProjectInfo.Create(ProjectId.CreateNewId("Test"), VersionStamp.Default, "Test", "Test", LanguageNames.CSharp, filePath: "/TestPath/SomePath/Test.csproj");
+                project = workspace.CurrentSolution.AddProject(info).GetProject(info.Id);
+            });
+
+            Project = project;
         }
 
         // We don't actually look at the project, we rely on the ProjectStateManager

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultTextBufferProviderTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultTextBufferProviderTest.cs
@@ -92,13 +92,16 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         private static Document CreateDocumentWithoutText()
         {
-            var project = ProjectInfo
-                .Create(ProjectId.CreateNewId(), VersionStamp.Default, "TestProject", "TestAssembly", LanguageNames.CSharp)
-                .WithFilePath("/TestProject.csproj");
-            var workspace = new AdhocWorkspace();
-            workspace.AddProject(project);
-            var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "Test.cshtml");
-            var document = workspace.AddDocument(documentInfo);
+            Document document = null;
+            TestWorkspace.Create(workspace =>
+            {
+                var project = ProjectInfo
+                    .Create(ProjectId.CreateNewId(), VersionStamp.Default, "TestProject", "TestAssembly", LanguageNames.CSharp)
+                    .WithFilePath("/TestProject.csproj");
+                workspace.AddProject(project);
+                var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "Test.cshtml");
+                document = workspace.AddDocument(documentInfo);
+            });
 
             return document;
         }

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         private EditorSettingsManagerInternal EditorSettingsManager => new DefaultEditorSettingsManagerInternal(Dispatcher);
 
-        private Workspace Workspace => new AdhocWorkspace();
+        private Workspace Workspace => TestWorkspace.Create();
 
         private ImportDocumentManager ImportDocumentManager => Mock.Of<ImportDocumentManager>();
 
@@ -57,9 +57,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public void ProjectManager_Changed_ProjectChanged_TriggersContextChanged()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(Dispatcher, FilePath, ProjectPath, ProjectManager, EditorSettingsManager, Workspace, TextBuffer, ImportDocumentManager);
+            Project project = null;
+            var workspace = TestWorkspace.Create(ws =>
+            {
+                project = ws.AddProject(ProjectInfo.Create(ProjectId.CreateNewId(), new VersionStamp(), "Test1", "TestAssembly", LanguageNames.CSharp, filePath: "C:/Some/Path/TestProject.csproj"));
+            });
+            var documentTracker = new DefaultVisualStudioDocumentTracker(Dispatcher, FilePath, ProjectPath, ProjectManager, EditorSettingsManager, workspace, TextBuffer, ImportDocumentManager);
 
-            var project = new AdhocWorkspace().AddProject(ProjectInfo.Create(ProjectId.CreateNewId(), new VersionStamp(), "Test1", "TestAssembly", LanguageNames.CSharp, filePath: "C:/Some/Path/TestProject.csproj"));
             var projectSnapshot = new DefaultProjectSnapshot(project);
             var projectChangedArgs = new ProjectChangeEventArgs(projectSnapshot, ProjectChangeKind.Changed);
 
@@ -81,9 +85,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public void ProjectManager_Changed_TagHelpersChanged_TriggersContextChanged()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(Dispatcher, FilePath, ProjectPath, ProjectManager, EditorSettingsManager, Workspace, TextBuffer, ImportDocumentManager);
+            Project project = null;
+            var workspace = TestWorkspace.Create(ws =>
+            {
+                project = ws.AddProject(ProjectInfo.Create(ProjectId.CreateNewId(), new VersionStamp(), "Test1", "TestAssembly", LanguageNames.CSharp, filePath: "C:/Some/Path/TestProject.csproj"));
+            });
+            var documentTracker = new DefaultVisualStudioDocumentTracker(Dispatcher, FilePath, ProjectPath, ProjectManager, EditorSettingsManager, workspace, TextBuffer, ImportDocumentManager);
 
-            var project = new AdhocWorkspace().AddProject(ProjectInfo.Create(ProjectId.CreateNewId(), new VersionStamp(), "Test1", "TestAssembly", LanguageNames.CSharp, filePath: "C:/Some/Path/TestProject.csproj"));
             var projectSnapshot = new DefaultProjectSnapshot(project);
             var projectChangedArgs = new ProjectChangeEventArgs(projectSnapshot, ProjectChangeKind.TagHelpersChanged);
 
@@ -105,9 +113,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public void ProjectManager_Changed_IgnoresUnknownProject()
         {
             // Arrange
-            var documentTracker = new DefaultVisualStudioDocumentTracker(Dispatcher, FilePath, ProjectPath, ProjectManager, EditorSettingsManager, Workspace, TextBuffer, ImportDocumentManager);
+            Project project = null;
+            var workspace = TestWorkspace.Create(ws =>
+            {
+                project = ws.AddProject(ProjectInfo.Create(ProjectId.CreateNewId(), new VersionStamp(), "Test1", "TestAssembly", LanguageNames.CSharp, filePath: "C:/Some/Other/Path/TestProject.csproj"));
+            });
+            var documentTracker = new DefaultVisualStudioDocumentTracker(Dispatcher, FilePath, ProjectPath, ProjectManager, EditorSettingsManager, workspace, TextBuffer, ImportDocumentManager);
 
-            var project = new AdhocWorkspace().AddProject(ProjectInfo.Create(ProjectId.CreateNewId(), new VersionStamp(), "Test1", "TestAssembly", LanguageNames.CSharp, filePath: "C:/Some/Other/Path/TestProject.csproj"));
             var projectSnapshot = new DefaultProjectSnapshot(project);
             var projectChangedArgs = new ProjectChangeEventArgs(projectSnapshot, ProjectChangeKind.Changed);
 

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionProviderTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionProviderTest.cs
@@ -108,13 +108,16 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public async Task ProvideCompletionAsync_DoesNotProvideCompletionsForDocumentWithoutPath()
         {
             // Arrange
-            var project = ProjectInfo
+            Document document = null;
+            TestWorkspace.Create(workspace =>
+            {
+                var project = ProjectInfo
                 .Create(ProjectId.CreateNewId(), VersionStamp.Default, "TestProject", "TestAssembly", LanguageNames.CSharp)
                 .WithFilePath("/TestProject.csproj");
-            var workspace = new AdhocWorkspace();
-            workspace.AddProject(project);
-            var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "Test.cshtml");
-            var document = workspace.AddDocument(documentInfo);
+                workspace.AddProject(project);
+                var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "Test.cshtml");
+                document = workspace.AddDocument(documentInfo);
+            });
 
             var codeDocumentProvider = new Mock<RazorCodeDocumentProvider>(MockBehavior.Strict);
             var completionProvider = new FailOnGetCompletionsProvider(new Lazy<RazorCodeDocumentProvider>(() => codeDocumentProvider.Object));
@@ -325,14 +328,17 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         private static Document CreateDocument()
         {
-            var project = ProjectInfo
+            Document document = null;
+            TestWorkspace.Create(workspace =>
+            {
+                var project = ProjectInfo
                 .Create(ProjectId.CreateNewId(), VersionStamp.Default, "TestProject", "TestAssembly", LanguageNames.CSharp)
                 .WithFilePath("/TestProject.csproj");
-            var workspace = new AdhocWorkspace();
-            workspace.AddProject(project);
-            var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "Test.cshtml");
-            var document = workspace.AddDocument(documentInfo);
-            document = document.WithFilePath("Test.cshtml");
+                workspace.AddProject(project);
+                var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "Test.cshtml");
+                document = workspace.AddDocument(documentInfo);
+                document = document.WithFilePath("Test.cshtml");
+            });
 
             return document;
         }

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorTextViewConnectionListenerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorTextViewConnectionListenerTest.cs
@@ -36,7 +36,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Arrange
             var textView = Mock.Of<ITextView>();
             var buffers = new Collection<ITextBuffer>();
-            var workspace = new AdhocWorkspace();
             var documentManager = new Mock<RazorDocumentManager>(MockBehavior.Strict);
             documentManager.Setup(d => d.OnTextViewClosed(textView, buffers)).Verifiable();
 

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotWorkerQueueTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotWorkerQueueTest.cs
@@ -16,10 +16,17 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     {
         public ProjectSnapshotWorkerQueueTest()
         {
-            Workspace = new AdhocWorkspace();
+            Project project1 = null;
+            Project project2 = null;
 
-            Project1 = Workspace.CurrentSolution.AddProject("Test1", "Test1", LanguageNames.CSharp);
-            Project2 = Workspace.CurrentSolution.AddProject("Test2", "Test2", LanguageNames.CSharp);
+            Workspace = TestWorkspace.Create(workspace =>
+            {
+                project1 = workspace.CurrentSolution.AddProject("Test1", "Test1", LanguageNames.CSharp);
+                project2 = workspace.CurrentSolution.AddProject("Test2", "Test2", LanguageNames.CSharp);
+            });
+
+            Project1 = project1;
+            Project2 = project2;
         }
 
         public Project Project1 { get; }

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
@@ -56,9 +56,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             projectService.Setup(p => p.GetProjectName(It.IsAny<IVsHierarchy>())).Returns(expectedProjectName);
             projectService.Setup(p => p.GetProjectPath(It.IsAny<IVsHierarchy>())).Returns(expectedProjectPath);
 
-            var workspace = new AdhocWorkspace();
-            CreateProjectInWorkspace(workspace, expectedProjectName, expectedProjectPath);
-            CreateProjectInWorkspace(workspace, "Test2", "Path/To/AnotherProject");
+            var workspace = TestWorkspace.Create(ws =>
+            {
+                CreateProjectInWorkspace(ws, expectedProjectName, expectedProjectPath);
+                CreateProjectInWorkspace(ws, "Test2", "Path/To/AnotherProject");
+            });
 
             var called = false;
             var projectManager = new Mock<ProjectSnapshotManagerBase>();
@@ -101,9 +103,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             projectService.Setup(p => p.GetProjectName(It.IsAny<IVsHierarchy>())).Returns(expectedProjectName);
             projectService.Setup(p => p.GetProjectPath(It.IsAny<IVsHierarchy>())).Returns(expectedProjectPath);
 
-            var workspace = new AdhocWorkspace();
-            CreateProjectInWorkspace(workspace, "Test2", "Path/To/AnotherProject");
-            CreateProjectInWorkspace(workspace, "Test3", "Path/To/DifferenProject");
+            var workspace = TestWorkspace.Create(ws =>
+            {
+                CreateProjectInWorkspace(ws, "Test2", "Path/To/AnotherProject");
+                CreateProjectInWorkspace(ws, "Test3", "Path/To/DifferenProject");
+            });
 
             var projectManager = new Mock<ProjectSnapshotManagerBase>();
             projectManager.SetupGet(p => p.Workspace).Returns(workspace);

--- a/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectBuildChangeTriggerTest.cs
+++ b/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/ProjectBuildChangeTriggerTest.cs
@@ -22,9 +22,11 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
             var expectedProjectName = "Test1";
             var expectedProjectPath = "Path/To/Project";
             var projectService = CreateProjectService(expectedProjectName, expectedProjectPath);
-            var workspace = new AdhocWorkspace();
-            CreateProjectInWorkspace(workspace, expectedProjectName, expectedProjectPath);
-            CreateProjectInWorkspace(workspace, "Test2", "Path/To/AnotherProject");
+            var workspace = TestWorkspace.Create(ws =>
+            {
+                CreateProjectInWorkspace(ws, expectedProjectName, expectedProjectPath);
+                CreateProjectInWorkspace(ws, "Test2", "Path/To/AnotherProject");
+            });
 
             var projectManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
             projectManager.SetupGet(p => p.Workspace).Returns(workspace);
@@ -46,8 +48,10 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
             // Arrange
             var args = new BuildEventArgs(monitor: null, success: true);
             var projectService = CreateProjectService("Test1", "Path/To/Project");
-            var workspace = new AdhocWorkspace();
-            CreateProjectInWorkspace(workspace, "Test2", "Path/To/AnotherProject");
+            var workspace = TestWorkspace.Create(ws =>
+            {
+                CreateProjectInWorkspace(ws, "Test2", "Path/To/AnotherProject");
+            });
             var projectManager = new Mock<ProjectSnapshotManagerBase>();
             projectManager.SetupGet(p => p.Workspace).Returns(workspace);
             projectManager


### PR DESCRIPTION
- This fixes flakey tests that use AdhocWorkspace.
- Created a new `TestWorkspace` type to lock on `AdhocWorkspace` construction. This type can't be constructed/changed in parallel.
- Updated test usages of `AdhocWorkspace` to make use of `TestWorkspace`.
- Added a `Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common` project to have the `TestWorkspace` type.

#1913