### PR TITLE
Remove explicit reference to NETStandard.Library when using .NET Framework

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -43,6 +43,7 @@
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <StreamJsonRpcPackageVersion>1.1.92</StreamJsonRpcPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.0-rc1-26419-03</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemRuntimeInteropServicesRuntimeInformationPackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationPackageVersion>
     <SystemValueTuplePackageVersion>4.5.0-rc1-26419-03</SystemValueTuplePackageVersion>
     <VisualStudio_NewtonsoftJsonPackageVersion>9.0.1</VisualStudio_NewtonsoftJsonPackageVersion>
     <VSIX_MicrosoftCodeAnalysisCommonPackageVersion>2.8.0-beta3</VSIX_MicrosoftCodeAnalysisCommonPackageVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,8 +7,4 @@
     <PackageTags>aspnetcore;cshtml;razor</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework' AND '$(OutputType)'=='library'">
-    <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibrary20PackageVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.CodeAnalysis.Razor/Microsoft.CodeAnalysis.Razor.csproj
+++ b/src/Microsoft.CodeAnalysis.Razor/Microsoft.CodeAnalysis.Razor.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimeInformationPackageVersion)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
I've been informed it's bad form to have NETStandard.Library in your package graph, so let's prune it.

This removes NETStandard.Library from the generated nuspec on .NET Framework projects, and adds the one package that provides API we actually need: System.Runtime.InteropServices.RuntimeInformation