### PR TITLE
Don't fail the build when ExtensionDependencyChecker fails

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Tasks/DotnetToolTask.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tasks/DotnetToolTask.cs
@@ -161,11 +161,13 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
                     if (result == 0)
                     {
+                        // Server execution succeeded.
                         Log.LogMessage(StandardOutputLoggingImportance, $"Server execution completed with return code {result}.");
                         return true;
                     }
-                    else
+                    else if (result == 2)
                     {
+                        // Server execution completed with a legit error. No need to fallback to cli execution.
                         Log.LogMessage(StandardOutputLoggingImportance, $"Server execution completed with return code {result}. For more info, check the server log file in the location specified by the RAZORBUILDSERVER_LOG environment variable.");
 
                         if (LogStandardErrorAsError)
@@ -179,9 +181,15 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
                         return true;
                     }
+                    else
+                    {
+                        // Server execution completed with an error but we still want to fallback to cli execution.
+                        Log.LogMessage(StandardOutputLoggingImportance, $"Server execution completed with return code {result}. For more info, check the server log file in the location specified by the RAZORBUILDSERVER_LOG environment variable.");
+                    }
                 }
                 else
                 {
+                    // Server execution failed. Fallback to cli execution.
                     Log.LogMessage(
                         StandardOutputLoggingImportance,
                         $"Server execution failed with response {response.Type}. For more info, check the server log file in the location specified by the RAZORBUILDSERVER_LOG environment variable.");

--- a/src/Microsoft.AspNetCore.Razor.Tools/CommandBase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/CommandBase.cs
@@ -11,6 +11,10 @@ namespace Microsoft.AspNetCore.Razor.Tools
 {
     internal abstract class CommandBase : CommandLineApplication
     {
+        public const int ExitCodeSuccess = 0;
+        public const int ExitCodeFailure = 1;
+        public const int ExitCodeFailureRazorError = 2;
+
         protected CommandBase(Application parent, string name)
             : base(throwOnUnexpectedArg: true)
         {
@@ -46,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
             if (!ValidateArguments())
             {
                 ShowHelp();
-                return 1;
+                return ExitCodeFailureRazorError;
             }
 
             return await ExecuteCoreAsync();

--- a/src/Microsoft.AspNetCore.Razor.Tools/DiscoverCommand.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/DiscoverCommand.cs
@@ -95,17 +95,17 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 }
             }
 
-            if (!Parent.Checker.Check(ExtensionFilePaths.Values))
-            {
-                Error.WriteLine($"Extenions could not be loaded. See output for details.");
-                return false;
-            }
-
             return true;
         }
 
         protected override Task<int> ExecuteCoreAsync()
         {
+            if (!Parent.Checker.Check(ExtensionFilePaths.Values))
+            {
+                Error.WriteLine($"Extenions could not be loaded. See output for details.");
+                return Task.FromResult(ExitCodeFailure);
+            }
+
             // Loading all of the extensions should succeed as the dependency checker will have already
             // loaded them.
             var extensions = new RazorExtension[ExtensionNames.Values.Count];
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 }
             }
 
-            return 0;
+            return ExitCodeSuccess;
         }
 
         private static byte[] Hash(string path)

--- a/src/Microsoft.AspNetCore.Razor.Tools/GenerateCommand.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/GenerateCommand.cs
@@ -49,6 +49,12 @@ namespace Microsoft.AspNetCore.Razor.Tools
 
         protected override Task<int> ExecuteCoreAsync()
         {
+            if (!Parent.Checker.Check(ExtensionFilePaths.Values))
+            {
+                Error.WriteLine($"Extensions could not be loaded. See output for details.");
+                return Task.FromResult(ExitCodeFailure);
+            }
+
             // Loading all of the extensions should succeed as the dependency checker will have already
             // loaded them.
             var extensions = new RazorExtension[ExtensionNames.Values.Count];
@@ -125,12 +131,6 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 }
             }
 
-            if (!Parent.Checker.Check(ExtensionFilePaths.Values))
-            {
-                Error.WriteLine($"Extensions could not be loaded. See output for details.");
-                return false;
-            }
-
             return true;
         }
 
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 }
             }
 
-            return success ? 0 : -1;
+            return success ? ExitCodeSuccess : ExitCodeFailureRazorError;
         }
 
         private VirtualRazorProjectFileSystem GetVirtualRazorProjectSystem(SourceItem[] inputItems)


### PR DESCRIPTION
Fixes #2256 

We want to make sure to not fail the build and fallback to cli execution when the ExtensionDependencyChecker fails to load an extension.