### PR TITLE
Make it so the RazorDirectiveCompletionProvider doesn't load extra as…

### DIFF
--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionProviderTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/RazorDirectiveCompletionProviderTest.cs
@@ -29,7 +29,10 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var razorBuffer = Mock.Of<ITextBuffer>(buffer => buffer.ContentType == Mock.Of<IContentType>());
             TextBufferProvider = Mock.Of<RazorTextBufferProvider>(provider => provider.TryGetFromDocument(It.IsAny<TextDocument>(), out razorBuffer) == true);
             CompletionFactsService = new DefaultRazorCompletionFactsService();
+            CompletionProviderDependencies = new Lazy<CompletionProviderDependencies>(() => new DefaultCompletionProviderDependencies(CompletionFactsService, CompletionBroker));
         }
+
+        private Lazy<CompletionProviderDependencies> CompletionProviderDependencies { get; }
 
         private IAsyncCompletionBroker CompletionBroker { get; }
 
@@ -51,8 +54,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var codeDocumentProvider = new Mock<RazorCodeDocumentProvider>();
             var completionProvider = new RazorDirectiveCompletionProvider(
                 new Lazy<RazorCodeDocumentProvider>(() => codeDocumentProvider.Object),
-                new Lazy<RazorCompletionFactsService>(() => CompletionFactsService),
-                CompletionBroker,
+                CompletionProviderDependencies,
                 TextBufferProvider);
 
             // Act
@@ -74,8 +76,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var codeDocumentProvider = new Mock<RazorCodeDocumentProvider>();
             var completionProvider = new RazorDirectiveCompletionProvider(
                 new Lazy<RazorCodeDocumentProvider>(() => codeDocumentProvider.Object),
-                new Lazy<RazorCompletionFactsService>(() => CompletionFactsService),
-                CompletionBroker,
+                CompletionProviderDependencies,
                 TextBufferProvider);
 
             // Act
@@ -93,7 +94,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var codeDocumentProvider = new Mock<RazorCodeDocumentProvider>(MockBehavior.Strict);
             var completionProvider = new FailOnGetCompletionsProvider(
                 new Lazy<RazorCodeDocumentProvider>(() => codeDocumentProvider.Object),
-                CompletionBroker,
+                CompletionProviderDependencies,
                 TextBufferProvider);
             var document = CreateDocument();
             document = document.WithFilePath("NotRazor.cs");
@@ -121,7 +122,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var codeDocumentProvider = new Mock<RazorCodeDocumentProvider>(MockBehavior.Strict);
             var completionProvider = new FailOnGetCompletionsProvider(
                 new Lazy<RazorCodeDocumentProvider>(() => codeDocumentProvider.Object),
-                CompletionBroker,
+                CompletionProviderDependencies,
                 TextBufferProvider);
             var context = CreateContext(1, completionProvider, document);
 
@@ -139,7 +140,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 .Returns(false);
             var completionProvider = new FailOnGetCompletionsProvider(
                 new Lazy<RazorCodeDocumentProvider>(() => codeDocumentProvider.Object),
-                CompletionBroker,
+                CompletionProviderDependencies,
                 TextBufferProvider);
             var document = CreateDocument();
             var context = CreateContext(1, completionProvider, document);
@@ -155,7 +156,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var codeDocumentProvider = CreateCodeDocumentProvider("@", Enumerable.Empty<DirectiveDescriptor>());
             var completionProvider = new FailOnGetCompletionsProvider(
                 codeDocumentProvider,
-                CompletionBroker,
+                CompletionProviderDependencies,
                 TextBufferProvider,
                 canGetSnapshotPoint: false);
             var document = CreateDocument();
@@ -222,10 +223,10 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             public FailOnGetCompletionsProvider(
                 Lazy<RazorCodeDocumentProvider> codeDocumentProvider,
-                IAsyncCompletionBroker asyncCompletionBroker,
+                Lazy<CompletionProviderDependencies> completionProviderDependencies,
                 RazorTextBufferProvider textBufferProvider,
                 bool canGetSnapshotPoint = true)
-                : base(codeDocumentProvider, new Lazy<RazorCompletionFactsService>(() => new DefaultRazorCompletionFactsService()), asyncCompletionBroker, textBufferProvider)
+                : base(codeDocumentProvider, completionProviderDependencies, textBufferProvider)
             {
                 _canGetSnapshotPoint = canGetSnapshotPoint;
             }


### PR DESCRIPTION
…semblies in C#.

- Added a layer of indirection to allow for proper Lazy loading of Razor and future async completion specific assemblies.