### PR TITLE
Don't import the SDK when cross-targeting

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Sdk/SDK/Sdk.props
+++ b/src/Microsoft.AspNetCore.Razor.Sdk/SDK/Sdk.props
@@ -9,7 +9,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <Import Project="$(MSBuildThisFileDirectory)..\build\netstandard2.0\Razor.Sdk.CurrentVersion.props" />
 

--- a/src/Microsoft.AspNetCore.Razor.Sdk/SDK/Sdk.targets
+++ b/src/Microsoft.AspNetCore.Razor.Sdk/SDK/Sdk.targets
@@ -12,9 +12,9 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(_RazorSdkCurrentVersionPath)"
-    Condition="'$(_RazorSdkCurrentVersionPath)' != '' AND Exists('$(_RazorSdkCurrentVersionPath)')" />
+    Condition="'$(IsCrossTargetingBuild)' != 'true' AND '$(_RazorSdkCurrentVersionPath)' != '' AND Exists('$(_RazorSdkCurrentVersionPath)')" />
 
   <Import Project="$(MSBuildThisFileDirectory)..\build\netstandard2.0\Razor.Sdk.CurrentVersion.targets"
-    Condition="'$(MicrosoftAspNetCoreRazorSdkTargetsImported)' != 'true'" />
+    Condition="'$(IsCrossTargetingBuild)' != 'true' AND '$(MicrosoftAspNetCoreRazorSdkTargetsImported)' != 'true'" />
 
 </Project>

--- a/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.Compilation.targets
+++ b/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.Compilation.targets
@@ -1,3 +1,15 @@
+<!--
+***********************************************************************************************
+Microsoft.AspNetCore.Razor.Design.Compilation.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+
 <Project>
   <!--
   What follows in this file is based on:

--- a/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Microsoft.AspNetCore.Razor.Sdk.props
+++ b/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Microsoft.AspNetCore.Razor.Sdk.props
@@ -1,8 +1,19 @@
+<!--
+***********************************************************************************************
+Microsoft.AspNetCore.Razor.Sdk.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
 <Project>
-  <Import Project="Sdk.CurrentVersion.props" />
+  <Import Project="Razor.Sdk.CurrentVersion.props" />
 
   <PropertyGroup>
     <!-- Redirect the SDK to use the targets from the current package -->
-    <_RazorSdkCurrentVersionPath>$(MSBuildFileDirectory)Sdk.CurrentVersion.targets</_RazorSdkCurrentVersionPath>
+    <RazorSdkTargetsPath>$(MSBuildFileDirectory)Sdk.CurrentVersion.targets</RazorSdkTargetsPath>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Microsoft.AspNetCore.Razor.Sdk.targets
+++ b/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Microsoft.AspNetCore.Razor.Sdk.targets
@@ -1,3 +1,14 @@
+<!--
+***********************************************************************************************
+Microsoft.AspNetCore.Razor.Sdk.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
 <Project>
-  <Import Project="Sdk.CurrentVersion.targets" />
+  <Import Project="Razor.Sdk.CurrentVersion.targets" />
 </Project>

--- a/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Razor.Sdk.CurrentVersion.props
+++ b/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Razor.Sdk.CurrentVersion.props
@@ -1,3 +1,14 @@
+<!--
+***********************************************************************************************
+Razor.Sdk.CurrentVersion.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
 <Project>
   <!--
     Properties and tasks supporting Razor MSBuild integration
@@ -27,11 +38,6 @@
       or publish-time. By default, the Razor SDK will suppress the copying of reference assemblies to the publish directory.
     -->
     <CopyRefAssembliesToPublishDirectory Condition="'$(CopyRefAssembliesToPublishDirectory)'==''">false</CopyRefAssembliesToPublishDirectory>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- This property is used by the SDK package to redirect the location of Sdk.CurrentVersion.targets -->
