### PR TITLE
Added a taghelpers overload to Process and ProcessDesignTime

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectEngine.cs
@@ -68,10 +68,23 @@ namespace Microsoft.AspNetCore.Razor.Language
             var importItems = importFeature.GetImports(projectItem);
             var importSourceDocuments = GetImportSourceDocuments(importItems);
 
+            return CreateCodeDocumentCore(sourceDocument, importSourceDocuments, tagHelpers: null);
+        }
+
+        internal override RazorCodeDocument CreateCodeDocumentCore(RazorSourceDocument sourceDocument, IReadOnlyList<RazorSourceDocument> importSourceDocuments, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            if (sourceDocument == null)
+            {
+                throw new ArgumentNullException(nameof(sourceDocument));
+            }
+
             var parserOptions = GetRequiredFeature<IRazorParserOptionsFactoryProjectFeature>().Create(ConfigureParserOptions);
             var codeGenerationOptions = GetRequiredFeature<IRazorCodeGenerationOptionsFactoryProjectFeature>().Create(ConfigureCodeGenerationOptions);
 
-            return RazorCodeDocument.Create(sourceDocument, importSourceDocuments, parserOptions, codeGenerationOptions);
+            var codeDocument = RazorCodeDocument.Create(sourceDocument, importSourceDocuments, parserOptions, codeGenerationOptions);
+            codeDocument.SetTagHelpers(tagHelpers);
+
+            return codeDocument;
         }
 
         protected override RazorCodeDocument CreateCodeDocumentDesignTimeCore(RazorProjectItem projectItem)
@@ -87,10 +100,23 @@ namespace Microsoft.AspNetCore.Razor.Language
             var importItems = importFeature.GetImports(projectItem);
             var importSourceDocuments = GetImportSourceDocuments(importItems, suppressExceptions: true);
 
+            return CreateCodeDocumentDesignTimeCore(sourceDocument, importSourceDocuments, tagHelpers: null);
+        }
+
+        internal override RazorCodeDocument CreateCodeDocumentDesignTimeCore(RazorSourceDocument sourceDocument, IReadOnlyList<RazorSourceDocument> importSourceDocuments, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            if (sourceDocument == null)
+            {
+                throw new ArgumentNullException(nameof(sourceDocument));
+            }
+
             var parserOptions = GetRequiredFeature<IRazorParserOptionsFactoryProjectFeature>().Create(ConfigureDesignTimeParserOptions);
             var codeGenerationOptions = GetRequiredFeature<IRazorCodeGenerationOptionsFactoryProjectFeature>().Create(ConfigureDesignTimeCodeGenerationOptions);
 
-            return RazorCodeDocument.Create(sourceDocument, importSourceDocuments, parserOptions, codeGenerationOptions);
+            var codeDocument = RazorCodeDocument.Create(sourceDocument, importSourceDocuments, parserOptions, codeGenerationOptions);
+            codeDocument.SetTagHelpers(tagHelpers);
+
+            return codeDocument;
         }
 
         protected override void ProcessCore(RazorCodeDocument codeDocument)

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorTagHelperBinderPhase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorTagHelperBinderPhase.cs
@@ -15,18 +15,23 @@ namespace Microsoft.AspNetCore.Razor.Language
             var syntaxTree = codeDocument.GetSyntaxTree();
             ThrowForMissingDocumentDependency(syntaxTree);
 
-            var feature = Engine.Features.OfType<ITagHelperFeature>().FirstOrDefault();
-            if (feature == null)
+            var descriptors = codeDocument.GetTagHelpers();
+            if (descriptors == null)
             {
-                // No feature, nothing to do.
-                return;
+                var feature = Engine.Features.OfType<ITagHelperFeature>().FirstOrDefault();
+                if (feature == null)
+                {
+                    // No feature, nothing to do.
+                    return;
+                }
+
+                descriptors = feature.GetDescriptors();
             }
 
             // We need to find directives in all of the *imports* as well as in the main razor file
             //
             // The imports come logically before the main razor file and are in the order they
             // should be processed.
-            var descriptors = feature.GetDescriptors();
             var visitor = new DirectiveVisitor(descriptors);
             var imports = codeDocument.GetImportSyntaxTrees();
             if (imports != null)

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorCodeDocumentExtensions.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorCodeDocumentExtensions.cs
@@ -29,6 +29,26 @@ namespace Microsoft.AspNetCore.Razor.Language
             document.Items[typeof(TagHelperDocumentContext)] = context;
         }
 
