### PR TITLE
Converted more parser tests to baselines

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/AddTagHelperChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/AddTagHelperChunkGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
@@ -62,6 +63,29 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             combiner.Add(AssemblyName, StringComparer.Ordinal);
 
             return combiner.CombinedHash;
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder("AddTagHelper:{");
+            builder.Append(LookupText);
+            builder.Append(";");
+            builder.Append(DirectiveText);
+            builder.Append(";");
+            builder.Append(TypePattern);
+            builder.Append(";");
+            builder.Append(AssemblyName);
+            builder.Append("}");
+
+            if (Diagnostics.Count > 0)
+            {
+                builder.Append(" [");
+                var ids = string.Join(", ", Diagnostics.Select(diagnostic => diagnostic.Id));
+                builder.Append(ids);
+                builder.Append("]");
+            }
+
+            return builder.ToString();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/DirectiveChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/DirectiveChunkGenerator.cs
@@ -60,8 +60,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             // This is used primarily at test time to show an identifiable representation of the chunk generator.
 
-            var builder = new StringBuilder("Directive {");
+            var builder = new StringBuilder("Directive:{");
             builder.Append(Descriptor.Directive);
+            builder.Append(";");
+            builder.Append(Descriptor.Kind);
+            builder.Append(";");
+            builder.Append(Descriptor.Usage);
             builder.Append("}");
 
             if (Diagnostics.Count > 0)

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/DirectiveTokenChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/DirectiveTokenChunkGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
@@ -15,7 +16,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             Descriptor = tokenDescriptor;
         }
 
-        public DirectiveTokenDescriptor Descriptor { get; set; }
+        public DirectiveTokenDescriptor Descriptor { get; }
 
         public override void Accept(ParserVisitor visitor, Span span)
         {
@@ -36,6 +37,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             combiner.Add(Type);
 
             return combiner.CombinedHash;
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder("DirectiveToken {");
+            builder.Append(Descriptor.Name);
+            builder.Append(";");
+            builder.Append(Descriptor.Kind);
+            builder.Append(";Opt:");
+            builder.Append(Descriptor.Optional);
+            builder.Append("}");
+
+            return builder.ToString();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/RazorCommentChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/RazorCommentChunkGenerator.cs
@@ -9,5 +9,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             visitor.VisitCommentBlock(this, block);
         }
+
+        public override string ToString()
+        {
+            return "RazorComment";
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/RemoveTagHelperChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/RemoveTagHelperChunkGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
@@ -62,6 +63,29 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             combiner.Add(AssemblyName, StringComparer.Ordinal);
 
             return combiner.CombinedHash;
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder("RemoveTagHelper:{");
+            builder.Append(LookupText);
+            builder.Append(";");
+            builder.Append(DirectiveText);
+            builder.Append(";");
+            builder.Append(TypePattern);
+            builder.Append(";");
+            builder.Append(AssemblyName);
+            builder.Append("}");
+
+            if (Diagnostics.Count > 0)
+            {
+                builder.Append(" [");
+                var ids = string.Join(", ", Diagnostics.Select(diagnostic => diagnostic.Id));
+                builder.Append(ids);
+                builder.Append("]");
+            }
+
+            return builder.ToString();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperChunkGenerator.cs
@@ -73,5 +73,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             visitor.VisitTagHelperBlock(this, block);
         }
