### PR TITLE
Fix #2054 - make TagHelperResolutionResult internal

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolutionResult.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolutionResult.cs
@@ -7,9 +7,9 @@ using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
-    public sealed class TagHelperResolutionResult
+    internal sealed class TagHelperResolutionResult
     {
-        internal static TagHelperResolutionResult Empty = new TagHelperResolutionResult(Array.Empty<TagHelperDescriptor>(), Array.Empty<RazorDiagnostic>());
+        internal static readonly TagHelperResolutionResult Empty = new TagHelperResolutionResult(Array.Empty<TagHelperDescriptor>(), Array.Empty<RazorDiagnostic>());
 
         public TagHelperResolutionResult(IReadOnlyList<TagHelperDescriptor> descriptors, IReadOnlyList<RazorDiagnostic> diagnostics)
         {


### PR DESCRIPTION
This type isn't used by WTE anymore.