### PR TITLE
Changed `GetDesiredIndentation` to be resilient to our SyntaxTree which occasionally has gaps.

### DIFF
--- a/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorIndentationFactsService.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorIndentationFactsService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var previousLineEndIndex = GetPreviousLineEndIndex(syntaxTreeSnapshot, line);
             var simulatedChange = new SourceChange(previousLineEndIndex, 0, string.Empty);
             var owningSpan = syntaxTree.Root.LocateOwner(simulatedChange);
-            if (owningSpan.Kind == SpanKindInternal.Code)
+            if (owningSpan == null || owningSpan.Kind == SpanKindInternal.Code)
             {
                 // Example,
                 // @{\n

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
@@ -167,6 +167,33 @@ namespace Microsoft.VisualStudio.Editor.Razor
             Assert.Equal(0, indentLevel);
         }
 
+        // This test verifies that we still operate on SyntaxTree's that have gaps in them. The gaps are temporary
+        // until our work with the parser has been completed.
+        [Fact]
+        public void GetDesiredIndentation_ReturnsNull_IfOwningSpanDoesNotExist()
+        {
+            // Arrange
+            var source = new StringTextSnapshot($@"
+<div>
+    <div>
+    </div>
+</div>
+");
+            var syntaxTree = GetSyntaxTree(new StringTextSnapshot("something else"));
+            var service = new DefaultRazorIndentationFactsService();
+
+            // Act
+            var indentation = service.GetDesiredIndentation(
+                syntaxTree,
+                source,
+                source.GetLineFromLineNumber(3),
+                indentSize: 4,
+                tabSize: 1);
+
+            // Assert
+            Assert.Null(indentation);
+        }
+
         [Fact]
         public void GetDesiredIndentation_ReturnsNull_IfOwningSpanIsCode()
         {


### PR DESCRIPTION
- Added a test to cover the scenario.

#2489