### PR TITLE
Don't print normal output as error

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Tools/CompilerHost.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/CompilerHost.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
 
                 var writer = ServerLogger.IsLoggingEnabled ? new StringWriter() : TextWriter.Null;
 
-                var checker = new DefaultExtensionDependencyChecker(Loader, writer);
+                var checker = new DefaultExtensionDependencyChecker(Loader, writer, writer);
                 var app = new Application(cancellationToken, Loader, checker, AssemblyReferenceProvider)
                 {
                     Out = writer,

--- a/src/Microsoft.AspNetCore.Razor.Tools/DefaultExtensionDependencyChecker.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/DefaultExtensionDependencyChecker.cs
@@ -26,15 +26,18 @@ namespace Microsoft.AspNetCore.Razor.Tools
 
         private readonly ExtensionAssemblyLoader _loader;
         private readonly TextWriter _output;
+        private readonly TextWriter _error;
         private readonly string[] _ignoredAssemblies;
 
         public DefaultExtensionDependencyChecker(
             ExtensionAssemblyLoader loader,
             TextWriter output,
+            TextWriter error,
             string[] ignoredAssemblies = null)
         {
             _loader = loader;
             _output = output;
+            _error = error;
             _ignoredAssemblies = ignoredAssemblies ?? DefaultIgnoredAssemblies;
         }
 
@@ -46,8 +49,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
             }
             catch (Exception ex)
             {
-                _output.WriteLine("Exception performing Extension dependency check:");
-                _output.WriteLine(ex.ToString());
+                _error.WriteLine("Exception performing Extension dependency check:");
+                _error.WriteLine(ex.ToString());
                 return false;
             }
         }
@@ -64,7 +67,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
 
                 if (!Path.IsPathRooted(item.FilePath))
                 {
-                    _output.WriteLine($"The file path '{item.FilePath}' is not a rooted path. File paths must be absolute and fully-qualified.");
+                    _error.WriteLine($"The file path '{item.FilePath}' is not a rooted path. File paths must be absolute and fully-qualified.");
                     return false;
                 }
 
@@ -83,7 +86,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                     }
 
                     // If we get here we can't resolve this assembly. This is an error.
-                    _output.WriteLine($"Extension assembly '{item.Identity.Name}' depends on '{reference.ToString()} which is missing.");
+                    _error.WriteLine($"Extension assembly '{item.Identity.Name}' depends on '{reference.ToString()} which is missing.");
                     return false;
                 }
             }
@@ -110,7 +113,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 var item = items[i];
                 if (item.Mvid != item.Assembly.ManifestModule.ModuleVersionId)
                 {
-                    _output.WriteLine($"Extension assembly '{item.Identity.Name}' at '{item.FilePath}' has a different ModuleVersionId than loaded assembly '{item.Assembly.FullName}'");
+                    _error.WriteLine($"Extension assembly '{item.Identity.Name}' at '{item.FilePath}' has a different ModuleVersionId than loaded assembly '{item.Assembly.FullName}'");
                     return false;
                 }
             }

--- a/src/Microsoft.AspNetCore.Razor.Tools/Program.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/Program.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
 
             // Prevent shadow copying.
             var loader = new DefaultExtensionAssemblyLoader(baseDirectory: null);
-            var checker = new DefaultExtensionDependencyChecker(loader, Console.Error);
+            var checker = new DefaultExtensionDependencyChecker(loader, Console.Out, Console.Error);
 
             var application = new Application(
                 cancel.Token,

--- a/test/Microsoft.AspNetCore.Razor.Tools.Test/DefaultExtensionDependencyCheckerTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Tools.Test/DefaultExtensionDependencyCheckerTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 var alphaFilePath = LoaderTestResources.Alpha.WriteToFile(directory.DirectoryPath, "Alpha.dll");
 
                 var loader = new TestDefaultExtensionAssemblyLoader(Path.Combine(directory.DirectoryPath, "shadow"));
-                var checker = new DefaultExtensionDependencyChecker(loader, output);
+                var checker = new DefaultExtensionDependencyChecker(loader, output, output);
 
                 // Act
                 var result = checker.Check(new[] { alphaFilePath, });
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 var deltaFilePath = LoaderTestResources.Delta.WriteToFile(directory.DirectoryPath, "Delta.dll");
 
                 var loader = new TestDefaultExtensionAssemblyLoader(Path.Combine(directory.DirectoryPath, "shadow"));
-                var checker = new DefaultExtensionDependencyChecker(loader, output);
+                var checker = new DefaultExtensionDependencyChecker(loader, output, output);
 
                 // Act
                 var result = checker.Check(new[] { alphaFilePath, betaFilePath, gammaFilePath, deltaFilePath, });
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 var deltaFilePath = LoaderTestResources.Delta.WriteToFile(directory.DirectoryPath, "Delta.dll");
 
                 var loader = new TestDefaultExtensionAssemblyLoader(Path.Combine(directory.DirectoryPath, "shadow"));
-                var checker = new DefaultExtensionDependencyChecker(loader, output);
+                var checker = new DefaultExtensionDependencyChecker(loader, output, output);
 
                 // This will cause the loader to cache some inconsistent information.
                 loader.LoadFromPath(alphaFilePath);
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 loader
                     .Setup(l => l.LoadFromPath(It.IsAny<string>()))
                     .Throws(new InvalidOperationException());
-                var checker = new DefaultExtensionDependencyChecker(loader.Object, output);
+                var checker = new DefaultExtensionDependencyChecker(loader.Object, output, output);
 
                 // Act
                 var result = checker.Check(new[] { deltaFilePath, });


### PR DESCRIPTION
#2117 

We were sending all output to Console.Error in the non-buildserver scenario.