### PR TITLE
[VSfM] Fix code completion disappearing/reseting because C# part of .cshtml in regenerated

### DIFF
--- a/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Editor/DefaultVisualStudioCompletionBroker.cs
+++ b/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/Editor/DefaultVisualStudioCompletionBroker.cs
@@ -19,7 +19,9 @@ namespace Microsoft.VisualStudio.Mac.LanguageServices.Razor.Editor
 
             if (textView.HasAggregateFocus)
             {
-                return CompletionWindowManager.IsVisible;
+                return CompletionWindowManager.IsVisible ||
+                                              (textView.Properties.TryGetProperty<bool>("RoslynCompletionPresenterSession.IsCompletionActive", out var visible)
+                                               && visible);
             }
 
             // Text view does not have focus, if the completion window is visible it's for a different text view.


### PR DESCRIPTION
Razor AddIn generation of C# projection content inside .cshtml depends on code completion being visible hence it needs to know state.
Since we are using Roslyn code completion API which doesn't have method to check if code completion is visible and also it's internal, only other way would be to make some public static field inside CSharpBinding which indicates visibility of code completion, hence it's better to just store this value inside textView.Properties. We should be able to remove this in 15.8 when we switch to new VSEditor code completion API.