### PR TITLE
Update RazorProjectEngine to use RazorConfiguration.

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/ModelDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/ModelDirective.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
             }
 
             builder.AddDirective(Directive);
-            builder.Features.Add(new Pass(builder.DesignTime));
+            builder.Features.Add(new Pass(builder.Configuration.DesignTime));
             return builder;
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/RazorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/RazorExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
 
         private static void EnsureDesignTime(RazorProjectEngineBuilder builder)
         {
-            if (builder.DesignTime)
+            if (builder.Configuration.DesignTime)
             {
                 return;
             }

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelDirective.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ModelDirective.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             }
 
             builder.AddDirective(Directive);
-            builder.Features.Add(new Pass(builder.DesignTime));
+            builder.Features.Add(new Pass(builder.Configuration.DesignTime));
             return builder;
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             builder.Features.Add(new RazorPageDocumentClassifierPass());
             builder.Features.Add(new MvcViewDocumentClassifierPass());
 
-            if (!builder.DesignTime)
+            if (!builder.Configuration.DesignTime)
             {
                 builder.Features.Add(new AssemblyAttributeInjectionPass());
                 builder.Features.Add(new InstrumentationPass());

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngineBuilder.cs
@@ -9,14 +9,14 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     internal class DefaultRazorProjectEngineBuilder : RazorProjectEngineBuilder
     {
-        public DefaultRazorProjectEngineBuilder(bool designTime, RazorProjectFileSystem fileSystem)
+        public DefaultRazorProjectEngineBuilder(RazorConfiguration configuration, RazorProjectFileSystem fileSystem)
         {
             if (fileSystem == null)
             {
                 throw new ArgumentNullException(nameof(fileSystem));
             }
 
-            DesignTime = designTime;
+            Configuration = configuration;
             FileSystem = fileSystem;
             Features = new List<IRazorFeature>();
             Phases = new List<IRazorEnginePhase>();
@@ -28,13 +28,13 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override IList<IRazorEnginePhase> Phases { get; }
 
-        public override bool DesignTime { get; }
+        public override RazorConfiguration Configuration { get; }
 
         public override RazorProjectEngine Build()
         {
             RazorEngine engine = null;
 
-            if (DesignTime)
+            if (Configuration.DesignTime)
             {
                 engine = RazorEngine.CreateDesignTimeEmpty(ConfigureRazorEngine);
             }

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorConfiguration.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorConfiguration.cs
@@ -7,8 +7,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public sealed class RazorConfiguration
     {
-        public static readonly RazorConfiguration DefaultRuntime = new RazorConfiguration(RazorLanguageVersion.Latest, designTime: false);
-        public static readonly RazorConfiguration DefaultDesignTime = new RazorConfiguration(RazorLanguageVersion.Latest, designTime: true);
+        public static readonly RazorConfiguration Default = new RazorConfiguration(RazorLanguageVersion.Latest, designTime: false);
 
         public RazorConfiguration(RazorLanguageVersion languageVersion, bool designTime)
         {

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorEngine.cs
@@ -17,14 +17,15 @@ namespace Microsoft.AspNetCore.Razor.Language
             return Create(configure: null);
         }
 
-        public static RazorEngine Create(Action<IRazorEngineBuilder> configure) => CreateCore(RazorConfiguration.DefaultRuntime, configure);
+        public static RazorEngine Create(Action<IRazorEngineBuilder> configure) => CreateCore(RazorConfiguration.Default, configure);
 
         public static RazorEngine CreateDesignTime()
         {
             return CreateDesignTime(configure: null);
         }
 
-        public static RazorEngine CreateDesignTime(Action<IRazorEngineBuilder> configure) => CreateCore(RazorConfiguration.DefaultDesignTime, configure);
+        public static RazorEngine CreateDesignTime(Action<IRazorEngineBuilder> configure)
+            => CreateCore(new RazorConfiguration(RazorLanguageVersion.Latest, designTime: true), configure);
 
         // Internal since RazorEngine APIs are going to be obsolete.
         internal static RazorEngine CreateCore(RazorConfiguration configuration, Action<IRazorEngineBuilder> configure)

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
@@ -20,74 +20,37 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public static RazorProjectEngine Create(RazorProjectFileSystem fileSystem) => Create(fileSystem, configure: null);
 
-        public static RazorProjectEngine Create(RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        public static RazorProjectEngine Create(RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure) => Create(fileSystem, RazorConfiguration.Default, configure);
+
+        public static RazorProjectEngine Create(
+            RazorProjectFileSystem fileSystem,
+            RazorConfiguration configuration,
+            Action<RazorProjectEngineBuilder> configure)
         {
             if (fileSystem == null)
             {
                 throw new ArgumentNullException(nameof(fileSystem));
             }
 
-            var builder = new DefaultRazorProjectEngineBuilder(designTime: false, fileSystem: fileSystem);
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var builder = new DefaultRazorProjectEngineBuilder(configuration, fileSystem);
 
             AddDefaults(builder);
-            AddRuntimeDefaults(builder);
+
+            if (configuration.DesignTime)
+            {
+                AddDesignTimeDefaults(builder);
+            }
+            else
+            {
+                AddRuntimeDefaults(builder);
+            }
+
             configure?.Invoke(builder);
-
-            return builder.Build();
-        }
-
-        public static RazorProjectEngine CreateDesignTime(RazorProjectFileSystem fileSystem) => CreateDesignTime(fileSystem, configure: null);
-
-        public static RazorProjectEngine CreateDesignTime(RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
-        {
-            if (fileSystem == null)
-            {
-                throw new ArgumentNullException(nameof(fileSystem));
-            }
-
-            var builder = new DefaultRazorProjectEngineBuilder(designTime: true, fileSystem: fileSystem);
-
-            AddDefaults(builder);
-            AddDesignTimeDefaults(builder);
-            configure?.Invoke(builder);
-
-            return builder.Build();
-        }
-
-        public static RazorProjectEngine CreateEmpty(RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
-        {
-            if (fileSystem == null)
-            {
-                throw new ArgumentNullException(nameof(fileSystem));
-            }
-
-            if (configure == null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
-
-            var builder = new DefaultRazorProjectEngineBuilder(designTime: false, fileSystem: fileSystem);
-
-            configure(builder);
-
-            return builder.Build();
-        }
-
-        public static RazorProjectEngine CreateDesignTimeEmpty(RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
-        {
-            if (fileSystem == null)
-            {
-                throw new ArgumentNullException(nameof(fileSystem));
-            }
-
-            if (configure == null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
-
-            var builder = new DefaultRazorProjectEngineBuilder(designTime: true, fileSystem: fileSystem);
-
-            configure(builder);
 
             return builder.Build();
         }
@@ -101,7 +64,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             var engineFeatures = new List<IRazorEngineFeature>();
             RazorEngine.AddDefaultFeatures(engineFeatures);
-            RazorEngine.AddDefaultDesignTimeFeatures(engineFeatures);
+            RazorEngine.AddDefaultDesignTimeFeatures(builder.Configuration, engineFeatures);
 
             AddEngineFeaturesAndPhases(builder, engineFeatures);
         }
@@ -110,7 +73,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             var engineFeatures = new List<IRazorEngineFeature>();
             RazorEngine.AddDefaultFeatures(engineFeatures);
-            RazorEngine.AddDefaultRuntimeFeatures(engineFeatures);
+            RazorEngine.AddDefaultRuntimeFeatures(builder.Configuration, engineFeatures);
 
             AddEngineFeaturesAndPhases(builder, engineFeatures);
         }

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilder.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngineBuilder.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public abstract IList<IRazorEnginePhase> Phases { get; }
 
-        public abstract bool DesignTime { get; }
+        public abstract RazorConfiguration Configuration { get; }
 
         public abstract RazorProjectEngine Build();
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineBuilderTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public void Build_AddsFeaturesToRazorEngine()
         {
             // Arrange
-            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            var builder = new DefaultRazorProjectEngineBuilder(RazorConfiguration.Default, Mock.Of<RazorProjectFileSystem>());
             builder.Features.Add(Mock.Of<IRazorEngineFeature>());
             builder.Features.Add(Mock.Of<IRazorEngineFeature>());
             builder.Features.Add(Mock.Of<IRazorProjectEngineFeature>());
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public void Build_AddsPhasesToRazorEngine()
         {
             // Arrange
-            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            var builder = new DefaultRazorProjectEngineBuilder(RazorConfiguration.Default, Mock.Of<RazorProjectFileSystem>());
             builder.Phases.Add(Mock.Of<IRazorEnginePhase>());
             builder.Phases.Add(Mock.Of<IRazorEnginePhase>());
 
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             // Arrange
             var fileSystem = Mock.Of<RazorProjectFileSystem>();
-            var builder = new DefaultRazorProjectEngineBuilder(false, fileSystem);
+            var builder = new DefaultRazorProjectEngineBuilder(RazorConfiguration.Default, fileSystem);
 
             // Act
             var projectEngine = builder.Build();

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorProjectEngineBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorProjectEngineBuilderExtensionsTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public void SetImportFeature_SetsTheImportFeature()
         {
             // Arrange
-            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            var builder = new DefaultRazorProjectEngineBuilder(RazorConfiguration.Default, Mock.Of<RazorProjectFileSystem>());
             var testFeature1 = Mock.Of<IRazorImportFeature>();
             var testFeature2 = Mock.Of<IRazorImportFeature>();
             builder.Features.Add(testFeature1);
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public void AddTargetExtension_CreatesAndAddsToTargetExtensionFeatureIfItDoesNotExist()
         {
             // Arrange
-            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            var builder = new DefaultRazorProjectEngineBuilder(RazorConfiguration.Default, Mock.Of<RazorProjectFileSystem>());
             var expectedExtension = Mock.Of<ICodeTargetExtension>();
 
             // Act
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public void AddTargetExtension_UsesExistingFeatureIfExistsAndAddsTo()
         {
             // Arrange
-            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            var builder = new DefaultRazorProjectEngineBuilder(RazorConfiguration.Default, Mock.Of<RazorProjectFileSystem>());
             var codeTargetExtensionFeature = new DefaultRazorTargetExtensionFeature();
             builder.Features.Add(codeTargetExtensionFeature);
             var expectedExtension = Mock.Of<ICodeTargetExtension>();
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public void AddDirective_CreatesAndAddsToDirectiveFeatureIfItDoesNotExist()
         {
             // Arrange
-            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            var builder = new DefaultRazorProjectEngineBuilder(RazorConfiguration.Default, Mock.Of<RazorProjectFileSystem>());
             var expectedDirective = Mock.Of<DirectiveDescriptor>();
 
             // Act
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public void AddDirective_UsesExistingFeatureIfExistsAndAddsTo()
         {
             // Arrange
-            var builder = new DefaultRazorProjectEngineBuilder(false, Mock.Of<RazorProjectFileSystem>());
+            var builder = new DefaultRazorProjectEngineBuilder(RazorConfiguration.Default, Mock.Of<RazorProjectFileSystem>());
             var directiveFeature = new DefaultRazorDirectiveFeature();
             builder.Features.Add(directiveFeature);
             var expecteDirective = Mock.Of<DirectiveDescriptor>();


### PR DESCRIPTION
- In this PR we do away with `CreateDesignTime` on the `RazorProjectEngine`. Instead we now have an overload that takes in a configuration and does the right thing.
- Updated `RazorProjectEngineBuilder` to have a configuration.
- Updated `RazorConfiguration` to only have a `Default`. Setting up a razor configuration for design time now requires calling code to construct the configuration manually.

/cc @mkArtakMSFT 