+        internal static IReadOnlyList<TagHelperDescriptor> GetTagHelpers(this RazorCodeDocument document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            return (document.Items[typeof(TagHelpersHolder)] as TagHelpersHolder)?.TagHelpers;
+        }
+
+        internal static void SetTagHelpers(this RazorCodeDocument document, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            document.Items[typeof(TagHelpersHolder)] = new TagHelpersHolder(tagHelpers);
+        }
+
         public static RazorSyntaxTree GetSyntaxTree(this RazorCodeDocument document)
         {
             if (document == null)
@@ -167,6 +187,16 @@ namespace Microsoft.AspNetCore.Razor.Language
             }
 
             public IReadOnlyList<RazorSyntaxTree> SyntaxTrees { get; }
+        }
+
+        private class TagHelpersHolder
+        {
+            public TagHelpersHolder(IReadOnlyList<TagHelperDescriptor> tagHelpers)
+            {
+                TagHelpers = tagHelpers;
+            }
+
+            public IReadOnlyList<TagHelperDescriptor> TagHelpers { get; }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/RazorProjectEngine.cs
@@ -35,6 +35,18 @@ namespace Microsoft.AspNetCore.Razor.Language
             return codeDocument;
         }
 
+        internal virtual RazorCodeDocument Process(RazorSourceDocument source, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var codeDocument = CreateCodeDocumentCore(source, importSources, tagHelpers);
+            ProcessCore(codeDocument);
+            return codeDocument;
+        }
+
         public virtual RazorCodeDocument ProcessDesignTime(RazorProjectItem projectItem)
         {
             if (projectItem == null)
@@ -47,9 +59,31 @@ namespace Microsoft.AspNetCore.Razor.Language
             return codeDocument;
         }
 
+        internal virtual RazorCodeDocument ProcessDesignTime(RazorSourceDocument source, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var codeDocument = CreateCodeDocumentDesignTimeCore(source, importSources, tagHelpers);
+            ProcessCore(codeDocument);
+            return codeDocument;
+        }
+
         protected abstract RazorCodeDocument CreateCodeDocumentCore(RazorProjectItem projectItem);
 
+        internal virtual RazorCodeDocument CreateCodeDocumentCore(RazorSourceDocument source, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            return RazorCodeDocument.Create(source, importSources);
+        }
+
         protected abstract RazorCodeDocument CreateCodeDocumentDesignTimeCore(RazorProjectItem projectItem);
