### PR TITLE
Make `TestProject.GetProjectDirectory` more thorough when finding project directory.

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.IO;
-using System.Reflection;
+using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -11,16 +11,18 @@ namespace Microsoft.AspNetCore.Razor.Language
     {
         public static string GetProjectDirectory(Type type)
         {
-            var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
-            var name = type.GetTypeInfo().Assembly.GetName().Name;
+            var solutionDir = TestPathUtilities.GetSolutionRootDirectory("Razor");
 
-            while (currentDirectory != null &&
-                !string.Equals(currentDirectory.Name, name, StringComparison.Ordinal))
+            var assemblyName = type.Assembly.GetName().Name;
+            var projectDirectory = Path.Combine(solutionDir, "test", assemblyName);
+            if (!Directory.Exists(projectDirectory))
             {
-                currentDirectory = currentDirectory.Parent;
+                throw new InvalidOperationException(
+$@"Could not locate project directory for type {type.FullName}.
+Directory probe path: {projectDirectory}.");
             }
 
-            return currentDirectory.FullName;
+            return projectDirectory;
         }
     }
 }


### PR DESCRIPTION
**Big Note:** I was unable to reproduce this issue and after digging through the code really can't see how things could be going wrong other than in our test project directory creation. Basically, in this PR i make our `GetProjectDirectory` a little more reliable in unknown scenarios and added some logic to help us diagnose future errors if they arise.

- Relaxed some restrictions to find project directory
- Added some logic to make future debugging/test failures more diagnosable.

#2184 