### PR TITLE
Add key contracts and builders for RazorProjectEngine.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorImportFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorImportFeature.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorImportFeature : IRazorImportFeature
+    {
+        public RazorProjectEngine ProjectEngine { get; set; }
+
+        public IReadOnlyList<RazorSourceDocument> GetImports(string sourceFilePath) => Array.Empty<RazorSourceDocument>();
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorProjectEngine : RazorProjectEngine
+    {
+        public DefaultRazorProjectEngine(
+            RazorEngine engine,
+            RazorProjectFileSystem fileSystem,
+            IReadOnlyList<IRazorProjectEngineFeature> features)
+        {
+            if (engine == null)
+            {
+                throw new ArgumentNullException(nameof(engine));
+            }
+
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(fileSystem));
+            }
+
+            if (features == null)
+            {
+                throw new ArgumentNullException(nameof(features));
+            }
+
+            Engine = engine;
+            FileSystem = fileSystem;
+            Features = features;
+
+            for (var i = 0; i < features.Count; i++)
+            {
+                features[i].ProjectEngine = this;
+            }
+        }
+
+        public override RazorProjectFileSystem FileSystem { get; }
+
+        public override RazorEngine Engine { get; }
+
+        public override IReadOnlyList<IRazorProjectEngineFeature> Features { get; }
+
+        public override RazorCodeDocument Process(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(filePath));
+            }
+
+            var projectItem = FileSystem.GetItem(filePath);
+            var sourceDocument = RazorSourceDocument.ReadFrom(projectItem);
+            var codeDocument = Process(sourceDocument);
+
+            return codeDocument;
+        }
+
+        public override RazorCodeDocument Process(RazorSourceDocument sourceDocument)
+        {
+            if (sourceDocument == null)
+            {
+                throw new ArgumentNullException(nameof(sourceDocument));
+            }
+
+            var importFeature = GetRequiredFeature<IRazorImportFeature>();
+            var imports = importFeature.GetImports(sourceDocument.FilePath);
+
+            var codeDocument = RazorCodeDocument.Create(sourceDocument, imports);
+
+            Engine.Process(codeDocument);
+
+            return codeDocument;
+        }
+
+        private TFeature GetRequiredFeature<TFeature>() where TFeature : IRazorProjectEngineFeature
+        {
+            var feature = Features.OfType<TFeature>().FirstOrDefault();
+            if (feature == null)
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatRazorProjectEngineMissingFeatureDependency(
+                        typeof(RazorProjectEngine).FullName,
+                        typeof(TFeature).FullName));
+            }
+
+            return feature;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineBuilder.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorProjectEngineBuilder : RazorProjectEngineBuilder
+    {
+        public DefaultRazorProjectEngineBuilder(bool designTime, RazorProjectFileSystem fileSystem)
+        {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(fileSystem));
+            }
+
+            DesignTime = designTime;
+            FileSystem = fileSystem;
+            Features = new List<IRazorFeature>();
+            Phases = new List<IRazorEnginePhase>();
+        }
+
+        public override RazorProjectFileSystem FileSystem { get; }
+
+        public override ICollection<IRazorFeature> Features { get; }
+
+        public override IList<IRazorEnginePhase> Phases { get; }
+
+        public override bool DesignTime { get; }
+
+        public override RazorProjectEngine Build()
+        {
+            RazorEngine engine = null;
+
+            if (DesignTime)
+            {
+                engine = RazorEngine.CreateDesignTimeEmpty(ConfigureRazorEngine);
+            }
+            else
+            {
+                engine = RazorEngine.CreateEmpty(ConfigureRazorEngine);
+            }
+
+            var projectEngineFeatures = Features.OfType<IRazorProjectEngineFeature>().ToArray();
+            var projectEngine = new DefaultRazorProjectEngine(engine, FileSystem, projectEngineFeatures);
+
+            return projectEngine;
+        }
+
+        private void ConfigureRazorEngine(IRazorEngineBuilder engineBuilder)
+        {
+            var engineFeatures = Features.OfType<IRazorEngineFeature>();
+            foreach (var engineFeature in engineFeatures)
+            {
+                engineBuilder.Features.Add(engineFeature);
+            }
+
+            for (var i = 0; i < Phases.Count; i++)
+            {
+                engineBuilder.Phases.Add(Phases[i]);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorFeature.cs
@@ -3,8 +3,7 @@
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public interface IRazorEngineFeature : IRazorFeature
+    public interface IRazorFeature
     {
-        RazorEngine Engine { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorImportFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorImportFeature.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public interface IRazorEngineFeature : IRazorFeature
+    public interface IRazorImportFeature : IRazorProjectEngineFeature
     {
-        RazorEngine Engine { get; set; }
+        IReadOnlyList<RazorSourceDocument> GetImports(string sourceFilePath);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorProjectEngineFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorProjectEngineFeature.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public interface IRazorEngineFeature : IRazorFeature
+    public interface IRazorProjectEngineFeature : IRazorFeature
     {
-        RazorEngine Engine { get; set; }
+        RazorProjectEngine ProjectEngine { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -1856,6 +1856,20 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static string FormatPropertyMustNotBeNull(object p0, object p1)
             => string.Format(CultureInfo.CurrentCulture, GetString("PropertyMustNotBeNull"), p0, p1);
 
+        /// <summary>
+        /// The '{0}' is missing feature '{1}'.
+        /// </summary>
+        internal static string RazorProjectEngineMissingFeatureDependency
+        {
+            get => GetString("RazorProjectEngineMissingFeatureDependency");
+        }
+
+        /// <summary>
+        /// The '{0}' is missing feature '{1}'.
+        /// </summary>
+        internal static string FormatRazorProjectEngineMissingFeatureDependency(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("RazorProjectEngineMissingFeatureDependency"), p0, p1);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectEngine
+    {
+        public abstract RazorProjectFileSystem FileSystem { get; }
+
+        public abstract RazorEngine Engine { get; }
+
+        public abstract IReadOnlyList<IRazorProjectEngineFeature> Features { get; }
+
+        public abstract RazorCodeDocument Process(string filePath);
+
+        public abstract RazorCodeDocument Process(RazorSourceDocument sourceDocument);
+
+        public static RazorProjectEngine Create(RazorProjectFileSystem fileSystem) => Create(fileSystem, configure: null);
+
+        public static RazorProjectEngine Create(RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(fileSystem));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(designTime: false, fileSystem: fileSystem);
+
+            AddDefaults(builder);
+            AddRuntimeDefaults(builder);
+            configure?.Invoke(builder);
+
+            return builder.Build();
+        }
+
+        public static RazorProjectEngine CreateDesignTime(RazorProjectFileSystem fileSystem) => CreateDesignTime(fileSystem, configure: null);
+
+        public static RazorProjectEngine CreateDesignTime(RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(fileSystem));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(designTime: true, fileSystem: fileSystem);
+
+            AddDefaults(builder);
+            AddDesignTimeDefaults(builder);
+            configure?.Invoke(builder);
+
+            return builder.Build();
+        }
+
+        public static RazorProjectEngine CreateEmpty(RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(fileSystem));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(designTime: false, fileSystem: fileSystem);
+
+            configure(builder);
+
+            return builder.Build();
+        }
+
+        public static RazorProjectEngine CreateDesignTimeEmpty(RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(fileSystem));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(designTime: true, fileSystem: fileSystem);
+
+            configure(builder);
+
+            return builder.Build();
+        }
+
+        private static void AddDefaults(RazorProjectEngineBuilder builder)
+        {
+            builder.Features.Add(new DefaultRazorImportFeature());
+        }
+
+        private static void AddDesignTimeDefaults(RazorProjectEngineBuilder builder)
+        {
+            var engineFeatures = new List<IRazorEngineFeature>();
+            RazorEngine.AddDefaultFeatures(engineFeatures);
+            RazorEngine.AddDefaultDesignTimeFeatures(engineFeatures);
+
+            AddEngineFeaturesAndPhases(builder, engineFeatures);
+        }
+
+        private static void AddRuntimeDefaults(RazorProjectEngineBuilder builder)
+        {
+            var engineFeatures = new List<IRazorEngineFeature>();
+            RazorEngine.AddDefaultFeatures(engineFeatures);
+            RazorEngine.AddDefaultRuntimeFeatures(engineFeatures);
+
+            AddEngineFeaturesAndPhases(builder, engineFeatures);
+        }
+
+        private static void AddEngineFeaturesAndPhases(RazorProjectEngineBuilder builder, IReadOnlyList<IRazorEngineFeature> engineFeatures)
+        {
+            for (var i = 0; i < engineFeatures.Count; i++)
+            {
+                var engineFeature = engineFeatures[i];
+                builder.Features.Add(engineFeature);
+            }
+
+            RazorEngine.AddDefaultPhases(builder.Phases);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilder.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectEngineBuilder
+    {
+        public abstract RazorProjectFileSystem FileSystem { get; }
+
+        public abstract ICollection<IRazorFeature> Features { get; }
+
+        public abstract IList<IRazorEnginePhase> Phases { get; }
+
+        public abstract bool DesignTime { get; }
+
+        public abstract RazorProjectEngine Build();
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilderExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public static class RazorProjectEngineBuilderExtensions
+    {
+        public static void SetImportFeature(this RazorProjectEngineBuilder builder, IRazorImportFeature feature)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (feature == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            // Remove any existing import features in favor of the new one we're given.
+            var existingFeatures = builder.Features.OfType<IRazorImportFeature>().ToArray();
+            foreach (var existingFeature in existingFeatures)
+            {
+                builder.Features.Remove(existingFeature);
+            }
+
+            builder.Features.Add(feature);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectFileSystem.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectFileSystem.cs
@@ -3,8 +3,7 @@
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public interface IRazorEngineFeature : IRazorFeature
+    public abstract class RazorProjectFileSystem : RazorProject
     {
-        RazorEngine Engine { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -533,4 +533,7 @@ Instead, wrap the contents of the block in "{{}}":
   <data name="PropertyMustNotBeNull" xml:space="preserve">
     <value>The '{0}.{1}' property must not be null.</value>
   </data>
+  <data name="RazorProjectEngineMissingFeatureDependency" xml:space="preserve">
+    <value>The '{0}' is missing feature '{1}'.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineBuilderTest.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class DefaultRazorProjectEngineBuilderTest
+    {
+        [Fact]
+        public void Build_AddsFeaturesToRazorEngine()
+        {
+            // Arrange
+            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            builder.Features.Add(Mock.Of<IRazorEngineFeature>());
+            builder.Features.Add(Mock.Of<IRazorEngineFeature>());
+            builder.Features.Add(Mock.Of<IRazorProjectEngineFeature>());
+
+            var features = builder.Features.ToArray();
+
+            // Act
+            var projectEngine = builder.Build();
+
+            // Assert
+            Assert.Collection(projectEngine.Engine.Features,
+                feature => Assert.Same(features[0], feature),
+                feature => Assert.Same(features[1], feature));
+        }
+
+        [Fact]
+        public void Build_AddsPhasesToRazorEngine()
+        {
+            // Arrange
+            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            builder.Phases.Add(Mock.Of<IRazorEnginePhase>());
+            builder.Phases.Add(Mock.Of<IRazorEnginePhase>());
+
+            var phases = builder.Phases.ToArray();
+
+            // Act
+            var projectEngine = builder.Build();
+
+            // Assert
+            Assert.Collection(projectEngine.Engine.Phases,
+                phase => Assert.Same(phases[0], phase),
+                phase => Assert.Same(phases[1], phase));
+        }
+
+        [Fact]
+        public void Build_CreatesProjectEngineWithFileSystem()
+        {
+            // Arrange
+            var fileSystem = Mock.Of<RazorProjectFileSystem>();
+            var builder = new DefaultRazorProjectEngineBuilder(false, fileSystem);
+
+            // Act
+            var projectEngine = builder.Build();
+
+            // Assert
+            Assert.Same(fileSystem, projectEngine.FileSystem);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineIntegrationTest.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class DefaultRazorProjectEngineIntegrationTest
+    {
+        [Fact]
+        public void Process_GetsImportsFromFeature()
+        {
+            // Arrange
+            var sourceDocument = TestRazorSourceDocument.Create();
+            var testImport = TestRazorSourceDocument.Create();
+            var importFeature = new Mock<IRazorImportFeature>();
+            importFeature.Setup(feature => feature.GetImports(It.IsAny<string>()))
+                .Returns(new[] { testImport });
+            var projectEngine = RazorProjectEngine.Create(TestRazorProjectFileSystem.Empty, builder =>
+            {
+                builder.SetImportFeature(importFeature.Object);
+            });
+
+            // Act
+            var codeDocument = projectEngine.Process(sourceDocument);
+
+            // Assert
+            var import = Assert.Single(codeDocument.Imports);
+            Assert.Same(testImport, import);
+        }
+
+        [Fact]
+        public void Process_GeneratesCodeDocumentWithValidCSharpDocument()
+        {
+            // Arrange
+            var sourceDocument = TestRazorSourceDocument.Create();
+            var projectEngine = RazorProjectEngine.Create(TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.Process(sourceDocument);
+
+            // Assert
+            var csharpDocument = codeDocument.GetCSharpDocument();
+            Assert.NotNull(csharpDocument);
+            Assert.Empty(csharpDocument.Diagnostics);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineTest.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class DefaultRazorProjectEngineTest
+    {
+        [Fact]
+        public void Process_AsksFileSystemForItems()
+        {
+            // Arrange
+            var razorProjectItem = new TestRazorProjectItem("/some/path.cshtml");
+            var testFileSystem = new Mock<RazorProjectFileSystem>();
+            testFileSystem.Setup(fileSystem => fileSystem.GetItem("/some/path.cshtml"))
+                .Returns(razorProjectItem)
+                .Verifiable();
+            var projectEngine = RazorProjectEngine.Create(testFileSystem.Object);
+
+            // Act
+            projectEngine.Process("/some/path.cshtml");
+
+            // Assert
+            testFileSystem.Verify();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorProjectEngineBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorProjectEngineBuilderExtensionsTest.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class RazorProjectEngineBuilderExtensionsTest
+    {
+        [Fact]
+        public void SetImportFeature_SetsTheImportFeature()
+        {
+            // Arrange
+            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            var testFeature1 = Mock.Of<IRazorImportFeature>();
+            var testFeature2 = Mock.Of<IRazorImportFeature>();
+            builder.Features.Add(testFeature1);
+            builder.Features.Add(testFeature2);
+            var newFeature = Mock.Of<IRazorImportFeature>();
+
+            // Act
+            builder.SetImportFeature(newFeature);
+
+            // Assert
+            var feature = Assert.Single(builder.Features);
+            Assert.Same(newFeature, feature);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestRazorProjectFileSystem.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestRazorProjectFileSystem.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class TestRazorProjectFileSystem : RazorProjectFileSystem
+    {
+        public static RazorProjectFileSystem Empty = new TestRazorProjectFileSystem();
+
+        private readonly Dictionary<string, RazorProjectItem> _lookup;
+
+        public TestRazorProjectFileSystem()
+            : this(new RazorProjectItem[0])
+        {
+        }
+
+        public TestRazorProjectFileSystem(IList<RazorProjectItem> items)
+        {
+            _lookup = items.ToDictionary(item => item.FilePath);
+        }
+
+        public override IEnumerable<RazorProjectItem> EnumerateItems(string basePath)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override RazorProjectItem GetItem(string path)
+        {
+            if (!_lookup.TryGetValue(path, out var value))
+            {
+                value = new NotFoundProjectItem("", path);
+            }
+
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
- These contracts introduce a new `RazorProjectEngine` concept which allows for users to configure 1 entity that's responsible for the RazorEngine and project.
- The `RazorProjectEngineBuilder` has a collection of features that are dispersed on the created `RazorEngine` and the `RazorProjectEngine`.
- Included a complete implementation of `RazorProjectEngine` it introduces the extension points for the project engine. The primary one includes the `IRazorImportFeature`. Allowing multiple imports to take part in import discovery will come later.
- Included a complete project engine builder implementation.

My goal for this design was to come up with a pattern that had 1 entry point to configure both the project engine and Razor engine resulting in a user (or framework) never having to create the RazorEngine manually. This allows for a framework to fully customize the Razor code generation process from finding imports to changing how your Razor turns into C#.

How this will play out in practice is you'll do:

```C#
var mvcEngine = RazorProjectEngine.Create(projectFileSystem, builder =>
{
    // Register all things MVC
    RazorExtensions.Register(builder);
});

var blazorEngine = RazorProjectEngine.Create(projectFileSystem, builder =>
{
    // Register all things Blazor
    BlazorExtensions.Register(builder);
});
```

Big take away is that `RazorProjectEngine` concepts and `RazorEngine` concepts are ambiguous in the `RazorProjectEngineBuilder`; that builder has the knowledge to split the features among the two engine/project engine properly.

#1828 

/cc @mkArtakMSFT 