### PR TITLE
Fix #1999

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.targets
@@ -167,8 +167,16 @@
       <RazorGenerate Include="@(Content)" Condition="'%(Content.Extension)'=='.cshtml'" />
     </ItemGroup>
 
-    <ItemGroup>
-      <RazorGenerate Update="@(RazorGenerate)" Condtion="'%(RazorGenerate.GeneratedOutput)'==''">
+    <!--
+      For preview1 we only support files that are within the project's directory hierarchy. 
+
+      This is similar to to a limitation in MvcPrecompilation. This will be improved for preview2,
+      tracked by https://github.com/aspnet/Razor/issues/1829
+    -->
+    <ItemGroup Condition="'@(RazorGenerate)'!=''">
+      <RazorGenerate 
+        Update="@(RazorGenerate)" 
+        Condition="'%(RazorGenerate.GeneratedOutput)'=='' and '$([System.IO.Path]::IsPathRooted(%(RazorGenerate.Identity)))'=='false'">
         <GeneratedOutput>$(RazorGenerateIntermediateOutputPath)%(RelativeDir)%(Filename).cs</GeneratedOutput>
       </RazorGenerate>
     </ItemGroup>

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
@@ -61,6 +61,18 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 msBuildProcessKind);
         }
 
+        internal void AddProjectFileContent(string content)
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
+            var existing = File.ReadAllText(Project.ProjectFilePath);
+            var updated = existing.Replace("<!-- Test Placeholder -->", content);
+            File.WriteAllText(Project.ProjectFilePath, updated);
+        }
+
         internal void ReplaceContent(string content, params string[] paths)
         {
             if (content == null)

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/ProjectDirectory.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/ProjectDirectory.cs
@@ -57,7 +57,10 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 
                 CopyGlobalJson(solutionRoot, destinationPath);
 
-                return new ProjectDirectory(destinationPath, Path.Combine(destinationPath, projectName));
+                return new ProjectDirectory(
+                    destinationPath, 
+                    Path.Combine(destinationPath, projectName),
+                    Path.Combine(destinationPath, projectName, projectName + ".csproj"));
             }
             catch
             {
@@ -132,13 +135,16 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             }
         }
 
-        private ProjectDirectory(string solutionPath, string directoryPath)
+        private ProjectDirectory(string solutionPath, string directoryPath, string projectFilePath)
         {
             SolutionPath = solutionPath;
             DirectoryPath = directoryPath;
+            ProjectFilePath = projectFilePath;
         }
 
         public string DirectoryPath { get; }
+
+        public string ProjectFilePath { get;}
 
         public string SolutionPath { get; }
 

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/RazorGenerateIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/RazorGenerateIntegrationTest.cs
@@ -247,5 +247,37 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
             Assert.FileCountEquals(result, 1, RazorIntermediateOutputPath, "*.cs");
         }
+
+        [Fact]
+        [InitializeTestProject("SimpleMvc")]
+        public async Task RazorGenerate_FileWithAbsolutePath_IgnoresFile()
+        {
+            // In preview1 we totally ignore files that are specified with an absolute path
+            var filePath = Path.Combine(Project.SolutionPath, "temp.cshtml");
+            File.WriteAllText(filePath, string.Empty);
+
+            AddProjectFileContent($@"
+<ItemGroup>
+  <Content Include=""{filePath}""/>
+</ItemGroup>");
+
+            var result = await DotnetMSBuild(RazorGenerateTarget);
+
+            Assert.BuildPassed(result);
+
+            // RazorGenerate should compile the assembly, but not the views.
+            Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.dll");
+            Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.PrecompiledViews.dll");
+
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewImports.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewStart.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Contact.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_Layout.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_ValidationScriptsPartial.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "Error.cs");
+            Assert.FileCountEquals(result, 8, RazorIntermediateOutputPath, "*.cs");
+        }
     }
 }

--- a/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
+++ b/test/testapps/AppWithP2PReference/AppWithP2PReference.csproj
@@ -6,6 +6,8 @@
     <ResolvedRazorCompileToolset Condition="'$(RazorCompileToolset)'==''">RazorSDK</ResolvedRazorCompileToolset>
   </PropertyGroup>
 
+  <!-- Test Placeholder -->
+
   <ItemGroup>
     <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj"/>
   </ItemGroup>

--- a/test/testapps/ClassLibrary/ClassLibrary.csproj
+++ b/test/testapps/ClassLibrary/ClassLibrary.csproj
@@ -6,6 +6,8 @@
     <ResolvedRazorCompileToolset Condition="'$(RazorCompileToolset)'==''">RazorSDK</ResolvedRazorCompileToolset>
   </PropertyGroup>
 
+  <!-- Test Placeholder -->
+
   <ItemGroup Condition="'$(BinariesRoot)'==''">
     <!-- In test scenarios $(BinariesRoot) is defined in a generated Directory.Build.props file -->
     <ProjectReference Include="..\..\Microsoft.AspNetCore.Razor.Test.MvcShim\Microsoft.AspNetCore.Razor.Test.MvcShim.csproj"/>

--- a/test/testapps/SimpleMvc/SimpleMvc.csproj
+++ b/test/testapps/SimpleMvc/SimpleMvc.csproj
@@ -6,6 +6,8 @@
     <ResolvedRazorCompileToolset Condition="'$(RazorCompileToolset)'==''">RazorSDK</ResolvedRazorCompileToolset>
   </PropertyGroup>
 
+  <!-- Test Placeholder -->
+
   <ItemGroup Condition="'$(BinariesRoot)'==''">
     <!-- In test scenarios $(BinariesRoot) is defined in a generated Directory.Build.props file -->
     <ProjectReference Include="..\..\Microsoft.AspNetCore.Razor.Test.MvcShim\Microsoft.AspNetCore.Razor.Test.MvcShim.csproj"/>

--- a/test/testapps/SimplePages/SimplePages.csproj
+++ b/test/testapps/SimplePages/SimplePages.csproj
@@ -6,6 +6,8 @@
     <ResolvedRazorCompileToolset Condition="'$(RazorCompileToolset)'==''">RazorSDK</ResolvedRazorCompileToolset>
   </PropertyGroup>
 
+  <!-- Test Placeholder -->
+
   <ItemGroup Condition="'$(BinariesRoot)'==''">
     <!-- In test scenarios $(BinariesRoot) is defined in a generated Directory.Build.props file -->
     <ProjectReference Include="..\..\Microsoft.AspNetCore.Razor.Test.MvcShim\Microsoft.AspNetCore.Razor.Test.MvcShim.csproj"/>


### PR DESCRIPTION
The fix for this for preview1 is to ignore any files with an absolute path. MvcPrecompilation
ignores files outside the project root, and we're aiming for parity.

This will have a proper fix in preview2