### PR TITLE
Fix #2149 give generated files distinct extension

### DIFF
--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -62,6 +62,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     Set to false to disable Razor code generation from using a persistent build server process.
     -->
     <UseRazorBuildServer Condition="'$(UseRazorBuildServer)'==''">true</UseRazorBuildServer>
+
+    <!--
+    Configures the file extension used for generated C# files.
+    -->
+    <RazorGenerateOutputFileExtension>.g.cshtml.cs</RazorGenerateOutputFileExtension>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true'">

--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -300,7 +300,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ItemGroup>
       <RazorGenerateWithTargetPath Condition="'%(RazorGenerateWithTargetPath.GeneratedOutput)' == ''">
-        <GeneratedOutput>$(RazorGenerateIntermediateOutputPath)$([System.IO.Path]::ChangeExtension('%(RazorGenerateWithTargetPath.TargetPath)', '.cs'))</GeneratedOutput>
+        <GeneratedOutput>$(RazorGenerateIntermediateOutputPath)$([System.IO.Path]::ChangeExtension('%(RazorGenerateWithTargetPath.TargetPath)', '$(RazorGenerateOutputFileExtension)'))</GeneratedOutput>
       </RazorGenerateWithTargetPath>
     </ItemGroup>
   </Target>

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildIncrementalismTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildIncrementalismTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             var result = await DotnetMSBuild("Build");
             var file = Path.Combine(Project.DirectoryPath, "SimpleTagHelper.cs");
             var tagHelperOutputCache = Path.Combine(IntermediateOutputPath, "SimpleMvc.TagHelpers.output.cache");
-            var generatedFile = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.cs");
+            var generatedFile = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.g.cshtml.cs");
 
             // Assert - 1
             Assert.BuildPassed(result);

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildIntrospectionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildIntrospectionTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             var result = await DotnetMSBuild("Build", "/t:_IntrospectRazorCompileItems");
 
             Assert.BuildPassed(result);
-            Assert.BuildOutputContainsLine(result, $"RazorCompile: {Path.Combine(IntermediateOutputPath, "Razor", "Views", "Home", "Index.cs")}");
+            Assert.BuildOutputContainsLine(result, $"RazorCompile: {Path.Combine(IntermediateOutputPath, "Razor", "Views", "Home", "Index.g.cshtml.cs")}");
             Assert.BuildOutputContainsLine(result, $"RazorCompile: {Path.Combine(IntermediateOutputPath, "SimpleMvc.RazorAssemblyInfo.cs")}");
         }
     }

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildServerIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildServerIntegrationTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             Assert.FileExists(result, IntermediateOutputPath, "Whitespace in name.Views.dll");
             Assert.FileExists(result, IntermediateOutputPath, "Whitespace in name.RazorCoreGenerate.cache");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.g.cshtml.cs");
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/RazorGenerateIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/RazorGenerateIntegrationTest.cs
@@ -40,15 +40,15 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                 Path.Combine(IntermediateOutputPath, "SimpleMvc.TagHelpers.output.cache"),
                 @"""Name"":""SimpleMvc.SimpleTagHelper""");
 
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewImports.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewStart.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Contact.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_Layout.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_ValidationScriptsPartial.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "Error.cs");
-            Assert.FileCountEquals(result, 8, RazorIntermediateOutputPath, "*.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewImports.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewStart.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Contact.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_Layout.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_ValidationScriptsPartial.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "Error.g.cshtml.cs");
+            Assert.FileCountEquals(result, 8, RazorIntermediateOutputPath, "*.g.cshtml.cs");
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.Views.dll");
 
             // The file should still be generated even if we had a Razor syntax error.
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.g.cshtml.cs");
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.Views.dll");
 
             // The file should still be generated even if we had a Razor syntax error.
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.g.cshtml.cs");
         }
 
         [ConditionalFact]
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             // Act - 1
             var result = await DotnetMSBuild(RazorGenerateTarget);
-            var generatedFile = Path.Combine(Project.DirectoryPath, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
+            var generatedFile = Path.Combine(Project.DirectoryPath, RazorIntermediateOutputPath, "Views", "Home", "About.g.cshtml.cs");
 
             // Assert - 1
             Assert.BuildPassed(result);
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             // Act - 1
             var result = await DotnetMSBuild(RazorGenerateTarget);
             var file = Path.Combine(Project.DirectoryPath, "Views", "Home", "Contact.cshtml");
-            var generatedFile = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Contact.cs");
+            var generatedFile = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Contact.g.cshtml.cs");
 
             // Assert - 1
             Assert.BuildPassed(result);
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
         {
             // Act - 1
             var result = await DotnetMSBuild(RazorGenerateTarget);
-            var file = Path.Combine(Project.DirectoryPath, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
+            var file = Path.Combine(Project.DirectoryPath, RazorIntermediateOutputPath, "Views", "Home", "About.g.cshtml.cs");
 
             // Assert - 1
             Assert.BuildPassed(result);
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             var result = await DotnetMSBuild(RazorGenerateTarget);
             var file = Path.Combine(Project.DirectoryPath, "Views", "Home", "Index.cshtml");
             var renamed = Path.Combine(Project.DirectoryPath, "Views", "Home", "NewIndex.cshtml");
-            var generated = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.cs");
+            var generated = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.g.cshtml.cs");
 
             // Assert - 1
             Assert.BuildPassed(result);
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             // Assert - 2
             Assert.BuildPassed(result);
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "NewIndex.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "NewIndex.g.cshtml.cs");
             Assert.FileDoesNotExist(result, generated);
         }
 
@@ -199,7 +199,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             // Act - 1
             var result = await DotnetMSBuild(RazorGenerateTarget);
             var file = Path.Combine(Project.DirectoryPath, "Views", "Home", "Index.cshtml");
-            var generatedFile = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.cs");
+            var generatedFile = Path.Combine(RazorIntermediateOutputPath, "Views", "Home", "Index.g.cshtml.cs");
 
             // Assert - 1
             Assert.BuildPassed(result);
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             // We shouldn't need to hash the files
             Assert.FileDoesNotExist(result, Path.Combine(IntermediateOutputPath, "SimpleMvc.RazorCoreGenerate.cache"));
 
-            Assert.FileCountEquals(result, 0, RazorIntermediateOutputPath, "*.cs");
+            Assert.FileCountEquals(result, 0, RazorIntermediateOutputPath, "*.g.cshtml.cs");
         }
 
         [Fact]
@@ -249,8 +249,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             Assert.BuildPassed(result);
 
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
-            Assert.FileCountEquals(result, 1, RazorIntermediateOutputPath, "*.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.g.cshtml.cs");
+            Assert.FileCountEquals(result, 1, RazorIntermediateOutputPath, "*.g.cshtml.cs");
         }
 
         [Fact]
