### PR TITLE
Added parameter validation for RazorTagHelper and RazorGenerate tasks

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Tasks/RazorGenerate.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tasks/RazorGenerate.cs
@@ -45,6 +45,12 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         protected override bool ValidateParameters()
         {
+            if (!Directory.Exists(ProjectRoot))
+            {
+                Log.LogError("The specified project root directory {0} doesn't exist.", ProjectRoot);
+                return false;
+            }
+
             if (Configuration.Length == 0)
             {
                 Log.LogError("The project {0} must provide a value for {1}.", ProjectRoot, nameof(Configuration));


### PR DESCRIPTION
#2079 

- Added validation for `ProjectRoot` in RazorGenerate
- Added validation for RazorTagHelper (Mostly copy-paste from RazorGenerate)
- We never had any unit tests for the tasks but the integration tests should cover this.