### PR TITLE
Allow content to be written after caught exception from child TagHelper.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
+++ b/src/Microsoft.AspNetCore.Razor.Runtime/Runtime/TagHelpers/TagHelperExecutionContext.cs
@@ -258,8 +258,14 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             if (childContent == null)
             {
                 _startTagHelperWritingScope(null);
-                await _executeChildContentAsync();
-                childContent = _endTagHelperWritingScope();
+                try
+                {
+                    await _executeChildContentAsync();
+                }
+                finally
+                {
+                    childContent = _endTagHelperWritingScope();
+                }
             }
 
             Debug.Assert(!Output.IsContentModified);
@@ -292,8 +298,14 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
             if (!useCachedResult || childContent == null)
             {
                 _startTagHelperWritingScope(encoder);
-                await _executeChildContentAsync();
-                childContent = _endTagHelperWritingScope();
+                try
+                {
+                    await _executeChildContentAsync();
+                }
+                finally
+                {
+                    childContent = _endTagHelperWritingScope();
+                }
 
                 if (encoder == null)
                 {

--- a/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Runtime.Test/Runtime/TagHelpers/TagHelperExecutionContextTest.cs
@@ -16,6 +16,53 @@ namespace Microsoft.AspNetCore.Razor.Runtime.TagHelpers
     public class TagHelperExecutionContextTest
     {
         [Fact]
+        public async Task SetOutputContentAsync_CanHandleExceptionThrowingChildContent()
+        {
+            // Arrange
+            var calledEnd = false;
+            var executionContext = new TagHelperExecutionContext(
+                "p",
+                tagMode: TagMode.StartTagAndEndTag,
+                items: new Dictionary<object, object>(),
+                uniqueId: string.Empty,
+                executeChildContentAsync: () => throw new Exception(),
+                startTagHelperWritingScope: _ => { },
+                endTagHelperWritingScope: () =>
+                {
+                    calledEnd = true;
+                    return new DefaultTagHelperContent();
+                });
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(async () => await executionContext.SetOutputContentAsync());
+            Assert.True(calledEnd);
+        }
+
+        [Fact]
+        public async Task GetChildContentAsync_CanHandleExceptionThrowingChildContent()
+        {
+            // Arrange
+            var calledEnd = false;
+            var executionContext = new TagHelperExecutionContext(
+                "p",
+                tagMode: TagMode.StartTagAndEndTag,
+                items: new Dictionary<object, object>(),
+                uniqueId: string.Empty,
+                executeChildContentAsync: () => throw new Exception(),
+                startTagHelperWritingScope: _ => { },
+                endTagHelperWritingScope: () =>
+                {
+                    calledEnd = true;
+                    return new DefaultTagHelperContent();
+                });
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(
+                async () => await executionContext.GetChildContentAsync(useCachedResult: false, encoder: null));
+            Assert.True(calledEnd);
+        }
+
+        [Fact]
         public async Task SetOutputContentAsync_SetsOutputsContent()
         {
             // Arrange


### PR DESCRIPTION
- The issue was that the `executeChildContentAsync` call was stopping the invocation of the `_endTagHelperWritingScope`. Therefore, we'd never finish the TagHelper content scope and all following content would be ignored.
- Added two tests to validate the new functionality.

#2561