### PR TITLE
Update korebuild VS version range

### DIFF
--- a/korebuild.json
+++ b/korebuild.json
@@ -5,7 +5,7 @@
     "visualstudio": {
       "required": false,
       "includePrerelease": true,
-      "versionRange": "[15.0.26730.03, 15.8)",
+      "versionRange": "[15.0.26730.03, 15.9)",
       "requiredWorkloads": [
         "Microsoft.VisualStudio.Component.VSSDK"
       ]


### PR DESCRIPTION
This removes the requirement to have a 15.7 VS to build the VSIX