### PR TITLE
Disable node-reuse to allow rebuilding

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildIntegrationTestBase.cs
@@ -62,7 +62,12 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             MSBuildProcessKind msBuildProcessKind = MSBuildProcessKind.Dotnet)
         {
             var timeout = suppressTimeout ? (TimeSpan?)Timeout.InfiniteTimeSpan : null;
-            var buildArgumentList = new List<string>();
+            var buildArgumentList = new List<string>
+            {
+                // Disable node-reuse. We don't want msbuild processes to stick around
+                // once the test is completed.
+                "/nr:false",
+            };
 
             if (!suppressRestore)
             {


### PR DESCRIPTION
Recent builds of msbuild have node reuse enabled by default. This locks up the task dlls after the test's completed preventing re-runs untill you kill the process.

Here's the process at work after running dotnet test.
```
"\.dotnet\x64\dotnet.exe" "\.dotnet\x64\sdk\2.1.300-preview2-008530\MSBuild.dll" \.dotnet\x64\sdk\2.1.300-preview2-008530\MSBuild.dll /nologo /nodemode:1 /nodeReuse:true
```