### PR TITLE
Allow building this repo with VS 15.x

### DIFF
--- a/korebuild.json
+++ b/korebuild.json
@@ -5,7 +5,7 @@
     "visualstudio": {
       "required": false,
       "includePrerelease": true,
-      "versionRange": "[15.0.26730.03, 15.8)",
+      "versionRange": "[15.0.26730.03, 16.0)",
       "requiredWorkloads": [
         "Microsoft.VisualStudio.Component.VSSDK"
       ]


### PR DESCRIPTION
This is more like an FYI PR. We need this change because our CI environments have updated or will update soon to VS 15.8