### PR TITLE
Make Block and Span cache Length.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/Span.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/Span.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
     {
         private static readonly int TypeHashCode = typeof(Span).GetHashCode();
         private string _content;
+        private int? _length;
         private SourceLocation _start;
 
         public Span(SpanBuilder builder)
@@ -32,7 +33,31 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public override bool IsBlock => false;
 
-        public override int Length => Content.Length;
+        public override int Length
+        {
+            get
+            {
+                if (_length == null)
+                {
+                    var length = 0;
+                    if (_content == null)
+                    {
+                        for (var i = 0; i < Symbols.Count; i++)
+                        {
+                            length += Symbols[i].Content.Length;
+                        }
+                    }
+                    else
+                    {
+                        length = _content.Length;
+                    }
+
+                    _length = length;
+                }
+
+                return _length.Value;
+            }
+        }
 
         public override SourceLocation Start => _start;
 
@@ -79,6 +104,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             ChunkGenerator = builder.ChunkGenerator ?? SpanChunkGenerator.Null;
             _start = builder.Start;
             _content = null;
+            _length = null;
+
+            Parent?.ChildChanged();
 
             // Since we took references to the values in SpanBuilder, clear its references out
             builder.Reset();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/SpanTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/SpanTest.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.Legacy
+{
+    public class SpanTest
+    {
+        [Fact]
+        public void ReplaceWith_ResetsLength()
+        {
+            // Arrange
+            var builder = new SpanBuilder(SourceLocation.Zero);
+            builder.Accept(new HtmlSymbol("hello", HtmlSymbolType.Text));
+            var span = builder.Build();
+            var newBuilder = new SpanBuilder(SourceLocation.Zero);
+            newBuilder.Accept(new HtmlSymbol("hi", HtmlSymbolType.Text));
+            var originalLength = span.Length;
+
+            // Act
+            span.ReplaceWith(newBuilder);
+
+            // Assert
+            Assert.Equal(5, originalLength);
+            Assert.Equal(2, span.Length);
+        }
+
+
+        // Note: This is more of an integration-like test. However, it's valuable to determine
+        // that the Span's ReplaceWith code is properly propogating change notifications to parents.
+        [Fact]
+        public void ReplaceWith_NotifiesParentChildHasChanged()
+        {
+            // Arrange
+            var spanBuilder = new SpanBuilder(SourceLocation.Zero);
+            spanBuilder.Accept(new HtmlSymbol("hello", HtmlSymbolType.Text));
+            var span = spanBuilder.Build();
+            var blockBuilder = new BlockBuilder()
+            {
+                Type = BlockKindInternal.Markup,
+            };
+            blockBuilder.Children.Add(span);
+            var block = blockBuilder.Build();
+            span.Parent = block;
+            var originalBlockLength = block.Length;
+            var newSpanBuilder = new SpanBuilder(SourceLocation.Zero);
+            newSpanBuilder.Accept(new HtmlSymbol("hi", HtmlSymbolType.Text));
+
+            // Act
+            span.ReplaceWith(newSpanBuilder);
+
+            // Assert
+            Assert.Equal(5, originalBlockLength);
+            Assert.Equal(2, block.Length);
+        }
+    }
+}


### PR DESCRIPTION
- Part of caching length required the `Span`'s `ReplaceWith` method to propagate its changes to its parents so that they can all invalidate their length caches.
- Added Span tests to validate the interaction of caching.
- There is no benchmarking infrastructure on this branch.

#1927

From 4.2s for MSN.cshtml in an isolated test to 0s 😉 

## Before
![image](https://user-images.githubusercontent.com/2008729/35021376-6a9b240c-fae5-11e7-93fd-c6ce75c08a3f.png)


## After
![image](https://user-images.githubusercontent.com/2008729/35021383-7d0b6fe8-fae5-11e7-8aa5-91bbdda6c164.png)

/cc @ToddGrun 