### PR TITLE
Pack should pack symbol nupkg

### DIFF
--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -58,6 +58,16 @@ Copyright (c) .NET Foundation. All rights reserved.
       RazorCoreCompile
     </RazorCompileDependsOn>
 
+    <BuiltProjectOutputGroupDependsOn>
+      $(BuiltProjectOutputGroupDependsOn);
+      _RazorAddBuiltProjectOutputGroupOutput
+    </BuiltProjectOutputGroupDependsOn>
+
+    <DebugSymbolsProjectOutputGroupDependsOn>
+      $(DebugSymbolsProjectOutputGroupDependsOn);
+      _RazorAddDebugSymbolsProjectOutputGroupOutput
+    </DebugSymbolsProjectOutputGroupDependsOn>
+
   </PropertyGroup>
 
   <!-- 
@@ -322,16 +332,22 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target 
     Name="_RazorAddBuiltProjectOutputGroupOutput"
-    DependsOnTargets="ResolveRazorGenerateInputs"
-    BeforeTargets="BuiltProjectOutputGroup"
+    DependsOnTargets="_ResolveRazorTargetPath;ResolveRazorGenerateInputs"
     Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
 
-    <PropertyGroup>
-      <RazorOutputPath Condition="'$(RazorOutputPath)'==''">$([MSBuild]::EnsureTrailingSlash('$(OutDir)'))</RazorOutputPath>
-    </PropertyGroup>
-
     <ItemGroup Condition="'@(RazorGenerate)'!= ''">
-      <BuiltProjectOutputGroupOutput Include="@(RazorIntermediateAssembly)" FinalOutputPath="$(RazorOutputPath)$(RazorTargetName).dll" />
+      <BuiltProjectOutputGroupOutput Include="%(RazorIntermediateAssembly.FullPath)" FinalOutputPath="$(RazorTargetPath)" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target
+    Name="_RazorAddDebugSymbolsProjectOutputGroupOutput"
+    DependsOnTargets="_ResolveRazorTargetPath;ResolveRazorGenerateInputs"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
+
+    <ItemGroup Condition="Exists('@(_RazorDebugSymbolsIntermediatePath)')">
+      <DebugSymbolsProjectOutputGroupOutput Include="%(_RazorDebugSymbolsIntermediatePath.FullPath)" FinalOutputPath="$(RazorTargetDir)$(RazorTargetName).pdb" />
     </ItemGroup>
     
   </Target>
@@ -399,18 +415,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target 
     Name="_RazorCopyFilesToOutputDirectory" 
-    DependsOnTargets="RazorCompile"
+    DependsOnTargets="_ResolveRazorTargetPath;RazorCompile"
     AfterTargets="CopyFilesToOutputDirectory"
     Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
-
-    <PropertyGroup>
-      <RazorOutputPath Condition="'$(RazorOutputPath)'==''">$([MSBuild]::EnsureTrailingSlash('$(OutDir)'))</RazorOutputPath>
-    </PropertyGroup>
 
     <!-- Copy the Razor dll  -->
     <Copy
       SourceFiles="@(RazorIntermediateAssembly)"
-      DestinationFolder="$(RazorOutputPath)"
+      DestinationFiles="$(RazorTargetPath)"
       SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"
@@ -489,6 +501,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       Text="A PackageReference for 'Microsoft.AspNetCore.Razor.Design' was not included in your project. This package is required to compile Razor files. Typically, a
       transitive reference to 'Microsoft.AspNetCore.Razor.Design' and references required to compile Razor files are obtained by adding a PackageReference
       for 'Microsoft.AspNetCore.Mvc' in your project. For more information, see https://go.microsoft.com/fwlink/?linkid=868374." />
+  </Target>
+
+  <Target Name="_ResolveRazorTargetPath">
+    <PropertyGroup>
+      <RazorOutputPath Condition="'$(RazorOutputPath)'==''">$([MSBuild]::EnsureTrailingSlash('$(OutDir)'))</RazorOutputPath>
+      <RazorTargetDir>$([MSBuild]::Escape($([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(RazorOutputPath)'))'))))))</RazorTargetDir>
+      <!-- Example, c:\MyProjects\MyProject\bin\debug\MyAssembly.Views.dll -->
+      <RazorTargetPath Condition=" '$(RazorTargetPath)' == '' ">$(RazorTargetDir)$(RazorTargetName).dll</RazorTargetPath>
+    </PropertyGroup>
   </Target>
 
   <PropertyGroup Condition="'$(RazorDesignTimeTargets)'==''">

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/Assert.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/Assert.cs
@@ -313,7 +313,9 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             }
         }
 
