### PR TITLE
Print an error when using Razor build with an older version of the Sdk

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.CodeGeneration.targets
+++ b/src/Microsoft.AspNetCore.Razor.Design/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.CodeGeneration.targets
@@ -4,8 +4,15 @@
     This target is explicitly imported by Razor SDK.
   -->
 
-  <UsingTask TaskName="Microsoft.AspNetCore.Razor.Tasks.RazorGenerate" AssemblyFile="$(RazorSdkBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.AspNetCore.Razor.Tasks.RazorTagHelper" AssemblyFile="$(RazorSdkBuildTasksAssembly)" />
+  <UsingTask
+    TaskName="Microsoft.AspNetCore.Razor.Tasks.RazorGenerate"
+    AssemblyFile="$(RazorSdkBuildTasksAssembly)"
+    Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
+
+  <UsingTask
+    TaskName="Microsoft.AspNetCore.Razor.Tasks.RazorTagHelper"
+    AssemblyFile="$(RazorSdkBuildTasksAssembly)"
+    Condition="'$(RazorSdkBuildTasksAssembly)' != ''" />
 
   <!-- 
     Consider these properties to be private to this targets file. The main Razor SDK should define all of the properties
@@ -51,7 +58,7 @@
 
   <Target
     Name="ResolveTagHelperRazorGenerateInputs"
-    DependsOnTargets="Compile"
+    DependsOnTargets="_EnsureRazorTasksAssemblyDefined;Compile"
     Inputs="$(MSBuildAllProjects);@(RazorReferencePath)"
     Outputs="$(_RazorTagHelperInputCache)"
     Condition="'@(RazorGenerateWithTargetPath)' != ''">
@@ -100,6 +107,7 @@
 
   <PropertyGroup>
     <RazorCoreGenerateDependsOn>
+      _EnsureRazorTasksAssemblyDefined;
       _HashRazorGenerateInputs;
       _ResolveRazorGenerateOutputs;
     </RazorCoreGenerateDependsOn>
@@ -147,6 +155,12 @@
     <ItemGroup>
       <RazorCompile Include="@(_RazorGenerateOutput)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="_EnsureRazorTasksAssemblyDefined">
+    <Error 
+      Text="Assembly location for Razor SDK Tasks was not specified. The most likely cause is an older incompatible version of Microsoft.NET.Sdk.Razor, or Microsoft.NET.Sdk.Web used by this project. Please target a newer version of the .NET Core SDK." 
+      Condition="'$(RazorSdkBuildTasksAssembly)' == ''" />
   </Target>
 
 </Project>


### PR DESCRIPTION
When referencing a 2.2 version of Razor.Design but targeting an older build of Razor.Sdk, builds currently fail with:

> The result "" of evaluating the value "$(RazorSdkBuildTasksAssembly)" of the "AssemblyFile" attribute in element <UsingTask> is not valid.

Since this affects also projects that do not contain any Razor files (e.g. API only MVC projects), users may find this frustrating. The fix here is to no-op if the variable isn't set and print a more meaningful error before we use the tasks.

