### PR TITLE
Changed AddDefaultImports to take strings instead of project items.

### DIFF
--- a/src/RazorPageGenerator/Program.cs
+++ b/src/RazorPageGenerator/Program.cs
@@ -68,7 +68,10 @@ Examples:
                     configure(builder);
                 }
 
-                builder.AddDefaultImports(DefaultImportItem.Instance);
+                builder.AddDefaultImports(@"
+@using System
+@using System.Threading.Tasks
+");
             });
             return projectEngine;
         }
@@ -151,37 +154,6 @@ Examples:
 
                 options.SuppressMetadataAttributes = true;
             }
-        }
-
-        private class DefaultImportItem : RazorProjectItem
-        {
-            private readonly byte[] _defaultImportBytes;
-
-            private DefaultImportItem()
-            {
-                var preamble = Encoding.UTF8.GetPreamble();
-                var content = @"
-@using System
-@using System.Threading.Tasks
-";
-                var contentBytes = Encoding.UTF8.GetBytes(content);
-
-                _defaultImportBytes = new byte[preamble.Length + contentBytes.Length];
-                preamble.CopyTo(_defaultImportBytes, 0);
-                contentBytes.CopyTo(_defaultImportBytes, preamble.Length);
-            }
-
-            public override string BasePath => null;
-
-            public override string FilePath => null;
-
-            public override string PhysicalPath => null;
-
-            public override bool Exists => true;
-
-            public static DefaultImportItem Instance { get; } = new DefaultImportItem();
-
-            public override Stream Read() => new MemoryStream(_defaultImportBytes);
         }
 
         private class FileSystemRazorProjectItemWrapper : RazorProjectItem

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
@@ -533,7 +533,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             {
                 RazorExtensions.Register(builder);
 
-                builder.AddDefaultImports(new TestRazorProjectItem("_TestImports.cshtml") { Content = "@addTagHelper *, Test" });
+                builder.AddDefaultImports("@addTagHelper *, Test");
 
                 if (tagHelpers != null)
                 {

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorSyntaxTreePartialParserTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorSyntaxTreePartialParserTest.cs
@@ -589,7 +589,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             {
                 RazorExtensions.Register(builder);
 
-                builder.AddDefaultImports(new TestRazorProjectItem("_TestImports.cshtml") { Content = "@addTagHelper *, Test" });
+                builder.AddDefaultImports("@addTagHelper *, Test");
 
                 if (tagHelpers != null)
                 {


### PR DESCRIPTION
- Strings here was important because any import added to the system dynamically needs to eventually make its way back to being a project item. With strings we can state that they do exist (have content) but do not have any file paths associated.
- Updated all call sites to use the new AddDefaultImports string based api.

#2080