### PR TITLE
Introduces a 'formatter' for formatting the IR

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblySigningCertName>Microsoft</AssemblySigningCertName>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/InjectIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/InjectIntermediateNode.cs
@@ -47,5 +47,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
 
             extension.WriteInjectProperty(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(MemberName);
+
+            formatter.WriteProperty(nameof(MemberName), MemberName);
+            formatter.WriteProperty(nameof(TypeName), TypeName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/ViewComponentTagHelperIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/ViewComponentTagHelperIntermediateNode.cs
@@ -47,5 +47,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
 
             extension.WriteViewComponentTagHelper(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(ClassName);
+
+            formatter.WriteProperty(nameof(ClassName), ClassName);
+            formatter.WriteProperty(nameof(TagHelper), TagHelper?.DisplayName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/InjectIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/InjectIntermediateNode.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
@@ -46,6 +45,14 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             }
 
             extension.WriteInjectProperty(context, this);
+        }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(MemberName);
+
+            formatter.WriteProperty(nameof(MemberName), MemberName);
+            formatter.WriteProperty(nameof(TypeName), TypeName);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTagHelperIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Razor.Extensions/ViewComponentTagHelperIntermediateNode.cs
@@ -47,5 +47,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
             extension.WriteViewComponentTagHelper(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(ClassName);
+
+            formatter.WriteProperty(nameof(ClassName), ClassName);
+            formatter.WriteProperty(nameof(TagHelper), TagHelper?.DisplayName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperCreateIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperCreateIntermediateNode.cs
@@ -48,5 +48,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteTagHelperCreate(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(TypeName);
+
+            formatter.WriteProperty(nameof(FieldName), FieldName);
+            formatter.WriteProperty(nameof(TagHelper), TagHelper?.DisplayName);
+            formatter.WriteProperty(nameof(TypeName), TypeName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperHtmlAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperHtmlAttributeIntermediateNode.cs
@@ -72,5 +72,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteTagHelperHtmlAttribute(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(AttributeName);
+
+            formatter.WriteProperty(nameof(AttributeName), AttributeName);
+            formatter.WriteProperty(nameof(AttributeStructure), AttributeStructure.ToString());
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperPropertyIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DefaultTagHelperPropertyIntermediateNode.cs
@@ -85,5 +85,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteTagHelperProperty(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(AttributeName);
+
+            formatter.WriteProperty(nameof(AttributeName), AttributeName);
+            formatter.WriteProperty(nameof(AttributeStructure), AttributeStructure.ToString());
+            formatter.WriteProperty(nameof(BoundAttribute), BoundAttribute?.DisplayName);
+            formatter.WriteProperty(nameof(FieldName), FieldName);
+            formatter.WriteProperty(nameof(IsIndexerNameMatch), IsIndexerNameMatch.ToString());
+            formatter.WriteProperty(nameof(PropertyName), PropertyName);
+            formatter.WriteProperty(nameof(TagHelper), TagHelper?.DisplayName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveIntermediateNode.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperHtmlAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperHtmlAttributeIntermediateNode.cs
@@ -44,5 +44,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteTagHelperHtmlAttribute(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(VariableName);
+
+            formatter.WriteProperty(nameof(VariableName), VariableName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperHtmlAttributeValueIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperHtmlAttributeValueIntermediateNode.cs
@@ -74,5 +74,15 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteTagHelperHtmlAttributeValue(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(AttributeName);
+
+            formatter.WriteProperty(nameof(AttributeName), AttributeName);
+            formatter.WriteProperty(nameof(AttributeStructure), AttributeStructure.ToString());
+            formatter.WriteProperty(nameof(Value), Value);
+            formatter.WriteProperty(nameof(VariableName), VariableName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperPropertyIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperPropertyIntermediateNode.cs
@@ -79,5 +79,19 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteTagHelperProperty(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(AttributeName);
+
+            formatter.WriteProperty(nameof(AttributeName), AttributeName);
+            formatter.WriteProperty(nameof(AttributeStructure), AttributeStructure.ToString());
+            formatter.WriteProperty(nameof(BoundAttribute), BoundAttribute?.DisplayName);
+            formatter.WriteProperty(nameof(FieldName), FieldName);
+            formatter.WriteProperty(nameof(IsIndexerNameMatch), IsIndexerNameMatch.ToString());
+            formatter.WriteProperty(nameof(PropertyName), PropertyName);
+            formatter.WriteProperty(nameof(TagHelper), TagHelper?.DisplayName);
+            formatter.WriteProperty(nameof(VariableName), VariableName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperPropertyValueIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/PreallocatedTagHelperPropertyValueIntermediateNode.cs
@@ -50,5 +50,15 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteTagHelperPropertyValue(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(AttributeName);
+
+            formatter.WriteProperty(nameof(AttributeName), AttributeName);
+            formatter.WriteProperty(nameof(AttributeStructure), AttributeStructure.ToString());
+            formatter.WriteProperty(nameof(Value), Value);
+            formatter.WriteProperty(nameof(VariableName), VariableName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/RazorCompiledItemAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/RazorCompiledItemAttributeIntermediateNode.cs
@@ -48,5 +48,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteRazorCompiledItemAttribute(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteProperty(nameof(Identifier), Identifier);
+            formatter.WriteProperty(nameof(Kind), Kind);
+            formatter.WriteProperty(nameof(TypeName), TypeName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/RazorCompiledItemMetadataAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/RazorCompiledItemMetadataAttributeIntermediateNode.cs
@@ -55,5 +55,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteRazorCompiledItemMetadataAttribute(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteProperty(nameof(Key), Key);
+            formatter.WriteProperty(nameof(Value), Value);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/SectionIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/SectionIntermediateNode.cs
@@ -44,5 +44,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
             extension.WriteSection(context, this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(SectionName);
+
+            formatter.WriteProperty(nameof(SectionName), SectionName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CSharpCodeAttributeValueIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CSharpCodeAttributeValueIntermediateNode.cs
@@ -20,5 +20,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitCSharpCodeAttributeValue(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteChildren(Children);
+
+            formatter.WriteProperty(nameof(Prefix), Prefix);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CSharpCodeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CSharpCodeIntermediateNode.cs
@@ -18,5 +18,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitCSharpCode(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteChildren(Children);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CSharpExpressionAttributeValueIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CSharpExpressionAttributeValueIntermediateNode.cs
@@ -20,5 +20,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitCSharpExpressionAttributeValue(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteChildren(Children);
+
+            formatter.WriteProperty(nameof(Prefix), Prefix);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CSharpExpressionIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/CSharpExpressionIntermediateNode.cs
@@ -18,5 +18,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitCSharpExpression(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteChildren(Children);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/ClassDeclarationIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/ClassDeclarationIntermediateNode.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 {
@@ -28,6 +29,17 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
             }
 
             visitor.VisitClassDeclaration(this);
+        }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(ClassName);
+
+            formatter.WriteProperty(nameof(BaseType), BaseType);
+            formatter.WriteProperty(nameof(ClassName), ClassName);
+            formatter.WriteProperty(nameof(Interfaces), string.Join(", ", Interfaces));
+            formatter.WriteProperty(nameof(Modifiers), string.Join(", ", Modifiers));
+            formatter.WriteProperty(nameof(TypeParameters), string.Join(", ", TypeParameters.Select(t => t.ParameterName)));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/DebuggerDisplayFormatter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/DebuggerDisplayFormatter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+{
+    internal class DebuggerDisplayFormatter : IntermediateNodeFormatterBase
+    {
+        public DebuggerDisplayFormatter()
+        {
+            Writer = new StringWriter();
+            ContentMode = FormatterContentMode.PreferContent;
+        }
+
+        public override string ToString()
+        {
+            return Writer.ToString();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/DirectiveIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/DirectiveIntermediateNode.cs
@@ -20,5 +20,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
         {
             visitor.VisitDirective(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(DirectiveName);
+
+            formatter.WriteProperty(nameof(Directive), Directive?.DisplayName);
+            formatter.WriteProperty(nameof(DirectiveName), DirectiveName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/DirectiveTokenIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/DirectiveTokenIntermediateNode.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright(c) .NET Foundation.All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text;
+
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 {
     public sealed class DirectiveTokenIntermediateNode : IntermediateNode
@@ -14,6 +16,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
         public override void Accept(IntermediateNodeVisitor visitor)
         {
             visitor.VisitDirectiveToken(this);
+        }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(Content);
+
+            formatter.WriteProperty(nameof(Content), Content);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/DocumentIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/DocumentIntermediateNode.cs
@@ -25,5 +25,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitDocument(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(DocumentKind);
+
+            formatter.WriteProperty(nameof(DocumentKind), DocumentKind);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/FieldDeclarationIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/FieldDeclarationIntermediateNode.cs
@@ -25,5 +25,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitFieldDeclaration(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(FieldName);
+
+            formatter.WriteProperty(nameof(FieldName), FieldName);
+            formatter.WriteProperty(nameof(FieldType), FieldType);
+            formatter.WriteProperty(nameof(Modifiers), string.Join(" ", Modifiers));
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlAttributeIntermediateNode.cs
@@ -24,5 +24,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitHtmlAttribute(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(AttributeName);
+
+            formatter.WriteProperty(nameof(AttributeName), AttributeName);
+            formatter.WriteProperty(nameof(Prefix), Prefix);
+            formatter.WriteProperty(nameof(Suffix), Suffix);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlAttributeValueIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlAttributeValueIntermediateNode.cs
@@ -20,5 +20,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitHtmlAttributeValue(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteChildren(Children);
+
+            formatter.WriteProperty(nameof(Prefix), Prefix);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlContentIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/HtmlContentIntermediateNode.cs
@@ -18,5 +18,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitHtml(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteChildren(Children);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateNode.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
+
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 {
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public abstract class IntermediateNode
     {
         private ItemCollection _annotations;
@@ -39,7 +42,30 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
         public bool HasDiagnostics => _diagnostics != null && _diagnostics.Count > 0;
 
         public SourceSpan? Source { get; set; }
-        
+
         public abstract void Accept(IntermediateNodeVisitor visitor);
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+        private string Tree
+        {
+            get
+            {
+                var formatter = new DebuggerDisplayFormatter();
+                formatter.FormatTree(this);
+                return formatter.ToString();
+            }
+        }
+
+        private string DebuggerToString()
+        {
+            var formatter = new DebuggerDisplayFormatter();
+            formatter.FormatNode(this);
+            return formatter.ToString();
+        }
+
+
+        public virtual void FormatNode(IntermediateNodeFormatter formatter)
+        {
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateNodeFormatter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateNodeFormatter.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+{
+    public abstract class IntermediateNodeFormatter
+    {
+        public abstract void WriteChildren(IntermediateNodeCollection children);
+
+        public abstract void WriteContent(string content);
+
+        public abstract void WriteProperty(string key, string value);
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateNodeFormatterBase.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateNodeFormatterBase.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language.Intermediate
+{
+    internal class IntermediateNodeFormatterBase : IntermediateNodeFormatter
+    {
+        private string _content;
+        private Dictionary<string, string> _properties = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        protected FormatterContentMode ContentMode { get; set; }
+
+        protected bool IncludeSource { get; set; }
+
+        protected TextWriter Writer { get; set; }
+
+        public override void WriteChildren(IntermediateNodeCollection children)
+        {
+            if (children == null)
+            {
+                throw new ArgumentNullException(nameof(children));
+            }
+
+            Writer.Write(" ");
+            Writer.Write("\"");
+            for (var i = 0; i < children.Count; i++)
+            {
+                var child = children[i] as IntermediateToken;
+                if (child != null)
+                {
+                    Writer.Write(EscapeNewlines(child.Content));
+                }
+            }
+            Writer.Write("\"");
+        }
+
+        public override void WriteContent(string content)
+        {
+            if (content == null)
+            {
+                return;
+            }
+
+            _content = EscapeNewlines(content);
+        }
+
+        public override void WriteProperty(string key, string value)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (value == null)
+            {
+                return;
+            }
+
+            _properties.Add(key, EscapeNewlines(value));
+        }
+
+        public void FormatNode(IntermediateNode node)
+        {
+            if (node == null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            BeginNode(node);
+            node.FormatNode(this);
+            EndNode(node);
+        }
+
+        public void FormatTree(IntermediateNode node)
+        {
+            if (node == null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            var visitor = new FormatterVisitor(this);
+            visitor.Visit(node);
+        }
+
+        private void BeginNode(IntermediateNode node)
+        {
+            Writer.Write(GetShortName(node));
+
+            if (IncludeSource)
+            {
+                Writer.Write(" ");
+                Writer.Write(node.Source?.ToString() ?? "(n/a)");
+            }
+        }
+
+        private void EndNode(IntermediateNode node)
+        {
+            if (_content != null && (_properties.Count == 0 || ContentMode == FormatterContentMode.PreferContent))
+            {
+                Writer.Write(" ");
+                Writer.Write("\"");
+                Writer.Write(EscapeNewlines(_content));
+                Writer.Write("\"");
+            }
+
+            if (_properties.Count > 0 && (_content == null || ContentMode == FormatterContentMode.PreferProperties))
+            {
+                Writer.Write(" ");
+                Writer.Write("{ ");
+                Writer.Write(string.Join(", ", _properties.Select(kvp => $"{kvp.Key}: \"{kvp.Value}\"")));
+                Writer.Write(" }");
+            }
+
+            _content = null;
+            _properties.Clear();
+        }
+
+        private string GetShortName(IntermediateNode node)
+        {
+            var typeName = node.GetType().Name;
+            return
+                typeName.EndsWith(nameof(IntermediateNode), StringComparison.Ordinal) ?
+                typeName.Substring(0, typeName.Length - nameof(IntermediateNode).Length) :
+                typeName;
+        }
+
+        private string EscapeNewlines(string content)
+        {
+            return content.Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+        }
+
+        // Depending on the usage of the formatter we might prefer thoroughness (properties)
+        // or brevity (content). Generally if a node has a single string that provides value
+        // it has content.
+        //
+        // Some nodes have neither: TagHelperBody
+        // Some nodes have content: HtmlContent
+        // Some nodes have properties: Document
+        // Some nodes have both: TagHelperProperty
+        protected enum FormatterContentMode
+        {
+            PreferContent,
+            PreferProperties,
+        }
+
+        protected class FormatterVisitor : IntermediateNodeWalker
+        {
+            private const int IndentSize = 2;
+
+            private readonly IntermediateNodeFormatterBase _formatter;
+            private int _indent = 0;
+
+            public FormatterVisitor(IntermediateNodeFormatterBase formatter)
+            {
+                _formatter = formatter;
+            }
+
+            public override void VisitDefault(IntermediateNode node)
+            {
+                // Indent
+                for (var i = 0; i < _indent; i++)
+                {
+                    _formatter.Writer.Write(' ');
+                }
+                _formatter.FormatNode(node);
+                _formatter.Writer.WriteLine();
+                
+                // Process children
+                _indent += IndentSize;
+                base.VisitDefault(node);
+                _indent -= IndentSize;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateToken.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/IntermediateToken.cs
@@ -26,7 +26,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitToken(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(Content);
+
+            formatter.WriteProperty(nameof(Content), Content);
+        }
     }
 }
-
-

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/MalformedDirectiveIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/MalformedDirectiveIntermediateNode.cs
@@ -20,5 +20,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
         {
             visitor.VisitMalformedDirective(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(DirectiveName);
+
+            formatter.WriteProperty(nameof(Directive), Directive?.DisplayName);
+            formatter.WriteProperty(nameof(DirectiveName), DirectiveName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/MethodDeclarationIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/MethodDeclarationIntermediateNode.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 {
@@ -28,5 +30,31 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
             visitor.VisitMethodDeclaration(this);
         }
 
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(MethodName);
+
+            formatter.WriteProperty(nameof(MethodName), MethodName);
+            formatter.WriteProperty(nameof(Modifiers), string.Join(", ", Modifiers));
+            formatter.WriteProperty(nameof(Parameters), string.Join(", ", Parameters.Select(FormatMethodParameter)));
+            formatter.WriteProperty(nameof(ReturnType), ReturnType);
+        }
+
+        private static string FormatMethodParameter(MethodParameter parameter)
+        {
+            var builder = new StringBuilder();
+            for (var i = 0; i <parameter.Modifiers.Count; i++)
+            {
+                builder.Append(parameter.Modifiers[i]);
+                builder.Append(" ");
+            }
+
+            builder.Append(parameter.TypeName);
+            builder.Append(" ");
+
+            builder.Append(parameter.ParameterName);
+
+            return builder.ToString();
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/NamespaceDeclarationIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/NamespaceDeclarationIntermediateNode.cs
@@ -20,5 +20,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitNamespaceDeclaration(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(Content);
+
+            formatter.WriteProperty(nameof(Content), Content);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperHtmlAttributeIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperHtmlAttributeIntermediateNode.cs
@@ -22,5 +22,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitTagHelperHtmlAttribute(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(AttributeName);
+
+            formatter.WriteProperty(nameof(AttributeName), AttributeName);
+            formatter.WriteProperty(nameof(AttributeStructure), AttributeStructure.ToString());
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperIntermediateNode.cs
@@ -44,5 +44,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitTagHelper(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(TagName);
+
+            formatter.WriteProperty(nameof(TagHelpers), string.Join(", ", TagHelpers.Select(t => t.DisplayName)));
+            formatter.WriteProperty(nameof(TagMode), TagMode.ToString());
+            formatter.WriteProperty(nameof(TagName), TagName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperPropertyIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/TagHelperPropertyIntermediateNode.cs
@@ -28,5 +28,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitTagHelperProperty(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(AttributeName);
+
+            formatter.WriteProperty(nameof(AttributeName), AttributeName);
+            formatter.WriteProperty(nameof(AttributeStructure), AttributeStructure.ToString());
+            formatter.WriteProperty(nameof(BoundAttribute), BoundAttribute?.DisplayName);
+            formatter.WriteProperty(nameof(IsIndexerNameMatch), IsIndexerNameMatch.ToString());
+            formatter.WriteProperty(nameof(TagHelper), TagHelper?.DisplayName);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Razor.Language/Intermediate/UsingDirectiveIntermediateNode.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Intermediate/UsingDirectiveIntermediateNode.cs
@@ -20,5 +20,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
             visitor.VisitUsingDirective(this);
         }
+
+        public override void FormatNode(IntermediateNodeFormatter formatter)
+        {
+            formatter.WriteContent(Content);
+
+            formatter.WriteProperty(nameof(Content), Content);
+        }
     }
 }


### PR DESCRIPTION
The new Formatter is used in debugger display, to resolve #2264

The next iteration (assuming we like this) will be to replat our testing
baseline infrastructure on top of this, and then start sharing that with
Blazor - related to #2265.

I found when implementing debugger display that I was duplicating a lot
of details between testing and this.

I also want to convert the Blazor tests to use shared infrastructure.
Right now the Blazor tests use a modified version of the Razor
infrastructure that has different features.