### PR TITLE
Change HTML splitting logic to not split on surrogate pairs.

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RuntimeNodeWriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/CodeGeneration/RuntimeNodeWriterTest.cs
@@ -340,6 +340,91 @@ if (true) { }
         }
 
         [Fact]
+        public void WriteHtmlLiteral_WithinMaxSize_WritesSingleLiteral()
+        {
+            // Arrange
+            var codeWriter = new CodeWriter();
+            var writer = new RuntimeNodeWriter();
+            var context = TestCodeRenderingContext.CreateRuntime();
+
+            // Act
+            writer.WriteHtmlLiteral(context, maxStringLiteralLength: 6, "Hello");
+
+            // Assert
+            var csharp = context.CodeWriter.GenerateCode();
+            Assert.Equal(
+@"WriteLiteral(""Hello"");
+",
+                csharp,
+                ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
+        public void WriteHtmlLiteral_GreaterThanMaxSize_WritesMultipleLiterals()
+        {
+            // Arrange
+            var codeWriter = new CodeWriter();
+            var writer = new RuntimeNodeWriter();
+            var context = TestCodeRenderingContext.CreateRuntime();
+
+            // Act
+            writer.WriteHtmlLiteral(context, maxStringLiteralLength: 6, "Hello World");
+
+            // Assert
+            var csharp = context.CodeWriter.GenerateCode();
+            Assert.Equal(
+@"WriteLiteral(""Hello "");
+WriteLiteral(""World"");
+",
+                csharp,
+                ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
+        public void WriteHtmlLiteral_GreaterThanMaxSize_SingleEmojisSplit()
+        {
+            // Arrange
+            var codeWriter = new CodeWriter();
+            var writer = new RuntimeNodeWriter();
+            var context = TestCodeRenderingContext.CreateRuntime();
+
+            // Act
+            writer.WriteHtmlLiteral(context, maxStringLiteralLength: 2, " 👦");
+
+            // Assert
+            var csharp = context.CodeWriter.GenerateCode();
+            Assert.Equal(
+@"WriteLiteral("" "");
+WriteLiteral(""👦"");
+",
+                csharp,
+                ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
+        public void WriteHtmlLiteral_GreaterThanMaxSize_SequencedZeroWithJoinedEmojisSplit()
+        {
+            // Arrange
+            var codeWriter = new CodeWriter();
+            var writer = new RuntimeNodeWriter();
+            var context = TestCodeRenderingContext.CreateRuntime();
+
+            // Act
+            writer.WriteHtmlLiteral(context, maxStringLiteralLength: 6, "👩‍👩‍👧‍👧👩‍👩‍👧‍👧");
+
+            // Assert
+            var csharp = context.CodeWriter.GenerateCode();
+            Assert.Equal(
+@"WriteLiteral(""👩‍👩‍"");
+WriteLiteral(""👧‍👧"");
+WriteLiteral(""👩‍👩‍"");
+WriteLiteral(""👧‍👧"");
+",
+                csharp,
+                ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
         public void WriteHtmlContent_RendersContentCorrectly()
         {
             // Arrange


### PR DESCRIPTION
- When a surrogate pair is about to be split down the middle we reduce the size of our split by 1 character. This way we split right before a surrogate pair. In the case of zero width joiners, if we split on a zero width joiner we still render valid bytes because the zero width joiner by itself can stand alone.
- Added tests for the various split cases.

#2470