### PR TITLE
[Design] Allow document tracker to be created without a project.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentGenerator/BackgroundDocumentGenerator.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentGenerator/BackgroundDocumentGenerator.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.Razor
             {
                 // We only want to store the last 'seen' version of any given document. That way when we pick one to process
                 // it's always the best version to use.
-                _files[new DocumentKey(project.FilePath, document.FilePath)] = document;
+                _files[new DocumentKey(project.Id, document.FilePath)] = document;
 
                 StartWorker();
             }
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 case ProjectChangeKind.ProjectAdded:
                 case ProjectChangeKind.ProjectChanged:
                     {
-                        var project = _projectManager.GetLoadedProject(e.ProjectFilePath);
+                        var project = _projectManager.GetLoadedProject(e.ProjectId);
                         foreach (var documentFilePath in project.DocumentFilePaths)
                         {
                             Enqueue(project, project.GetDocument(documentFilePath));
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 case ProjectChangeKind.DocumentAdded:
                 case ProjectChangeKind.DocumentChanged:
                     {
-                        var project = _projectManager.GetLoadedProject(e.ProjectFilePath);
+                        var project = _projectManager.GetLoadedProject(e.ProjectId);
                         Enqueue(project, project.GetDocument(e.DocumentFilePath));
 
                         break;

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentKey.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentKey.cs
@@ -2,26 +2,27 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
     public struct DocumentKey : IEquatable<DocumentKey>
     {
-        public DocumentKey(string projectFilePath, string documentFilePath)
+        public DocumentKey(ProjectId projectId, string documentFilePath)
         {
-            ProjectFilePath = projectFilePath;
+            ProjectId = projectId;
             DocumentFilePath = documentFilePath;
         }
 
-        public string ProjectFilePath { get; }
+        public ProjectId ProjectId { get; }
 
         public string DocumentFilePath { get; }
 
         public bool Equals(DocumentKey other)
         {
             return
-                FilePathComparer.Instance.Equals(ProjectFilePath, other.ProjectFilePath) &&
+                FilePathComparer.Instance.Equals(ProjectId, other.ProjectId) &&
                 FilePathComparer.Instance.Equals(DocumentFilePath, other.DocumentFilePath);
         }
 
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Razor
         public override int GetHashCode()
         {
             var hash = new HashCodeCombiner();
-            hash.Add(ProjectFilePath, FilePathComparer.Instance);
+            hash.Add(ProjectId);
             hash.Add(DocumentFilePath, FilePathComparer.Instance);
             return hash;
         }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentKey.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentKey.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Razor
         public bool Equals(DocumentKey other)
         {
             return
-                FilePathComparer.Instance.Equals(ProjectId, other.ProjectId) &&
+                ProjectId == other.ProjectId &&
                 FilePathComparer.Instance.Equals(DocumentFilePath, other.DocumentFilePath);
         }
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotProjectEngineFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotProjectEngineFactory.cs
@@ -17,7 +17,17 @@ namespace Microsoft.CodeAnalysis.Razor
 
         public RazorProjectEngine Create(ProjectSnapshot project)
         {
-            return Create(project, RazorProjectFileSystem.Create(Path.GetDirectoryName(project.FilePath)), null);
+            RazorProjectFileSystem fileSystem;
+            if (project.FilePath != null)
+            {
+                fileSystem = RazorProjectFileSystem.Create(Path.GetDirectoryName(project.FilePath));
+            }
+            else
+            {
+                fileSystem = RazorProjectFileSystem.Empty;
+            }
+
+            return Create(project, fileSystem, null);
         }
 
         public RazorProjectEngine Create(ProjectSnapshot project, RazorProjectFileSystem fileSystem)
@@ -42,7 +52,17 @@ namespace Microsoft.CodeAnalysis.Razor
                 throw new ArgumentNullException(nameof(project));
             }
 
-            return Create(project, RazorProjectFileSystem.Create(Path.GetDirectoryName(project.FilePath)), configure);
+            RazorProjectFileSystem fileSystem;
+            if (project.FilePath != null)
+            {
+                fileSystem = RazorProjectFileSystem.Create(Path.GetDirectoryName(project.FilePath));
+            }
+            else
+            {
+                fileSystem = RazorProjectFileSystem.Empty;
+            }
+
+            return Create(project, fileSystem, configure);
         }
 
         public abstract RazorProjectEngine Create(ProjectSnapshot project, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure);

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshot.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshot.cs
@@ -27,6 +27,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             _documents = new Dictionary<string, DefaultDocumentSnapshot>(FilePathComparer.Instance);
         }
 
+        public override ProjectId Id => HostProject.Id;
+
         public ProjectState State { get; }
 
         public override RazorConfiguration Configuration => HostProject.Configuration;

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/HostProject.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/HostProject.cs
@@ -8,8 +8,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal class HostProject
     {
-        public HostProject(string projectFilePath, RazorConfiguration razorConfiguration)
+        public HostProject(ProjectId projectId, string projectFilePath, RazorConfiguration razorConfiguration)
         {
+            if (projectId == null)
+            {
+                throw new ArgumentNullException(nameof(projectId));
+            }
+
             if (projectFilePath == null)
             {
                 throw new ArgumentNullException(nameof(projectFilePath));
@@ -20,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 throw new ArgumentNullException(nameof(razorConfiguration));
             }
 
+            Id = projectId;
             FilePath = projectFilePath;
             Configuration = razorConfiguration;
         }
@@ -27,5 +33,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public RazorConfiguration Configuration { get; }
 
         public string FilePath { get; }
+
+        public ProjectId Id { get; }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/LiveShareProjectSnapshotBase.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/LiveShareProjectSnapshotBase.cs
@@ -25,6 +25,8 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces.ProjectSystem
 
         public override Project WorkspaceProject => throw new NotImplementedException();
 
+        public override ProjectId Id => throw new NotImplementedException();
+
         public override DocumentSnapshot GetDocument(string filePath) => throw new NotImplementedException();
 
         public override RazorProjectEngine GetProjectEngine() => throw new NotImplementedException();

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/MiscellaneousProjectSnapshot.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/MiscellaneousProjectSnapshot.cs
@@ -9,26 +9,20 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
-    internal class EphemeralProjectSnapshot : ProjectSnapshot
+    internal class MiscellaneousProjectSnapshot : ProjectSnapshot
     {
         private static readonly Task<IReadOnlyList<TagHelperDescriptor>> EmptyTagHelpers = Task.FromResult<IReadOnlyList<TagHelperDescriptor>>(Array.Empty<TagHelperDescriptor>());
 
         private readonly HostWorkspaceServices _services;
         private readonly Lazy<RazorProjectEngine> _projectEngine;
 
-        public EphemeralProjectSnapshot(HostWorkspaceServices services, string filePath)
+        public MiscellaneousProjectSnapshot(HostWorkspaceServices services)
         {
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            if (filePath == null)
-            {
-                throw new ArgumentNullException(nameof(filePath));
-            }
-
-            FilePath = filePath;
             _services = services;
             Id = ProjectId.CreateNewId();
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
@@ -7,30 +7,30 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal class ProjectChangeEventArgs : EventArgs
     {
-        public ProjectChangeEventArgs(string projectFilePath, ProjectChangeKind kind)
+        public ProjectChangeEventArgs(ProjectId projectId, ProjectChangeKind kind)
         {
-            if (projectFilePath == null)
+            if (projectId == null)
             {
-                throw new ArgumentNullException(nameof(projectFilePath));
+                throw new ArgumentNullException(nameof(projectId));
             }
 
-            ProjectFilePath = projectFilePath;
+            ProjectId = projectId;
             Kind = kind;
         }
 
-        public ProjectChangeEventArgs(string projectFilePath, string documentFilePath, ProjectChangeKind kind)
+        public ProjectChangeEventArgs(ProjectId projectId, string documentFilePath, ProjectChangeKind kind)
         {
-            if (projectFilePath == null)
+            if (projectId == null)
             {
-                throw new ArgumentNullException(nameof(projectFilePath));
+                throw new ArgumentNullException(nameof(projectId));
             }
 
-            ProjectFilePath = projectFilePath;
+            ProjectId = projectId;
             DocumentFilePath = documentFilePath;
             Kind = kind;
         }
 
-        public string ProjectFilePath { get; }
+        public ProjectId ProjectId { get; }
 
         public string DocumentFilePath { get; }
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
@@ -9,6 +9,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal abstract class ProjectSnapshot
     {
+        public abstract ProjectId Id { get; }
+
         public abstract RazorConfiguration Configuration { get; }
 
         public abstract IEnumerable<string> DocumentFilePaths { get; }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
@@ -17,6 +17,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public abstract ProjectSnapshot GetLoadedProject(string filePath);
 
+        public abstract ProjectSnapshot GetLoadedProject(ProjectId projectId);
+
         public abstract ProjectSnapshot GetOrCreateProject(string filePath);
     }
 }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManagerBase.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManagerBase.cs
@@ -12,7 +12,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public abstract void DocumentAdded(HostProject hostProject, HostDocument hostDocument, TextLoader textLoader);
 
-        // Yeah this is kinda ugly.
         public abstract void DocumentOpened(ProjectId projectId, string documentFilePath, SourceText sourceText);
 
         public abstract void DocumentClosed(ProjectId projectId, string documentFilePath, TextLoader textLoader);

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManagerBase.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManagerBase.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public abstract void DocumentAdded(HostProject hostProject, HostDocument hostDocument, TextLoader textLoader);
 
         // Yeah this is kinda ugly.
-        public abstract void DocumentOpened(string projectFilePath, string documentFilePath, SourceText sourceText);
+        public abstract void DocumentOpened(ProjectId projectId, string documentFilePath, SourceText sourceText);
 
-        public abstract void DocumentClosed(string projectFilePath, string documentFilePath, TextLoader textLoader);
+        public abstract void DocumentClosed(ProjectId projectId, string documentFilePath, TextLoader textLoader);
 
-        public abstract void DocumentChanged(string projectFilePath, string documentFilePath, TextLoader textLoader);
+        public abstract void DocumentChanged(ProjectId projectId, string documentFilePath, TextLoader textLoader);
 
-        public abstract void DocumentChanged(string projectFilePath, string documentFilePath, SourceText sourceText);
+        public abstract void DocumentChanged(ProjectId projectId, string documentFilePath, SourceText sourceText);
 
         public abstract void DocumentRemoved(HostProject hostProject, HostDocument hostDocument);
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -83,6 +83,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             _tagHelpers = older._tagHelpers?.ForkFor(this, difference);
         }
 
+        public ProjectId Id => HostProject.Id;
+
         // Internal set for testing.
         public IReadOnlyDictionary<string, DocumentState> Documents { get; internal set; }
 

--- a/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceBase.cs
+++ b/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceBase.cs
@@ -39,20 +39,23 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
             var workspaceProject = solution.GetProject(projectHandle.WorkspaceProjectId);
 
-            return new SerializedProjectSnapshot(projectHandle.FilePath, projectHandle.Configuration, workspaceProject);
+            return new SerializedProjectSnapshot(projectHandle.FilePath, projectHandle.HostProjectId, projectHandle.Configuration, workspaceProject);
         }
 
         private class SerializedProjectSnapshot : ProjectSnapshot
         {
-            public SerializedProjectSnapshot(string filePath, RazorConfiguration configuration, Project workspaceProject)
+            public SerializedProjectSnapshot(string filePath, ProjectId id, RazorConfiguration configuration, Project workspaceProject)
             {
                 FilePath = filePath;
+                Id = id;
                 Configuration = configuration;
                 WorkspaceProject = workspaceProject;
 
                 IsInitialized = true;
                 Version = VersionStamp.Default;
             }
+
+            public override ProjectId Id { get; }
 
             public override RazorConfiguration Configuration { get; }
 
@@ -65,6 +68,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
             public override VersionStamp Version { get; }
 
             public override Project WorkspaceProject { get; }
+
 
             public override DocumentSnapshot GetDocument(string filePath)
             {

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTracker.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTracker.cs
@@ -59,11 +59,6 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(filePath));
             }
 
-            if (projectPath == null)
-            {
-                throw new ArgumentNullException(nameof(projectPath));
-            }
-
             if (projectManager == null)
             {
                 throw new ArgumentNullException(nameof(projectManager));
@@ -126,6 +121,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public override string FilePath => _filePath;
 
         public override string ProjectPath => _projectPath;
+
+        public override ProjectId ProjectId => _projectSnapshot?.Id;
 
         public Task PendingTagHelperTask => _computingTagHelpers.task ?? Task.CompletedTask;
 
@@ -284,11 +281,10 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             _foregroundDispatcher.AssertForegroundThread();
 
-            if (_projectPath != null &&
-                string.Equals(_projectPath, e.ProjectFilePath, StringComparison.OrdinalIgnoreCase))
+            if (ProjectId == e.ProjectId)
             {
                 // This will be the new snapshot unless the project was removed.
-                _projectSnapshot = _projectManager.GetLoadedProject(e.ProjectFilePath);
+                _projectSnapshot = _projectManager.GetLoadedProject(e.ProjectId);
 
                 switch (e.Kind)
                 {
@@ -309,7 +305,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                     case ProjectChangeKind.ProjectRemoved:
 
                         // Fall back to ephemeral project
-                        _projectSnapshot = _projectManager.GetOrCreateProject(ProjectPath);
+                        _projectSnapshot = _projectManager.GetOrCreateProject(_projectPath);
                         OnContextChanged(ContextChangeKind.ProjectChanged);
                         break;
 

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTracker.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTracker.cs
@@ -20,13 +20,14 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         private readonly ForegroundDispatcher _foregroundDispatcher;
         private readonly string _filePath;
-        private readonly string _projectPath;
+        private readonly ProjectPathProvider _projectPathProvider;
         private readonly ProjectSnapshotManager _projectManager;
         private readonly WorkspaceEditorSettings _workspaceEditorSettings;
         private readonly ITextBuffer _textBuffer;
         private readonly ImportDocumentManager _importDocumentManager;
         private readonly List<ITextView> _textViews;
         private readonly Workspace _workspace;
+        private string _projectPath;
         private bool _isSupportedProject;
         private ProjectSnapshot _projectSnapshot;
         private int _subscribeCount;
@@ -42,7 +43,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public DefaultVisualStudioDocumentTracker(
             ForegroundDispatcher dispatcher,
             string filePath,
-            string projectPath,
+            ProjectPathProvider projectPathProvider,
             ProjectSnapshotManager projectManager,
             WorkspaceEditorSettings workspaceEditorSettings,
             Workspace workspace,
@@ -57,6 +58,11 @@ namespace Microsoft.VisualStudio.Editor.Razor
             if (string.IsNullOrEmpty(filePath))
             {
                 throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(filePath));
+            }
+
+            if (projectPathProvider == null)
+            {
+                throw new ArgumentNullException(nameof(projectPathProvider));
             }
 
             if (projectManager == null)
@@ -86,7 +92,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             _foregroundDispatcher = dispatcher;
             _filePath = filePath;
-            _projectPath = projectPath;
+            _projectPathProvider = projectPathProvider;
             _projectManager = projectManager;
             _workspaceEditorSettings = workspaceEditorSettings;
             _textBuffer = textBuffer;
@@ -180,6 +186,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 return;
             }
 
+            _projectPathProvider.TryGetProjectPath(TextBuffer, out _projectPath);
             _projectSnapshot = _projectManager.GetOrCreateProject(_projectPath);
             _isSupportedProject = true;
 

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactory.cs
@@ -87,11 +87,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 return null;
             }
 
-            if (!_projectPathProvider.TryGetProjectPath(textBuffer, out var projectPath))
-            {
-                return null;
-            }
-
+            _projectPathProvider.TryGetProjectPath(textBuffer, out var projectPath);
             var filePath = textDocument.FilePath;
             var tracker = new DefaultVisualStudioDocumentTracker(_foregroundDispatcher, filePath, projectPath, _projectManager, _workspaceEditorSettings, _workspace, textBuffer, _importDocumentManager);
 

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactory.cs
@@ -87,9 +87,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 return null;
             }
 
-            _projectPathProvider.TryGetProjectPath(textBuffer, out var projectPath);
             var filePath = textDocument.FilePath;
-            var tracker = new DefaultVisualStudioDocumentTracker(_foregroundDispatcher, filePath, projectPath, _projectManager, _workspaceEditorSettings, _workspace, textBuffer, _importDocumentManager);
+            var tracker = new DefaultVisualStudioDocumentTracker(_foregroundDispatcher, filePath, _projectPathProvider, _projectManager, _workspaceEditorSettings, _workspace, textBuffer, _importDocumentManager);
 
             return tracker;
         }

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -180,7 +180,16 @@ namespace Microsoft.VisualStudio.Editor.Razor
             Debug.Assert(_projectEngine.Engine != null);
             Debug.Assert(_projectEngine.FileSystem != null);
 
-            var projectDirectory = Path.GetDirectoryName(_documentTracker.ProjectPath);
+            string projectDirectory;
+            if (_documentTracker.ProjectPath != null)
+            {
+                projectDirectory = Path.GetDirectoryName(_documentTracker.ProjectPath);
+            }
+            else
+            {
+                projectDirectory = "/";
+            }
+
             _parser = new BackgroundParser(_projectEngine, FilePath, projectDirectory);
             _parser.ResultsReady += OnResultsReady;
             _parser.Start();

--- a/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocument.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocument.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
@@ -24,7 +25,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
 
         public EditorDocument(
             EditorDocumentManager documentManager,
-            string projectFilePath,
+            ProjectId projectId,
             string documentFilePath,
             TextLoader textLoader,
             FileChangeTracker fileTracker,
@@ -39,9 +40,9 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 throw new ArgumentNullException(nameof(documentManager));
             }
 
-            if (projectFilePath == null)
+            if (projectId == null)
             {
-                throw new ArgumentNullException(nameof(projectFilePath));
+                throw new ArgumentNullException(nameof(projectId));
             }
 
             if (documentFilePath == null)
@@ -60,7 +61,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             }
 
             _documentManager = documentManager;