@@ -271,8 +271,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             Assert.BuildPassed(result);
 
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
-            Assert.FileCountEquals(result, 1, RazorIntermediateOutputPath, "*.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.g.cshtml.cs");
+            Assert.FileCountEquals(result, 1, RazorIntermediateOutputPath, "*.g.cshtml.cs");
         }
 
         [Fact]
@@ -293,13 +293,13 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             Assert.BuildPassed(result);
 
-            Assert.FileExists(result, RazorIntermediateOutputPath, "LinkedFile.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "LinkedFileOut", "LinkedFile2.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "LinkedFileOut", "LinkedFileWithRename.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "LinkedFile.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "LinkedFileOut", "LinkedFile2.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "LinkedFileOut", "LinkedFileWithRename.g.cshtml.cs");
 
-            Assert.BuildOutputContainsLine(result, $@"RazorGenerateWithTargetPath: {Path.Combine("..", "LinkedDir", "LinkedFile.cshtml")} LinkedFile.cshtml {Path.Combine(RazorIntermediateOutputPath, "LinkedFile.cs")}");
-            Assert.BuildOutputContainsLine(result, $@"RazorGenerateWithTargetPath: {Path.Combine("..", "LinkedDir", "LinkedFile2.cshtml")} LinkedFileOut\LinkedFile2.cshtml {Path.Combine(RazorIntermediateOutputPath, "LinkedFileOut", "LinkedFile2.cs")}");
-            Assert.BuildOutputContainsLine(result, $@"RazorGenerateWithTargetPath: {Path.Combine("..", "LinkedDir", "LinkedFile3.cshtml")} LinkedFileOut\LinkedFileWithRename.cshtml {Path.Combine(RazorIntermediateOutputPath, "LinkedFileOut", "LinkedFileWithRename.cs")}");
+            Assert.BuildOutputContainsLine(result, $@"RazorGenerateWithTargetPath: {Path.Combine("..", "LinkedDir", "LinkedFile.cshtml")} LinkedFile.cshtml {Path.Combine(RazorIntermediateOutputPath, "LinkedFile.g.cshtml.cs")}");
+            Assert.BuildOutputContainsLine(result, $@"RazorGenerateWithTargetPath: {Path.Combine("..", "LinkedDir", "LinkedFile2.cshtml")} LinkedFileOut\LinkedFile2.cshtml {Path.Combine(RazorIntermediateOutputPath, "LinkedFileOut", "LinkedFile2.g.cshtml.cs")}");
+            Assert.BuildOutputContainsLine(result, $@"RazorGenerateWithTargetPath: {Path.Combine("..", "LinkedDir", "LinkedFile3.cshtml")} LinkedFileOut\LinkedFileWithRename.cshtml {Path.Combine(RazorIntermediateOutputPath, "LinkedFileOut", "LinkedFileWithRename.g.cshtml.cs")}");
         }
 
         [Fact]
@@ -348,17 +348,17 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(result, IntermediateOutputPath, "SimpleMvc.dll");
             Assert.FileDoesNotExist(result, IntermediateOutputPath, "SimpleMvc.Views.dll");
 
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewImports.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewStart.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Contact.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_Layout.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_ValidationScriptsPartial.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "Error.cs");
-            Assert.FileExists(result, RazorIntermediateOutputPath, "temp.cs");
-            Assert.FileCountEquals(result, 9, RazorIntermediateOutputPath, "*.cs");
-            Assert.BuildOutputContainsLine(result, $@"RazorGenerateWithTargetPath: {filePath} temp.cshtml {Path.Combine(RazorIntermediateOutputPath, "temp.cs")}");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewImports.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "_ViewStart.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "About.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Contact.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Home", "Index.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_Layout.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "_ValidationScriptsPartial.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "Views", "Shared", "Error.g.cshtml.cs");
+            Assert.FileExists(result, RazorIntermediateOutputPath, "temp.g.cshtml.cs");
+            Assert.FileCountEquals(result, 9, RazorIntermediateOutputPath, "*.g.cshtml.cs");
+            Assert.BuildOutputContainsLine(result, $@"RazorGenerateWithTargetPath: {filePath} temp.cshtml {Path.Combine(RazorIntermediateOutputPath, "temp.g.cshtml.cs")}");
         }
     }
 }


### PR DESCRIPTION
Gives our generated a files an extension that isn't used for any other
purpose (that we know of). This is handy for tooling to be able to
quickly know if a file is 'ours'. This comes up in places like
IVsSymbolicNavigationNotify (go to definition).