### PR TITLE
Fix build break

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
@@ -162,14 +162,15 @@
   </Target>
 
   <!--
-    This target is called after PrepareForPublish when RazorCompileOnBuild=true so that we can hook into publish.
+    This target is called after PrepareForPublish when RazorCompileOnPublish=true so that we can hook into publish.
     This target just hooks up other targets since Publish and PrepareForPublish don't have a DependsOnTargets
     property we can use. 
   -->
   <Target 
     Name="_RazorPrepareForPublish"
     AfterTargets="PrepareForPublish"
-    DependsOnTargets="RazorCompile">
+    DependsOnTargets="RazorCompile"
+    Condition="'$(RazorCompileOnPublish)'=='true'">
   </Target>
 
   <!--

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PublishIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PublishIntegrationTest.cs
@@ -93,6 +93,23 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
         [Fact]
         [InitializeTestProject("SimpleMvc")]
+        public async Task Publish_NoopsWith_RazorCompileOnPublishFalse()
+        {
+            Directory.Delete(Path.Combine(Project.DirectoryPath, "Views"), recursive: true);
+
+            var result = await DotnetMSBuild("Publish", "/p:RazorCompileOnPublish=false");
+
+            Assert.BuildPassed(result);
+
+            // Everything we do should noop - including building the app. 
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc.dll");
+            Assert.FileExists(result, PublishOutputPath, "SimpleMvc.pdb");
+            Assert.FileDoesNotExist(result, PublishOutputPath, "SimpleMvc.PrecompiledViews.dll");
+            Assert.FileDoesNotExist(result, PublishOutputPath, "SimpleMvc.PrecompiledViews.pdb");
+        }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
         public async Task Publish_SkipsCopyingBinariesToOutputDirectory_IfCopyBuildOutputToOutputDirectory_IsUnset()
         {
             var result = await DotnetMSBuild("Publish", "/p:RazorCompileOnBuild=true /p:CopyBuildOutputToPublishDirectory=false");


### PR DESCRIPTION
We didn't have a test for the case where RazorCompileOnPublish is false
and Publish is being called. This is breaking the precompilation repo.