### PR TITLE
Update Razor SDK packing logic to not include Pack at properties layer.

### DIFF
--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -67,10 +67,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true'">
-    <Content Include="**\*.cshtml" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-
+    <Content Include="**\*.cshtml" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
     <None Remove="**\*.cshtml" />
   </ItemGroup>
 

--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -326,6 +326,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       
       <Content Condition="'%(Content.Extension)'=='.cshtml'" CopyToPublishDirectory="Never" />
     </ItemGroup>
+
+    <ItemGroup Condition="
+      '$(ResolvedRazorCompileToolset)'=='RazorSdk' and
+      '$(EnableDefaultRazorGenerateItems)'=='true'">
+
+      <Content Condition="'%(Content.Extension)'=='.cshtml'" Pack="$(IncludeRazorContentInPack)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="AssignRazorGenerateTargetPaths" Condition="'@(RazorGenerate)' != ''">


### PR DESCRIPTION
- We now rely on the Razor source inputs layer to add packing to cshtml content items.
- **NOTE:** VS doesn't respect the Razor sdk reference as part of packages for design time builds; therefore, in order for this change to truly fix the RCL -> copy scenario users will need a new CLI that has these Razor sdk changes included.

Will port this to the 2.1 patch branch once this PR is signed off on.:

![image](https://i.imgur.com/0XUKMSz.gif)

#2378 
