### PR TITLE
Add support for RazorProjectEngine imports.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultImportFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultImportFeature.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultImportFeature : RazorProjectEngineFeatureBase, IRazorImportFeature
+    {
+        private IEnumerable<IRazorImportExpander> _expanders;
+
+        public IReadOnlyList<RazorSourceDocument> GetImports(string sourceFilePath)
+        {
+            if (string.IsNullOrEmpty(sourceFilePath))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(sourceFilePath));
+            }
+
+            if (!_expanders.Any())
+            {
+                return Array.Empty<RazorSourceDocument>();
+            }
+
+            var importExpanderContext = new ImportExpanderContext(sourceFilePath);
+            foreach (var expander in _expanders)
+            {
+                expander.Populate(importExpanderContext);
+            }
+
+            var imports = importExpanderContext.Results.ToArray();
+            return imports;
+        }
+
+        protected override void OnInitialized()
+        {
+            _expanders = ProjectEngine.Features.OfType<IRazorImportExpander>().OrderBy(expander => expander.Order);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorProjectEngine : RazorProjectEngine
+    {
+        public DefaultRazorProjectEngine(
+            RazorEngine engine,
+            RazorProjectFileSystem projectFileSystem,
+            IReadOnlyList<IRazorProjectEngineFeature> features)
+        {
+            if (engine == null)
+            {
+                throw new ArgumentNullException(nameof(engine));
+            }
+
+            if (projectFileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(projectFileSystem));
+            }
+
+            if (features == null)
+            {
+                throw new ArgumentNullException(nameof(features));
+            }
+
+            Engine = engine;
+            ProjectFileSystem = projectFileSystem;
+            Features = features;
+
+            for (var i = 0; i < features.Count; i++)
+            {
+                features[i].ProjectEngine = this;
+            }
+        }
+
+        public override RazorProjectFileSystem ProjectFileSystem { get; }
+
+        public override RazorEngine Engine { get; }
+
+        public override IReadOnlyList<IRazorProjectEngineFeature> Features { get; }
+
+        public override RazorCodeDocument Process(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(filePath));
+            }
+
+            var projectItem = ProjectFileSystem.GetItem(filePath);
+            var sourceDocument = RazorSourceDocument.ReadFrom(projectItem);
+            var codeDocument = Process(sourceDocument);
+
+            return codeDocument;
+        }
+
+        public override RazorCodeDocument Process(RazorSourceDocument sourceDocument)
+        {
+            if (sourceDocument == null)
+            {
+                throw new ArgumentNullException(nameof(sourceDocument));
+            }
+
+            var importFeature = GetRequiredFeature<IRazorImportFeature>();
+            var imports = importFeature.GetImports(sourceDocument.FilePath);
+
+            var codeDocument = RazorCodeDocument.Create(sourceDocument, imports);
+
+            Engine.Process(codeDocument);
+
+            return codeDocument;
+        }
+
+        private TFeature GetRequiredFeature<TFeature>() where TFeature : IRazorProjectEngineFeature
+        {
+            var feature = Features.OfType<TFeature>().FirstOrDefault();
+            if (feature == null)
+            {
+                throw new InvalidOperationException(
+                    Resources.FormatMissingFeatureDependency(
+                        typeof(RazorProjectEngine).FullName,
+                        typeof(TFeature).FullName));
+            }
+
+            return feature;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineBuilder.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal class DefaultRazorProjectEngineBuilder : RazorProjectEngineBuilder
+    {
+        public DefaultRazorProjectEngineBuilder(bool designTime, RazorProjectFileSystem projectFileSystem)
+        {
+            if (projectFileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(projectFileSystem));
+            }
+
+            DesignTime = designTime;
+            ProjectFileSystem = projectFileSystem;
+            Features = new List<IRazorFeature>();
+            Phases = new List<IRazorEnginePhase>();
+        }
+
+        public override RazorProjectFileSystem ProjectFileSystem { get; }
+
+        public override ICollection<IRazorFeature> Features { get; }
+
+        public override IList<IRazorEnginePhase> Phases { get; }
+
+        public override bool DesignTime { get; }
+
+        public override RazorProjectEngine Build()
+        {
+            RazorEngine engine = null;
+
+            if (DesignTime)
+            {
+                engine = RazorEngine.CreateDesignTimeEmpty(ConfigureRazorEngine);
+            }
+            else
+            {
+                engine = RazorEngine.CreateEmpty(ConfigureRazorEngine);
+            }
+
+            var projectEngineFeatures = Features.OfType<IRazorProjectEngineFeature>().ToArray();
+            var projectEngine = new DefaultRazorProjectEngine(engine, ProjectFileSystem, projectEngineFeatures);
+
+            return projectEngine;
+        }
+
+        private void ConfigureRazorEngine(IRazorEngineBuilder engineBuilder)
+        {
+            var engineFeatures = Features.OfType<IRazorEngineFeature>();
+            foreach (var engineFeature in engineFeatures)
+            {
+                engineBuilder.Features.Add(engineFeature);
+            }
+
+            for (var i = 0; i < Phases.Count; i++)
+            {
+                engineBuilder.Phases.Add(Phases[i]);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorFeature.cs
@@ -3,8 +3,7 @@
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public interface IRazorEngineFeature : IRazorFeature
+    public interface IRazorFeature
     {
-        RazorEngine Engine { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorImportExpander.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorImportExpander.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public interface IRazorImportExpander : IRazorProjectEngineFeature
+    {
+        int Order { get; }
+
+        void Populate(ImportExpanderContext context);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorImportFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorImportFeature.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public interface IRazorEngineFeature : IRazorFeature
+    public interface IRazorImportFeature : IRazorProjectEngineFeature
     {
-        RazorEngine Engine { get; set; }
+        IReadOnlyList<RazorSourceDocument> GetImports(string sourceFilePath);
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/IRazorProjectEngineFeature.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/IRazorProjectEngineFeature.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    public interface IRazorEngineFeature : IRazorFeature
+    public interface IRazorProjectEngineFeature : IRazorFeature
     {
-        RazorEngine Engine { get; set; }
+        RazorProjectEngine ProjectEngine { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/ImportExpanderContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/ImportExpanderContext.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public sealed class ImportExpanderContext
+    {
+        public ImportExpanderContext(string sourceFilePath)
+        {
+            if (string.IsNullOrEmpty(sourceFilePath))
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(sourceFilePath));
+            }
+
+            SourceFilePath = sourceFilePath;
+            Results = new List<RazorSourceDocument>();
+        }
+
+        public string SourceFilePath { get; }
+
+        public IList<RazorSourceDocument> Results { get; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Properties/Resources.Designer.cs
@@ -1856,6 +1856,20 @@ namespace Microsoft.AspNetCore.Razor.Language
         internal static string FormatPropertyMustNotBeNull(object p0, object p1)
             => string.Format(CultureInfo.CurrentCulture, GetString("PropertyMustNotBeNull"), p0, p1);
 
+        /// <summary>
+        /// The '{0}' is missing feature '{1}'.
+        /// </summary>
+        internal static string MissingFeatureDependency
+        {
+            get => GetString("MissingFeatureDependency");
+        }
+
+        /// <summary>
+        /// The '{0}' is missing feature '{1}'.
+        /// </summary>
+        internal static string FormatMissingFeatureDependency(object p0, object p1)
+            => string.Format(CultureInfo.CurrentCulture, GetString("MissingFeatureDependency"), p0, p1);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
@@ -40,8 +40,25 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public static RazorEngine CreateEmpty(Action<IRazorEngineBuilder> configure)
         {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
             var builder = new DefaultRazorEngineBuilder(designTime: false);
-            configure?.Invoke(builder);
+            configure(builder);
+            return builder.Build();
+        }
+
+        public static RazorEngine CreateDesignTimeEmpty(Action<IRazorEngineBuilder> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var builder = new DefaultRazorEngineBuilder(designTime: true);
+            configure(builder);
             return builder.Build();
         }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectEngine
+    {
+        public abstract RazorProjectFileSystem ProjectFileSystem { get; }
+
+        public abstract RazorEngine Engine { get; }
+
+        public abstract IReadOnlyList<IRazorProjectEngineFeature> Features { get; }
+
+        public abstract RazorCodeDocument Process(string filePath);
+
+        public abstract RazorCodeDocument Process(RazorSourceDocument sourceDocument);
+
+        public static RazorProjectEngine Create(RazorProjectFileSystem projectFileSystem) => Create(projectFileSystem, configure: null);
+
+        public static RazorProjectEngine Create(RazorProjectFileSystem projectFileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (projectFileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(projectFileSystem));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(designTime: false, projectFileSystem: projectFileSystem);
+
+            AddRuntimeDefaults(builder);
+            configure?.Invoke(builder);
+
+            return builder.Build();
+        }
+
+        public static RazorProjectEngine CreateDesignTime(RazorProjectFileSystem projectFileSystem) => CreateDesignTime(projectFileSystem, configure: null);
+
+        public static RazorProjectEngine CreateDesignTime(RazorProjectFileSystem projectFileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (projectFileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(projectFileSystem));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(designTime: true, projectFileSystem: projectFileSystem);
+
+            AddDesignTimeDefaults(builder);
+            configure?.Invoke(builder);
+
+            return builder.Build();
+        }
+
+        public static RazorProjectEngine CreateEmpty(RazorProjectFileSystem projectFileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (projectFileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(projectFileSystem));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(designTime: false, projectFileSystem: projectFileSystem);
+
+            configure(builder);
+
+            return builder.Build();
+        }
+
+        public static RazorProjectEngine CreateDesignTimeEmpty(RazorProjectFileSystem projectFileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (projectFileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(projectFileSystem));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(designTime: true, projectFileSystem: projectFileSystem);
+
+            configure(builder);
+
+            return builder.Build();
+        }
+
+        private static void AddDesignTimeDefaults(RazorProjectEngineBuilder builder)
+        {
+            var defaultEngine = RazorEngine.CreateDesignTime();
+
+            AddEngineFeaturesAndPhases(builder, defaultEngine);
+        }
+
+        private static void AddRuntimeDefaults(RazorProjectEngineBuilder builder)
+        {
+            var defaultEngine = RazorEngine.Create();
+
+            AddEngineFeaturesAndPhases(builder, defaultEngine);
+        }
+
+        private static void AddEngineFeaturesAndPhases(RazorProjectEngineBuilder builder, RazorEngine defaultEngine)
+        {
+            // Lift default features from the engine into the project engine builder
+            for (var i = 0; i < defaultEngine.Features.Count; i++)
+            {
+                var engineFeature = defaultEngine.Features[i];
+                builder.Features.Add(engineFeature);
+            }
+
+            // Lift default phases from the engine into the project engine builder
+            for (var i = 0; i < defaultEngine.Phases.Count; i++)
+            {
+                var enginePhase = defaultEngine.Phases[i];
+                builder.Phases.Add(enginePhase);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             var builder = new DefaultRazorProjectEngineBuilder(designTime: false, projectFileSystem: projectFileSystem);
 
+            AddDefaults(builder);
             AddRuntimeDefaults(builder);
             configure?.Invoke(builder);
 
@@ -46,6 +47,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             var builder = new DefaultRazorProjectEngineBuilder(designTime: true, projectFileSystem: projectFileSystem);
 
+            AddDefaults(builder);
             AddDesignTimeDefaults(builder);
             configure?.Invoke(builder);
 
@@ -88,6 +90,11 @@ namespace Microsoft.AspNetCore.Razor.Language
             configure(builder);
 
             return builder.Build();
+        }
+
+        private static void AddDefaults(RazorProjectEngineBuilder builder)
+        {
+            builder.Features.Add(new DefaultImportFeature());
         }
 
         private static void AddDesignTimeDefaults(RazorProjectEngineBuilder builder)

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilder.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectEngineBuilder
+    {
+        public abstract RazorProjectFileSystem ProjectFileSystem { get; }
+
+        public abstract ICollection<IRazorFeature> Features { get; }
+
+        public abstract IList<IRazorEnginePhase> Phases { get; }
+
+        public abstract bool DesignTime { get; }
+
+        public abstract RazorProjectEngine Build();
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineFeatureBase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineFeatureBase.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectEngineFeatureBase : IRazorProjectEngineFeature
+    {
+        private RazorProjectEngine _projectEngine;
+
+        public RazorProjectEngine ProjectEngine
+        {
+            get => _projectEngine;
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _projectEngine = value;
+                OnInitialized();
+            }
+        }
+
+        protected virtual void OnInitialized()
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectFileSystem.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectFileSystem.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public abstract class RazorProjectFileSystem : RazorProject
+    {
+        public static new RazorProjectFileSystem Create(string rootDirectoryPath)
+        {
+            throw new NotImplementedException("TODO");
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
+++ b/src/Microsoft.AspNetCore.Razor.Language/Resources.resx
@@ -533,4 +533,7 @@ Instead, wrap the contents of the block in "{{}}":
   <data name="PropertyMustNotBeNull" xml:space="preserve">
     <value>The '{0}.{1}' property must not be null.</value>
   </data>
+  <data name="MissingFeatureDependency" xml:space="preserve">
+    <value>The '{0}' is missing feature '{1}'.</value>
+  </data>
 </root>

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultImportFeatureTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultImportFeatureTest.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class DefaultImportFeatureTest
+    {
+        [Fact]
+        public void GetImports_ReturnsEmptyImportsWhenZeroExpanders()
+        {
+            // Arrange
+            var projectEngine = RazorProjectEngine.CreateEmpty(Mock.Of<RazorProjectFileSystem>(), builder => { });
+            var importFeature = new DefaultImportFeature()
+            {
+                ProjectEngine = projectEngine,
+            };
+
+            // Act
+            var imports = importFeature.GetImports("somepath");
+
+            // Assert
+            Assert.Empty(imports);
+        }
+
+        [Fact]
+        public void GetImports_InvokesExpandersWithCorrectData()
+        {
+            // Arrange
+            var sourceFilePath = "/Views/Index.cshtml";
+            var expander1 = new Mock<IRazorImportExpander>();
+            expander1.Setup(expander => expander.Populate(It.IsAny<ImportExpanderContext>()))
+                .Callback<ImportExpanderContext>(context =>
+                {
+                    Assert.Equal(sourceFilePath, context.SourceFilePath);
+                    Assert.Empty(context.Results);
+                })
+                .Verifiable();
+            var projectEngine = RazorProjectEngine.CreateEmpty(
+                Mock.Of<RazorProjectFileSystem>(),
+                builder =>
+                {
+                    builder.Features.Add(expander1.Object);
+                });
+            var importFeature = new DefaultImportFeature()
+            {
+                ProjectEngine = projectEngine,
+            };
+
+            // Act
+            importFeature.GetImports(sourceFilePath);
+
+            // Assert
+            expander1.Verify();
+        }
+
+        // This is more of an integration test that tests the end-to-end behavior of having expanders, 
+        // them adding to the context and then returning the final import result.
+        [Fact]
+        public void GetImports_PopulatesImportsFromAllExpanders()
+        {
+            // Arrange
+            var sourceDocument1 = TestRazorSourceDocument.Create();
+            var expander1 = new Mock<IRazorImportExpander>();
+            expander1.Setup(expander => expander.Populate(It.IsAny<ImportExpanderContext>()))
+                .Callback<ImportExpanderContext>(context => context.Results.Add(sourceDocument1));
+            var sourceDocument2 = TestRazorSourceDocument.Create();
+            var expander2 = new Mock<IRazorImportExpander>();
+            expander2.Setup(expander => expander.Populate(It.IsAny<ImportExpanderContext>()))
+                .Callback<ImportExpanderContext>(context => context.Results.Add(sourceDocument2));
+            var projectEngine = RazorProjectEngine.CreateEmpty(
+                Mock.Of<RazorProjectFileSystem>(), 
+                builder => 
+                {
+                    builder.Features.Add(expander1.Object);
+                    builder.Features.Add(expander2.Object);
+                });
+            var importFeature = new DefaultImportFeature()
+            {
+                ProjectEngine = projectEngine,
+            };
+
+            // Act
+            var imports = importFeature.GetImports("somepath");
+
+            // Assert
+            Assert.Collection(
+                imports,
+                import => Assert.Same(sourceDocument1, import),
+                import => Assert.Same(sourceDocument2, import));
+        }
+    }
+}


### PR DESCRIPTION
- Added default implementation of the Razor import feature that consumes all expanders in the system.
- Added an `IRazorImportExpander` API that allow implementations to participate in creation of a list of imports given a source file path.
- Added `DefaultImportFeature` to the default list of features added to a `RazorProjectEngine`.
- Added tests for `DefaultImportFeature`

#1828