### PR TITLE
Include portable symbols in nupkgs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,9 +17,6 @@
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblySigningCertName>Microsoft</AssemblySigningCertName>
-
-    <!-- Generate full pdbs for desktop targeting projects on platforms that support generating full pdbs. -->
-    <DebugType Condition="'$(OS)'=='Windows_NT' AND '$(TargetFramework)'=='net46'">full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <BenchmarkDotNetPackageVersion>0.10.11</BenchmarkDotNetPackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-1010</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-1012</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.1.0-preview1-28193</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
     <MicrosoftAspNetCoreHtmlAbstractionsPackageVersion>2.1.0-preview1-28193</MicrosoftAspNetCoreHtmlAbstractionsPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview1-28193</MicrosoftAspNetCoreTestingPackageVersion>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview1-1010
-commithash:75ca924dfbd673c38841025b04c4dcd93b84f56d
+version:2.1.0-preview1-1012
+commithash:692d90ec605e64b329e04480d81d3a551536973b


### PR DESCRIPTION
Part of https://github.com/aspnet/Universe/issues/131.

We will need to convert portable PDBs to full later in our build. See https://github.com/aspnet/Coherence-Signed/issues/763. Labeling this PR as <kbd>blocked</kbd> until we have a plan to address this.