+
+        public override string ToString()
+        {
+            return "TagHelper";
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperPrefixDirectiveChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperPrefixDirectiveChunkGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
@@ -47,6 +48,25 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             combiner.Add(DirectiveText, StringComparer.Ordinal);
 
             return combiner.CombinedHash;
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder("TagHelperPrefix:{");
+            builder.Append(Prefix);
+            builder.Append(";");
+            builder.Append(DirectiveText);
+            builder.Append("}");
+
+            if (Diagnostics.Count > 0)
+            {
+                builder.Append(" [");
+                var ids = string.Join(", ", Diagnostics.Select(diagnostic => diagnostic.Id));
+                builder.Append(ids);
+                builder.Append("]");
+            }
+
+            return builder.ToString();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TemplateBlockChunkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TemplateBlockChunkGenerator.cs
@@ -19,5 +19,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         {
             //context.ChunkTreeBuilder.EndParentChunk();
         }
+
+        public override string ToString()
+        {
+            return "Template";
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpAutoCompleteTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/CSharpAutoCompleteTest.cs
@@ -10,136 +10,49 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     public class CSharpAutoCompleteTest : CsHtmlCodeParserTestBase
     {
+        public CSharpAutoCompleteTest()
+        {
+            UseBaselineTests = true;
+        }
+
         [Fact]
         public void FunctionsDirectiveAutoCompleteAtEOF()
         {
-            // Arrange
-            var chunkGenerator = new DirectiveChunkGenerator(FunctionsDirective.Directive);
-            chunkGenerator.Diagnostics.Add(
-                RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
-                    new SourceSpan(new SourceLocation(10, 0, 10), contentLength: 1), FunctionsDirective.Directive.Directive, "}", "{"));
-
-            // Act & Assert
-            ParseBlockTest(
-                "@functions{",
-                new[] { FunctionsDirective.Directive },
-                new DirectiveBlock(chunkGenerator,
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("functions").Accepts(AcceptedCharactersInternal.None),
-                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None),
-                    Factory.EmptyCSharp().AsCodeBlock()));
+            // Arrange, Act & Assert
+            ParseBlockTest("@functions{", new[] { FunctionsDirective.Directive });
         }
 
         [Fact]
         public void SectionDirectiveAutoCompleteAtEOF()
         {
-            // Arrange
-            var chunkGenerator = new DirectiveChunkGenerator(SectionDirective.Directive);
-            chunkGenerator.Diagnostics.Add(
-                RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
-                    new SourceSpan(new SourceLocation(16, 0, 16), contentLength: 1), "section", "}", "{"));
-
-            // Act & Assert
-            ParseBlockTest(
-                "@section Header {",
-                new[] { SectionDirective.Directive },
-                new DirectiveBlock(chunkGenerator,
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("section").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
-                    Factory.Span(SpanKindInternal.Code, "Header", CSharpSymbolType.Identifier)
-                        .AsDirectiveToken(SectionDirective.Directive.Tokens.First()),
-                    Factory.Span(SpanKindInternal.Markup, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.AllWhiteSpace),
-                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None),
-                    new MarkupBlock(
-                        Factory.EmptyHtml())));
+            // Arrange, Act & Assert
+            ParseBlockTest("@section Header {", new[] { SectionDirective.Directive });
         }
 
         [Fact]
         public void VerbatimBlockAutoCompleteAtEOF()
         {
-            ParseBlockTest("@{",
-                new StatementBlock(
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("{").Accepts(AcceptedCharactersInternal.None),
-                    Factory.EmptyCSharp()
-                        .AsStatement()
-                        .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString) { AutoCompleteString = "}" })
-                    ),
-                RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
-                    new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), Resources.BlockName_Code, "}", "{"));
+            ParseBlockTest("@{");
         }
 
         [Fact]
         public void FunctionsDirectiveAutoCompleteAtStartOfFile()
         {
-            // Arrange
-            var chunkGenerator = new DirectiveChunkGenerator(FunctionsDirective.Directive);
-            chunkGenerator.Diagnostics.Add(
-                RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
-                    new SourceSpan(new SourceLocation(10, 0, 10), contentLength: 1), "functions", "}", "{"));
-
-            // Act & Assert
-            ParseBlockTest(
-                "@functions{" + Environment.NewLine + "foo",
-                new[] { FunctionsDirective.Directive },
-                new DirectiveBlock(chunkGenerator,
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("functions").Accepts(AcceptedCharactersInternal.None),
-                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None),
-                Factory.Code(Environment.NewLine + "foo").AsCodeBlock()));
+            // Arrange, Act & Assert
+            ParseBlockTest("@functions{" + Environment.NewLine + "foo", new[] { FunctionsDirective.Directive });
         }
 
         [Fact]
         public void SectionDirectiveAutoCompleteAtStartOfFile()
         {
-            // Arrange
-            var chunkGenerator = new DirectiveChunkGenerator(SectionDirective.Directive);
-            chunkGenerator.Diagnostics.Add(
-                RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
-                    new SourceSpan(new SourceLocation(16, 0, 16), contentLength: 1), "section", "}", "{"));
-
-            // Act & Assert
-            ParseBlockTest(
-                "@section Header {" + Environment.NewLine + "<p>Foo</p>",
-                new[] { SectionDirective.Directive },
-                new DirectiveBlock(chunkGenerator,
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("section").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Span(SpanKindInternal.Code, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.WhiteSpace),
-                    Factory.Span(SpanKindInternal.Code, "Header", CSharpSymbolType.Identifier).AsDirectiveToken(SectionDirective.Directive.Tokens.First()),
-                    Factory.Span(SpanKindInternal.Markup, " ", CSharpSymbolType.WhiteSpace).Accepts(AcceptedCharactersInternal.AllWhiteSpace),
-                    Factory.MetaCode("{").AutoCompleteWith("}", atEndOfSpan: true).Accepts(AcceptedCharactersInternal.None),
-                    new MarkupBlock(
-                        Factory.Markup(Environment.NewLine),
-                        new MarkupTagBlock(
-                            Factory.Markup("<p>")),
-                        Factory.Markup("Foo"),
-                        new MarkupTagBlock(
-                            Factory.Markup("</p>")))));
+            // Arrange, Act & Assert
+            ParseBlockTest("@section Header {" + Environment.NewLine + "<p>Foo</p>", new[] { SectionDirective.Directive });
         }
 
         [Fact]
         public void VerbatimBlockAutoCompleteAtStartOfFile()
         {
-            ParseBlockTest(
-                "@{" + Environment.NewLine + "<p></p>",
-                new StatementBlock(
-                    Factory.CodeTransition(),
-                    Factory.MetaCode("{").Accepts(AcceptedCharactersInternal.None),
-                    Factory.Code(Environment.NewLine)
-                        .AsStatement()
-                        .With(new AutoCompleteEditHandler(CSharpLanguageCharacteristics.Instance.TokenizeString) { AutoCompleteString = "}" }),
-                    new MarkupBlock(
-                        new MarkupTagBlock(
-                            Factory.Markup("<p>").Accepts(AcceptedCharactersInternal.None)),
-                        new MarkupTagBlock(
-                            Factory.Markup("</p>").Accepts(AcceptedCharactersInternal.None))),
-                    Factory.Span(SpanKindInternal.Code, new CSharpSymbol(string.Empty, CSharpSymbolType.Unknown))
-                        .With(new StatementChunkGenerator())
-                    ),
-                RazorDiagnosticFactory.CreateParsing_ExpectedEndOfBlockBeforeEOF(
-                        new SourceSpan(new SourceLocation(1, 0, 1), contentLength: 1), Resources.BlockName_Code, "}", "{"));
+            ParseBlockTest("@{" + Environment.NewLine + "<p></p>");
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/FunctionsDirectiveAutoCompleteAtEOF.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/FunctionsDirectiveAutoCompleteAtEOF.syntaxtree.txt
@@ -1,0 +1,9 @@
+Directive block - Gen<Directive:{functions;CodeBlock;Unrestricted} [RZ1006]> - 11 - (0:0,0)
+    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.Transition;[@];
+    MetaCode span - Gen<None> - [functions] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+        CSharpSymbolType.Identifier;[functions];
+    MetaCode span - Gen<None> - [{] - AutoCompleteEditHandler;Accepts:None,AutoComplete:[}];AtEnd - (10:0,10) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [] - CodeBlockEditHandler;Accepts:Any;CodeBlock - (11:0,11) - Symbols:1
+        CSharpSymbolType.Unknown;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/FunctionsDirectiveAutoCompleteAtStartOfFile.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/FunctionsDirectiveAutoCompleteAtStartOfFile.syntaxtree.txt
@@ -1,0 +1,10 @@
+Directive block - Gen<Directive:{functions;CodeBlock;Unrestricted} [RZ1006]> - 16 - (0:0,0)
+    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.Transition;[@];
+    MetaCode span - Gen<None> - [functions] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+        CSharpSymbolType.Identifier;[functions];
+    MetaCode span - Gen<None> - [{] - AutoCompleteEditHandler;Accepts:None,AutoComplete:[}];AtEnd - (10:0,10) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [LFfoo] - CodeBlockEditHandler;Accepts:Any;CodeBlock - (11:0,11) - Symbols:2
+        CSharpSymbolType.NewLine;[LF];
+        CSharpSymbolType.Identifier;[foo];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/SectionDirectiveAutoCompleteAtEOF.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/SectionDirectiveAutoCompleteAtEOF.syntaxtree.txt
@@ -1,0 +1,16 @@
+Directive block - Gen<Directive:{section;RazorBlock;Unrestricted} [RZ1006]> - 17 - (0:0,0)
+    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.Transition;[@];
+    MetaCode span - Gen<None> - [section] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+        CSharpSymbolType.Identifier;[section];
+    Code span - Gen<None> - [ ] - SpanEditHandler;Accepts:WhiteSpace - (8:0,8) - Symbols:1
+        CSharpSymbolType.WhiteSpace;[ ];
+    Code span - Gen<DirectiveToken {SectionName;Member;Opt:False}> - [Header] - DirectiveTokenEditHandler;Accepts:NonWhiteSpace - (9:0,9) - Symbols:1
+        CSharpSymbolType.Identifier;[Header];
+    Markup span - Gen<None> - [ ] - SpanEditHandler;Accepts:AllWhiteSpace - (15:0,15) - Symbols:1
+        CSharpSymbolType.WhiteSpace;[ ];
+    MetaCode span - Gen<None> - [{] - AutoCompleteEditHandler;Accepts:None,AutoComplete:[}];AtEnd - (16:0,16) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Markup block - Gen<None> - 0 - (17:0,17)
+        Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (17:0,17) - Symbols:1
+            HtmlSymbolType.Unknown;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/SectionDirectiveAutoCompleteAtStartOfFile.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/SectionDirectiveAutoCompleteAtStartOfFile.syntaxtree.txt
@@ -1,0 +1,29 @@
+Directive block - Gen<Directive:{section;RazorBlock;Unrestricted} [RZ1006]> - 29 - (0:0,0)
+    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.Transition;[@];
+    MetaCode span - Gen<None> - [section] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+        CSharpSymbolType.Identifier;[section];
+    Code span - Gen<None> - [ ] - SpanEditHandler;Accepts:WhiteSpace - (8:0,8) - Symbols:1
+        CSharpSymbolType.WhiteSpace;[ ];
+    Code span - Gen<DirectiveToken {SectionName;Member;Opt:False}> - [Header] - DirectiveTokenEditHandler;Accepts:NonWhiteSpace - (9:0,9) - Symbols:1
+        CSharpSymbolType.Identifier;[Header];
+    Markup span - Gen<None> - [ ] - SpanEditHandler;Accepts:AllWhiteSpace - (15:0,15) - Symbols:1
+        CSharpSymbolType.WhiteSpace;[ ];
+    MetaCode span - Gen<None> - [{] - AutoCompleteEditHandler;Accepts:None,AutoComplete:[}];AtEnd - (16:0,16) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Markup block - Gen<None> - 12 - (17:0,17)
+        Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:Any - (17:0,17) - Symbols:1
+            HtmlSymbolType.NewLine;[LF];
+        Tag block - Gen<None> - 3 - (19:1,0)
+            Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (19:1,0) - Symbols:3
+                HtmlSymbolType.OpenAngle;[<];
+                HtmlSymbolType.Text;[p];
+                HtmlSymbolType.CloseAngle;[>];
+        Markup span - Gen<Markup> - [Foo] - SpanEditHandler;Accepts:Any - (22:1,3) - Symbols:1
+            HtmlSymbolType.Text;[Foo];
+        Tag block - Gen<None> - 4 - (25:1,6)
+            Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (25:1,6) - Symbols:4
+                HtmlSymbolType.OpenAngle;[<];
+                HtmlSymbolType.ForwardSlash;[/];
+                HtmlSymbolType.Text;[p];
+                HtmlSymbolType.CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/VerbatimBlockAutoCompleteAtEOF.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/VerbatimBlockAutoCompleteAtEOF.diagnostics.txt
@@ -1,0 +1,1 @@
+(1,2): Error RZ1006: The code block is missing a closing "}" character.  Make sure you have a matching "}" character for all the "{" characters within this block, and that none of the "}" characters are being interpreted as markup.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/VerbatimBlockAutoCompleteAtEOF.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/VerbatimBlockAutoCompleteAtEOF.syntaxtree.txt
@@ -1,0 +1,7 @@
+Statement block - Gen<None> - 2 - (0:0,0)
+    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.Transition;[@];
+    MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[}];AtEOL - (2:0,2) - Symbols:1
+        CSharpSymbolType.Unknown;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/VerbatimBlockAutoCompleteAtStartOfFile.diagnostics.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/VerbatimBlockAutoCompleteAtStartOfFile.diagnostics.txt
@@ -1,0 +1,1 @@
+(1,2): Error RZ1006: The code block is missing a closing "}" character.  Make sure you have a matching "}" character for all the "{" characters within this block, and that none of the "}" characters are being interpreted as markup.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/VerbatimBlockAutoCompleteAtStartOfFile.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpAutoCompleteTest/VerbatimBlockAutoCompleteAtStartOfFile.syntaxtree.txt
@@ -1,0 +1,21 @@
+Statement block - Gen<None> - 11 - (0:0,0)
+    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.Transition;[@];
+    MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [LF] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[}];AtEOL - (2:0,2) - Symbols:1
+        CSharpSymbolType.NewLine;[LF];
+    Markup block - Gen<None> - 7 - (4:1,0)
+        Tag block - Gen<None> - 3 - (4:1,0)
+            Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:None - (4:1,0) - Symbols:3
+                HtmlSymbolType.OpenAngle;[<];
+                HtmlSymbolType.Text;[p];
+                HtmlSymbolType.CloseAngle;[>];
+        Tag block - Gen<None> - 4 - (7:1,3)
+            Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:None - (7:1,3) - Symbols:4
+                HtmlSymbolType.OpenAngle;[<];
+                HtmlSymbolType.ForwardSlash;[/];
+                HtmlSymbolType.Text;[p];
+                HtmlSymbolType.CloseAngle;[>];
+    Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (11:1,7) - Symbols:1
+        CSharpSymbolType.Unknown;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionAcceptsTrailingNewlineInDesignTimeMode.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionAcceptsTrailingNewlineInDesignTimeMode.syntaxtree.txt
@@ -1,8 +1,15 @@
-Statement block - NullParentChunkGenerator - 9 - (0:0,0)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - { - (0:0,0)
-    Code span - StatementChunkGenerator - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL -  - (1:0,1)
-    Expression block - ExpressionChunkGenerator - 5 - (1:0,1)
-        Transition span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - @ - (1:0,1)
-        Code span - ExpressionChunkGenerator - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 - foo. - (2:0,2)
-    Code span - StatementChunkGenerator - SpanEditHandler;Accepts:Any - LF - (6:0,6)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - } - (8:1,0)
+Statement block - Gen<None> - 9 - (0:0,0)
+    MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL - (1:0,1) - Symbols:1
+        CSharpSymbolType.Unknown;[];
+    Expression block - Gen<Expr> - 5 - (1:0,1)
+        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+            CSharpSymbolType.Transition;[@];
+        Code span - Gen<Expr> - [foo.] - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 - (2:0,2) - Symbols:2
+            CSharpSymbolType.Identifier;[foo];
+            CSharpSymbolType.Dot;[.];
+    Code span - Gen<Stmt> - [LF] - SpanEditHandler;Accepts:Any - (6:0,6) - Symbols:1
+        CSharpSymbolType.NewLine;[LF];
+    MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (8:1,0) - Symbols:1
+        CSharpSymbolType.RightBrace;[}];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionDoesNotAcceptDotAfterAt.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionDoesNotAcceptDotAfterAt.syntaxtree.txt
@@ -1,8 +1,14 @@
-Statement block - NullParentChunkGenerator - 4 - (0:0,0)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - { - (0:0,0)
-    Code span - StatementChunkGenerator - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL -  - (1:0,1)
-    Expression block - ExpressionChunkGenerator - 1 - (1:0,1)
-        Transition span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - @ - (1:0,1)
-        Code span - ExpressionChunkGenerator - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 -  - (2:0,2)
-    Code span - StatementChunkGenerator - SpanEditHandler;Accepts:Any - . - (2:0,2)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - } - (3:0,3)
+Statement block - Gen<None> - 4 - (0:0,0)
+    MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL - (1:0,1) - Symbols:1
+        CSharpSymbolType.Unknown;[];
+    Expression block - Gen<Expr> - 1 - (1:0,1)
+        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+            CSharpSymbolType.Transition;[@];
+        Code span - Gen<Expr> - [] - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 - (2:0,2) - Symbols:1
+            CSharpSymbolType.Unknown;[];
+    Code span - Gen<Stmt> - [.] - SpanEditHandler;Accepts:Any - (2:0,2) - Symbols:1
+        CSharpSymbolType.Dot;[.];
+    MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (3:0,3) - Symbols:1
+        CSharpSymbolType.RightBrace;[}];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionDoesNotAcceptTrailingNewlineInRunTimeMode.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionDoesNotAcceptTrailingNewlineInRunTimeMode.syntaxtree.txt
@@ -1,8 +1,15 @@
-Statement block - NullParentChunkGenerator - 9 - (0:0,0)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - { - (0:0,0)
-    Code span - StatementChunkGenerator - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL -  - (1:0,1)
-    Expression block - ExpressionChunkGenerator - 5 - (1:0,1)
-        Transition span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - @ - (1:0,1)
-        Code span - ExpressionChunkGenerator - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 - foo. - (2:0,2)
-    Code span - StatementChunkGenerator - SpanEditHandler;Accepts:Any - LF - (6:0,6)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - } - (8:1,0)
+Statement block - Gen<None> - 9 - (0:0,0)
+    MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL - (1:0,1) - Symbols:1
+        CSharpSymbolType.Unknown;[];
+    Expression block - Gen<Expr> - 5 - (1:0,1)
+        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+            CSharpSymbolType.Transition;[@];
+        Code span - Gen<Expr> - [foo.] - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 - (2:0,2) - Symbols:2
+            CSharpSymbolType.Identifier;[foo];
+            CSharpSymbolType.Dot;[.];
+    Code span - Gen<Stmt> - [LF] - SpanEditHandler;Accepts:Any - (6:0,6) - Symbols:1
+        CSharpSymbolType.NewLine;[LF];
+    MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (8:1,0) - Symbols:1
+        CSharpSymbolType.RightBrace;[}];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionWithOnlySingleAtAcceptsSingleSpaceOrNewlineAtDesignTime.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionWithOnlySingleAtAcceptsSingleSpaceOrNewlineAtDesignTime.syntaxtree.txt
@@ -1,8 +1,15 @@
-Statement block - NullParentChunkGenerator - 11 - (0:0,0)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - { - (0:0,0)
-    Code span - StatementChunkGenerator - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL - LF     - (1:0,1)
-    Expression block - ExpressionChunkGenerator - 1 - (7:1,4)
-        Transition span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - @ - (7:1,4)
-        Code span - ExpressionChunkGenerator - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 -  - (8:1,5)
-    Code span - StatementChunkGenerator - SpanEditHandler;Accepts:Any - LF - (8:1,5)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - } - (10:2,0)
+Statement block - Gen<None> - 11 - (0:0,0)
+    MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [LF    ] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL - (1:0,1) - Symbols:2
+        CSharpSymbolType.NewLine;[LF];
+        CSharpSymbolType.WhiteSpace;[    ];
+    Expression block - Gen<Expr> - 1 - (7:1,4)
+        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (7:1,4) - Symbols:1
+            CSharpSymbolType.Transition;[@];
+        Code span - Gen<Expr> - [] - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 - (8:1,5) - Symbols:1
+            CSharpSymbolType.Unknown;[];
+    Code span - Gen<Stmt> - [LF] - SpanEditHandler;Accepts:Any - (8:1,5) - Symbols:1
+        CSharpSymbolType.NewLine;[LF];
+    MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (10:2,0) - Symbols:1
+        CSharpSymbolType.RightBrace;[}];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionWithOnlySingleAtOutputsZeroLengthCodeSpan.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/InnerImplicitExpressionWithOnlySingleAtOutputsZeroLengthCodeSpan.syntaxtree.txt
@@ -1,8 +1,14 @@
-Statement block - NullParentChunkGenerator - 3 - (0:0,0)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - { - (0:0,0)
-    Code span - StatementChunkGenerator - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL -  - (1:0,1)
-    Expression block - ExpressionChunkGenerator - 1 - (1:0,1)
-        Transition span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - @ - (1:0,1)
-        Code span - ExpressionChunkGenerator - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 -  - (2:0,2)
-    Code span - StatementChunkGenerator - SpanEditHandler;Accepts:Any -  - (2:0,2)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - } - (2:0,2)
+Statement block - Gen<None> - 3 - (0:0,0)
+    MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL - (1:0,1) - Symbols:1
+        CSharpSymbolType.Unknown;[];
+    Expression block - Gen<Expr> - 1 - (1:0,1)
+        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+            CSharpSymbolType.Transition;[@];
+        Code span - Gen<Expr> - [] - ImplicitExpressionEditHandler;Accepts:NonWhiteSpace;ImplicitExpression[ATD];K14 - (2:0,2) - Symbols:1
+            CSharpSymbolType.Unknown;[];
+    Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (2:0,2) - Symbols:1
+        CSharpSymbolType.Unknown;[];
+    MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (2:0,2) - Symbols:1
+        CSharpSymbolType.RightBrace;[}];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/VerbatimBlock.syntaxtree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/CSharpVerbatimBlockTest/VerbatimBlock.syntaxtree.txt
@@ -1,5 +1,14 @@
-Statement block - NullParentChunkGenerator - 11 - (0:0,0)
-    Transition span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - @ - (0:0,0)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - { - (1:0,1)
-    Code span - StatementChunkGenerator - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL -  foo();  - (2:0,2)
-    MetaCode span - NullSpanChunkGenerator - SpanEditHandler;Accepts:None - } - (10:0,10)
+Statement block - Gen<None> - 11 - (0:0,0)
+    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Symbols:1
+        CSharpSymbolType.Transition;[@];
+    MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Symbols:1
+        CSharpSymbolType.LeftBrace;[{];
+    Code span - Gen<Stmt> - [ foo(); ] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL - (2:0,2) - Symbols:6
+        CSharpSymbolType.WhiteSpace;[ ];
+        CSharpSymbolType.Identifier;[foo];
+        CSharpSymbolType.LeftParenthesis;[(];
+        CSharpSymbolType.RightParenthesis;[)];
+        CSharpSymbolType.Semicolon;[;];
+        CSharpSymbolType.WhiteSpace;[ ];
+    MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (10:0,10) - Symbols:1
+        CSharpSymbolType.RightBrace;[}];

--- a/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/ParserTestBase.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/ParserTestBase.cs
@@ -278,6 +278,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             ParseBlockTest(document, null, designTime, new RazorDiagnostic[0]);
         }
 
+        internal virtual void ParseBlockTest(string document, IEnumerable<DirectiveDescriptor> directives)
+        {
+            ParseBlockTest(document, directives, null);
+        }
+
         internal virtual void ParseBlockTest(string document, params RazorDiagnostic[] expectedErrors)
         {
             ParseBlockTest(document, false, expectedErrors);


### PR DESCRIPTION
#2263 

- Converted `CSharpAutoCompleteTest` to use baselines
- More changes to the serializer to include symbols
- Regenerated baselines