### PR TITLE
Add Razor document tracking to FallbackRazorProjectHost.

### DIFF
--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
@@ -302,7 +302,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return true;
         }
 
-
         private HostDocument[] GetCurrentDocuments(IProjectSubscriptionUpdate update)
         {
             if (!update.CurrentState.TryGetValue(Rules.RazorGenerateWithTargetPath.SchemaName, out var rule))

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/ManageProjectSystemSchema.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/ManageProjectSystemSchema.cs
@@ -12,5 +12,26 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             public static readonly string ItemName = "ResolvedCompilationReference";
         }
+
+        public static class ContentItem
+        {
+            public static readonly string SchemaName = "Content";
+
+            public static readonly string ItemName = "Content";
+        }
+
+        public static class NoneItem
+        {
+            public static readonly string SchemaName = "None";
+
+            public static readonly string ItemName = "None";
+        }
+
+        public static class ItemReference
+        {
+            public static readonly string FullPathPropertyName = "FullPath";
+
+            public static readonly string LinkPropertyName = "Link";
+        }
     }
 }


### PR DESCRIPTION
- VisualStudio defaults to adding a `<none>` link item when right click -> add existing item for Razor files; therefore, this also includes the knowledge of the "None" item group when finding Razor files.
- Added unit and functional tests to verify the new `FallbackRazorProjectHost` behavior.
- Added new schema items to represent the `Content` and `None` item type information (pulled from the project system repo).

#2373