### PR TITLE
Make content files work better in class library projects referencing …

### DIFF
--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -19,6 +19,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <PropertyGroup>
     <!--
+    Set to true to automatically include certain file types, such as .cshtml files, as content in the project.
+    When referenced via Microsoft.NET.Sdk.Web, this additionally includes all files under wwwroot, and any config files.
+    -->
+    <EnableDefaultContentItems Condition="'$(EnableDefaultContentItems)'==''">true</EnableDefaultContentItems>
+
+    <!--
       Set to true to automatically include Razor (.cshtml) files in @(RazorGenerate) from @(Content).
     -->
     <EnableDefaultRazorGenerateItems Condition="'$(EnableDefaultRazorGenerateItems)'==''">true</EnableDefaultRazorGenerateItems>
@@ -46,13 +52,23 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RazorCompileToolset>Implicit</RazorCompileToolset>
 
     <!--
+    Configures whether all Razor content items (.cshtml files) will be marked to be included in the produced NuGet package as content.
+
+    All Content items are included in a NuGet package as content files. This setting can be used to control this behavior for Razor content items.
+    -->
+    <IncludeRazorContentInPack Condition="'$(IncludeRazorContentInPack)'==''">false</IncludeRazorContentInPack>
+
+    <!--
     Set to true to allow a Razor code generation to use a persistent build server process.
     -->
     <UseRazorBuildServer Condition="'$(UseRazorBuildServer)'==''">false</UseRazorBuildServer>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true'">
-    <Content Include="**\*.cshtml" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
+    <Content Include="**\*.cshtml" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)">
+      <Pack>$(IncludeRazorContentInPack)</Pack>
+    </Content>
+
     <None Remove="**\*.cshtml" />
   </ItemGroup>
 

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/Assert.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/Assert.cs
@@ -233,6 +233,33 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             }
         }
 
+        public static void NuspecDoesNotContain(MSBuildResult result, string nuspecPath, string expected)
+        {
+            if (result == null)
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
+            if (nuspecPath == null)
+            {
+                throw new ArgumentNullException(nameof(nuspecPath));
+            }
+
+            if (expected == null)
+            {
+                throw new ArgumentNullException(nameof(expected));
+            }
+
+            nuspecPath = Path.Combine(result.Project.DirectoryPath, nuspecPath);
+            FileExists(result, nuspecPath);
+
+            var content = File.ReadAllText(nuspecPath);
+            if (content.Contains(expected))
+            {
+                throw new NuspecFoundException(result, nuspecPath, content, expected);
+            }
+        }
+
         public static void NupkgContains(MSBuildResult result, string nupkgPath, string filePath)
         {
             if (result == null)
@@ -503,6 +530,34 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                         $"expected: {Expected}" + Environment.NewLine +
                         Environment.NewLine +
                         $"actual: {Content}";
+                }
+            }
+        }
+
+        private class NuspecFoundException : MSBuildXunitException
+        {
+            public NuspecFoundException(MSBuildResult result, string filePath, string content, string expected)
+                : base(result)
+            {
+                FilePath = filePath;
+                Content = content;
+                Expected = expected;
+            }
+
+            public string Content { get; }
+
+            public string Expected { get; }
+
+            public string FilePath { get; }
+
+            protected override string Heading
+            {
+                get
+                {
+                    return
+                        $"nuspec: '{FilePath}' should not contain the content {Expected}." +
+                        Environment.NewLine +
+                        $"actual content: {Content}";
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PackIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PackIntegrationTest.cs
@@ -26,6 +26,39 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 $"<file src=\"{Path.Combine("bin", Configuration, "netcoreapp2.0", "ClassLibrary.PrecompiledViews.dll")}\" " +
                 $"target=\"{Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.PrecompiledViews.dll")}\" />");
 
+            Assert.NuspecDoesNotContain(
+                result,
+                Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
+                @"<files include=""any/netcoreapp2.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
+
+            Assert.NupkgContains(
+                result,
+                Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.nupkg"),
+                Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.PrecompiledViews.dll"));
+        }
+
+        [Fact]
+        [InitializeTestProject("ClassLibrary")]
+        public async Task Pack_IncludesRazorFilesAsContent_WhenIncludeRazorContentInPack_IsSet()
+        {
+            var result = await DotnetMSBuild("Pack", "/p:RazorCompileOnBuild=true /p:IncludeRazorContentInPack=true");
+
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, OutputPath, "ClassLibrary.dll");
+            Assert.FileExists(result, OutputPath, "ClassLibrary.PrecompiledViews.dll");
+
+            Assert.NuspecContains(
+                result,
+                Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
+                $"<file src=\"{Path.Combine("bin", Configuration, "netcoreapp2.0", "ClassLibrary.PrecompiledViews.dll")}\" " +
+                $"target=\"{Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.PrecompiledViews.dll")}\" />");
+
+            Assert.NuspecContains(
+                result,
+                Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
+                @"<files include=""any/netcoreapp2.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
+
             Assert.NupkgContains(
                 result,
                 Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.nupkg"),

--- a/test/testapps/ClassLibrary/ClassLibrary.csproj
+++ b/test/testapps/ClassLibrary/ClassLibrary.csproj
@@ -24,12 +24,6 @@
 
   <!-- Test Placeholder -->
 
-  <ItemGroup>
-    <Content Include="**\*.cshtml">
-      <Pack>false</Pack>
-    </Content>
-  </ItemGroup>
-
   <Import Project="$(SolutionRoot)src\Microsoft.AspNetCore.Mvc.Razor.Extensions\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
…Razor Sdk

* Include cshtml files as content when referencing Razor Sdk
* Exclude cshtml files added by default from being packed

Fixes #1980