### PR TITLE
Handle Mutex creation exceptions

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
@@ -58,6 +58,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             bool suppressRestore = false,
             bool suppressTimeout = false,
             bool suppressBuildServer = false,
+            string buildServerPipeName = null,
             MSBuildProcessKind msBuildProcessKind = MSBuildProcessKind.Dotnet)
         {
             var timeout = suppressTimeout ? (TimeSpan?)Timeout.InfiniteTimeSpan : null;
@@ -70,7 +71,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             if (!suppressBuildServer)
             {
-                buildArgumentList.Add($"/p:_RazorBuildServerPipeName={BuildServer.PipeName}");
+                buildArgumentList.Add($"/p:_RazorBuildServerPipeName={buildServerPipeName ?? BuildServer.PipeName}");
             }
 
             buildArgumentList.Add($"/t:{target} /p:Configuration={Configuration} {args}");


### PR DESCRIPTION
https://github.com/aspnet/Razor/issues/2226

Handling Mutex creation exceptions the same way roslyn handles them. We log the exception and fallback to in process cli execution instead of blowing up.

Suggest reviewing this with ?w=1