### PR TITLE
Prepare for Web SDK changes

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
@@ -165,7 +165,7 @@
     Name="_RazorPrepareForPublish"
     AfterTargets="PrepareForPublish"
     DependsOnTargets="RazorCompile"
-    Condition="'$(RazorCompileOnPublish)'=='true'">
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true'">
   </Target>
 
   <!--
@@ -174,9 +174,10 @@
   <Target 
     Name="_RazorAddBuiltProjectOutputGroupOutput"
     DependsOnTargets="ResolveRazorGenerateInputs"
-    BeforeTargets="BuiltProjectOutputGroup">
+    BeforeTargets="BuiltProjectOutputGroup"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
 
-    <ItemGroup Condition="'@(RazorGenerate)'!= '' and '$(RazorCompileOnBuild)' == 'true'">
+    <ItemGroup Condition="'@(RazorGenerate)'!= ''">
       <BuiltProjectOutputGroupOutput Include="@(RazorIntermediateAssembly)" FinalOutputPath="$(Outdir)$(RazorTargetName).dll" />
     </ItemGroup>
     
@@ -190,7 +191,7 @@
     Name="_RazorGetCopyToOutputDirectoryItems"
     BeforeTargets="GetCopyToOutputDirectoryItems"
     DependsOnTargets="RazorCompile"
-    Condition="'$(RazorCompileOnBuild)'=='true'">
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
 
     <!-- 
       This condition needs to be inside the target because it the itemgroup will be populated after the target's
@@ -220,7 +221,7 @@
     Name="_RazorGetCopyToPublishDirectoryItems"
     BeforeTargets="GetCopyToPublishDirectoryItems"
     DependsOnTargets="RazorCompile"
-    Condition="'$(RazorCompileOnBuild)'=='true' or '$(RazorCompileOnPublish)'=='true'">
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true'">
 
     <!-- 
       This condition needs to be inside the target because it the itemgroup will be populated after the target's
@@ -247,7 +248,7 @@
     Name="_RazorCopyFilesToOutputDirectory" 
     DependsOnTargets="RazorCompile"
     AfterTargets="CopyFilesToOutputDirectory"
-    Condition="'$(RazorCompileOnBuild)'=='true'">
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
 
     <!-- Copy the Razor dll  -->
     <Copy
@@ -294,7 +295,7 @@
   <Target
     Name="_RazorComputeFilesToPublish"
     AfterTargets="ComputeRefAssembliesToPublish"
-    Condition="'@(RazorGenerate)'!='' and ('$(RazorCompileOnBuild)'=='true' or '$(RazorCompileOnPublish)'=='true')">
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true' and '@(RazorGenerate)'!=''">
 
     <!-- If we generated an assembly/pdb then include those -->
     <ItemGroup>

--- a/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
+++ b/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <!-- Workaround until we get a new SDK build -->
+    <ResolvedRazorCompileToolset Condition="'$(RazorCompileToolset)'==''">RazorSDK</ResolvedRazorCompileToolset>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/testapps/ClassLibrary/ClassLibrary.csproj
+++ b/test/testapps/ClassLibrary/ClassLibrary.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <!-- Workaround until we get a new SDK build -->
+    <ResolvedRazorCompileToolset Condition="'$(RazorCompileToolset)'==''">RazorSDK</ResolvedRazorCompileToolset>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BinariesRoot)'==''">

--- a/test/testapps/SimpleMvc/SimpleMvc.csproj
+++ b/test/testapps/SimpleMvc/SimpleMvc.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <!-- Workaround until we get a new SDK build -->
+    <ResolvedRazorCompileToolset Condition="'$(RazorCompileToolset)'==''">RazorSDK</ResolvedRazorCompileToolset>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BinariesRoot)'==''">

--- a/test/testapps/SimplePages/SimplePages.csproj
+++ b/test/testapps/SimplePages/SimplePages.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <!-- Workaround until we get a new SDK build -->
+    <ResolvedRazorCompileToolset Condition="'$(RazorCompileToolset)'==''">RazorSDK</ResolvedRazorCompileToolset>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BinariesRoot)'==''">


### PR DESCRIPTION
The Web SDK is going to set a new msbuild property to tell us that the
Razor SDK should be active. This hasn't been integrated into our build
system yet, so I'm temporarily hacking it until we get that change. At
that time I'll remove the special cases in these projects.