### PR TITLE
 Generate deterministic id for tag helpers

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperTargetExtension.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
                 var uniqueId = (string)context.Items[CodeRenderingContext.SuppressUniqueIds];
                 if (uniqueId == null)
                 {
-                    uniqueId = Guid.NewGuid().ToString("N");
+                    uniqueId = GetDeterministicId(context);
                 }
 
                 context.CodeWriter.WriteStringLiteral(node.TagName)
@@ -635,6 +635,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
             }
 
             return builder.ToString();
+        }
+
+        // Internal for testing
+        internal static string GetDeterministicId(CodeRenderingContext context)
+        {
+            // Use the file checksum along with the absolute position in the generated code to create a unique id for each tag helper call site.
+            var checksum = Checksum.BytesToString(context.SourceDocument.GetChecksum());
+            var uniqueId = checksum + context.CodeWriter.Location.AbsoluteIndex;
+
+            return uniqueId;
         }
 
         private static string GetPropertyAccessor(DefaultTagHelperPropertyIntermediateNode node)

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/DefaultTagHelperTargetExtensionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/DefaultTagHelperTargetExtensionTest.cs
@@ -1118,6 +1118,20 @@ private global::Microsoft.AspNetCore.Razor.Runtime.TagHelpers.TagHelperScopeMana
                 ignoreLineEndingDifferences: true);
         }
 
+        [Fact]
+        public void GetDeterministicId_IsDeterministic()
+        {
+            // Arrange
+            var context = TestCodeRenderingContext.CreateRuntime(suppressUniqueIds: null);
+
+            // Act
+            var firstId = DefaultTagHelperTargetExtension.GetDeterministicId(context);
+            var secondId = DefaultTagHelperTargetExtension.GetDeterministicId(context);
+
+            // Assert
+            Assert.Equal(firstId, secondId);
+        }
+
         private static void Push(CodeRenderingContext context, TagHelperIntermediateNode node)
         {
             ((DefaultCodeRenderingContext)context).AncestorsInternal.Push(node);


### PR DESCRIPTION
#2449 

- Using the hash of file checksum along with the absolute position in the generated code to create the unique id.
- Regenerated baselines