### PR TITLE
Remove VisualStudioWorkspaceAccessor.Workspace.

### DIFF
--- a/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioWorkspaceAccessor.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioWorkspaceAccessor.cs
@@ -8,8 +8,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
 {
     internal abstract class VisualStudioWorkspaceAccessor
     {
-        public abstract Workspace Workspace { get; }
-
         public abstract bool TryGetWorkspace(ITextBuffer textBuffer, out Workspace workspace);
     }
 }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultVisualStudioWorkspaceAccessor.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/DefaultVisualStudioWorkspaceAccessor.cs
@@ -46,8 +46,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
             _defaultWorkspace = defaultWorkspace;
         }
 
-        public override Workspace Workspace => _defaultWorkspace;
-
         public override bool TryGetWorkspace(ITextBuffer textBuffer, out Workspace workspace)
         {
             if (textBuffer == null)

--- a/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/DefaultVisualStudioWorkspaceAccessor.cs
+++ b/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/DefaultVisualStudioWorkspaceAccessor.cs
@@ -28,8 +28,6 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor
             _projectService = projectService;
         }
 
-        public override Workspace Workspace => TypeSystemService.Workspace;
-
         public override bool TryGetWorkspace(ITextBuffer textBuffer, out Workspace workspace)
         {
             if (textBuffer == null)


### PR DESCRIPTION
- This property used to represent a "primary Workspace". Now that we're moving away from having a "primary Workspace" this needs to go away.

#2001 

/cc @mkArtakMSFT 