### PR TITLE
Better logging to help debug test failure

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildProcessManager.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildProcessManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             TimeSpan? timeout = null,
             MSBuildProcessKind msBuildProcessKind = MSBuildProcessKind.Dotnet)
         {
-            timeout = timeout ?? TimeSpan.FromSeconds(60);
+            timeout = timeout ?? TimeSpan.FromSeconds(120);
 
             var processStartInfo = new ProcessStartInfo()
             {
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
                 // This is a timeout.
                 process.Kill();
-                throw new TimeoutException($"command '${process.StartInfo.FileName} {process.StartInfo.Arguments}' timed out after {timeout}.");
+                throw new TimeoutException($"command '${process.StartInfo.FileName} {process.StartInfo.Arguments}' timed out after {timeout}. Output: {output.ToString()}");
             });
 
             var waitTask = Task.Run(() =>


### PR DESCRIPTION
https://github.com/aspnet/Razor/issues/2571

Looks like all these tests have suddenly started timing out during restore on Mac. My guess is either restore is slow on Mac for some reason or there is some underlying problem in MsBuild with Mac. Either way this should help us debug what's really going on