### PR TITLE
Add support for MvcPrecompilation settings

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.CodeGeneration.targets
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.CodeGeneration.targets
@@ -96,8 +96,8 @@
     Condition="'@(RazorGenerate)'!= ''">
 
     <RemoveDir
-      Directories="$(RazorGenerateOutputPath)"
-      Condition = "Exists('$(RazorGenerateOutputPath)')"/>
+      Directories="$(RazorGenerateIntermediateOutputPath)"
+      Condition = "Exists('$(RazorGenerateIntermediateOutputPath)')"/>
 
     <MakeDir
       Directories="%(_RazorGenerateOutput.RelativeDir)"
@@ -110,7 +110,7 @@
       Sources="@(RazorGenerate)"
       ProjectRoot="$(MSBuildProjectDirectory)"
       TagHelperManifest="$(_RazorTagHelperOutputCache)"
-      OutputPath="$(RazorGenerateOutputPath)" />
+      OutputPath="$(RazorGenerateIntermediateOutputPath)" />
 
     <ItemGroup>
       <FileWrites Include="@(_RazorGenerateOutput)" />
@@ -120,6 +120,18 @@
   <Target Name="_ResolveGeneratedRazorCompileInputs" BeforeTargets="ResolveRazorCompileInputs">
     <ItemGroup>
       <RazorCompile Include="@(_RazorGenerateOutput)" />
