### PR TITLE
Don't smart indent code inside of Razor block constructs.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/CSharpCodeParser.cs
@@ -1820,6 +1820,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             Span.ChunkGenerator = new StatementChunkGenerator();
                             var existingEditHandler = Span.EditHandler;
                             Span.EditHandler = new CodeBlockEditHandler(Language.TokenizeString);
+
+                            AddMarkerSymbolIfNecessary();
+
                             Output(SpanKindInternal.Code);
 
                             Span.EditHandler = existingEditHandler;

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpAutoCompleteTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpAutoCompleteTest.cs
@@ -26,7 +26,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 new DirectiveBlock(chunkGenerator,
                     Factory.CodeTransition(),
                     Factory.MetaCode("functions").Accepts(AcceptedCharactersInternal.None),
-                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None)));
+                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None),
+                    Factory.EmptyCSharp().AsCodeBlock()));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpDirectivesTest.cs
@@ -949,7 +949,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                     Factory.Span(SpanKindInternal.Markup, " ", markup: false).Accepts(AcceptedCharactersInternal.AllWhiteSpace),
                     Factory.MetaCode("{")
                         .AutoCompleteWith("}", atEndOfSpan: true)
-                        .Accepts(AcceptedCharactersInternal.None)));
+                        .Accepts(AcceptedCharactersInternal.None),
+                    Factory.EmptyCSharp().AsCodeBlock()));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -63,6 +63,11 @@ global::System.Object __typeHelper = ";
         #pragma warning disable 1998
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
+#line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+            
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -82,3 +82,5 @@ Document -
                 HtmlContent - (339:23,9 [3] IncompleteDirectives.cshtml)
                     IntermediateToken - (339:23,9 [3] IncompleteDirectives.cshtml) - Html - {\n
                 MalformedDirective - (342:24,0 [12] IncompleteDirectives.cshtml) - functions
+                    CSharpCode - (354:24,12 [0] IncompleteDirectives.cshtml)
+                        IntermediateToken - (354:24,12 [0] IncompleteDirectives.cshtml) - CSharp - 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -63,3 +63,8 @@ Source Location: (326:21,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrat
 Generated Location: (1463:55,0 [0] )
 ||
 
+Source Location: (354:24,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (1879:66,12 [0] )
+||
+

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -52,3 +52,5 @@ Document -
                 HtmlContent - (339:23,9 [3] IncompleteDirectives.cshtml)
                     IntermediateToken - (339:23,9 [3] IncompleteDirectives.cshtml) - Html - {\n
                 MalformedDirective - (342:24,0 [12] IncompleteDirectives.cshtml) - functions
+                    CSharpCode - (354:24,12 [0] IncompleteDirectives.cshtml)
+                        IntermediateToken - (354:24,12 [0] IncompleteDirectives.cshtml) - CSharp - 


### PR DESCRIPTION
- Prior to this change we weren't strict enough with where our smart indenter ran. We made the assumption that every code block could be smart indented and then Roslyn would "do the right thing". However, in nested code block scenarios we found that Roslyn and us would both indent resulting in extra newlines. These changes make the criteria for applying smart indentation a little stricter.
- Updated directive code block parsing to add a C# marker symbol in cases of an empty code block directive.
- Added unit tests to verify new smart indenter behavior.
- Updated existing tests to expect new syntax tree marker symbol for empty directive bits.
- Regenerated baselines.

![image](https://i.imgur.com/WpS0uad.gif)

@rynowak / @ajaybhargavb if you could review asap por favor 😄, time sensitive

#2410