### PR TITLE
Normalize the tool assembly path before using it as the base for pipe…

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Tasks/DotnetToolTask.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tasks/DotnetToolTask.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 Log.LogMessage(StandardOutputLoggingImportance, $"ServerResponseFile = '{responseFileCommands}'");
 
                 // The server contains the tools for discovering tag helpers and generating Razor code.
-                var clientDir = Path.GetDirectoryName(ToolAssembly);
+                var clientDir = Path.GetFullPath(Path.GetDirectoryName(ToolAssembly));
                 var workingDir = CurrentDirectoryToUse();
                 var tempDir = ServerConnection.GetTempPath(workingDir);
                 var serverPaths = new ServerPaths(

--- a/src/Microsoft.AspNetCore.Razor.Tools/ShutdownCommand.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/ShutdownCommand.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                             Error.Write(ex);
                         }
 
-                        Out.Write("Server pid:{0} shut down", response.ServerProcessId);
+                        Out.Write("Server pid:{0} shut down completed.", response.ServerProcessId);
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildServerTestFixture.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildServerTestFixture.cs
@@ -39,11 +39,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
                     throw new TimeoutException($"Shutting down the build server at pipe {PipeName} took longer than expected.{Environment.NewLine}Output: {output}.");
                 });
 
-                var application = new Application(cts.Token, Mock.Of<ExtensionAssemblyLoader>(), Mock.Of<ExtensionDependencyChecker>(), (path, properties) => Mock.Of<PortableExecutableReference>())
-                {
-                    Out = writer,
-                    Error = writer,
-                };
+                var application = new Application(cts.Token, Mock.Of<ExtensionAssemblyLoader>(), Mock.Of<ExtensionDependencyChecker>(), (path, properties) => Mock.Of<PortableExecutableReference>(), writer, writer);
+
                 var exitCode = application.Execute("shutdown", "-w", "-p", PipeName);
                 if (exitCode != 0)
                 {


### PR DESCRIPTION
… name

#2230 

The actual reason for this bug was the tool assembly path that MsBuild passes in looks like
`C:\Users\ajbaaska\.nuget\packages\microsoft.aspnetcore.razor.design\2.1.0-preview2-t000\build\netstandard2.0\..\..\tools\rzc.dll`

but the shutdown command uses the path
`C:\Users\ajbaaska\.nuget\packages\microsoft.aspnetcore.razor.design\2.1.0-preview2-t000\build\netstandard2.0\tools\rzc.dll`

Notice the lack of `\build\netstandard2.0\..\..\`

So calling `Path.GetFullPath` before using this to compute pipe name fixes the problem.

Added a test