### PR TITLE
Re-enable hanging test

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildServerIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/BuildServerIntegrationTest.cs
@@ -143,9 +143,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             // it reaches server creation part.
         }
 
-        // Skipping on linux/mac because of https://github.com/aspnet/Razor/issues/2507.
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        [Fact]
         [InitializeTestProject("SimpleMvc")]
         public async Task ManualServerShutdown_NoPipeName_ShutsDownServer()
         {


### PR DESCRIPTION
#2525 

- Figured out the root cause for the hang and added a timeout to prevent it.
- Re-enabled the test on linux and Mac