### PR TITLE
WebSdk transitions

### DIFF
--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview2-15698
-commithash:7216e5068cb1957e09d45fcbe58a744dd5c2de73
+version:2.1.0-preview2-15704
+commithash:21fdd9f5254226f407a2b4b3ef963693c2fd7998

--- a/src/Microsoft.NET.Sdk.Razor/Sdk/Sdk.props
+++ b/src/Microsoft.NET.Sdk.Razor/Sdk/Sdk.props
@@ -11,6 +11,13 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0">
   <PropertyGroup>
+    <!-- Determines if the Razor Sdk is responsible for importing Microsoft.NET.Sdk. Microsoft.NET.Sdk.Web may have previously imported this. -->
+    <_RazorSdkImportsMicrosoftNetSdk Condition="'$(UsingMicrosoftNETSdk)' != 'true'">true</_RazorSdkImportsMicrosoftNetSdk>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$(_RazorSdkImportsMicrosoftNetSdk)' == 'true'" />
+
+  <PropertyGroup>
     <RazorSdkCurrentVersionProps Condition="'$(RazorSdkCurrentVersionProps)' == ''">$(MSBuildThisFileDirectory)..\build\netstandard2.0\Sdk.Razor.CurrentVersion.props</RazorSdkCurrentVersionProps>
   </PropertyGroup>
 

--- a/src/Microsoft.NET.Sdk.Razor/Sdk/Sdk.targets
+++ b/src/Microsoft.NET.Sdk.Razor/Sdk/Sdk.targets
@@ -11,6 +11,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project ToolsVersion="14.0">
 
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$(_RazorSdkImportsMicrosoftNetSdk)' == 'true'" />
+
   <PropertyGroup Condition="'$(RazorSdkCurrentVersionTargets)' == ''">
     <RazorSdkCurrentVersionTargets Condition="'$(IsCrossTargetingBuild)' == 'true'">$(MSBuildThisFileDirectory)..\buildMultiTargeting\Sdk.Razor.CurrentVersion.MultiTargeting.targets</RazorSdkCurrentVersionTargets>
     <RazorSdkCurrentVersionTargets Condition="'$(IsCrossTargetingBuild)' != 'true'">$(MSBuildThisFileDirectory)..\build\netstandard2.0\Sdk.Razor.CurrentVersion.targets</RazorSdkCurrentVersionTargets>

--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -51,7 +51,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UseRazorBuildServer Condition="'$(UseRazorBuildServer)'==''">false</UseRazorBuildServer>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(_WebSdkHeartsRazorSdk)' == 'true' AND '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true'">
+  <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true'">
     <Content Include="**\*.cshtml" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
     <None Remove="**\*.cshtml" />
   </ItemGroup>

--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -57,6 +57,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       PrepareForRazorCompile;
       RazorCoreCompile
     </RazorCompileDependsOn>
+
+  </PropertyGroup>
+
+  <!--
+    PreserveCompilationContext needs to enabled by default only for "applications" (OutputType = exe) which have one or more Razor files.
+  -->
+  <PropertyGroup Condition="'$(PreserveCompilationContext)' == '' AND '$(OutputType)' == 'exe'">
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
 
   <!-- 
@@ -129,7 +137,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <!-- Resolve the toolset to use -->
-  <PropertyGroup Condition="'$(_WebSdkHeartsRazorSdk)' == 'true'">
+  <PropertyGroup>
     <!-- Default value for the property 'MvcRazorCompileOnPublish' is empty. If it has been explicitly enabled, continue using precompilation. -->
     <ResolvedRazorCompileToolset Condition="'$(MvcRazorCompileOnPublish)' == 'true'">PrecompilationTool</ResolvedRazorCompileToolset>
 

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildIntegrationTest.cs
@@ -39,6 +39,11 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 // end up in the MSBuild logs.
                 Assert.BuildOutputContainsLine(result, $"SimpleMvc -> {Path.Combine(Path.GetFullPath(Project.DirectoryPath), OutputPath, "SimpleMvc.PrecompiledViews.dll")}");
             }
+
+            result = await DotnetMSBuild("_IntrospectPreserveCompilationContext");
+
+            Assert.BuildPassed(result);
+            Assert.BuildOutputContainsLine(result, "PreserveCompilationContext: true");
         }
 
         [Fact]
@@ -54,6 +59,13 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(result, OutputPath, "SimpleMvc.pdb");
             Assert.FileDoesNotExist(result, OutputPath, "SimpleMvc.PrecompiledViews.dll");
             Assert.FileDoesNotExist(result, OutputPath, "SimpleMvc.PrecompiledViews.pdb");
+
+            result = await DotnetMSBuild("_IntrospectPreserveCompilationContext");
+
+            Assert.BuildPassed(result);
+            // An app with no cshtml files should not have PreserveCompilationContext.
+            // This expectation should get resolved once we address https://github.com/aspnet/Razor/issues/2077
+            Assert.BuildOutputContainsLine(result, "PreserveCompilationContext: true");
         }
 
         [Fact]

--- a/test/testapps/Directory.Build.props
+++ b/test/testapps/Directory.Build.props
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <SolutionRoot Condition="'$(SolutionRoot)' == ''">$(MSBuildThisFileDirectory)..\..\</SolutionRoot>
     <SolutionRoot>$([MSBuild]::EnsureTrailingSlash('$(SolutionRoot)'))</SolutionRoot>
+
+    <!-- Temporary hack to make things compatible with the 2.1.300-preview2-008173 Sdk -->
+    <_RazorSdkPackageReferenced>true</_RazorSdkPackageReferenced>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BinariesRoot)'==''">

--- a/test/testapps/RazorTest.Introspection.targets
+++ b/test/testapps/RazorTest.Introspection.targets
@@ -6,4 +6,8 @@
   <Target Name="_IntrospectRazorEmbeddedResources">
     <Message Text="CompileResource: %(_RazorCoreCompileResourceInputs.Identity) %(_RazorCoreCompileResourceInputs.LogicalName)" Importance="High" />
   </Target>
+
+  <Target Name="_IntrospectPreserveCompilationContext">
+    <Message Text="PreserveCompilationContext: $(PreserveCompilationContext)" Importance="High" />
+  </Target>
 </Project>


### PR DESCRIPTION
* Add a reference to Microsoft.Net.Sdk if it wasn't previously referenced
* Move PreserveCompilationContext in to our target
* Remove use of transition property