### PR TITLE
Change ForegroundDispatcher to be a MEF service.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/DefaultEditorSettingsManagerInternalFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/DefaultEditorSettingsManagerInternalFactory.cs
@@ -12,6 +12,19 @@ namespace Microsoft.CodeAnalysis.Razor.Editor
     [ExportLanguageServiceFactory(typeof(EditorSettingsManagerInternal), RazorLanguage.Name)]
     internal class DefaultEditorSettingsManagerInternalFactory : ILanguageServiceFactory
     {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+
+        [ImportingConstructor]
+        public DefaultEditorSettingsManagerInternalFactory(ForegroundDispatcher foregroundDispatcher)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+        }
+
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
             if (languageServices == null)
@@ -19,9 +32,7 @@ namespace Microsoft.CodeAnalysis.Razor.Editor
                 throw new ArgumentNullException(nameof(languageServices));
             }
 
-            var foregroundDispatcher = languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>();
-
-            return new DefaultEditorSettingsManagerInternal(foregroundDispatcher);
+            return new DefaultEditorSettingsManagerInternal(_foregroundDispatcher);
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ForegroundDispatcher.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ForegroundDispatcher.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
-    internal abstract class ForegroundDispatcher : IWorkspaceService
+    internal abstract class ForegroundDispatcher
     {
         public abstract bool IsForegroundThread { get; }
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManagerFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManagerFactory.cs
@@ -14,11 +14,24 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     internal class DefaultProjectSnapshotManagerFactory : ILanguageServiceFactory
     {
         private readonly IEnumerable<ProjectSnapshotChangeTrigger> _triggers;
+        private readonly ForegroundDispatcher _foregroundDispatcher;
 
         [ImportingConstructor]
         public DefaultProjectSnapshotManagerFactory(
+            ForegroundDispatcher foregroundDispatcher,
             [ImportMany] IEnumerable<ProjectSnapshotChangeTrigger> triggers)
         {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (triggers == null)
+            {
+                throw new ArgumentNullException(nameof(triggers));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
             _triggers = triggers;
         }
 
@@ -30,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
 
             return new DefaultProjectSnapshotManager(
-                languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>(),
+                _foregroundDispatcher,
                 languageServices.WorkspaceServices.GetRequiredService<ErrorReporter>(),
                 languageServices.GetRequiredService<ProjectSnapshotWorker>(),
                 _triggers, 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotWorkerFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotWorkerFactory.cs
@@ -11,10 +11,23 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     [ExportLanguageServiceFactory(typeof(ProjectSnapshotWorker), RazorLanguage.Name)]
     internal class DefaultProjectSnapshotWorkerFactory : ILanguageServiceFactory
     {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+
+        [ImportingConstructor]
+        public DefaultProjectSnapshotWorkerFactory(ForegroundDispatcher foregroundDispatcher)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new System.ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+        }
+
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
             return new DefaultProjectSnapshotWorker(
-                languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>(),
+                _foregroundDispatcher,
                 languageServices.GetRequiredService<ProjectExtensibilityConfigurationFactory>(),
                 languageServices.GetRequiredService<TagHelperResolver>());
         }

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactoryFactory.cs
@@ -14,16 +14,23 @@ namespace Microsoft.VisualStudio.Editor.Razor
     [ExportLanguageServiceFactory(typeof(BraceSmartIndenterFactory), RazorLanguage.Name, ServiceLayer.Default)]
     internal class DefaultBraceSmartIndenterFactoryFactory : ILanguageServiceFactory
     {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly IEditorOperationsFactoryService _editorOperationsFactory;
 
         [ImportingConstructor]
-        public DefaultBraceSmartIndenterFactoryFactory(IEditorOperationsFactoryService editorOperationsFactory)
+        public DefaultBraceSmartIndenterFactoryFactory(ForegroundDispatcher foregroundDispatcher, IEditorOperationsFactoryService editorOperationsFactory)
         {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
             if (editorOperationsFactory == null)
             {
                 throw new ArgumentNullException(nameof(editorOperationsFactory));
             }
 
+            _foregroundDispatcher = foregroundDispatcher;
             _editorOperationsFactory = editorOperationsFactory;
         }
 
@@ -34,8 +41,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentNullException(nameof(languageServices));
             }
 
-            var dispatcher = languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>();
-            return new DefaultBraceSmartIndenterFactory(dispatcher, _editorOperationsFactory);
+            return new DefaultBraceSmartIndenterFactory(_foregroundDispatcher, _editorOperationsFactory);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultImportDocumentManagerFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultImportDocumentManagerFactory.cs
@@ -13,6 +13,19 @@ namespace Microsoft.VisualStudio.Editor.Razor
     [ExportLanguageServiceFactory(typeof(ImportDocumentManager), RazorLanguage.Name, ServiceLayer.Default)]
     internal class DefaultImportDocumentManagerFactory : ILanguageServiceFactory
     {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+
+        [ImportingConstructor]
+        public DefaultImportDocumentManagerFactory(ForegroundDispatcher foregroundDispatcher)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+        }
+
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
             if (languageServices == null)
@@ -20,13 +33,12 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentNullException(nameof(languageServices));
             }
 
-            var dispatcher = languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>();
             var errorReporter = languageServices.WorkspaceServices.GetRequiredService<ErrorReporter>();
             var fileChangeTrackerFactory = languageServices.GetRequiredService<FileChangeTrackerFactory>();
             var templateEngineFactoryService = languageServices.GetRequiredService<RazorTemplateEngineFactoryService>();
 
             return new DefaultImportDocumentManager(
-                dispatcher,
+                _foregroundDispatcher,
                 errorReporter,
                 fileChangeTrackerFactory,
                 templateEngineFactoryService);

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorDocumentManagerFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorDocumentManagerFactory.cs
@@ -13,16 +13,23 @@ namespace Microsoft.VisualStudio.Editor.Razor
     [ExportLanguageServiceFactory(typeof(RazorDocumentManager), RazorLanguage.Name, ServiceLayer.Default)]
     internal class DefaultRazorDocumentManagerFactory : ILanguageServiceFactory
     {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly RazorEditorFactoryService _editorFactoryService;
 
         [ImportingConstructor]
-        public DefaultRazorDocumentManagerFactory(RazorEditorFactoryService editorFactoryService)
+        public DefaultRazorDocumentManagerFactory(ForegroundDispatcher foregroundDispatcher, RazorEditorFactoryService editorFactoryService)
         {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
             if (editorFactoryService == null)
             {
                 throw new ArgumentNullException(nameof(editorFactoryService));
             }
 
+            _foregroundDispatcher = foregroundDispatcher;
             _editorFactoryService = editorFactoryService;
         }
 
@@ -33,10 +40,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentNullException(nameof(languageServices));
             }
 
-            var dispatcher = languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>();
             var projectService = languageServices.GetRequiredService<TextBufferProjectService>();
 
-            return new DefaultRazorDocumentManager(dispatcher, _editorFactoryService, projectService);
+            return new DefaultRazorDocumentManager(_foregroundDispatcher, _editorFactoryService, projectService);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactoryFactory.cs
@@ -16,16 +16,23 @@ namespace Microsoft.VisualStudio.Editor.Razor
     [ExportLanguageServiceFactory(typeof(VisualStudioDocumentTrackerFactory), RazorLanguage.Name, ServiceLayer.Default)]
     internal class DefaultVisualStudioDocumentTrackerFactoryFactory : ILanguageServiceFactory
     {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly ITextDocumentFactoryService _textDocumentFactory;
 
         [ImportingConstructor]
-        public DefaultVisualStudioDocumentTrackerFactoryFactory(ITextDocumentFactoryService textDocumentFactory)
+        public DefaultVisualStudioDocumentTrackerFactoryFactory(ForegroundDispatcher foregroundDispatcher, ITextDocumentFactoryService textDocumentFactory)
         {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
             if (textDocumentFactory == null)
             {
                 throw new ArgumentNullException(nameof(textDocumentFactory));
             }
 
+            _foregroundDispatcher = foregroundDispatcher;
             _textDocumentFactory = textDocumentFactory;
         }
 
@@ -36,14 +43,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentNullException(nameof(languageServices));
             }
 
-            var dispatcher = languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>();
             var projectManager = languageServices.GetRequiredService<ProjectSnapshotManager>();
             var editorSettingsManager = languageServices.GetRequiredService<EditorSettingsManagerInternal>();
             var projectService = languageServices.GetRequiredService<TextBufferProjectService>();
             var importDocumentManager = languageServices.GetRequiredService<ImportDocumentManager>();
 
             return new DefaultVisualStudioDocumentTrackerFactory(
-                dispatcher,
+                _foregroundDispatcher,
                 projectManager,
                 editorSettingsManager,
                 projectService,

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParserFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParserFactoryFactory.cs
@@ -13,6 +13,18 @@ namespace Microsoft.VisualStudio.Editor.Razor
     [ExportLanguageServiceFactory(typeof(VisualStudioRazorParserFactory), RazorLanguage.Name, ServiceLayer.Default)]
     internal class DefaultVisualStudioRazorParserFactoryFactory : ILanguageServiceFactory
     {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+
+        [ImportingConstructor]
+        public DefaultVisualStudioRazorParserFactoryFactory(ForegroundDispatcher foregroundDispatcher)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+        }
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
             if (languageServices == null)
@@ -21,13 +33,12 @@ namespace Microsoft.VisualStudio.Editor.Razor
             }
 
             var workspaceServices = languageServices.WorkspaceServices;
-            var dispatcher = workspaceServices.GetRequiredService<ForegroundDispatcher>();
             var errorReporter = workspaceServices.GetRequiredService<ErrorReporter>();
             var completionBroker = languageServices.GetRequiredService<VisualStudioCompletionBroker>();
             var templateEngineFactoryService = languageServices.GetRequiredService<RazorTemplateEngineFactoryService>();
 
             return new DefaultVisualStudioRazorParserFactory(
-                dispatcher,
+                _foregroundDispatcher,
                 errorReporter,
                 completionBroker,
                 templateEngineFactoryService);

--- a/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
@@ -20,14 +20,14 @@ namespace Microsoft.VisualStudio.Editor.Razor
         private readonly RazorDocumentManager _documentManager;
 
         [ImportingConstructor]
-        public RazorTextViewConnectionListener(VisualStudioWorkspaceAccessor workspaceAccessor)
+        public RazorTextViewConnectionListener(ForegroundDispatcher foregroundDispatcher, VisualStudioWorkspaceAccessor workspaceAccessor)
         {
             if (workspaceAccessor == null)
             {
                 throw new ArgumentNullException(nameof(workspaceAccessor));
             }
 
-            _foregroundDispatcher = workspaceAccessor.Workspace.Services.GetRequiredService<ForegroundDispatcher>();
+            _foregroundDispatcher = foregroundDispatcher;
 
             var languageServices = workspaceAccessor.Workspace.Services.GetLanguageServices(RazorLanguage.Name);
             _documentManager = languageServices.GetRequiredService<RazorDocumentManager>();

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultFileChangeTrackerFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultFileChangeTrackerFactoryFactory.cs
@@ -17,15 +17,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
     internal class DefaultFileChangeTrackerFactoryFactory : ILanguageServiceFactory
     {
         private readonly IVsFileChangeEx _fileChangeService;
+        private readonly ForegroundDispatcher _foregroundDispatcher;
 
         [ImportingConstructor]
-        public DefaultFileChangeTrackerFactoryFactory(SVsServiceProvider serviceProvider)
+        public DefaultFileChangeTrackerFactoryFactory(ForegroundDispatcher foregroundDispatcher, SVsServiceProvider serviceProvider)
         {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
             if (serviceProvider == null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider));
             }
 
+            _foregroundDispatcher = foregroundDispatcher;
             _fileChangeService = serviceProvider.GetService(typeof(SVsFileChangeEx)) as IVsFileChangeEx;
         }
 
@@ -36,9 +43,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 throw new ArgumentNullException(nameof(languageServices));
             }
 
-            var foregroundDispatcher = languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>();
             var errorReporter = languageServices.WorkspaceServices.GetRequiredService<ErrorReporter>();
-            return new DefaultFileChangeTrackerFactory(foregroundDispatcher, errorReporter, _fileChangeService);
+            return new DefaultFileChangeTrackerFactory(_foregroundDispatcher, errorReporter, _fileChangeService);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioForegroundDispatcher.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioForegroundDispatcher.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Composition;
+using System.ComponentModel.Composition;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor
 {
-    [Shared]
-    [ExportWorkspaceService(typeof(ForegroundDispatcher), ServiceLayer.Host)]
+    [System.Composition.Shared]
+    [Export(typeof(ForegroundDispatcher))]
     internal class VisualStudioForegroundDispatcher : ForegroundDispatcher
     {
         public override TaskScheduler BackgroundScheduler { get; } = TaskScheduler.Default;

--- a/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/DefaultFileChangeTrackerFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/DefaultFileChangeTrackerFactoryFactory.cs
@@ -14,6 +14,19 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
     [ExportLanguageServiceFactory(typeof(FileChangeTrackerFactory), RazorLanguage.Name, ServiceLayer.Default)]
     internal class DefaultFileChangeTrackerFactoryFactory : ILanguageServiceFactory
     {
+        private readonly ForegroundDispatcher _foregroundDispatcher;
+
+        [ImportingConstructor]
+        public DefaultFileChangeTrackerFactoryFactory(ForegroundDispatcher foregroundDispatcher)
+        {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            _foregroundDispatcher = foregroundDispatcher;
+        }
+
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
             if (languageServices == null)
@@ -21,9 +34,7 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
                 throw new ArgumentNullException(nameof(languageServices));
             }
 
-            var foregroundDispatcher = languageServices.WorkspaceServices.GetRequiredService<ForegroundDispatcher>();
-            var errorReporter = languageServices.WorkspaceServices.GetRequiredService<ErrorReporter>();
-            return new DefaultFileChangeTrackerFactory(foregroundDispatcher);
+            return new DefaultFileChangeTrackerFactory(_foregroundDispatcher);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectBuildChangeTrigger.cs
+++ b/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectBuildChangeTrigger.cs
@@ -19,14 +19,19 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
         private ProjectSnapshotManagerBase _projectManager;
 
         [ImportingConstructor]
-        public ProjectBuildChangeTrigger(VisualStudioWorkspaceAccessor workspaceAccessor)
+        public ProjectBuildChangeTrigger(ForegroundDispatcher foregroundDispatcher, VisualStudioWorkspaceAccessor workspaceAccessor)
         {
+            if (foregroundDispatcher == null)
+            {
+                throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
             if (workspaceAccessor == null)
             {
                 throw new ArgumentNullException(nameof(workspaceAccessor));
             }
 
-            _foregroundDispatcher = workspaceAccessor.Workspace.Services.GetRequiredService<ForegroundDispatcher>();
+            _foregroundDispatcher = foregroundDispatcher;
 
             var languageServices = workspaceAccessor.Workspace.Services.GetLanguageServices(RazorLanguage.Name);
             _projectService = languageServices.GetRequiredService<TextBufferProjectService>();

--- a/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioForegroundDispatcher.cs
+++ b/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioForegroundDispatcher.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Composition;
+using System.ComponentModel.Composition;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Razor;
 
 namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
 {
-    [Shared]
-    [ExportWorkspaceService(typeof(ForegroundDispatcher), ServiceLayer.Host)]
+    [System.Composition.Shared]
+    [Export(typeof(ForegroundDispatcher))]
     internal class VisualStudioForegroundDispatcher : ForegroundDispatcher
     {
         public override TaskScheduler BackgroundScheduler { get; } = TaskScheduler.Default;


### PR DESCRIPTION
- The `ForegroundDispatcher` needed to be accessible by services without requiring a workspace; given that it doesn't have any ties to the `Workspace` other than being a service of one I was able to move it into a MEF service.
- Updated all workspace inclusions of the dispatcher to use importing constructors instead.
- Updated the Mac + Windows implementations to be exported as MEF pieces.

#1979

**Note:** Working on testing all these bits in VS with WTEs latest bits but have to do a build and install in their code base which takes a decent amount of time 😉 

/cc @mkArtakMSFT 