-            ProjectFilePath = projectFilePath;
+            ProjectId = projectId;
             DocumentFilePath = documentFilePath;
             TextLoader = textLoader;
             _fileTracker = fileTracker;
@@ -87,7 +88,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             }
         }
 
-        public string ProjectFilePath { get; }
+        public ProjectId ProjectId { get; }
 
         public string DocumentFilePath { get; }
 

--- a/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerBase.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerBase.cs
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 var textBuffer = GetTextBufferForOpenDocument(key.DocumentFilePath);
                 document = new EditorDocument(
                     this,
-                    key.ProjectFilePath,
+                    key.ProjectId,
                     key.DocumentFilePath,
                     new FileTextLoader(key.DocumentFilePath, defaultEncoding: null),
                     _fileChangeTrackerFactory.Create(key.DocumentFilePath),
@@ -199,7 +199,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
 
             _foregroundDispatcher.AssertForegroundThread();
 
-            var key = new DocumentKey(document.ProjectFilePath, document.DocumentFilePath);
+            var key = new DocumentKey(document.ProjectId, document.DocumentFilePath);
             if (_documentsByFilePath.TryGetValue(document.DocumentFilePath, out var documents))
             {
                 documents.Remove(key);

--- a/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             {
                 case ProjectChangeKind.DocumentAdded:
                     {
-                        var key = new DocumentKey(e.ProjectFilePath, e.DocumentFilePath);
+                        var key = new DocumentKey(e.ProjectId, e.DocumentFilePath);
                         var document = _documentManager.GetOrCreateDocument(key, _onChangedOnDisk, _onChangedInEditor, _onOpened, _onClosed);
                         if (document.IsOpenInEditor)
                         {
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 case ProjectChangeKind.DocumentRemoved:
                     {
                         // This class 'owns' the document entry so it's safe for us to dispose it.
-                        if (_documentManager.TryGetDocument(new DocumentKey(e.ProjectFilePath, e.DocumentFilePath), out var document))
+                        if (_documentManager.TryGetDocument(new DocumentKey(e.ProjectId, e.DocumentFilePath), out var document))
                         {
                             document.Dispose();
                         }
@@ -87,25 +87,25 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
         private void Document_ChangedOnDisk(object sender, EventArgs e)
         {
             var document = (EditorDocument)sender;
-            _projectManager.DocumentChanged(document.ProjectFilePath, document.DocumentFilePath, document.TextLoader);
+            _projectManager.DocumentChanged(document.ProjectId, document.DocumentFilePath, document.TextLoader);
         }
 
         private void Document_ChangedInEditor(object sender, EventArgs e)
         {
             var document = (EditorDocument)sender;
-            _projectManager.DocumentChanged(document.ProjectFilePath, document.DocumentFilePath, document.EditorTextContainer.CurrentText);
+            _projectManager.DocumentChanged(document.ProjectId, document.DocumentFilePath, document.EditorTextContainer.CurrentText);
         }
 
         private void Document_Opened(object sender, EventArgs e)
         {
             var document = (EditorDocument)sender;
-            _projectManager.DocumentOpened(document.ProjectFilePath, document.DocumentFilePath, document.EditorTextContainer.CurrentText);
+            _projectManager.DocumentOpened(document.ProjectId, document.DocumentFilePath, document.EditorTextContainer.CurrentText);
         }
 
         private void Document_Closed(object sender, EventArgs e)
         {
             var document = (EditorDocument)sender;
-            _projectManager.DocumentClosed(document.ProjectFilePath, document.DocumentFilePath, document.TextLoader);
+            _projectManager.DocumentClosed(document.ProjectId, document.DocumentFilePath, document.TextLoader);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioDocumentTracker.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/VisualStudioDocumentTracker.cs
@@ -28,6 +28,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
         public abstract string ProjectPath { get; }
 
+        public abstract ProjectId ProjectId { get; }
+
         public abstract Project Project { get; }
 
         internal abstract ProjectSnapshot ProjectSnapshot { get; }

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
@@ -89,13 +89,13 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             var cookie = _runningDocumentTable.GetDocumentCookie(document.DocumentFilePath);
             if (cookie != VSConstants.VSCOOKIE_NIL)
             {
-                TrackOpenDocument(cookie, new DocumentKey(document.ProjectFilePath, document.DocumentFilePath));
+                TrackOpenDocument(cookie, new DocumentKey(document.ProjectId, document.DocumentFilePath));
             }
         }
 
         protected override void OnDocumentClosed(EditorDocument document)
         {
-            var key = new DocumentKey(document.ProjectFilePath, document.DocumentFilePath);
+            var key = new DocumentKey(document.ProjectId, document.DocumentFilePath);
             if (_cookiesByDocument.TryGetValue(key, out var cookie))
             {
                 UntrackOpenDocument(cookie, key);

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultRazorProjectHost.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 {
                     if (TryGetConfiguration(update.Value.CurrentState, out var configuration))
                     {
-                        var hostProject = new HostProject(CommonServices.UnconfiguredProject.FullPath, configuration);
+                        var hostProject = CreateHostProject(CommonServices.UnconfiguredProject.FullPath, configuration);
 
                         // We need to deal with the case where the project was uninitialized, but now
                         // is valid for Razor. In that case we might have previously seen all of the documents

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackRazorProjectHost.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackRazorProjectHost.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     }
 
                     var configuration = FallbackRazorConfiguration.SelectConfiguration(version);
-                    var hostProject = new HostProject(CommonServices.UnconfiguredProject.FullPath, configuration);
+                    var hostProject = CreateHostProject(CommonServices.UnconfiguredProject.FullPath, configuration);
 
                     // We need to deal with the case where the project was uninitialized, but now
                     // is valid for Razor. In that case we might have previously seen all of the documents

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotHandle.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotHandle.cs
@@ -8,19 +8,27 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal sealed class ProjectSnapshotHandle
     {
-        public ProjectSnapshotHandle(string filePath, RazorConfiguration configuration, ProjectId workspaceProjectId)
+        public ProjectSnapshotHandle(string filePath, ProjectId hostProjectId, RazorConfiguration configuration, ProjectId workspaceProjectId)
         {
             if (filePath == null)
             {
                 throw new ArgumentNullException(nameof(filePath));
             }
 
+            if (hostProjectId == null)
+            {
+                throw new ArgumentNullException(nameof(hostProjectId));
+            }
+
             FilePath = filePath;
+            HostProjectId = hostProjectId;
             Configuration = configuration;
             WorkspaceProjectId = workspaceProjectId;
         }
 
         public RazorConfiguration Configuration { get; }
+
+        public ProjectId HostProjectId { get; set; }
 
         public string FilePath { get; }
 

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotHandleJsonConverter.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotHandleJsonConverter.cs
@@ -28,12 +28,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
 
             var obj = JObject.Load(reader);
             var filePath = obj[nameof(ProjectSnapshotHandle.FilePath)].Value<string>();
+            var id = obj[nameof(ProjectSnapshotHandle.HostProjectId)].Value<string>();
+            var hostProjectId = ProjectId.CreateFromSerialized(Guid.Parse(id));
             var configuration = obj[nameof(ProjectSnapshotHandle.Configuration)].ToObject<RazorConfiguration>(serializer);
-            
-            var id = obj[nameof(ProjectSnapshotHandle.WorkspaceProjectId)].Value<string>();
+
+            id = obj[nameof(ProjectSnapshotHandle.WorkspaceProjectId)].Value<string>();
             var workspaceProjectId = id == null ? null : ProjectId.CreateFromSerialized(Guid.Parse(id));
 
-            return new ProjectSnapshotHandle(filePath, configuration, workspaceProjectId);
+            return new ProjectSnapshotHandle(filePath, hostProjectId, configuration, workspaceProjectId);
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -44,6 +46,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
 
             writer.WritePropertyName(nameof(ProjectSnapshotHandle.FilePath));
             writer.WriteValue(handle.FilePath);
+
+            writer.WritePropertyName(nameof(ProjectSnapshotHandle.HostProjectId));
+            writer.WriteValue(handle.HostProjectId.Id);
 
             if (handle.Configuration == null)
             {

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotJsonConverter.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/Serialization/ProjectSnapshotJsonConverter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Serialization
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var project = (ProjectSnapshot)value;
-            var handle = new ProjectSnapshotHandle(project.FilePath, project.Configuration, project.WorkspaceProject?.Id);
+            var handle = new ProjectSnapshotHandle(project.FilePath, project.Id, project.Configuration, project.WorkspaceProject?.Id);
 
             ProjectSnapshotHandleJsonConverter.Instance.WriteJson(writer, handle, serializer);
         }

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
@@ -199,7 +199,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 Assert.Equal(ContextChangeKind.ProjectChanged, args.Kind);
                 called = true;
 
-                Assert.Same(ProjectManager.GetLoadedProject(DocumentTracker.ProjectPath), DocumentTracker.ProjectSnapshot);
+                Assert.Same(ProjectManager.GetLoadedProject(DocumentTracker.ProjectId), DocumentTracker.ProjectSnapshot);
             };
 
             // Act
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 Assert.Equal(ContextChangeKind.ProjectChanged, args.Kind);
                 called = true;
 
-                Assert.Same(ProjectManager.GetLoadedProject(DocumentTracker.ProjectPath), DocumentTracker.ProjectSnapshot);
+                Assert.Same(ProjectManager.GetLoadedProject(DocumentTracker.ProjectId), DocumentTracker.ProjectSnapshot);
             };
 
             // Act

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
@@ -602,7 +602,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 tracker.TextBuffer == textBuffer &&
                 tracker.TextViews == new[] { focusedTextView } &&
                 tracker.FilePath == TestLinePragmaFileName &&
-                tracker.ProjectPath == TestProjectPath &&
+                tracker.ProjectId == TestProjectPath &&
                 tracker.ProjectSnapshot == ProjectSnapshot &&
                 tracker.IsSupportedProject == true);
             textBuffer.Properties.AddProperty(typeof(VisualStudioDocumentTracker), documentTracker);

--- a/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/DocumentCollectionViewModel.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/DocumentCollectionViewModel.cs
@@ -38,14 +38,14 @@ namespace Microsoft.VisualStudio.RazorExtension.RazorInfo
             {
                 case ProjectChangeKind.DocumentAdded:
                     {
-                        _project = _projectManager.GetLoadedProject(e.ProjectFilePath);
+                        _project = _projectManager.GetLoadedProject(e.ProjectId);
                         Documents.Add(new DocumentItemViewModel(_projectManager, _project.GetDocument(e.DocumentFilePath), _errorHandler));
                         break;
                     }
 
                 case ProjectChangeKind.DocumentRemoved:
                     {
-                        _project = _projectManager.GetLoadedProject(e.ProjectFilePath);
+                        _project = _projectManager.GetLoadedProject(e.ProjectId);
 
                         for (var i = Documents.Count - 1; i >= 0; i--)
                         {
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.RazorExtension.RazorInfo
 
                 case ProjectChangeKind.DocumentChanged:
                     {
-                        _project = _projectManager.GetLoadedProject(e.ProjectFilePath);
+                        _project = _projectManager.GetLoadedProject(e.ProjectId);
                         for (var i = Documents.Count - 1; i >= 0; i--)
                         {
                             if (Documents[i].FilePath == e.DocumentFilePath)

--- a/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/ProjectViewModel.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/ProjectViewModel.cs
@@ -3,16 +3,20 @@
 
 #if RAZOR_EXTENSION_DEVELOPER_MODE
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.RazorExtension.RazorInfo
 {
     public class ProjectViewModel : NotifyPropertyChanged
     {
-        internal ProjectViewModel(string filePath)
+        internal ProjectViewModel(string filePath, ProjectId projectId)
         {
             FilePath = filePath;
+            ProjectId = projectId;
         }
-        
+
+        public ProjectId ProjectId { get; }
+
         public string FilePath { get; }
 
         public string Name => Path.GetFileNameWithoutExtension(FilePath);

--- a/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/RazorInfoToolWindow.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/RazorInfoToolWindow.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.RazorExtension.RazorInfo
             
             foreach (var project in _projectManager.Projects)
             {
-                DataContext.Projects.Add(new ProjectViewModel(project.FilePath));
+                DataContext.Projects.Add(new ProjectViewModel(project.FilePath, project.Id));
             }
 
             if (DataContext.Projects.Count > 0)

--- a/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/RazorInfoViewModel.cs
+++ b/tooling/Microsoft.VisualStudio.RazorExtension/RazorInfo/RazorInfoViewModel.cs
@@ -103,7 +103,8 @@ namespace Microsoft.VisualStudio.RazorExtension.RazorInfo
             {
                 case ProjectChangeKind.ProjectAdded:
                     {
-                        var added = new ProjectViewModel(e.ProjectFilePath);
+                        var projectSnapshot = _projectManager.GetLoadedProject(e.ProjectId);
+                        var added = new ProjectViewModel(projectSnapshot.FilePath, projectSnapshot.Id);
                         Projects.Add(added);
 
                         if (Projects.Count == 1)
@@ -120,7 +121,7 @@ namespace Microsoft.VisualStudio.RazorExtension.RazorInfo
                         for (var i = Projects.Count - 1; i >= 0; i--)
                         {
                             var project = Projects[i];
-                            if (project.FilePath == e.ProjectFilePath)
+                            if (project.ProjectId == e.ProjectId)
                             {
                                 removed = project;
                                 Projects.RemoveAt(i);
@@ -138,7 +139,7 @@ namespace Microsoft.VisualStudio.RazorExtension.RazorInfo
 
                 case ProjectChangeKind.ProjectChanged:
                     {
-                        if (SelectedProject != null && SelectedProject.FilePath == e.ProjectFilePath)
+                        if (SelectedProject != null && SelectedProject.ProjectId == e.ProjectId)
                         {
                             OnSelectedProjectChanged();
                         }
@@ -150,7 +151,7 @@ namespace Microsoft.VisualStudio.RazorExtension.RazorInfo
                 case ProjectChangeKind.DocumentRemoved:
                 case ProjectChangeKind.DocumentChanged:
                     {
-                        if (SelectedProject != null && SelectedProject.FilePath == e.ProjectFilePath)
+                        if (SelectedProject != null && SelectedProject.ProjectId == e.ProjectId)
                         {
                             Documents?.OnChange(e);
                         }


### PR DESCRIPTION
- Part of this work involved moving our Project lookup logic to use a `ProjectId`. The caveat to this approach is there were some scenarios when all we had was a file path so we needed to maintain both ways to lookup a project (with and without a file path).
- Updated `DefaultProjectSnapshotManager` to track projects by a dual key of projectids and file paths.
- Updated project system bits to properly create host projects with unchanging `ProjectId`s.
- Added a miscellaneous project for cases when a document tracker did not have a project path.
- Updated serializers to properly serialize project ids as part of a project handle.

#2350