+      <RazorEmbeddedResource Include="@(RazorGenerate)" Condition="$(EmbedRazorGenerateSources)">
+        <LogicalName>/$([System.String]::Copy('%(Identity)').Replace('\','/'))</LogicalName>
+        <Type>Non-Resx</Type>
+        <WithCulture>false</WithCulture>
+      </RazorEmbeddedResource>
+    </ItemGroup>
+
+    <!-- Similar to _GenerateCompileInputs -->
+    <ItemGroup>
+      <_RazorCoreCompileResourceInputs 
+        Include="@(RazorEmbeddedResource)" 
+        Condition="'%(RazorEmbeddedResource.WithCulture)'=='false' and '%(RazorEmbeddedResource.Type)'=='Non-Resx' " />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.Compilation.targets
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.Compilation.targets
@@ -17,11 +17,13 @@
     Replace @(_DebugSymbolsIntermediatePath) with @(_RazorDebugSymbolsIntermediatePath)
     Replace @(IntermediateAssembly) with @(RazorIntermediateAssembly)
     Replace @(ReferencePathWithRefAssemblies) with @(RazorReferencePath)
+    Remove @(_CoreCompileResourceInputs) with @(_RazorCoreCompileResourceInputs)
 
     Set TargetType="$(OutputType)" to TargetType="Library" - Razor is always a .dll
 
     Remove Returns="@(CscCommandLineArgs)"
-    Remove @(_CoreCompileResourceInputs)
+    
+    Remove @(EmbeddedFiles)
     Remove $(ApplicationIcon) $(Win32Resource) $(Win32Manifest)
     Remove @(EmbeddedDocumentation) and @(EmbeddedFiles)
     Remove @(CustomAdditionalCompileInputs) and @(CustomAdditionalCompileOutputs)
@@ -43,7 +45,8 @@
                   @(CompiledLicenseFile);
                   @(LinkResource);
                   $(ResolvedCodeAnalysisRuleSet);
-                  @(AdditionalFiles)"
+                  @(AdditionalFiles);
+                  @(_RazorCoreCompileResourceInputs)"
           Outputs="@(RazorIntermediateAssembly);
                    @(_RazorDebugSymbolsIntermediatePath);
                    $(NonExistentFile)"
@@ -134,7 +137,7 @@
          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"
          References="@(RazorReferencePath)"
          ReportAnalyzer="$(ReportAnalyzer)"
-         Resources="@(CompiledLicenseFile)"
+         Resources="@(_RazorCoreCompileResourceInputs);@(CompiledLicenseFile)"
          ResponseFiles="$(CompilerResponseFile)"
          RuntimeMetadataVersion="$(RuntimeMetadataVersion)"
          SharedCompilationId="$(SharedCompilationId)"

--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.props
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.props
@@ -10,10 +10,10 @@
     <!--
       Set to true to automatically include Razor (.cshtml) files in @(RazorGenerate) from @(Content).
     -->
-    <EnableDefaultRazorGenerateItems>true</EnableDefaultRazorGenerateItems>
+    <EnableDefaultRazorGenerateItems Condition="'$(EnableDefaultRazorGenerateItems)'==''">true</EnableDefaultRazorGenerateItems>
 
     <!-- 
-      Set to true to copy RazorGenerate items to the publish directory (.cshtml) files.
+      Set to true to copy RazorGenerate items (.cshtml) to the publish directory.
 
       Typically Razor files are not needed for a published application if they participate in compilation at build-time
       or publish-time. By default, the Razor SDK will suppress the copying of RazorGenerate items to the publish directory.
@@ -21,7 +21,7 @@
     <CopyRazorGenerateFilesToPublishDirectory Condition="'$(CopyRazorGenerateFilesToPublishDirectory)'==''">false</CopyRazorGenerateFilesToPublishDirectory>
 
     <!-- 
-      Set to true to copy reference assembly items to the publish directory (.cshtml) files.
+      Set to true to copy reference assembly items to the publish directory.
 
       Typically reference assemblies are not needed for a published application if Razor compilation occurs at build-time
       or publish-time. By default, the Razor SDK will suppress the copying of reference assemblies to the publish directory.

--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.props
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.props
@@ -4,6 +4,32 @@
   -->
 
   <!--
+    Default properties for common Razor SDK behavior.
+  -->
+  <PropertyGroup>
+    <!--
+      Set to true to automatically include Razor (.cshtml) files in @(RazorGenerate) from @(Content).
+    -->
+    <EnableDefaultRazorGenerateItems>true</EnableDefaultRazorGenerateItems>
+
+    <!-- 
+      Set to true to copy RazorGenerate items to the publish directory (.cshtml) files.
+
+      Typically Razor files are not needed for a published application if they participate in compilation at build-time
+      or publish-time. By default, the Razor SDK will suppress the copying of RazorGenerate items to the publish directory.
+    -->
+    <CopyRazorGenerateFilesToPublishDirectory Condition="'$(CopyRazorGenerateFilesToPublishDirectory)'==''">false</CopyRazorGenerateFilesToPublishDirectory>
+
+    <!-- 
+      Set to true to copy reference assembly items to the publish directory (.cshtml) files.
+
+      Typically reference assemblies are not needed for a published application if Razor compilation occurs at build-time
+      or publish-time. By default, the Razor SDK will suppress the copying of reference assemblies to the publish directory.
+    -->
+    <CopyRefAssembliesToPublishDirectory Condition="'$(CopyRefAssembliesToPublishDirectory)'==''">false</CopyRefAssembliesToPublishDirectory>
+  </PropertyGroup>
+
+  <!--
     Razor also attaches itself by default to some of the standard .NET targets. Uses these properties to
     configure this behaviour.
   -->

--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
@@ -6,8 +6,7 @@
   -->
 
   <!--
-    This is a hook to import a set of targets before the Razor targets. By default this is used by MvcPrecompilation
-    so that we can interop between the 2.0 feature set and the 2.1+ features.
+    This is a hook to import a set of targets before the Razor targets. By default this is unused.
   -->
   <Import Project="$(CustomBeforeRazorSdkTargets)" Condition="'$(CustomBeforeRazorSdkTargets)' != '' and Exists('$(CustomBeforeRazorSdkTargets)')"/>
 
@@ -42,45 +41,71 @@
   </PropertyGroup>
 
   <!-- 
-    Default values for properties that affect Razor MSBuild behavior. 
+    Default values for properties that affect Razor targets to the standard build lifecycle.
+  -->
+  <PropertyGroup Condition="'$(RazorCompileOnBuild)'==''">
+    <RazorCompileOnBuild>false</RazorCompileOnBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(RazorCompileOnPublish)'==''">
+    <!-- Always compile on publish by default if we're compiling on build -->
+    <RazorCompileOnPublish Condition="'$(RazorCompileOnBuild)'=='true'"/>
+
+    <!-- Compatibility with the old MVC Precompilation setting -->
+    <RazorCompileOnPublish Condition="'$(RazorCompileOnPublish)'==''">$(MvcRazorCompileOnPublish)</RazorCompileOnPublish>
+
+    <!-- Default to on if MvcRazorCompileOnPublish isn't set for some reason -->
+    <RazorCompileOnPublish Condition="'$(RazorCompileOnPublish)'==''">true</RazorCompileOnPublish>
+  </PropertyGroup>
+
+
+  <!--
+    Properties that configure Razor SDK, but need to be defined in targets due to evaluation order.
   -->
   <PropertyGroup>
-    <!--
-      Razor also attaches itself by default to some of the standard .NET targets. Uses these properties to
-      configure this behaviour.
-    -->
-    <RazorCompileOnBuild Condition="'$(RazorCompileOnBuild)'==''">false</RazorCompileOnBuild>
-    <RazorCompileOnPublish Condition="'$(RazorCompileOnPublish)'==''">true</RazorCompileOnPublish>
-
     <!-- Output directory used for generated files -->
-    <RazorGenerateOutputPath Condition="'$(RazorGenerateOutputPath)'==''">$(IntermediateOutputPath)Razor\</RazorGenerateOutputPath>
+    <RazorGenerateIntermediateOutputPath Condition="'$(RazorGenerateIntermediateOutputPath)'==''">$(IntermediateOutputPath)Razor\</RazorGenerateIntermediateOutputPath>
     
     <!-- File name (without extension) of the assembly produced by Razor -->
     <RazorTargetName Condition="'$(RazorTargetName)'==''">$(TargetName).PrecompiledViews</RazorTargetName>
 
-    <!-- 
-      Set to true to copy RazorGenerate items to the publish directory (.cshtml) files.
+    <!--
+      The compatibility zone - these properties were provided by the MVC Precompilation tool and they
+      map to supported settings in Razor SDK.
 
-      Typically Razor files are not needed for a published application if they participate in compilation at build-time
-      or publish-time. By default, the Razor SDK will suppress the copying of RazorGenerate items to the publish directory.
+      We want to set the defaults for these in the .props file, but we need to process the old settings here
+      in case they were set in the project file. The consequence of this is that the old settings will override
+      the new ones if they are set to conflicting values.
     -->
-    <CopyRazorGenerateFilesToPublishDirectory Condition="'$(CopyRazorGenerateFilesToPublishDirectory)'==''">false</CopyRazorGenerateFilesToPublishDirectory>
+    <CopyRazorGenerateFilesToPublishDirectory Condition="'$(MvcRazorExcludeViewFilesFromPublish)'=='true'">false</CopyRazorGenerateFilesToPublishDirectory>
+    <CopyRazorGenerateFilesToPublishDirectory Condition="'$(MvcRazorExcludeViewFilesFromPublish)'=='false'">true</CopyRazorGenerateFilesToPublishDirectory>
+
+    <CopyRefAssembliesToPublishDirectory Condition="'$(MvcRazorExcludeRefAssembliesFromPublish)'=='true'">false</CopyRefAssembliesToPublishDirectory>
+    <CopyRefAssembliesToPublishDirectory Condition="'$(MvcRazorExcludeRefAssembliesFromPublish)'=='false'">true</CopyRefAssembliesToPublishDirectory>
 
     <!-- 
-      Set to true to copy reference assembly items to the publish directory (.cshtml) files.
-
-      Typically reference assemblies are not needed for a published application if Razor compilation occurs at build-time
-      or publish-time. By default, the Razor SDK will suppress the copying of reference assemblies to the publish directory.
+      We can't set the actual default value here due to evaluation order (depends on $(OutDir).
+      
+      This handles a compatibility case with MVC Precompilation.
     -->
-    <CopyRefAssembliesToPublishDirectory Condition="'$(CopyRefAssembliesToPublishDirectory)'==''">false</CopyRefAssembliesToPublishDirectory>
+    <RazorOutputPath Condition="'$(MvcRazorOutputPath)'!=''">$([MSBuild]::EnsureTrailingSlash('$(MvcRazorOutputPath)'))</RazorOutputPath>
+
+    <!--
+      Configures the 'project root' that we pass to CLI tools that process the project. There isn't really
+      a common scenario for configuring this, but MVC Precompilation provided it.
+    -->
+    <_RazorProjectDirectory Condition="'$(MvcRazorContentRoot)'!=''">$(MvcRazorContentRoot)</_RazorProjectDirectory>
+    <_RazorProjectDirectory Condition="'$(_RazorProjectDirectory)'==''">$(MSBuildProjectDirectory)</_RazorProjectDirectory>
+
+    <!--
+      Configures whether all of the @(RazorGenerate) items will be added as embedded files to the produced assembly.
+
+      When true, everything in @(RazorGenerate) will be added to @(RazorEmbeddedFiles) and passed to CSC.  
+    -->
+    <EmbedRazorGenerateSources Condition="'$(MvcRazorEmbedViewSources)'!=''">$(MvcRazorEmbedViewSources)</EmbedRazorGenerateSources>
+    <EmbedRazorGenerateSources Condition="'$(EmbedRazorGenerateSources)'==''">false</EmbedRazorGenerateSources>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Used to creating the final compiled Razor dll -->
-    <RazorIntermediateAssembly Include="$(IntermediateOutputPath)$(RazorTargetName).dll" />
-  </ItemGroup>
-
-  <!-- Implementation details here... -->
   <PropertyGroup>
     <!-- Similar to https://github.com/Microsoft/msbuild/blob/908cc9ccd4961441628f68e37a148183a87bb067/src/Tasks/Microsoft.Common.CurrentVersion.targets#L146-L153 -->
     <_RazorDebugSymbolsProduced>false</_RazorDebugSymbolsProduced>
@@ -92,10 +117,14 @@
     <_RazorDebugSymbolsProduced Condition="'$(DebugType)'=='embedded'">false</_RazorDebugSymbolsProduced>
   </PropertyGroup>
 
+  <!--
+    Properties that configure Razor SDK, but need to be defined in targets due to evaluation order.
+  -->
   <ItemGroup>
-    <!-- These are also referenced in .Compilation.targets - don't just casually change these -->
+    <!-- Used to creating the final compiled Razor dll -->
+    <RazorIntermediateAssembly Condition="'$(RazorIntermediateAssembly)'==''" Include="$(IntermediateOutputPath)$(RazorTargetName).dll" />
+    <!-- Used in Compilation.targets -->   
     <_RazorDebugSymbolsIntermediatePath Condition="'$(_RazorDebugSymbolsProduced)'=='true'" Include="$(IntermediateOutputPath)$(RazorTargetName).pdb" />
-    <_RazorDebugSymbolsOutputPath Include="@(_RazorDebugSymbolsIntermediatePath->'$(OutDir)%(Filename)%(Extension)')" />
   </ItemGroup>
 
   <!--
@@ -129,9 +158,25 @@
     lots of work when there are no inputs for code generation.
   -->
   <Target Name="ResolveRazorGenerateInputs">
+    <!--
+      In MVC Precompilation MvcRazorFilesToCompile also had the effect of suppressing the default
+      items for Razor code generation. As with all of these MVC Precompilation back-compat settings,
+      using the old thing, overrides the new thing.
+    -->
+    <PropertyGroup Condition="'@(MvcRazorFilesToCompile)'!=''">
+      <EnableDefaultRazorGenerateItems>false</EnableDefaultRazorGenerateItems>
+    </PropertyGroup>
     <ItemGroup>
-      <RazorGenerate Include="@(Content)" Condition="'%(Content.Extension)'=='.cshtml'">
-        <GeneratedOutput>$(RazorGenerateOutputPath)%(RelativeDir)%(Filename).cs</GeneratedOutput>
+      <RazorGenerate Include="@(MvcRazorFilesToCompile)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(EnableDefaultRazorGenerateItems)'=='true'">
+      <RazorGenerate Include="@(Content)" Condition="'%(Content.Extension)'=='.cshtml'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <RazorGenerate Update="@(RazorGenerate)" Condtion="'%(RazorGenerate.GeneratedOutput)'==''">
+        <GeneratedOutput>$(RazorGenerateIntermediateOutputPath)%(RelativeDir)%(Filename).cs</GeneratedOutput>
       </RazorGenerate>
     </ItemGroup>
   </Target>
@@ -177,8 +222,12 @@
     BeforeTargets="BuiltProjectOutputGroup"
     Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
 
+    <PropertyGroup>
+      <RazorOutputPath Condition="'$(RazorOutputPath)'==''">$([MSBuild]::EnsureTrailingSlash('$(OutDir)'))</RazorOutputPath>
+    </PropertyGroup>
+
     <ItemGroup Condition="'@(RazorGenerate)'!= ''">
-      <BuiltProjectOutputGroupOutput Include="@(RazorIntermediateAssembly)" FinalOutputPath="$(Outdir)$(RazorTargetName).dll" />
+      <BuiltProjectOutputGroupOutput Include="@(RazorIntermediateAssembly)" FinalOutputPath="$(RazorOutputPath)$(RazorTargetName).dll" />
     </ItemGroup>
     
   </Target>
@@ -250,10 +299,14 @@
     AfterTargets="CopyFilesToOutputDirectory"
     Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
 
+    <PropertyGroup>
+      <RazorOutputPath Condition="'$(RazorOutputPath)'==''">$([MSBuild]::EnsureTrailingSlash('$(OutDir)'))</RazorOutputPath>
+    </PropertyGroup>
+
     <!-- Copy the Razor dll  -->
     <Copy
       SourceFiles="@(RazorIntermediateAssembly)"
-      DestinationFolder="$(OutDir)"
+      DestinationFolder="$(RazorOutputPath)"
       SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"
@@ -274,7 +327,7 @@
     <!-- Copy the Razor debug information file (.pdb), if any -->
     <Copy
       SourceFiles="@(_RazorDebugSymbolsIntermediatePath)"
-      DestinationFiles="@(_RazorDebugSymbolsOutputPath)"
+      DestinationFolder="$(RazorOutputPath)"
       SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"

--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
@@ -49,7 +49,7 @@
 
   <PropertyGroup Condition="'$(RazorCompileOnPublish)'==''">
     <!-- Always compile on publish by default if we're compiling on build -->
-    <RazorCompileOnPublish Condition="'$(RazorCompileOnBuild)'=='true'"/>
+    <RazorCompileOnPublish Condition="'$(RazorCompileOnBuild)'=='true'">true</RazorCompileOnPublish>
 
     <!-- Compatibility with the old MVC Precompilation setting -->
     <RazorCompileOnPublish Condition="'$(RazorCompileOnPublish)'==''">$(MvcRazorCompileOnPublish)</RazorCompileOnPublish>
@@ -84,18 +84,11 @@
     <CopyRefAssembliesToPublishDirectory Condition="'$(MvcRazorExcludeRefAssembliesFromPublish)'=='false'">true</CopyRefAssembliesToPublishDirectory>
 
     <!-- 
-      We can't set the actual default value here due to evaluation order (depends on $(OutDir).
+      We can't set the actual default value here due to evaluation order (depends on $(OutDir)).
       
       This handles a compatibility case with MVC Precompilation.
     -->
     <RazorOutputPath Condition="'$(MvcRazorOutputPath)'!=''">$([MSBuild]::EnsureTrailingSlash('$(MvcRazorOutputPath)'))</RazorOutputPath>
-
-    <!--
-      Configures the 'project root' that we pass to CLI tools that process the project. There isn't really
-      a common scenario for configuring this, but MVC Precompilation provided it.
-    -->
-    <_RazorProjectDirectory Condition="'$(MvcRazorContentRoot)'!=''">$(MvcRazorContentRoot)</_RazorProjectDirectory>
-    <_RazorProjectDirectory Condition="'$(_RazorProjectDirectory)'==''">$(MSBuildProjectDirectory)</_RazorProjectDirectory>
 
     <!--
       Configures whether all of the @(RazorGenerate) items will be added as embedded files to the produced assembly.

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildIntegrationTest.cs
@@ -102,6 +102,38 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
         [Fact]
         [InitializeTestProject("SimpleMvc")]
+        public async Task Build_RazorOutputPath_SetToNonDefault()
+        {
+            var customOutputPath = Path.Combine("bin", Configuration, TargetFramework, "Razor");
+            var result = await DotnetMSBuild("Build", $"/p:RazorCompileOnBuild=true /p:RazorOutputPath={customOutputPath}");
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.dll");
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.pdb");
+
+            Assert.FileExists(result, customOutputPath, "SimpleMvc.PrecompiledViews.dll");
+            Assert.FileExists(result, customOutputPath, "SimpleMvc.PrecompiledViews.pdb");
+        }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task Build_MvcRazorOutputPath_SetToNonDefault()
+        {
+            var customOutputPath = Path.Combine("bin", Configuration, TargetFramework, "Razor");
+            var result = await DotnetMSBuild("Build", $"/p:RazorCompileOnBuild=true /p:MvcRazorOutputPath={customOutputPath}");
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.dll");
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.pdb");
+
+            Assert.FileExists(result, customOutputPath, "SimpleMvc.PrecompiledViews.dll");
+            Assert.FileExists(result, customOutputPath, "SimpleMvc.PrecompiledViews.pdb");
+        }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
         public async Task Build_SkipsCopyingBinariesToOutputDirectory_IfCopyBuildOutputToOutputDirectory_IsUnset()
         {
             var result = await DotnetMSBuild("Build", "/p:RazorCompileOnBuild=true /p:CopyBuildOutputToOutputDirectory=false");

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/RazorCompileIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/RazorCompileIntegrationTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -39,6 +41,69 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.pdb");
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.dll");
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.pdb");
+        }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")] 
+        public async Task RazorCompile_EmbedRazorGenerateSources_EmbedsCshtmlFiles()
+        {
+            var result = await DotnetMSBuild("RazorCompile", "/p:EmbedRazorGenerateSources=true");
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.dll");
+
+            var assembly = LoadAssemblyFromBytes(result.Project.DirectoryPath, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.dll");
+            var resources = assembly.GetManifestResourceNames();
+
+            Assert.Equal(new string[]
+            {
+                "/Views/_ViewImports.cshtml",
+                "/Views/_ViewStart.cshtml",
+                "/Views/Home/About.cshtml",
+                "/Views/Home/Contact.cshtml",
+                "/Views/Home/Index.cshtml",
+                "/Views/Shared/_Layout.cshtml",
+                "/Views/Shared/_ValidationScriptsPartial.cshtml",
+                "/Views/Shared/Error.cshtml",
+            },
+            resources.OrderBy(r => r));
+        }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task RazorCompile_MvcRazorEmbedViewSources_EmbedsCshtmlFiles()
+        {
+            var result = await DotnetMSBuild("RazorCompile", "/p:EmbedRazorGenerateSources=true");
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.dll");
+
+            var assembly = LoadAssemblyFromBytes(result.Project.DirectoryPath, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.dll");
+            var resources = assembly.GetManifestResourceNames();
+
+            Assert.Equal(new string[]
+            {
+                "/Views/_ViewImports.cshtml",
+                "/Views/_ViewStart.cshtml",
+                "/Views/Home/About.cshtml",
+                "/Views/Home/Contact.cshtml",
+                "/Views/Home/Index.cshtml",
+                "/Views/Shared/_Layout.cshtml",
+                "/Views/Shared/_ValidationScriptsPartial.cshtml",
+                "/Views/Shared/Error.cshtml",
+            },
+            resources.OrderBy(r => r));
+        }
+
+        private Assembly LoadAssemblyFromBytes(params string[] paths)
+        {
+            // We need to load the assembly from bytes to load it without locking the file - and yes, we need to
+            // load the pdb too, or else the CLR will load/lock it based on the path specified in the assembly.
+            var assemblyBytes = File.ReadAllBytes(Path.Combine(paths));
+            var symbolBytes = File.ReadAllBytes(Path.ChangeExtension(Path.Combine(paths), ".pdb"));
+            return Assembly.Load(assemblyBytes, symbolBytes);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/RazorGenerateIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/RazorGenerateIntegrationTest.cs
@@ -200,5 +200,52 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             
             Assert.FileCountEquals(result, 0, RazorIntermediateOutputPath, "*.cs");
         }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task RazorGenerate_MvcRazorFilesToCompile_OverridesDefaultItems()
+        {
+            var content = @"
+<Project>
+  <Import Project=""$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"" />
+  <ItemGroup>
+    <MvcRazorFilesToCompile Include=""Views/Home/About.cshtml"" />
+  </ItemGroup>
+</Project>
+";
+            File.WriteAllText(Path.Combine(Project.DirectoryPath, "Directory.Build.props"), content);
+
+            var result = await DotnetMSBuild(RazorGenerateTarget);
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
+            Assert.FileCountEquals(result, 1, RazorIntermediateOutputPath, "*.cs");
+        }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task RazorGenerate_EnableDefaultRazorGenerateItems_False_OverridesDefaultItems()
+        {
+            var content = @"
+<Project>
+  <Import Project=""$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"" />
+  <PropertyGroup>
+    <EnableDefaultRazorGenerateItems>false</EnableDefaultRazorGenerateItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <RazorGenerate Include=""Views/Home/About.cshtml"" />
+  </ItemGroup>
+</Project>
+";
+            File.WriteAllText(Path.Combine(Project.DirectoryPath, "Directory.Build.props"), content);
+
+            var result = await DotnetMSBuild(RazorGenerateTarget);
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
+            Assert.FileCountEquals(result, 1, RazorIntermediateOutputPath, "*.cs");
+        }
     }
 }


### PR DESCRIPTION
Adds support to the Razor SDK for various legacy features of the MVC
Precompilation tool.

- MvcRazorCompileOnPublish
- MvcRazorExcludeViewFilesFromPublish
- MvcRazorExcludeRefAssembliesFromPublish
- MvcRazorOutputPath
- MvcRazorContentRoot
- MvcRazorEmbedViewSources
- MvcRazorFilesToCompile