### PR TITLE
Update GenerateMPACK to capture PDBs.

### DIFF
--- a/build/MPack.targets
+++ b/build/MPack.targets
@@ -44,13 +44,12 @@
       3. All language service binaries
     -->
 
-  
     <MakeDir Directories="$(MPackIntermediateOutputPath)" Condition="!Exists('$(MPackIntermediateOutputPath)')" />
     <Delete Files="$(MPackOutputPath)" Condition="Exists('$(MPackOutputPath)')" />
 
     <!-- We need to resolve the language service assemblies to generate an addin.info for the mpack -->
     <XmlPeek XmlInputPath="$(MPackManifest)" Query="/ExtensionModel/Runtime/Import/@assembly">
-      <Output TaskParameter="Result" ItemName="LanguageServiceAssemblies" />
+      <Output TaskParameter="Result" ItemName="LanguageServiceAssemblyNames" />
     </XmlPeek>
 
     <!-- We need to resolve the addin dependencies to generate an addin.info for the mpack -->
@@ -61,7 +60,7 @@
     <ItemGroup>
       <AddinInfoLines Include="&lt;Addin id=&quot;$(AddinId)&quot; namespace=&quot;$(AddinNamespace)&quot; version=&quot;$(AddinVersion)&quot; name=&quot;$(AddinDetailedName)&quot; author=&quot;$(Authors)&quot; description=&quot;$(Description)&quot; category=&quot;$(AddinCategory)&quot;&gt;" />
       <AddinInfoLines Include="  &lt;Runtime&gt;" />
-      <AddinInfoLines Include="    &lt;Import assembly=&quot;%(LanguageServiceAssemblies.Identity)&quot; /&gt;" />
+      <AddinInfoLines Include="    &lt;Import assembly=&quot;%(LanguageServiceAssemblyNames.Identity)&quot; /&gt;" />
       <AddinInfoLines Include="    &lt;Import assembly=&quot;$(AddinName).dll&quot; /&gt;" />
       <AddinInfoLines Include="  &lt;/Runtime&gt;" />
       <AddinInfoLines Include="  &lt;Dependencies&gt;" />
@@ -70,10 +69,17 @@
       <AddinInfoLines Include="&lt;/Addin&gt;" />
     </ItemGroup>
 
+    <ItemGroup>
+      <LanguageServiceAssemblies Include="$(LanguageServiceOutputPath)%(LanguageServiceAssemblyNames.Identity)" />
+      <LanguageServicePDBs Include="%(LanguageServiceAssemblies.RootDir)%(Directory)%(FileName).pdb" Condition="Exists('%(LanguageServiceAssemblies.RootDir)%(Directory)%(FileName).pdb')" />
+    </ItemGroup>
+
     <!-- Generate the addin.info and gather sources for mpack zipping-->
     <WriteLinesToFile File="$(AddinInfoFilePath)" Lines="@(AddinInfoLines)" Overwrite="true" />
-    <Copy SourceFiles="$(LanguageServiceOutputPath)\%(LanguageServiceAssemblies.Identity)" DestinationFolder="$(MPackIntermediateOutputPath)" />
+    <Copy SourceFiles="%(LanguageServiceAssemblies.Identity)" DestinationFolder="$(MPackIntermediateOutputPath)" />
+    <Copy SourceFiles="%(LanguageServicePDBs.Identity)" DestinationFolder="$(MPackIntermediateOutputPath)" />
     <Copy SourceFiles="$(AddinOutputPath)$(AddinName).dll" DestinationFolder="$(MPackIntermediateOutputPath)" />
+    <Copy SourceFiles="$(AddinOutputPath)$(AddinName).pdb" DestinationFolder="$(MPackIntermediateOutputPath)" />
 
     <ItemGroup>
       <MPackFiles Include="$(MPackIntermediateOutputPath)\*" />

--- a/build/MPack.targets
+++ b/build/MPack.targets
@@ -58,36 +58,36 @@
     </XmlPeek>
 
     <ItemGroup>
