### PR TITLE
Fix flaky dispatcher test

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Tools/DefaultRequestDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/DefaultRequestDispatcher.cs
@@ -383,6 +383,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
                                 ServerLogger.Log("End writing response.");
 
                                 reason = ConnectionResult.Reason.CompilationCompleted;
+
+                                _eventBus.CompilationCompleted();
                             }
                             catch
                             {

--- a/src/Microsoft.AspNetCore.Razor.Tools/EventBus.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/EventBus.cs
@@ -37,6 +37,13 @@ namespace Microsoft.AspNetCore.Razor.Tools
         public virtual void ConnectionCompleted(int count)
         {
         }
+        
+        /// <summary>
+        /// Called when a compilation is completed successfully and the response is written to the stream.
+        /// </summary>
+        public virtual void CompilationCompleted()
+        {
+        }
 
         /// <summary>
         /// Called when a bad client connection was detected and the server will be shutting down as a 

--- a/test/Microsoft.AspNetCore.Razor.Tools.Test/Infrastructure/TestableEventBus.cs
+++ b/test/Microsoft.AspNetCore.Razor.Tools.Test/Infrastructure/TestableEventBus.cs
@@ -2,21 +2,27 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.AspNetCore.Razor.Tools
 {
     internal class TestableEventBus : EventBus
     {
-        public int ListeningCount;
-        public int ConnectionCount;
-        public int CompletedCount;
-        public DateTime? LastProcessedTime;
-        public TimeSpan? KeepAlive;
-        public bool HasDetectedBadConnection;
-        public bool HitKeepAliveTimeout;
         public event EventHandler Listening;
+        public event EventHandler CompilationComplete;
+
+        public int ListeningCount { get; private set; }
+
+        public int ConnectionCount { get; private set; }
+
+        public int CompletedCount { get; private set; }
+
+        public DateTime? LastProcessedTime { get; private set; }
+
+        public TimeSpan? KeepAlive { get; private set; }
+
+        public bool HasDetectedBadConnection { get; private set; }
+
+        public bool HitKeepAliveTimeout { get; private set; }
 
         public override void ConnectionListening()
         {
@@ -33,6 +39,11 @@ namespace Microsoft.AspNetCore.Razor.Tools
         {
             CompletedCount += count;
             LastProcessedTime = DateTime.Now;
+        }
+
+        public override void CompilationCompleted()
+        {
+            CompilationComplete?.Invoke(this, EventArgs.Empty);
         }
 
         public override void UpdateKeepAlive(TimeSpan timeSpan)

--- a/test/Microsoft.AspNetCore.Razor.Tools.Test/ServerLifecycleTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Tools.Test/ServerLifecycleTest.cs
@@ -116,7 +116,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
         /// A shutdown request should not abort an existing compilation.  It should be allowed to run to 
         /// completion.
         /// </summary>
-        [ConditionalFact(Skip = "Skipping temporarily on non-windows. https://github.com/aspnet/Razor/issues/1991")]
+        // Skipping temporarily on non-windows. https://github.com/aspnet/Razor/issues/1991
+        [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public async Task ServerRunning_ShutdownRequest_DoesNotAbortCompilation()
         {
@@ -153,7 +154,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
         /// <summary>
         /// Multiple clients should be able to send shutdown requests to the server.
         /// </summary>
-        [ConditionalFact(Skip = "Skipping temporarily on non-windows. https://github.com/aspnet/Razor/issues/1991")]
+        // Skipping temporarily on non-windows. https://github.com/aspnet/Razor/issues/1991
+        [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public async Task ServerRunning_MultipleShutdownRequests_HandlesSuccessfully()
         {
@@ -191,7 +193,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
             }
         }
 
-        [ConditionalFact(Skip = "Skipping temporarily on non-windows. https://github.com/aspnet/Razor/issues/1991")]
+        // Skipping temporarily on non-windows. https://github.com/aspnet/Razor/issues/1991
+        [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public async Task ServerRunning_CancelCompilation_CancelsSuccessfully()
         {


### PR DESCRIPTION
#2018 

The problem here was there was nothing ensuring Compilations are fully completed and written to the response before we send the client disconnect. Although I couldn't reproduce the exact failure from the CI, I am fairly certain this is the issue. I was able to make it fail by adding a delay in the compile task (which shouldn't happen).
The fix was to add a callback that would trigger when a compilation is fully completed and then wait on it before disconnecting.