+
+        internal virtual RazorCodeDocument CreateCodeDocumentDesignTimeCore(RazorSourceDocument source, IReadOnlyList<RazorSourceDocument> importSources, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            return RazorCodeDocument.Create(source, importSources);
+        }
 
         protected abstract void ProcessCore(RazorCodeDocument codeDocument);
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultDocumentSnapshot.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultDocumentSnapshot.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Text;
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal class DefaultDocumentSnapshot : DocumentSnapshot
     {
-        public DefaultDocumentSnapshot(ProjectSnapshot project, DocumentState state)
+        public DefaultDocumentSnapshot(DefaultProjectSnapshot project, DocumentState state)
         {
             if (project == null)
             {
@@ -27,13 +27,18 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             State = state;
         }
 
-        public ProjectSnapshot Project { get; }
+        public DefaultProjectSnapshot Project { get; }
 
         public DocumentState State { get; }
 
         public override string FilePath => State.HostDocument.FilePath;
 
         public override string TargetPath => State.HostDocument.TargetPath;
+
+        public override IReadOnlyList<DocumentSnapshot> GetImports()
+        {
+            return State.Imports.GetImports(Project, this);
+        }
 
         public override Task<SourceText> GetTextAsync()
         {

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentImportsTracker.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentImportsTracker.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
+{
+    internal class DocumentImportsTracker
+    {
+        private readonly object _lock;
+
+        private IReadOnlyList<DocumentSnapshot> _imports;
+
+        public DocumentImportsTracker()
+        {
+            _lock = new object();
+        }
+
+        public IReadOnlyList<DocumentSnapshot> GetImports(ProjectSnapshot project, DocumentSnapshot document)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (_imports == null)
+            {
+                lock (_lock)
+                {
+                    if (_imports == null)
+                    {
+                        _imports = GetImportsCore(project, document);
+                    }
+                }
+            }
+
+            return _imports;
+        }
+
+        private IReadOnlyList<DocumentSnapshot> GetImportsCore(ProjectSnapshot project, DocumentSnapshot document)
+        {
+            var projectEngine = project.GetProjectEngine();
+            var importFeature = projectEngine.ProjectFeatures.OfType<IImportProjectFeature>().FirstOrDefault();
+            var projectItem = projectEngine.FileSystem.GetItem(document.FilePath);
+            var importItems = importFeature?.GetImports(projectItem).Where(i => i.Exists);
+            if (importItems == null)
+            {
+                return Array.Empty<DocumentSnapshot>();
+            }
+
+            var imports = new List<DocumentSnapshot>();
+            foreach (var item in importItems)
+            {
+                if (item.PhysicalPath == null)
+                {
+                    // This is a default import.
+                    var defaultImport = new DefaultImportDocumentSnapshot(project, item);
+                    imports.Add(defaultImport);
+                }
+                else
+                {
+                    var import = project.GetDocument(item.PhysicalPath);
+                    if (import == null)
+                    {
+                        // We are not tracking this document in this project. So do nothing.
+                        continue;
+                    }
+
+                    imports.Add(import);
+                }
+            }
+
+            return imports;
+        }
+
+        private class DefaultImportDocumentSnapshot : DocumentSnapshot
+        {
+            private ProjectSnapshot _project;
+            private RazorProjectItem _importItem;
+            private SourceText _sourceText;
+            private VersionStamp _version;
+            private DocumentGeneratedOutputTracker _generatedOutput;
+
+            public DefaultImportDocumentSnapshot(ProjectSnapshot project, RazorProjectItem item)
+            {
+                _project = project;
+                _importItem = item;
+                _version = VersionStamp.Default;
+                _generatedOutput = new DocumentGeneratedOutputTracker(null);
+            }
+
+            public override string FilePath => null;
+
+            public override string TargetPath => null;
+
+            public override Task<RazorCodeDocument> GetGeneratedOutputAsync()
+            {
+                return _generatedOutput.GetGeneratedOutputInitializationTask(_project, this);
+            }
+
+            public override IReadOnlyList<DocumentSnapshot> GetImports()
+            {
+                return Array.Empty<DocumentSnapshot>();
+            }
+
+            public async override Task<SourceText> GetTextAsync()
+            {
+                using (var stream = _importItem.Read())
+                using (var reader = new StreamReader(stream))
+                {
+                    var content = await reader.ReadToEndAsync();
+                    _sourceText = SourceText.From(content);
+                }
+
+                return _sourceText;
+            }
+
+            public override Task<VersionStamp> GetTextVersionAsync()
+            {
+                return Task.FromResult(_version);
+            }
+
+            public override bool TryGetText(out SourceText result)
+            {
+                if (_sourceText != null)
+                {
+                    result = _sourceText;
+                    return true;
+                }
+
+                result = null;
+                return false;
+            }
+
+            public override bool TryGetTextVersion(out VersionStamp result)
+            {
+                result = _version;
+                return true;
+            }
+
+            public override bool TryGetGeneratedOutput(out RazorCodeDocument result)
+            {
+                if (_generatedOutput.IsResultAvailable)
+                {
+                    result = GetGeneratedOutputAsync().Result;
+                    return true;
+                }
+
+                result = null;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Text;
@@ -13,6 +13,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public abstract string FilePath { get; }
 
         public abstract string TargetPath { get; }
+
+        public abstract IReadOnlyList<DocumentSnapshot> GetImports();
 
         public abstract Task<SourceText> GetTextAsync();
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         private VersionStamp? _version;
 
         private DocumentGeneratedOutputTracker _generatedOutput;
+        private DocumentImportsTracker _imports;
 
         public static DocumentState Create(
             HostWorkspaceServices services,
@@ -44,7 +45,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return new DocumentState(services, hostDocument, null, null, loader);
         }
 
-        private DocumentState(
+        // Internal for testing
+        internal DocumentState(
             HostWorkspaceServices services,
             HostDocument hostDocument,
             SourceText text,
@@ -79,6 +81,25 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 }
 
                 return _generatedOutput;
+            }
+        }
+
+        public DocumentImportsTracker Imports
+        {
+            get
+            {
+                if (_imports == null)
+                {
+                    lock (_lock)
+                    {
+                        if (_imports == null)
+                        {
+                            _imports = new DocumentImportsTracker();
+                        }
+                    }
+                }
+
+                return _imports;
             }
         }
 
@@ -148,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return false;
         }
 
-        public DocumentState WithConfigurationChange()
+        public virtual DocumentState WithConfigurationChange()
         {
             var state = new DocumentState(Services, HostDocument, _sourceText, _version, _loader);
 
@@ -160,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return state;
         }
 
-        public DocumentState WithWorkspaceProjectChange()
+        public virtual DocumentState WithWorkspaceProjectChange()
         {
             var state = new DocumentState(Services, HostDocument, _sourceText, _version, _loader);
 
@@ -175,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return state;
         }
 
-        public DocumentState WithText(SourceText sourceText, VersionStamp version)
+        public virtual DocumentState WithText(SourceText sourceText, VersionStamp version)
         {
             if (sourceText == null)
             {
@@ -185,8 +206,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return new DocumentState(Services, HostDocument, sourceText, version, null);
         }
 
-
-        public DocumentState WithTextLoader(Func<Task<TextAndVersion>> loader)
+        public virtual DocumentState WithTextLoader(Func<Task<TextAndVersion>> loader)
         {
             if (loader == null)
             {

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -83,7 +83,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             _tagHelpers = older._tagHelpers?.ForkFor(this, difference);
         }
 
-        public IReadOnlyDictionary<string, DocumentState> Documents { get; }
+        // Internal set for testing.
+        public IReadOnlyDictionary<string, DocumentState> Documents { get; internal set; }
 
         public HostProject HostProject { get; }
 
@@ -293,7 +294,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var documents = new Dictionary<string, DocumentState>(FilePathComparer.Instance);
             foreach (var kvp in Documents)
             {
-                documents.Add(kvp.Key, kvp.Value.WithConfigurationChange());
+                documents.Add(kvp.Key, kvp.Value.WithWorkspaceProjectChange());
             }
 
             var state = new ProjectState(this, difference, HostProject, workspaceProject, documents);

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/SourceTextExtensions.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/SourceTextExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.CodeAnalysis.Text
+{
+    internal static class SourceTextExtensions
+    {
+        public static RazorSourceDocument GetRazorSourceDocument(this SourceText sourceText, string fileName)
+        {
+            if (sourceText == null)
+            {
+                throw new ArgumentNullException(nameof(sourceText));
+            }
+
+            var content = sourceText.ToString();
+
+            return RazorSourceDocument.Create(content, fileName);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
@@ -32,6 +32,16 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             _onClosed = Document_Closed;
         }
 
+        // For testing purposes only.
+        internal EditorDocumentManagerListener(EditorDocumentManager documentManager, EventHandler onChangedOnDisk, EventHandler onChangedInEditor, EventHandler onOpened, EventHandler onClosed)
+        {
+            _documentManager = documentManager;
+            _onChangedOnDisk = onChangedOnDisk;
+            _onChangedInEditor = onChangedInEditor;
+            _onOpened = onOpened;
+            _onClosed = onClosed;
+        }
+
         public override void Initialize(ProjectSnapshotManagerBase projectManager)
         {
             if (projectManager == null)
@@ -45,17 +55,18 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             _projectManager.Changed += ProjectManager_Changed;
         }
 
-        private void ProjectManager_Changed(object sender, ProjectChangeEventArgs e)
+        // Internal for testing.
+        internal void ProjectManager_Changed(object sender, ProjectChangeEventArgs e)
         {
             switch (e.Kind)
             {
                 case ProjectChangeKind.DocumentAdded:
                     {
                         var key = new DocumentKey(e.ProjectFilePath, e.DocumentFilePath);
-                        var document = _documentManager.GetOrCreateDocument(key, _onChangedOnDisk, _onChangedOnDisk, _onOpened, _onClosed);
+                        var document = _documentManager.GetOrCreateDocument(key, _onChangedOnDisk, _onChangedInEditor, _onOpened, _onClosed);
                         if (document.IsOpenInEditor)
                         {
-                            Document_Opened(document, EventArgs.Empty);
+                            _onOpened(document, EventArgs.Empty);
                         }
 
                         break;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/DefaultRazorProjectEngineIntegrationTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using Moq;
 using Xunit;
@@ -90,6 +92,148 @@ namespace Microsoft.AspNetCore.Razor.Language
             var csharpDocument = codeDocument.GetCSharpDocument();
             Assert.NotNull(csharpDocument);
             Assert.Empty(csharpDocument.Diagnostics);
+        }
+
+        [Fact]
+        public void Process_WithImportsAndTagHelpers_SetsOnCodeDocument()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+            var importItem = new TestRazorProjectItem("_import.cshtml");
+            var expectedImports = new[] { RazorSourceDocument.ReadFrom(importItem) };
+            var expectedTagHelpers = new[]
+            {
+                TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly").Build(),
+                TagHelperDescriptorBuilder.Create("Test2TagHelper", "TestAssembly").Build(),
+            };
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), expectedImports, expectedTagHelpers);
+
+            // Assert
+            var tagHelpers = codeDocument.GetTagHelpers();
+            Assert.Same(expectedTagHelpers, tagHelpers);
+            Assert.Equal(expectedImports, codeDocument.Imports);
+        }
+
+        [Fact]
+        public void Process_WithNullTagHelpers_SetsOnCodeDocument()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), Array.Empty<RazorSourceDocument>(), tagHelpers: null);
+
+            // Assert
+            var tagHelpers = codeDocument.GetTagHelpers();
+            Assert.Null(tagHelpers);
+        }
+
+        [Fact]
+        public void Process_SetsNullTagHelpersOnCodeDocument()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.Process(projectItem);
+
+            // Assert
+            var tagHelpers = codeDocument.GetTagHelpers();
+            Assert.Null(tagHelpers);
+        }
+
+        [Fact]
+        public void Process_WithNullImports_SetsEmptyListOnCodeDocument()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), importSources: null, tagHelpers: null);
+
+            // Assert
+            Assert.Empty(codeDocument.Imports);
+        }
+
+        [Fact]
+        public void ProcessDesignTime_WithImportsAndTagHelpers_SetsOnCodeDocument()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+            var importItem = new TestRazorProjectItem("_import.cshtml");
+            var expectedImports = new[] { RazorSourceDocument.ReadFrom(importItem) };
+            var expectedTagHelpers = new[]
+            {
+                TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly").Build(),
+                TagHelperDescriptorBuilder.Create("Test2TagHelper", "TestAssembly").Build(),
+            };
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), expectedImports, expectedTagHelpers);
+
+            // Assert
+            var tagHelpers = codeDocument.GetTagHelpers();
+            Assert.Same(expectedTagHelpers, tagHelpers);
+            Assert.Equal(expectedImports, codeDocument.Imports);
+        }
+
+        [Fact]
+        public void ProcessDesignTime_WithNullTagHelpers_SetsOnCodeDocument()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), Array.Empty<RazorSourceDocument>(), tagHelpers: null);
+
+            // Assert
+            var tagHelpers = codeDocument.GetTagHelpers();
+            Assert.Null(tagHelpers);
+        }
+
+        [Fact]
+        public void ProcessDesignTime_SetsNullTagHelpersOnCodeDocument()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.ProcessDesignTime(projectItem);
+
+            // Assert
+            var tagHelpers = codeDocument.GetTagHelpers();
+            Assert.Null(tagHelpers);
+        }
+
+        [Fact]
+        public void ProcessDesignTime_WithNullImports_SetsEmptyListOnCodeDocument()
+        {
+            // Arrange
+            var projectItem = new TestRazorProjectItem("Index.cshtml");
+
+            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty);
+
+            // Act
+            var codeDocument = projectEngine.ProcessDesignTime(RazorSourceDocument.ReadFrom(projectItem), importSources: null, tagHelpers: null);
+
+            // Assert
+            Assert.Empty(codeDocument.Imports);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/RazorCodeDocumentExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/RazorCodeDocumentExtensionsTest.cs
@@ -57,6 +57,22 @@ namespace Microsoft.AspNetCore.Razor.Language
         }
 
         [Fact]
