### PR TITLE
Exclude Visual Studio packages from default NGPV ruleset

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -5,7 +5,11 @@
     ],
     "packages": {
       "Microsoft.AspNetCore.Razor.TagHelpers.Testing.Sources": {},
-      "RazorPageGenerator": {}
+      "RazorPageGenerator": {},
+      "Microsoft.CodeAnalysis.Remote.Razor": {},
+      "Microsoft.VisualStudio.Editor.Razor": {},
+      "Microsoft.VisualStudio.LanguageServices.Razor": {},
+      "Microsoft.VisualStudio.Mac.LanguageServices.Razor": {}
     }
   },
   "Default": { // Rules to run for packages not listed in any other set.

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-rtm-15783
-commithash:5fc2b2f607f542a2ffde11c19825e786fc1a3774
+version:2.1.0-rtm-15788
+commithash:13fd0b77c6790a640fdc830078aecc5b7e7821cc


### PR DESCRIPTION
These packages are failing NGPV on stabilized builds on the pre-release dependency rule because these nupkgs use pre-release VS packages. These packages are not actually consumed as nupkgs by VS, so exclude them from NGPV's default rules.