### PR TITLE
Override MicrosoftNETCoreApp22PackageVersion

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -25,6 +25,7 @@
       <TemplateProperties>
         MSBuildLocation=$(VisualStudioMSBuildx86Path);
         MicrosoftNETCoreAppVersion=$(MicrosoftNETCoreApp22PackageVersion);
+        MicrosoftNETCoreApp22PackageVersion=$(MicrosoftNETCoreApp22PackageVersion);
         NETStandardLibraryVersion=$(NETStandardLibrary20PackageVersion)
       </TemplateProperties>
     </PropertyGroup>


### PR DESCRIPTION
In Universe, when the versions of MicrosoftNETCoreApp22PackageVersion are different between Universe and Razor, the samples get passed the Razor one, which is wrong. Here I'm attempting to prevent that from happening.

@NTaylorMullen is my understanding of this correct?