-        public static void NupkgContains(MSBuildResult result, string nupkgPath, string filePath)
+        // This method extracts the nupkg to a fixed directory path. To avoid the extra work of
+        // cleaning up after each invocation, this method accepts multiple files.
+        public static void NupkgContains(MSBuildResult result, string nupkgPath, params string[] filePaths)
         {
             if (result == null)
             {
@@ -325,20 +327,23 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 throw new ArgumentNullException(nameof(nupkgPath));
             }
 
-            if (filePath == null)
+            if (filePaths == null)
             {
-                throw new ArgumentNullException(nameof(filePath));
+                throw new ArgumentNullException(nameof(filePaths));
             }
 
             nupkgPath = Path.Combine(result.Project.DirectoryPath, nupkgPath);
             FileExists(result, nupkgPath);
 
-            var unzipped = Path.Combine(result.Project.DirectoryPath, "nupkg");
+            var unzipped = Path.Combine(result.Project.DirectoryPath, Path.GetFileNameWithoutExtension(nupkgPath));
             ZipFile.ExtractToDirectory(nupkgPath, unzipped);
 
-            if (!File.Exists(Path.Combine(unzipped, filePath)))
+            foreach (var filePath in filePaths)
             {
-                throw new NupkgFileMissingException(result, nupkgPath, filePath);
+                if (!File.Exists(Path.Combine(unzipped, filePath)))
+                {
+                    throw new NupkgFileMissingException(result, nupkgPath, filePath);
+                }
             }
         }
 

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PackIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PackIntegrationTest.cs
@@ -23,8 +23,14 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.NuspecContains(
                 result,
                 Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                $"<file src=\"{Path.Combine("bin", Configuration, "netcoreapp2.0", "ClassLibrary.Views.dll")}\" " +
+                $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp2.0", "ClassLibrary.Views.dll")}\" " +
                 $"target=\"{Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.Views.dll")}\" />");
+
+            Assert.NuspecDoesNotContain(
+                result,
+                Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
+                $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp2.0", "ClassLibrary.Views.pdb")}\" " +
+                $"target=\"{Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.Views.pdb")}\" />");
 
             Assert.NuspecDoesNotContain(
                 result,
@@ -35,6 +41,33 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 result,
                 Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.nupkg"),
                 Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.Views.dll"));
+        }
+
+        [Fact]
+        [InitializeTestProject("ClassLibrary")]
+        public async Task Pack_WithIncludeSymbols_IncludesRazorPdb()
+        {
+            var result = await DotnetMSBuild("Pack", "/p:RazorCompileOnBuild=true /p:IncludeSymbols=true");
+
+            Assert.BuildPassed(result);
+
+            Assert.NuspecContains(
+                result,
+                Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.symbols.nuspec"),
+                $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp2.0", "ClassLibrary.Views.dll")}\" " +
+                $"target=\"{Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.Views.dll")}\" />");
+
+            Assert.NuspecContains(
+                result,
+                Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.symbols.nuspec"),
+                $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp2.0", "ClassLibrary.Views.pdb")}\" " +
+                $"target=\"{Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.Views.pdb")}\" />");
+
+            Assert.NupkgContains(
+                result,
+                Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.symbols.nupkg"),
+                Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.Views.dll"),
+                Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.Views.pdb"));
         }
 
         [Fact]
@@ -51,7 +84,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.NuspecContains(
                 result,
                 Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
-                $"<file src=\"{Path.Combine("bin", Configuration, "netcoreapp2.0", "ClassLibrary.Views.dll")}\" " +
+                $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netcoreapp2.0", "ClassLibrary.Views.dll")}\" " +
                 $"target=\"{Path.Combine("lib", "netcoreapp2.0", "ClassLibrary.Views.dll")}\" />");
 
             Assert.NuspecContains(


### PR DESCRIPTION
* Update path calculation for BuiltProjectOutputGroupOutput to include full path. This matches
  the behavior of Microsoft.Common.targets.
* Add Razor symbols to DebugSymbolsProjectOutputGroupOutput

Fixes #2116