-    <_RazorSdkCurrentVersionPath>$(MSBuildThisFileDirectory)Sdk.CurrentVersions.target</_RazorSdkCurrentVersionPath>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Razor.Sdk.CurrentVersion.targets
+++ b/src/Microsoft.AspNetCore.Razor.Sdk/build/netstandard2.0/Razor.Sdk.CurrentVersion.targets
@@ -1,4 +1,15 @@
-﻿<Project>
+﻿<!--
+***********************************************************************************************
+Razor.Sdk.CurrentVersion.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project>
   <!-- 
     Targets supporting Razor MSBuild integration. Contain support for generating C# code using Razor
     and including the generated code in the project lifecycle, including compiling, publishing and producing
@@ -9,10 +20,6 @@
     This is a hook to import a set of targets before the Razor targets. By default this is unused.
   -->
   <Import Project="$(CustomBeforeRazorSdkTargets)" Condition="'$(CustomBeforeRazorSdkTargets)' != '' and Exists('$(CustomBeforeRazorSdkTargets)')"/>
-
-  <PropertyGroup>
-    <MicrosoftAspNetCoreRazorSdkTargetsImported>true</MicrosoftAspNetCoreRazorSdkTargetsImported>
-  </PropertyGroup>
 
   <!--
     Razor defines two primary targets:

--- a/src/Microsoft.AspNetCore.Razor.Sdk/buildMultiTargeting/Microsoft.AspNetCore.Razor.Sdk.targets
+++ b/src/Microsoft.AspNetCore.Razor.Sdk/buildMultiTargeting/Microsoft.AspNetCore.Razor.Sdk.targets
@@ -1,6 +1,6 @@
 <!--
 ***********************************************************************************************
-Sdk.targets
+Microsoft.AspNetCore.Razor.Sdk.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -10,12 +10,5 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project>
-
-  <PropertyGroup Condition="'$(RazorSdkTargetsPath)' == ''">
-    <RazorSdkTargetsPath Condition="'$(IsCrossTargetingBuild)' == 'true'">$(MSBuildThisFileDirectory)..\buildMultiTargeting\Razor.Sdk.CurrentVersion.MultiTargeting.targets</RazorSdkTargetsPath>
-    <RazorSdkTargetsPath Condition="'$(IsCrossTargetingBuild)' != 'true'">$(MSBuildThisFileDirectory)..\build\netstandard2.0\Razor.Sdk.CurrentVersion.targets</RazorSdkTargetsPath>
-  </PropertyGroup>
-
-  <Import Project="$(RazorSdkTargetsPath)" />
-
+  <Import Project="Razor.Sdk.CurrentVersion.MultiTargeting.targets" />
 </Project>

--- a/src/Microsoft.AspNetCore.Razor.Sdk/buildMultiTargeting/Razor.Sdk.CurrentVersion.MultiTargeting.targets
+++ b/src/Microsoft.AspNetCore.Razor.Sdk/buildMultiTargeting/Razor.Sdk.CurrentVersion.MultiTargeting.targets
@@ -1,0 +1,26 @@
+﻿<!--
+***********************************************************************************************
+Razor.Sdk.CurrentVersion.MultiTargeting.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project>
+
+  <PropertyGroup>
+    <RazorSdkTargetsImported>true</RazorSdkTargetsImported>
+  </PropertyGroup>
+
+  <Target Name="RazorCompile">
+    <Error Text="The 'RazorCompile' target is not supported without specifying a target framework. The current project targets multiple frameworks, please specify a framework to execute this target." />
+  </Target>
+
+  <Target Name="RazorGenerate">
+    <Error Text="The 'RazorGenerate' target is not supported without specifying a target framework. The current project targets multiple frameworks, please specify a framework to execute this target." />
+  </Target>
+
+</Project>


### PR DESCRIPTION
When we invoke `dotnet msbuild /t:RazorGenerate` on a cross-targeting project, the build fails saying it cannot find the target `ResolveReferences`. This is because the target is only defined for inner builds. The change in essence follows the same pattern as the CSharp targets where targets like `Compile` are only available in the inner build.