### PR TITLE
Update Razor SDK packing logic to not include Pack at properties layer.

### DIFF
--- a/korebuild.json
+++ b/korebuild.json
@@ -5,7 +5,7 @@
     "visualstudio": {
       "required": false,
       "includePrerelease": true,
-      "minVersion": "15.0.26730.03",
+      "versionRange": "[15.0.26730.03, 15.8)",
       "requiredWorkloads": [
         "Microsoft.VisualStudio.Component.VSSDK"
       ]

--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -67,10 +67,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true'">
-    <Content Include="**\*.cshtml" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-
+    <Content Include="**\*.cshtml" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)" />
     <None Remove="**\*.cshtml" />
   </ItemGroup>
 

--- a/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -74,6 +74,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       ResolveRazorGenerateInputs
     </PrepareForBuildDependsOn>
 
+    <GenerateNuspecDependsOn>
+      ResolveRazorGenerateInputs;
+      $(GenerateNuspecDependsOn)
+    </GenerateNuspecDependsOn>
+
     <PrepareForRunDependsOn>
       _RazorPrepareForRun;
       $(PrepareForRunDependsOn)
@@ -325,6 +330,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       '$(RazorCompileOnPublish)'=='true'">
       
       <Content Condition="'%(Content.Extension)'=='.cshtml'" CopyToPublishDirectory="Never" />
+    </ItemGroup>
+
+    <ItemGroup Condition="
+      '$(ResolvedRazorCompileToolset)'=='RazorSdk' and
+      '$(EnableDefaultRazorGenerateItems)'=='true'">
+
+      <Content Condition="'%(Content.Extension)'=='.cshtml'" Pack="$(IncludeRazorContentInPack)" />
     </ItemGroup>
   </Target>
 

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PackIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PackIntegrationTest.cs
@@ -17,6 +17,46 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
         [Fact]
         [InitializeTestProject("ClassLibrary")]
+        public async Task Pack__NoBuild_Works_IncludesRazorAssembly()
+        {
+            var result = await DotnetMSBuild("Build");
+            Assert.BuildPassed(result);
+
+            result = await DotnetMSBuild("Pack", "/p:NoBuild=true");
+            Assert.BuildPassed(result);
+
+            Assert.FileExists(result, OutputPath, "ClassLibrary.dll");
+            Assert.FileExists(result, OutputPath, "ClassLibrary.Views.dll");
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // Travis on OSX produces different full paths in C# and MSBuild
+                Assert.NuspecContains(
+                    result,
+                    Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
+                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netstandard2.0", "ClassLibrary.Views.dll")}\" " +
+                    $"target=\"{Path.Combine("lib", "netstandard2.0", "ClassLibrary.Views.dll")}\" />");
+
+                Assert.NuspecDoesNotContain(
+                    result,
+                    Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
+                    $"<file src=\"{Path.Combine(Project.DirectoryPath, "bin", Configuration, "netstandard2.0", "ClassLibrary.Views.pdb")}\" " +
+                    $"target=\"{Path.Combine("lib", "netstandard2.0", "ClassLibrary.Views.pdb")}\" />");
+            }
+
+            Assert.NuspecDoesNotContain(
+                result,
+                Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
+                @"<files include=""any/netstandard2.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
+
+            Assert.NupkgContains(
+                result,
+                Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.nupkg"),
+                Path.Combine("lib", "netstandard2.0", "ClassLibrary.Views.dll"));
+        }
+
+        [Fact]
+        [InitializeTestProject("ClassLibrary")]
         public async Task Pack_Works_IncludesRazorAssembly()
         {
             var result = await DotnetMSBuild("Pack");

--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PackIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/PackIntegrationTest.cs
@@ -17,7 +17,28 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
         [Fact]
         [InitializeTestProject("ClassLibrary")]
-        public async Task Pack__NoBuild_Works_IncludesRazorAssembly()
+        public async Task Pack_NoBuild_IncludeRazorContent_IncludesRazorViewContent()
+        {
+            var result = await DotnetMSBuild("Build");
+            Assert.BuildPassed(result);
+
+            result = await DotnetMSBuild("Pack", "/p:NoBuild=true /p:IncludeRazorContentInPack=true");
+            Assert.BuildPassed(result);
+
+            Assert.NuspecContains(
+                result,
+                Path.Combine("obj", Configuration, "ClassLibrary.1.0.0.nuspec"),
+                @"<files include=""any/netstandard2.0/Views/Shared/_Layout.cshtml"" buildAction=""Content"" />");
+
+            Assert.NupkgContains(
+                result,
+                Path.Combine("bin", Configuration, "ClassLibrary.1.0.0.nupkg"),
+                Path.Combine("contentFiles", "any", "netstandard2.0", "Views", "Shared", "_Layout.cshtml"));
+        }
+
+        [Fact]
+        [InitializeTestProject("ClassLibrary")]
+        public async Task Pack_NoBuild_Works_IncludesRazorAssembly()
         {
             var result = await DotnetMSBuild("Build");
             Assert.BuildPassed(result);


### PR DESCRIPTION
- We now rely on the Razor source inputs layer to add packing to cshtml content items.

#2378 
#2384 

@mkArtakMSFT This is ready to go, let me know when i'm good to merge.