### PR TITLE
Show error if page directive is not at the top of file

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/Properties/Resources.Designer.cs
@@ -263,6 +263,20 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             => string.Format(CultureInfo.CurrentCulture, GetString("PageDirectiveCannotBeImported"), p0, p1);
 
         /// <summary>
+        /// The '@{0}' directive must exist at the top of the file. Only comments and whitespace are allowed before the '@{0}' directive.
+        /// </summary>
+        internal static string PageDirectiveMustExistAtTheTopOfFile
+        {
+            get => GetString("PageDirectiveMustExistAtTheTopOfFile");
+        }
+
+        /// <summary>
+        /// The '@{0}' directive must exist at the top of the file. Only comments and whitespace are allowed before the '@{0}' directive.
+        /// </summary>
+        internal static string FormatPageDirectiveMustExistAtTheTopOfFile(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("PageDirectiveMustExistAtTheTopOfFile"), p0);
+
+        /// <summary>
         /// Mark the page as a Razor Page.
         /// </summary>
         internal static string PageDirective_Description

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensionsDiagnosticFactory.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/RazorExtensionsDiagnosticFactory.cs
@@ -113,5 +113,19 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
             return diagnostic;
         }
+
+        internal static readonly RazorDiagnosticDescriptor PageDirective_MustExistAtTheTopOfFile =
+            new RazorDiagnosticDescriptor(
+                $"{DiagnosticPrefix}3906",
+                () => Resources.PageDirectiveMustExistAtTheTopOfFile,
+                RazorDiagnosticSeverity.Error);
+
+        public static RazorDiagnostic CreatePageDirective_MustExistAtTheTopOfFile(SourceSpan source)
+        {
+            var fileName = Path.GetFileName(source.FilePath);
+            var diagnostic = RazorDiagnostic.Create(PageDirective_MustExistAtTheTopOfFile, source, PageDirective.Directive.Directive);
+
+            return diagnostic;
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/Resources.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/Resources.resx
@@ -171,6 +171,9 @@
   <data name="PageDirectiveCannotBeImported" xml:space="preserve">
     <value>The '@{0}' directive specified in {1} file will not be imported. The directive must appear at the top of each Razor cshtml file.</value>
   </data>
+  <data name="PageDirectiveMustExistAtTheTopOfFile" xml:space="preserve">
+    <value>The '@{0}' directive must precede all other elements defined in a Razor file.</value>
+  </data>
   <data name="PageDirective_Description" xml:space="preserve">
     <value>Mark the page as a Razor Page.</value>
   </data>

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/RazorPageDocumentClassifierPassTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/RazorPageDocumentClassifierPassTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
@@ -34,6 +35,72 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             var directive = Assert.Single(pageDirectives);
             var diagnostic = Assert.Single(directive.Node.Diagnostics);
             Assert.Equal(expectedDiagnostic, diagnostic);
+        }
+
+        [Fact]
+        public void RazorPageDocumentClassifierPass_LogsErrorIfDirectiveNotAtTopOfFile()
+        {
+            // Arrange
+            var sourceSpan = new SourceSpan(
+                "Test.cshtml",
+                absoluteIndex: 14 + Environment.NewLine.Length * 2,
+                lineIndex: 2,
+                characterIndex: 0,
+                length: 5 + Environment.NewLine.Length);
+
+            var expectedDiagnostic = RazorExtensionsDiagnosticFactory.CreatePageDirective_MustExistAtTheTopOfFile(sourceSpan);
+            var content = @"
+@somethingelse
+@page
+";
+            var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, "Test.cshtml"));
+
+            var engine = CreateEngine();
+            var irDocument = CreateIRDocument(engine, codeDocument);
+            var pass = new RazorPageDocumentClassifierPass
+            {
+                Engine = engine
+            };
+
+            // Act
+            pass.Execute(codeDocument, irDocument);
+            var visitor = new Visitor();
+            visitor.Visit(irDocument);
+
+            // Assert
+            var pageDirectives = irDocument.FindDirectiveReferences(PageDirective.Directive);
+            var directive = Assert.Single(pageDirectives);
+            var diagnostic = Assert.Single(directive.Node.Diagnostics);
+            Assert.Equal(expectedDiagnostic, diagnostic);
+        }
+
+        [Fact]
+        public void RazorPageDocumentClassifierPass_DoesNotLogErrorIfCommentAndWhitespaceBeforeDirective()
+        {
+            // Arrange
+            var content = @"
+@* some comment *@
+     
+@page
+";
+            var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, "Test.cshtml"));
+
+            var engine = CreateEngine();
+            var irDocument = CreateIRDocument(engine, codeDocument);
+            var pass = new RazorPageDocumentClassifierPass
+            {
+                Engine = engine
+            };
+
+            // Act
+            pass.Execute(codeDocument, irDocument);
+            var visitor = new Visitor();
+            visitor.Visit(irDocument);
+
+            // Assert
+            var pageDirectives = irDocument.FindDirectiveReferences(PageDirective.Directive);
+            var directive = Assert.Single(pageDirectives);
+            Assert.Empty(directive.Node.Diagnostics);
         }
 
         [Fact]


### PR DESCRIPTION
aspnet/Mvc#6633

Once we know that an `@page` exists in the document, we can process the same document again with `ParseLeadingDirectives=true` and make sure if the `@page` exists in the resulting code document. If not, log an error.