### PR TITLE
Don't publish the refs directory when the app does not have any Razor…

### DIFF
--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -492,17 +492,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(CopyRazorGenerateFilesToPublishDirectory)'=='false'">
       <ResolvedFileToPublish Remove="%(RazorGenerate.FullPath)"/>
     </ItemGroup>
+  </Target>
 
+  <Target
+    Name="_RazorRemoveRefAssembliesFromPublish"
+    AfterTargets="ComputeRefAssembliesToPublish"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true' and '$(CopyRefAssembliesToPublishDirectory)'=='false'">
     <!--
       The ref assemblies are published whenever PreserveCompilationContext is true, which we expect to be true for
       most usages of Razor. There's no setting that excludes just the ref assemblies, so we do it ourselves. 
     -->
-    <ItemGroup Condition="'$(CopyRefAssembliesToPublishDirectory)'=='false'">
+    <ItemGroup>
       <ResolvedFileToPublish 
         Remove="%(ResolvedFileToPublish.Identity)"
         Condition="'%(ResolvedFileToPublish.RelativePath)'=='$(RefAssembliesFolderName)\%(Filename)%(Extension)'"/>
     </ItemGroup>
-
   </Target>
 
   <Target Name="_CheckForMissingRazorCompiler" Condition="'$(IsRazorCompilerReferenced)' != 'true'">

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PublishIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PublishIntegrationTest.cs
@@ -142,6 +142,9 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.FileExists(result, PublishOutputPath, "SimpleMvc.pdb");
             Assert.FileDoesNotExist(result, PublishOutputPath, "SimpleMvc.Views.dll");
             Assert.FileDoesNotExist(result, PublishOutputPath, "SimpleMvc.Views.pdb");
+
+            // By default refs will not be copied on publish
+            Assert.FileCountEquals(result, 0, Path.Combine(PublishOutputPath, "refs"), "*.dll");
         }
 
         [Fact]


### PR DESCRIPTION
… files