### PR TITLE
Protect against unreadable _ViewImports at design time.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/FileSystemRazorProjectItem.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/FileSystemRazorProjectItem.cs
@@ -30,6 +30,6 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override string PhysicalPath => File.FullName;
 
-        public override Stream Read() => File.OpenRead();
+        public override Stream Read() => new FileStream(PhysicalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
     }
 }


### PR DESCRIPTION
- This is a safe fix for the VS15.6 release to protect against VS crashing when it cannot read a `_ViewImports.cshtml`  associated with a Razor document.
- In the case that we can't resolve the imports for a Razor document we fall back to using the default imports.

#2106