### PR TITLE
Fix dispose logic for EditorDocument

### DIFF
--- a/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocument.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocument.cs
@@ -149,9 +149,17 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 _fileTracker.Changed -= ChangeTracker_Changed;
                 _fileTracker.StopListening();
 
-                EditorTextContainer.TextChanged -= TextContainer_Changed;
-                EditorTextContainer = null;
-                EditorTextBuffer = null;
+                if (EditorTextBuffer != null)
+                {
+                    _snapshotTracker.StopTracking(EditorTextBuffer);
+                    EditorTextBuffer = null;
+                }
+
+                if (EditorTextContainer != null)
+                {
+                    EditorTextContainer.TextChanged -= TextContainer_Changed;
+                    EditorTextContainer = null;
+                }
 
                 _documentManager.RemoveDocument(this);
 

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
         public void EditorDocument_CreatedWhileOpened()
         {
             // Arrange & Act
-            var document = new EditorDocument(
+            using (var document = new EditorDocument(
                 DocumentManager,
                 ProjectFilePath,
                 DocumentFilePath,
@@ -50,19 +50,20 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 changedOnDisk: null,
                 changedInEditor: null,
                 opened: null,
-                closed: null);
-
-            // Assert
-            Assert.True(document.IsOpenInEditor);
-            Assert.Same(TextBuffer, document.EditorTextBuffer);
-            Assert.NotNull(document.EditorTextContainer);
+                closed: null))
+            {
+                // Assert
+                Assert.True(document.IsOpenInEditor);
+                Assert.Same(TextBuffer, document.EditorTextBuffer);
+                Assert.NotNull(document.EditorTextContainer);
+            }
         }
 
         [Fact]
         public void EditorDocument_CreatedWhileClosed()
         {
             // Arrange & Act
-            var document = new EditorDocument(
+            using (var document = new EditorDocument(
                 DocumentManager,
                 ProjectFilePath,
                 DocumentFilePath,
@@ -72,12 +73,13 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 changedOnDisk: null,
                 changedInEditor: null,
                 opened: null,
-                closed: null);
-            
-            // Assert
-            Assert.False(document.IsOpenInEditor);
-            Assert.Null(document.EditorTextBuffer);
-            Assert.Null(document.EditorTextContainer);
+                closed: null))
+            {
+                // Assert
+                Assert.False(document.IsOpenInEditor);
+                Assert.Null(document.EditorTextBuffer);
+                Assert.Null(document.EditorTextContainer);
+            }
         }
 
         private class TestSourceTextContainer : SourceTextContainer


### PR DESCRIPTION
This could throw when the document is disposed and wasn't open in the
editor.

Improved the tests to cover dispose as well for both cases.