+        public void GetAndSetTagHelpers_ReturnsTagHelpers()
+        {
+            // Arrange
+            var codeDocument = TestRazorCodeDocument.CreateEmpty();
+
+            var expected = new[] { TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly").Build() };
+            codeDocument.SetTagHelpers(expected);
+
+            // Act
+            var actual = codeDocument.GetTagHelpers();
+
+            // Assert
+            Assert.Same(expected, actual);
+        }
+
+        [Fact]
         public void GetIRDocument_ReturnsIRDocument()
         {
             // Arrange

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerListenerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerListenerTest.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Test;
+using Microsoft.VisualStudio.Text;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Documents
+{
+    public class EditorDocumentManagerListenerTest
+    {
+        public EditorDocumentManagerListenerTest()
+        {
+            ProjectFilePath = "C:\\project1\\project.csproj";
+            DocumentFilePath = "c:\\project1\\file1.cshtml";
+            TextLoader = TextLoader.From(TextAndVersion.Create(SourceText.From("FILE"), VersionStamp.Default));
+            FileChangeTracker = new DefaultFileChangeTracker(DocumentFilePath);
+
+            TextBuffer = new TestTextBuffer(new StringTextSnapshot("Hello"));
+        }
+
+        private string ProjectFilePath { get; }
+
+        private string DocumentFilePath { get; }
+
+        private TextLoader TextLoader { get; }
+
+        private FileChangeTracker FileChangeTracker { get; }
+
+        private TestTextBuffer TextBuffer { get; }
+
+        [Fact]
+        public void ProjectManager_Changed_DocumentAdded_InvokesGetOrCreateDocument()
+        {
+            // Arrange
+            var changedOnDisk = new EventHandler((o, args) => { });
+            var changedInEditor = new EventHandler((o, args) => { });
+            var opened = new EventHandler((o, args) => { });
+            var closed = new EventHandler((o, args) => { });
+
+            var editorDocumentManger = new Mock<EditorDocumentManager>(MockBehavior.Strict);
+            editorDocumentManger
+                .Setup(e => e.GetOrCreateDocument(It.IsAny<DocumentKey>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>()))
+                .Returns(GetEditorDocument())
+                .Callback<DocumentKey, EventHandler, EventHandler, EventHandler, EventHandler>((key, onChangedOnDisk, onChangedInEditor, onOpened, onClosed) =>
+                {
+                    Assert.Same(changedOnDisk, onChangedOnDisk);
+                    Assert.Same(changedInEditor, onChangedInEditor);
+                    Assert.Same(opened, onOpened);
+                    Assert.Same(closed, onClosed);
+                });
+
+            var listener = new EditorDocumentManagerListener(editorDocumentManger.Object, changedOnDisk, changedInEditor, opened, closed);
+
+            // Act & Assert
+            listener.ProjectManager_Changed(null, new ProjectChangeEventArgs("/Path/to/project.csproj", ProjectChangeKind.DocumentAdded));
+        }
+
+        [Fact]
+        public void ProjectManager_Changed_OpenDocumentAdded_InvokesOnOpened()
+        {
+            // Arrange
+            var called = false;
+            var opened = new EventHandler((o, args) => { called = true; });
+
+            var editorDocumentManger = new Mock<EditorDocumentManager>(MockBehavior.Strict);
+            editorDocumentManger
+                .Setup(e => e.GetOrCreateDocument(It.IsAny<DocumentKey>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>()))
+                .Returns(GetEditorDocument(isOpen: true));
+
+            var listener = new EditorDocumentManagerListener(editorDocumentManger.Object, onChangedOnDisk: null, onChangedInEditor: null, onOpened: opened, onClosed: null);
+
+            // Act
+            listener.ProjectManager_Changed(null, new ProjectChangeEventArgs("/Path/to/project.csproj", ProjectChangeKind.DocumentAdded));
+
+            // Assert
+            Assert.True(called);
+        }
+
+        private EditorDocument GetEditorDocument(bool isOpen = false)
+        {
+            var document = new EditorDocument(
+                Mock.Of<EditorDocumentManager>(),
+                ProjectFilePath,
+                DocumentFilePath,
+                TextLoader,
+                FileChangeTracker,
+                isOpen ? TextBuffer : null,
+                changedOnDisk: null,
+                changedInEditor: null,
+                opened: null,
+                closed: null);
+
+            return document;
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentTest.cs
@@ -81,32 +81,5 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 Assert.Null(document.EditorTextContainer);
             }
         }
-
-        private class TestSourceTextContainer : SourceTextContainer
-        {
-            public override event EventHandler<TextChangeEventArgs> TextChanged;
-
-            private SourceText _currentText;
-
-            public TestSourceTextContainer()
-                : this(SourceText.From(string.Empty))
-            {
-            }
-
-            public TestSourceTextContainer(SourceText text)
-            {
-                _currentText = text;
-            }
-
-            public override SourceText CurrentText => _currentText;
-
-            public void PushChange(SourceText text)
-            {
-                var args = new TextChangeEventArgs(_currentText, text);
-                _currentText = text;
-
-                TextChanged?.Invoke(this, args);
-            }
-        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/Razor/issues/2345

We want to have a way to specify the taghelper descriptors to use while processing a specific document.
- Added an overload to Process and ProcessDesignTime to take in a list `TagHelperDescriptor`s
- Added the corresponding `CreateCodeDocumentCore` overload
- Added `GetTagHelpers` and `SetTagHelpers` extension methods for CodeDocument
- Added the necessary plumbing to use the taghelpers from the CodeDocument when available and fallback logic.
- Added/updated tests