### PR TITLE
Allow TagHelpers to occur after unclosed C# blocks without assert failures.

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -136,8 +136,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 // scope. Block scopes are special cases in Razor such as @<p> would cause an error because there's no
                 // matching end </p> tag in the template block scope and therefore doesn't make sense as a tag helper.
                 BuildMalformedTagHelpers(_trackerStack.Count - activeTrackers, errorSink);
-
-                Debug.Assert(activeTrackers == _trackerStack.Count);
             }
 
             BuildCurrentlyTrackedBlock();


### PR DESCRIPTION
- This scenario wasn't considered previously.

#2566 

FYI mostly, waiting for 2.2 to be open.