### PR TITLE
Fix BackgroundDocumentGenerator flaky tests.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentGenerator/BackgroundDocumentGenerator.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentGenerator/BackgroundDocumentGenerator.cs
@@ -56,6 +56,9 @@ namespace Microsoft.CodeAnalysis.Razor
         // Used in unit tests to ensure we can know when background work finishes.
         public ManualResetEventSlim NotifyBackgroundWorkStarting { get; set; }
 
+        // Used in unit tests to ensure we can know when background has captured its current workload.
+        public ManualResetEventSlim NotifyBackgroundCapturedWorkload { get; set; }
+
         // Used in unit tests to ensure we can control when background work completes.
         public ManualResetEventSlim BlockBackgroundWorkCompleting { get; set; }
 
@@ -90,6 +93,14 @@ namespace Microsoft.CodeAnalysis.Razor
             if (NotifyBackgroundWorkCompleted != null)
             {
                 NotifyBackgroundWorkCompleted.Set();
+            }
+        }
+
+        private void OnBackgroundCapturedWorkload()
+        {
+            if (NotifyBackgroundCapturedWorkload != null)
+            {
+                NotifyBackgroundCapturedWorkload.Set();
             }
         }
 
@@ -160,6 +171,8 @@ namespace Microsoft.CodeAnalysis.Razor
                     work = _files.Values.ToArray();
                     _files.Clear();
                 }
+
+                OnBackgroundCapturedWorkload();
 
                 for (var i = 0; i < work.Length; i++)
                 {

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             queue.BlockBackgroundWorkStart.Set();
             queue.BlockBackgroundWorkCompleting.Set();
 
-            await Task.Run(() => queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(1)));
+            await Task.Run(() => queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
             Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");
@@ -120,6 +120,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 Delay = TimeSpan.FromMilliseconds(1),
                 BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false),
                 NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false),
+                NotifyBackgroundCapturedWorkload = new ManualResetEventSlim(initialState: false),
                 BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false),
                 NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false),
             };
@@ -136,6 +137,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             await Task.Run(() => queue.NotifyBackgroundWorkStarting.Wait(TimeSpan.FromSeconds(1)));
 
             Assert.True(queue.IsScheduledOrRunning, "Worker should be processing now");
+
+            await Task.Run(() => queue.NotifyBackgroundCapturedWorkload.Wait(TimeSpan.FromSeconds(1)));
             Assert.False(queue.HasPendingNotifications, "Worker should have taken all notifications");
 
             queue.Enqueue(project, project.GetDocument(Documents[1].FilePath));
@@ -144,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Allow work to complete, which should restart the timer.
             queue.BlockBackgroundWorkCompleting.Set();
 
-            await Task.Run(() => queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(1)));
+            await Task.Run(() => queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
             queue.NotifyBackgroundWorkCompleted.Reset();
 
             // It should start running again right away.
@@ -155,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             queue.BlockBackgroundWorkStart.Set();
 
             queue.BlockBackgroundWorkCompleting.Set();
-            await Task.Run(() => queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(1)));
+            await Task.Run(() => queue.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
             Assert.False(queue.IsScheduledOrRunning, "Queue should not have restarted");
             Assert.False(queue.HasPendingNotifications, "Queue should have processed all notifications");


### PR DESCRIPTION
- Some time spans were too aggressive for parsing a Razor file on a slow environment.
- Fixed an obvious race where we'd expect 0 pending notifications when it was possible to be in the process of clearing notifications.

#2506