-      <AddinInfoLines Include="&lt;Addin id=&quot;$(AddinId)&quot; namespace=&quot;$(AddinNamespace)&quot; version=&quot;$(AddinVersion)&quot; name=&quot;$(AddinDetailedName)&quot; author=&quot;$(Authors)&quot; description=&quot;$(Description)&quot; category=&quot;$(AddinCategory)&quot;&gt;" />
-      <AddinInfoLines Include="  &lt;Runtime&gt;" />
-      <AddinInfoLines Include="    &lt;Import assembly=&quot;%(LanguageServiceAssemblyNames.Identity)&quot; /&gt;" />
-      <AddinInfoLines Include="    &lt;Import assembly=&quot;$(AddinName).dll&quot; /&gt;" />
-      <AddinInfoLines Include="  &lt;/Runtime&gt;" />
-      <AddinInfoLines Include="  &lt;Dependencies&gt;" />
-      <AddinInfoLines Include="    %(AddinDependencies.Identity)" />
-      <AddinInfoLines Include="  &lt;/Dependencies&gt;" />
-      <AddinInfoLines Include="&lt;/Addin&gt;" />
+      <AddinInfoLine Include="&lt;Addin id=&quot;$(AddinId)&quot; namespace=&quot;$(AddinNamespace)&quot; version=&quot;$(AddinVersion)&quot; name=&quot;$(AddinDetailedName)&quot; author=&quot;$(Authors)&quot; description=&quot;$(Description)&quot; category=&quot;$(AddinCategory)&quot;&gt;" />
+      <AddinInfoLine Include="  &lt;Runtime&gt;" />
+      <AddinInfoLine Include="    &lt;Import assembly=&quot;%(LanguageServiceAssemblyNames.Identity)&quot; /&gt;" />
+      <AddinInfoLine Include="    &lt;Import assembly=&quot;$(AddinName).dll&quot; /&gt;" />
+      <AddinInfoLine Include="  &lt;/Runtime&gt;" />
+      <AddinInfoLine Include="  &lt;Dependencies&gt;" />
+      <AddinInfoLine Include="    %(AddinDependencies.Identity)" />
+      <AddinInfoLine Include="  &lt;/Dependencies&gt;" />
+      <AddinInfoLine Include="&lt;/Addin&gt;" />
     </ItemGroup>
 
     <ItemGroup>
-      <LanguageServiceAssemblies Include="$(LanguageServiceOutputPath)%(LanguageServiceAssemblyNames.Identity)" />
-      <LanguageServicePDBs Include="%(LanguageServiceAssemblies.RootDir)%(Directory)%(FileName).pdb" Condition="Exists('%(LanguageServiceAssemblies.RootDir)%(Directory)%(FileName).pdb')" />
+      <LanguageServiceAssembly Include="$(LanguageServiceOutputPath)%(LanguageServiceAssemblyNames.Identity)" />
+      <LanguageServicePDB Include="%(LanguageServiceAssembly.RootDir)%(Directory)%(FileName).pdb" Condition="Exists('%(LanguageServiceAssembly.RootDir)%(Directory)%(FileName).pdb')" />
     </ItemGroup>
 
     <!-- Generate the addin.info and gather sources for mpack zipping-->
-    <WriteLinesToFile File="$(AddinInfoFilePath)" Lines="@(AddinInfoLines)" Overwrite="true" />
-    <Copy SourceFiles="%(LanguageServiceAssemblies.Identity)" DestinationFolder="$(MPackIntermediateOutputPath)" />
-    <Copy SourceFiles="%(LanguageServicePDBs.Identity)" DestinationFolder="$(MPackIntermediateOutputPath)" />
+    <WriteLinesToFile File="$(AddinInfoFilePath)" Lines="@(AddinInfoLine)" Overwrite="true" />
+    <Copy SourceFiles="%(LanguageServiceAssembly.Identity)" DestinationFolder="$(MPackIntermediateOutputPath)" />
+    <Copy SourceFiles="%(LanguageServicePDB.Identity)" DestinationFolder="$(MPackIntermediateOutputPath)" />
     <Copy SourceFiles="$(AddinOutputPath)$(AddinName).dll" DestinationFolder="$(MPackIntermediateOutputPath)" />
     <Copy SourceFiles="$(AddinOutputPath)$(AddinName).pdb" DestinationFolder="$(MPackIntermediateOutputPath)" />
 
     <ItemGroup>
-      <MPackFiles Include="$(MPackIntermediateOutputPath)\*" />
+      <MPackFile Include="$(MPackIntermediateOutputPath)\*" />
     </ItemGroup>
 
     <ZipArchive
       File="$(MPackOutputPath)"
-      SourceFiles="@(MPackFiles)"
+      SourceFiles="@(MPackFile)"
       WorkingDirectory="$(MPackIntermediateOutputPath)" />
   </Target>
 


### PR DESCRIPTION
- VS Mac expects pdbs to sit side-by-side.

@natemcmaster does our GenerateMPACK target run prior to the Portable => Full windows pdb conversion? We need the MPack PDBs to be portable is why I ask.

#1968 

/cc @KirillOsenkov 