### PR TITLE
Fixed flaky shutdown tests

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Tools.Test/Infrastructure/ServerUtilities.cs
+++ b/test/Microsoft.AspNetCore.Razor.Tools.Test/Infrastructure/ServerUtilities.cs
@@ -26,7 +26,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
         internal static ServerData CreateServer(
             string pipeName = null,
             CompilerHost compilerHost = null,
-            ConnectionHost connectionHost = null)
+            ConnectionHost connectionHost = null,
+            Action<object, EventArgs> onListening = null)
         {
             pipeName = pipeName ?? Guid.NewGuid().ToString();
             compilerHost = compilerHost ?? CompilerHost.Create();
@@ -40,6 +41,10 @@ namespace Microsoft.AspNetCore.Razor.Tools
             {
                 var eventBus = new TestableEventBus();
                 eventBus.Listening += (sender, e) => { serverListenSource.TrySetResult(true); };
+                if (onListening != null)
+                {
+                    eventBus.Listening += (sender, e) => onListening(sender, e);
+                }
                 try
                 {
                     RunServer(


### PR DESCRIPTION
https://github.com/aspnet/Razor/issues/1991

The flakiness was caused by the race between the compilation and the shutdown requests. There was nothing guaranteeing that compilation was in progress before shutdown is seen.

