### PR TITLE
Ensure PreserveCompilationContext is set if we're targeting precompilation tool

### DIFF
--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -166,6 +166,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MvcRazorCompileOnPublish Condition="'$(MvcRazorCompileOnPublish)' == ''">true</MvcRazorCompileOnPublish>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Set PreserveCompilationContext = true, if RazorCompileToolSet = PrecompilationTool since the precompilation tool requires it to work correctly.
+      This is an important to maintain back-compat when the Sdk is used to compile 2.0 applications.
+    -->
+    <PreserveCompilationContext Condition="'$(PreserveCompilationContext)'=='' AND '$(ResolvedRazorCompileToolset)' == 'PrecompilationTool'">true</PreserveCompilationContext>
+  </PropertyGroup>
+
   <!--
     Properties that configure Razor SDK, but need to be defined in targets due to evaluation order.
   -->


### PR DESCRIPTION
PreserveCompilationContext must be set for precompilation tool to work, even when
the app has no views.

Fixes #2168