### PR TITLE
Don't limit parallel threads for Razor.Design tests

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Design.Test/xunit.runner.json
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/xunit.runner.json
@@ -1,4 +1,5 @@
 {
   "methodDisplay": "method",
-  "shadowCopy": false
+  "shadowCopy": false,
+  "maxParallelThreads": -1
 }


### PR DESCRIPTION
#2134 

The build server tests try to shutdown multiple servers in parallel which needs a lot of threads. So in slower machines they just timeout. 