### PR TITLE
Make brace indenter smarter about making edits to non-valid content kinds.

### DIFF
--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactory.cs
@@ -11,14 +11,21 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         private readonly IEditorOperationsFactoryService _editorOperationsFactory;
         private readonly ForegroundDispatcher _dispatcher;
+        private readonly TextBufferCodeDocumentProvider _codeDocumentProvider;
 
         public DefaultBraceSmartIndenterFactory(
             ForegroundDispatcher dispatcher,
+            TextBufferCodeDocumentProvider codeDocumentProvider,
             IEditorOperationsFactoryService editorOperationsFactory)
         {
             if (dispatcher == null)
             {
                 throw new ArgumentNullException(nameof(dispatcher));
+            }
+
+            if (codeDocumentProvider == null)
+            {
+                throw new ArgumentNullException(nameof(codeDocumentProvider));
             }
 
             if (editorOperationsFactory == null)
@@ -27,6 +34,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             }
 
             _dispatcher = dispatcher;
+            _codeDocumentProvider = codeDocumentProvider;
             _editorOperationsFactory = editorOperationsFactory;
         }
 
@@ -39,7 +47,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             _dispatcher.AssertForegroundThread();
 
-            var braceSmartIndenter = new BraceSmartIndenter(_dispatcher, documentTracker, _editorOperationsFactory);
+            var braceSmartIndenter = new BraceSmartIndenter(_dispatcher, documentTracker, _codeDocumentProvider, _editorOperationsFactory);
 
             return braceSmartIndenter;
         }

--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultBraceSmartIndenterFactoryFactory.cs
@@ -15,14 +15,23 @@ namespace Microsoft.VisualStudio.Editor.Razor
     internal class DefaultBraceSmartIndenterFactoryFactory : ILanguageServiceFactory
     {
         private readonly ForegroundDispatcher _foregroundDispatcher;
+        private readonly TextBufferCodeDocumentProvider _codeDocumentProvider;
         private readonly IEditorOperationsFactoryService _editorOperationsFactory;
 
         [ImportingConstructor]
-        public DefaultBraceSmartIndenterFactoryFactory(ForegroundDispatcher foregroundDispatcher, IEditorOperationsFactoryService editorOperationsFactory)
+        public DefaultBraceSmartIndenterFactoryFactory(
+            ForegroundDispatcher foregroundDispatcher, 
+            TextBufferCodeDocumentProvider codeDocumentProvider, 
+            IEditorOperationsFactoryService editorOperationsFactory)
         {
             if (foregroundDispatcher == null)
             {
                 throw new ArgumentNullException(nameof(foregroundDispatcher));
+            }
+
+            if (codeDocumentProvider == null)
+            {
+                throw new ArgumentNullException(nameof(codeDocumentProvider));
             }
 
             if (editorOperationsFactory == null)
@@ -31,6 +40,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             }
 
             _foregroundDispatcher = foregroundDispatcher;
+            _codeDocumentProvider = codeDocumentProvider;
             _editorOperationsFactory = editorOperationsFactory;
         }
 
@@ -41,7 +51,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 throw new ArgumentNullException(nameof(languageServices));
             }
 
-            return new DefaultBraceSmartIndenterFactory(_foregroundDispatcher, _editorOperationsFactory);
+            return new DefaultBraceSmartIndenterFactory(_foregroundDispatcher, _codeDocumentProvider, _editorOperationsFactory);
         }
     }
 }


### PR DESCRIPTION
- Prior to this change our brace smart indenter would indent JavaScript blocks incorrectly because it didn't take into account where in a Razor file the brace that it was indenting existed.
- Made it so the brace smart indenter only functions in code/metacode locations within the SyntaxTree.
- Updated and added tests to account for new behavior.

#2297