### PR TITLE
Fix: Missing Html intellisense after directives

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -1779,7 +1779,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         }
 
                         Span.ChunkGenerator = SpanChunkGenerator.Null;
-                        Output(SpanKindInternal.None, AcceptedCharactersInternal.WhiteSpace);
+
+                        // This should contain the optional whitespace after the optional semicolon and the new line.
+                        // Output as Markup as we want intellisense here.
+                        Output(SpanKindInternal.Markup, AcceptedCharactersInternal.WhiteSpace);
                         break;
                     case DirectiveKind.RazorBlock:
                         AcceptWhile(IsSpacingToken(includeNewLines: true, includeComments: true));

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                         Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                         Factory.Span(SpanKindInternal.Code, "System.Text.Encoding.ASCIIEncoding", markup: false).AsDirectiveToken(descriptor.Tokens[0]),
-                        Factory.Span(SpanKindInternal.None, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
+                        Factory.Span(SpanKindInternal.Markup, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
                     Factory.EmptyHtml(),
                     new DirectiveBlock(new DirectiveChunkGenerator(descriptor),
                         Factory.CodeTransition(),
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                         Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                         Factory.Span(SpanKindInternal.Code, "System.Text.Encoding.ASCIIEncoding", markup: false).AsDirectiveToken(descriptor.Tokens[0]),
-                        Factory.Span(SpanKindInternal.None, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
+                        Factory.Span(SpanKindInternal.Markup, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
                     Factory.EmptyHtml(),
                     new DirectiveBlock(chunkGenerator,
                         Factory.CodeTransition(),
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                         Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                         Factory.Span(SpanKindInternal.Code, "System.Text.Encoding.ASCIIEncoding", markup: false).AsDirectiveToken(customDescriptor.Tokens[0]),
-                        Factory.Span(SpanKindInternal.None, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
+                        Factory.Span(SpanKindInternal.Markup, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
                     Factory.EmptyHtml(),
                     new DirectiveBlock(new DirectiveChunkGenerator(somethingDescriptor),
                         Factory.CodeTransition(),
@@ -176,14 +176,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                         Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                         Factory.Span(SpanKindInternal.Code, "System.Text.Encoding.ASCIIEncoding", markup: false).AsDirectiveToken(customDescriptor.Tokens[0]),
-                        Factory.Span(SpanKindInternal.None, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
+                        Factory.Span(SpanKindInternal.Markup, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
                     Factory.Markup(Environment.NewLine),
                     new DirectiveBlock(new DirectiveChunkGenerator(somethingDescriptor),
                         Factory.CodeTransition(),
                         Factory.MetaCode("something").Accepts(AcceptedCharactersInternal.None),
                         Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                         Factory.Span(SpanKindInternal.Code, "Else", markup: false).AsDirectiveToken(somethingDescriptor.Tokens[0]),
-                        Factory.Span(SpanKindInternal.None, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
+                        Factory.Span(SpanKindInternal.Markup, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
                     Factory.Markup(Environment.NewLine),
                     BlockFactory.MarkupTagBlock("<p>"),
                     Factory.Markup("This is extra"),
@@ -350,7 +350,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void BuiltInDirectiveErorrsIfNotAtStartOfLine()
+        public void BuiltInDirectiveErrorsIfNotAtStartOfLine()
         {
             // Act & Assert
             ParseCodeBlockTest("{  @addTagHelper \"*, Foo\"" + Environment.NewLine + "}",
@@ -381,7 +381,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
-        public void ExtensibleDirectiveErorrsIfNotAtStartOfLine()
+        public void ExtensibleDirectiveErrorsIfNotAtStartOfLine()
         {
             // Arrange
             var descriptor = DirectiveDescriptor.CreateDirective(
@@ -407,7 +407,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         Factory.MetaCode("custom").Accepts(AcceptedCharactersInternal.None),
                         Factory.Span(SpanKindInternal.Code, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                         Factory.Span(SpanKindInternal.Code, "System.Text.Encoding.ASCIIEncoding", markup: false).AsDirectiveToken(descriptor.Tokens[0]),
-                        Factory.Span(SpanKindInternal.None, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
+                        Factory.Span(SpanKindInternal.Markup, Environment.NewLine, markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)),
                     Factory.EmptyCSharp().AsStatement(),
                     Factory.MetaCode("}").Accepts(AcceptedCharactersInternal.None)));
         }
@@ -769,7 +769,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.Span(SpanKindInternal.Code, "\"hello\"", markup: false).AsDirectiveToken(descriptor.Tokens[0]),
                     Factory.Span(SpanKindInternal.None, " ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace),
                     Factory.MetaCode(";").Accepts(AcceptedCharactersInternal.WhiteSpace),
-                    Factory.Span(SpanKindInternal.None, "  ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
+                    Factory.Span(SpanKindInternal.Markup, "  ", markup: false).Accepts(AcceptedCharactersInternal.WhiteSpace)));
         }
 
         [Theory]


### PR DESCRIPTION
https://github.com/aspnet/Razor/issues/2173

We were outputting the newline after a directive as `SpanKind.None` which was preventing intellisense from getting invoked.

Fixed this to have the following behavior,
Html intellisense **should work** at the pipe in the following cases:
```c#
@model DateTime   ;  |
```
```c#
@model DateTime
|
```
```c#
@page |
```
```c#
@page
|
```

Html intellisense **shouldn't work** at the pipe in the following cases:
```c#
@model DateTime |
```
``` c#
@model DateTime   |  ;   
```

I've verified all of the above cases work with this code in VS. Also, updated the unit tests.