### PR TITLE
Made the Visual Studio parser smarter about overlapping reparse requests.

### DIFF
--- a/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParserResultsReadyEventArgs.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParserResultsReadyEventArgs.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using static Microsoft.VisualStudio.Editor.Razor.BackgroundParser;
+
+namespace Microsoft.VisualStudio.Editor.Razor
+{
+    internal class BackgroundParserResultsReadyEventArgs : EventArgs
+    {
+        public BackgroundParserResultsReadyEventArgs(ChangeReference edit, RazorCodeDocument codeDocument)
+        {
+            ChangeReference = edit;
+            CodeDocument = codeDocument;
+        }
+
+        public ChangeReference ChangeReference { get; }
+
+        public RazorCodeDocument CodeDocument { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Editor;
 using Microsoft.VisualStudio.Text;
+using static Microsoft.VisualStudio.Editor.Razor.BackgroundParser;
 using ITextBuffer = Microsoft.VisualStudio.Text.ITextBuffer;
 using Timer = System.Threading.Timer;
 
@@ -317,8 +318,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             _dispatcher.AssertForegroundThread();
 
-            _latestChangeReference = new ChangeReference(change, snapshot);
-            _parser.QueueChange(change, snapshot);
+            _latestChangeReference = _parser.QueueChange(change, snapshot);
         }
 
         private void OnNotifyForegroundIdle()
@@ -357,7 +357,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             }
         }
 
-        private void OnResultsReady(object sender, DocumentStructureChangedEventArgs args)
+        private void OnResultsReady(object sender, BackgroundParserResultsReadyEventArgs args)
         {
             _dispatcher.AssertBackgroundThread();
 
@@ -375,21 +375,25 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 return;
             }
 
-            var args = (DocumentStructureChangedEventArgs)state;
+            var backgroundParserArgs = (BackgroundParserResultsReadyEventArgs)state;
             if (_latestChangeReference == null || // extra hardening
-                !_latestChangeReference.IsAssociatedWith(args) ||
-                args.Snapshot != TextBuffer.CurrentSnapshot)
+                _latestChangeReference != backgroundParserArgs.ChangeReference ||
+                backgroundParserArgs.ChangeReference.Snapshot != TextBuffer.CurrentSnapshot)
             {
                 // In the middle of parsing a newer change or about to parse a newer change.
                 return;
             }
 
             _latestChangeReference = null;
-            _codeDocument = args.CodeDocument;
-            _snapshot = args.Snapshot;
+            _codeDocument = backgroundParserArgs.CodeDocument;
+            _snapshot = backgroundParserArgs.ChangeReference.Snapshot;
             _partialParser = new RazorSyntaxTreePartialParser(CodeDocument.GetSyntaxTree());
 
-            DocumentStructureChanged?.Invoke(this, args);
+            var documentStructureChangedArgs = new DocumentStructureChangedEventArgs(
+                backgroundParserArgs.ChangeReference.Change, 
+                backgroundParserArgs.ChangeReference.Snapshot, 
+                backgroundParserArgs.CodeDocument);
+            DocumentStructureChanged?.Invoke(this, documentStructureChangedArgs);
         }
 
         private void ConfigureProjectEngine(RazorProjectEngineBuilder builder)
@@ -430,26 +434,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
             public IReadOnlyList<TagHelperDescriptor> GetDescriptors()
             {
                 return _tagHelpers;
-            }
-        }
-
-        // Internal for testing
-        internal class ChangeReference
-        {
-            public ChangeReference(SourceChange change, ITextSnapshot snapshot)
-            {
-                Change = change;
-                Snapshot = snapshot;
-            }
-
-            public SourceChange Change { get; }
-
-            public ITextSnapshot Snapshot { get; }
-
-            public bool IsAssociatedWith(DocumentStructureChangedEventArgs other)
-            {
-                return Change == other.SourceChange &&
-                    Snapshot == other.Snapshot;
             }
         }
     }


### PR DESCRIPTION
- Prior to this the parser would think that a non-latest reparse request was the latest because the only way we would check to see if a change reference was "latest" would be to do an equality check on the snapshot and `SourceChange`; the issue here was that `SourceChange` was null but the snapshots were the same. Problems could arise with this due to project context changes.
- Added tests to validate the new reparse behavior.
- Renamed `Edit` in the `BackgroundParser` to `ChangeReference` also refactored all the "edit" text in `BackgroundParser` to be `ChangerReference` like.
- Added a new event args to be the DTO between the internal and external parser implementations. This is how we could pas additional information in order to determine "latest" change reference.

#2336