### PR TITLE
Add experimental flag to un-special-case data-

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs
@@ -931,7 +931,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             // First, determine if this is a 'data-' attribute (since those can't use conditional attributes)
             var name = string.Concat(nameSymbols.Select(s => s.Content));
-            var attributeCanBeConditional = !name.StartsWith("data-", StringComparison.OrdinalIgnoreCase);
+            var attributeCanBeConditional = 
+                Context.FeatureFlags.EXPERIMENTAL_AllowConditionalDataDashAttributes ||
+                !name.StartsWith("data-", StringComparison.OrdinalIgnoreCase);
 
             // Accept the whitespace and name
             Accept(whitespace);

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/ParserContext.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
             Source = new SeekableTextReader(chars, source.FilePath);
             DesignTimeMode = options.DesignTime;
+            FeatureFlags = options.FeatureFlags;
             ParseLeadingDirectives = options.ParseLeadingDirectives;
             Builder = new SyntaxTreeBuilder();
             ErrorSink = new ErrorSink();
@@ -32,6 +33,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         public SyntaxTreeBuilder Builder { get; }
 
         public ErrorSink ErrorSink { get; set; }
+
+        public RazorParserFeatureFlags FeatureFlags { get; }
 
         public HashSet<string> SeenDirectives { get; }
 

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorParserFeatureFlags.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorParserFeatureFlags.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         {
             var allowMinimizedBooleanTagHelperAttributes = false;
             var allowHtmlCommentsInTagHelpers = false;
+            var experimental_AllowConditionalDataDashAttributes = false;
 
             if (version.CompareTo(RazorLanguageVersion.Version_2_1) >= 0)
             {
@@ -17,24 +18,40 @@ namespace Microsoft.AspNetCore.Razor.Language
                 allowHtmlCommentsInTagHelpers = true;
             }
 
-            return new DefaultRazorParserFeatureFlags(allowMinimizedBooleanTagHelperAttributes, allowHtmlCommentsInTagHelpers);
+            if (version.CompareTo(RazorLanguageVersion.Experimental) >= 0)
+            {
+                experimental_AllowConditionalDataDashAttributes = true;
+            }
+
+            return new DefaultRazorParserFeatureFlags(
+                allowMinimizedBooleanTagHelperAttributes,
+                allowHtmlCommentsInTagHelpers,
+                experimental_AllowConditionalDataDashAttributes);
         }
 
         public abstract bool AllowMinimizedBooleanTagHelperAttributes { get; }
 
         public abstract bool AllowHtmlCommentsInTagHelpers { get; }
 
