### PR TITLE
Fix TagHelperDescriptor.Kind serialization

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/TagHelperDescriptorJsonConverter.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/TagHelperDescriptorJsonConverter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
             var diagnostics = descriptor[nameof(TagHelperDescriptor.Diagnostics)].Value<JArray>();
             var metadata = descriptor[nameof(TagHelperDescriptor.Metadata)].Value<JObject>();
 
-            var builder = TagHelperDescriptorBuilder.Create(typeName, assemblyName);
+            var builder = TagHelperDescriptorBuilder.Create(descriptorKind, typeName, assemblyName);
 
             builder.Documentation = documentation;
             builder.TagOutputHint = tagOutputHint;


### PR DESCRIPTION
#2139 

- We were never passing in the `TagHelperDescriptorKind` to the builder when we reconstruct the descriptor.
- Added a test.