### PR TITLE
Change final code documents to not contain non-existent imports.

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineIntegrationTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // Arrange
             var projectItem = new TestRazorProjectItem("Index.cshtml");
 
-            var testImport = Mock.Of<RazorProjectItem>(i => i.Read() == new MemoryStream() && i.FilePath == "testvalue");
+            var testImport = Mock.Of<RazorProjectItem>(i => i.Read() == new MemoryStream() && i.FilePath == "testvalue" && i.Exists == true);
             var importFeature = new Mock<IImportProjectFeature>();
             importFeature
                 .Setup(feature => feature.GetImports(It.IsAny<RazorProjectItem>()))

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineTest.cs
@@ -9,29 +9,19 @@ namespace Microsoft.AspNetCore.Razor.Language
     public class DefaultRazorProjectEngineTest
     {
         [Fact]
-        public void ConvertToSourceDocument_ConvertsNormalImports()
+        public void GetImportSourceDocuments_DoesNotIncludeNonExistentItems()
         {
             // Arrange
-            var projectItem = new TestRazorProjectItem("Index.cshtml");
+            var existingItem = new TestRazorProjectItem("Index.cshtml");
+            var nonExistentItem = Mock.Of<RazorProjectItem>(item => item.Exists == false);
+            var items = new[] { existingItem, nonExistentItem };
 
             // Act
-            var sourceDocument = DefaultRazorProjectEngine.ConvertToSourceDocument(projectItem);
+            var sourceDocuments = DefaultRazorProjectEngine.GetImportSourceDocuments(items);
 
             // Assert
-            Assert.NotNull(sourceDocument);
-        }
-
-        [Fact]
-        public void ConvertToSourceDocument_ConvertsMarkerImports()
-        {
-            // Arrange
-            var projectItem = Mock.Of<RazorProjectItem>(item => item.FilePath == "Index.cshtml" && item.Exists == false);
-
-            // Act
-            var sourceDocument = DefaultRazorProjectEngine.ConvertToSourceDocument(projectItem);
-
-            // Assert
-            Assert.NotNull(sourceDocument);
+            var sourceDocument = Assert.Single(sourceDocuments);
+            Assert.Equal(existingItem.FilePath, sourceDocument.FilePath);
         }
     }
 }


### PR DESCRIPTION
- Existent imports are imports that have content that contribute to the processing of a Razor document. Prior to this we had a legacy expectation that code documents had empty markers in them for all of their import locations. This proved troublesome when cross-referencing files that had file paths and were supposed to be existent but weren't in metadata. Now that we have a project engine with a de-coupled import feature we can rely on the import feature for finding all locations of important files and then strip out any non-existent items.

This solves an issue where when we're trying to determine if a precompiled view is dirty we know if a `_ViewImports.cshtml` was deleted (and not just a marker to begin with).