+        public abstract bool EXPERIMENTAL_AllowConditionalDataDashAttributes { get; }
+
         private class DefaultRazorParserFeatureFlags : RazorParserFeatureFlags
         {
-            public DefaultRazorParserFeatureFlags(bool allowMinimizedBooleanTagHelperAttributes, bool allowHtmlCommentsInTagHelpers)
+            public DefaultRazorParserFeatureFlags(
+                bool allowMinimizedBooleanTagHelperAttributes,
+                bool allowHtmlCommentsInTagHelpers,
+                bool experimental_AllowConditionalDataDashAttributes)
             {
                 AllowMinimizedBooleanTagHelperAttributes = allowMinimizedBooleanTagHelperAttributes;
                 AllowHtmlCommentsInTagHelpers = allowHtmlCommentsInTagHelpers;
+                EXPERIMENTAL_AllowConditionalDataDashAttributes = experimental_AllowConditionalDataDashAttributes;
             }
 
             public override bool AllowMinimizedBooleanTagHelperAttributes { get; }
 
             public override bool AllowHtmlCommentsInTagHelpers { get; }
+
+            public override bool EXPERIMENTAL_AllowConditionalDataDashAttributes { get; }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
@@ -1957,7 +1957,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             Block expected,
             params RazorDiagnostic[] expectedErrors)
         {
-            var result = ParseCodeBlock(document, descriptors, designTime: false);
+            var result = ParseCodeBlock(RazorLanguageVersion.Latest, document, descriptors, designTime: false);
 
             EvaluateResults(result, expected, expectedErrors);
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CodeParserTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CodeParserTestBase.cs
@@ -9,9 +9,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
     {
         internal abstract ISet<string> KeywordSet { get; }
 
-        internal override RazorSyntaxTree ParseBlock(string document, IEnumerable<DirectiveDescriptor> directives, bool designTime)
+        internal override RazorSyntaxTree ParseBlock(
+            RazorLanguageVersion version, 
+            string document, 
+            IEnumerable<DirectiveDescriptor> directives, 
+            bool designTime)
         {
-            return ParseCodeBlock(document, directives, designTime);
+            return ParseCodeBlock(version, document, directives, designTime);
         }
 
         internal void ImplicitExpressionTest(string input, params RazorDiagnostic[] errors)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlAttributeTest.cs
@@ -560,6 +560,30 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         [Fact]
+        public void ConditionalAttributesAreEnabledForDataAttributesWithExperimentalFlag()
+        {
+            ParseBlockTest(
+                RazorLanguageVersion.Experimental,
+                "<span data-foo='@foo'></span>",
+                new MarkupBlock(
+                    new MarkupTagBlock(
+                        Factory.Markup("<span"),
+                        new MarkupBlock(
+                            new AttributeBlockChunkGenerator("data-foo", new LocationTagged<string>(" data-foo='", 5, 0, 5), new LocationTagged<string>("'", 20, 0, 20)),
+                            Factory.Markup(" data-foo='").With(SpanChunkGenerator.Null),
+                            new MarkupBlock(new DynamicAttributeBlockChunkGenerator(new LocationTagged<string>(string.Empty, 16, 0, 16), 16, 0, 16),
+                                new ExpressionBlock(
+                                    Factory.CodeTransition(),
+                                    Factory.Code("foo")
+                                           .AsImplicitExpression(CSharpCodeParser.DefaultKeywords)
+                                           .Accepts(AcceptedCharactersInternal.NonWhiteSpace))),
+                            Factory.Markup("'").With(SpanChunkGenerator.Null)),
+                        Factory.Markup(">").Accepts(AcceptedCharactersInternal.None)),
+                    new MarkupTagBlock(
+                        Factory.Markup("</span>").Accepts(AcceptedCharactersInternal.None))));
+        }
+
+        [Fact]
         public void ConditionalAttributesAreDisabledForDataAttributesInBlock()
         {
             ParseBlockTest("<span data-foo='@foo'></span>",

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/MarkupParserTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/MarkupParserTestBase.cs
@@ -1,16 +1,19 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     public abstract class MarkupParserTestBase : CodeParserTestBase
     {
-        internal override RazorSyntaxTree ParseBlock(string document, IEnumerable<DirectiveDescriptor> directives, bool designTime)
+        internal override RazorSyntaxTree ParseBlock(
+            RazorLanguageVersion version,
+            string document,
+            IEnumerable<DirectiveDescriptor> directives,
+            bool designTime)
         {
-            return ParseHtmlBlock(document, directives, designTime);
+            return ParseHtmlBlock(version, document, directives, designTime);
         }
 
         internal virtual void SingleSpanDocumentTest(string document, BlockKindInternal blockKind, SpanKindInternal spanType)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperBlockRewriterTest.cs
@@ -3962,7 +3962,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     .Build(),
             };
 
-            var featureFlags = new TestRazorParserFeatureFlags(allowMinimizedBooleanTagHelperAttributes: false, allowHtmlCommentsInTagHelper: false);
+            var featureFlags = new TestRazorParserFeatureFlags();
 
             var expectedOutput = new MarkupBlock(
                 new MarkupTagHelperBlock(
@@ -3994,15 +3994,21 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         private class TestRazorParserFeatureFlags : RazorParserFeatureFlags
         {
-            public TestRazorParserFeatureFlags(bool allowMinimizedBooleanTagHelperAttributes, bool allowHtmlCommentsInTagHelper)
+            public TestRazorParserFeatureFlags(
+                bool allowMinimizedBooleanTagHelperAttributes = false,
+                bool allowHtmlCommentsInTagHelper = false,
+                bool experimental_AllowConditionalDataDashAttributes = false)
             {
                 AllowMinimizedBooleanTagHelperAttributes = allowMinimizedBooleanTagHelperAttributes;
                 AllowHtmlCommentsInTagHelpers = allowHtmlCommentsInTagHelper;
+                EXPERIMENTAL_AllowConditionalDataDashAttributes = experimental_AllowConditionalDataDashAttributes;
             }
 
             public override bool AllowMinimizedBooleanTagHelperAttributes { get; }
 
             public override bool AllowHtmlCommentsInTagHelpers { get; }
+
+            public override bool EXPERIMENTAL_AllowConditionalDataDashAttributes { get; }
         }
     }
 }


### PR DESCRIPTION
This change allows blazor to opt into treating data- attributes the same
way as normal attributes in the parser.