### PR TITLE
Fix #2041 - Add static constructor to DocumentWriter

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DocumentWriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/DocumentWriter.cs
@@ -2,12 +2,30 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
 {
     public abstract class DocumentWriter
     {
+        public static DocumentWriter CreateDefault(CodeTarget codeTarget, RazorCodeGenerationOptions options)
+        {
+            if (codeTarget == null)
+            {
+                throw new ArgumentNullException(nameof(codeTarget));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            return new DefaultDocumentWriter(codeTarget, options);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("This method was intended to be static, use CreateDefault instead.")]
         public DocumentWriter Create(CodeTarget codeTarget, RazorCodeGenerationOptions options)
         {
             if (codeTarget == null)

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorCSharpLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorCSharpLoweringPhase.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new InvalidOperationException(message);
             }
 
-            var writer = new DefaultDocumentWriter(documentNode.Target, documentNode.Options);
+            var writer = DocumentWriter.CreateDefault(documentNode.Target, documentNode.Options);
             var cSharpDocument = writer.WriteDocument(codeDocument, documentNode);
             codeDocument.SetCSharpDocument(cSharpDocument);
         }


### PR DESCRIPTION
The instance Create method was always supposed to be static.