### PR TITLE
New baselines for HtmlBlockTest

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlBlockTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlBlockTest.cs
@@ -8,6 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     public class HtmlBlockTest : CsHtmlMarkupParserTestBase
     {
+        public HtmlBlockTest()
+        {
+            UseNewSyntaxTree = true;
+        }
+
         [Fact]
         public void HandlesUnbalancedTripleDashHTMLComments()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AcceptsEmptyTextTag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AcceptsEmptyTextTag.stree.txt
@@ -1,7 +1,7 @@
-Markup block - Gen<None> - 7 - (0:0,0)
-    Tag block - Gen<None> - 7 - (0:0,0)
-        Transition span - Gen<None> - [<text/>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[text];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..7) - FullWidth: 7 - [<text/>]
+    MarkupTagBlock - [0..7) - FullWidth: 7
+        MarkupTransition - [0..7) - FullWidth: 7 - Gen<None> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[text];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AcceptsTextTagAsOuterTagButDoesNotRender.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AcceptsTextTagAsOuterTagButDoesNotRender.stree.txt
@@ -1,25 +1,25 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Tag block - Gen<None> - 6 - (0:0,0)
-        Transition span - Gen<None> - [<text>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[text];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [Foo Bar ] - SpanEditHandler;Accepts:None - (6:0,6) - Tokens:4
-        SyntaxKind.Text;[Foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[Bar];
-        SyntaxKind.Whitespace;[ ];
-    Tag block - Gen<None> - 5 - (14:0,14)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (14:0,14) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [ Baz] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:2
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[Baz];
-    Tag block - Gen<None> - 7 - (23:0,23)
-        Transition span - Gen<None> - [</text>] - SpanEditHandler;Accepts:None - (23:0,23) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[text];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..30) - FullWidth: 30 - [<text>Foo Bar <foo> Baz</text>]
+    MarkupTagBlock - [0..6) - FullWidth: 6
+        MarkupTransition - [0..6) - FullWidth: 6 - Gen<None> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[text];
+            CloseAngle;[>];
+    MarkupTextLiteral - [6..14) - FullWidth: 8 - Gen<Markup> - SpanEditHandler;Accepts:None
+        Text;[Foo];
+        Whitespace;[ ];
+        Text;[Bar];
+        Whitespace;[ ];
+    MarkupTagBlock - [14..19) - FullWidth: 5
+        MarkupTextLiteral - [14..19) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [19..23) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Whitespace;[ ];
+        Text;[Baz];
+    MarkupTagBlock - [23..30) - FullWidth: 7
+        MarkupTransition - [23..30) - FullWidth: 7 - Gen<None> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[text];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsCloseAngleBracketInAttributeValueIfDoubleQuoted.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsCloseAngleBracketInAttributeValueIfDoubleQuoted.stree.txt
@@ -1,30 +1,34 @@
-Markup block - Gen<None> - 26 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 15 - (5:0,5)
-        Markup span - Gen<Markup> - [<bar] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[bar];
-        Markup block - Gen<Attr:baz, baz="@(9:0,9),"@(16:0,16)> - 8 - (9:0,9)
-            Markup span - Gen<None> - [ baz="] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[baz];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(15:0,15)> - [>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (20:0,20)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..26) - FullWidth: 26 - [<foo><bar baz=">" /></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTagBlock - [5..20) - FullWidth: 15
+        MarkupTextLiteral - [5..9) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[bar];
+        MarkupAttributeBlock - [9..17) - FullWidth: 8
+            MarkupTextLiteral - [9..10) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [10..13) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[baz];
+            Equals;[=];
+            MarkupTextLiteral - [14..15) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+            GenericBlock - [15..16) - FullWidth: 1
+                MarkupLiteralAttributeValue - [15..16) - FullWidth: 1
+                    MarkupTextLiteral - [15..16) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        CloseAngle;[>];
+            MarkupTextLiteral - [16..17) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+        MarkupTextLiteral - [17..20) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];
+    MarkupTagBlock - [20..26) - FullWidth: 6
+        MarkupTextLiteral - [20..26) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsCloseAngleBracketInAttributeValueIfSingleQuoted.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsCloseAngleBracketInAttributeValueIfSingleQuoted.stree.txt
@@ -1,30 +1,34 @@
-Markup block - Gen<None> - 26 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 15 - (5:0,5)
-        Markup span - Gen<Markup> - [<bar] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[bar];
-        Markup block - Gen<Attr:baz, baz='@(9:0,9),'@(16:0,16)> - 8 - (9:0,9)
-            Markup span - Gen<None> - [ baz='] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[baz];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(15:0,15)> - [>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (20:0,20)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..26) - FullWidth: 26 - [<foo><bar baz='>' /></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTagBlock - [5..20) - FullWidth: 15
+        MarkupTextLiteral - [5..9) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[bar];
+        MarkupAttributeBlock - [9..17) - FullWidth: 8
+            MarkupTextLiteral - [9..10) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [10..13) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[baz];
+            Equals;[=];
+            MarkupTextLiteral - [14..15) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [15..16) - FullWidth: 1
+                MarkupLiteralAttributeValue - [15..16) - FullWidth: 1
+                    MarkupTextLiteral - [15..16) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        CloseAngle;[>];
+            MarkupTextLiteral - [16..17) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [17..20) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];
+    MarkupTagBlock - [20..26) - FullWidth: 6
+        MarkupTextLiteral - [20..26) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsSlashInAttributeValueIfDoubleQuoted.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsSlashInAttributeValueIfDoubleQuoted.stree.txt
@@ -1,34 +1,38 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 13 - (5:0,5)
-        Markup span - Gen<Markup> - [<bar] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[bar];
-        Markup block - Gen<Attr:baz, baz="@(9:0,9),"@(16:0,16)> - 8 - (9:0,9)
-            Markup span - Gen<None> - [ baz="] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[baz];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(15:0,15)> - [/] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                SyntaxKind.ForwardSlash;[/];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (18:0,18)
-        Markup span - Gen<Markup> - [</bar>] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[bar];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (24:0,24)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..30) - FullWidth: 30 - [<foo><bar baz="/"></bar></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTagBlock - [5..18) - FullWidth: 13
+        MarkupTextLiteral - [5..9) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[bar];
+        MarkupAttributeBlock - [9..17) - FullWidth: 8
+            MarkupTextLiteral - [9..10) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [10..13) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[baz];
+            Equals;[=];
+            MarkupTextLiteral - [14..15) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+            GenericBlock - [15..16) - FullWidth: 1
+                MarkupLiteralAttributeValue - [15..16) - FullWidth: 1
+                    MarkupTextLiteral - [15..16) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        ForwardSlash;[/];
+            MarkupTextLiteral - [16..17) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+        MarkupTextLiteral - [17..18) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:None
+            CloseAngle;[>];
+    MarkupTagBlock - [18..24) - FullWidth: 6
+        MarkupTextLiteral - [18..24) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[bar];
+            CloseAngle;[>];
+    MarkupTagBlock - [24..30) - FullWidth: 6
+        MarkupTextLiteral - [24..30) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsSlashInAttributeValueIfSingleQuoted.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsSlashInAttributeValueIfSingleQuoted.stree.txt
@@ -1,34 +1,38 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 13 - (5:0,5)
-        Markup span - Gen<Markup> - [<bar] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[bar];
-        Markup block - Gen<Attr:baz, baz='@(9:0,9),'@(16:0,16)> - 8 - (9:0,9)
-            Markup span - Gen<None> - [ baz='] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[baz];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(15:0,15)> - [/] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                SyntaxKind.ForwardSlash;[/];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (18:0,18)
-        Markup span - Gen<Markup> - [</bar>] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[bar];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (24:0,24)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..30) - FullWidth: 30 - [<foo><bar baz='/'></bar></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTagBlock - [5..18) - FullWidth: 13
+        MarkupTextLiteral - [5..9) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[bar];
+        MarkupAttributeBlock - [9..17) - FullWidth: 8
+            MarkupTextLiteral - [9..10) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [10..13) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[baz];
+            Equals;[=];
+            MarkupTextLiteral - [14..15) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [15..16) - FullWidth: 1
+                MarkupLiteralAttributeValue - [15..16) - FullWidth: 1
+                    MarkupTextLiteral - [15..16) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        ForwardSlash;[/];
+            MarkupTextLiteral - [16..17) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [17..18) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:None
+            CloseAngle;[>];
+    MarkupTagBlock - [18..24) - FullWidth: 6
+        MarkupTextLiteral - [18..24) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[bar];
+            CloseAngle;[>];
+    MarkupTagBlock - [24..30) - FullWidth: 6
+        MarkupTextLiteral - [24..30) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsStartAndEndTagsToDifferInCase.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsStartAndEndTagsToDifferInCase.stree.txt
@@ -1,25 +1,25 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Tag block - Gen<None> - 4 - (0:0,0)
-        Markup span - Gen<Markup> - [<li>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[li];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 3 - (4:0,4)
-        Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [Foo] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:1
-        SyntaxKind.Text;[Foo];
-    Tag block - Gen<None> - 4 - (10:0,10)
-        Markup span - Gen<Markup> - [</P>] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[P];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (14:0,14)
-        Markup span - Gen<Markup> - [</lI>] - SpanEditHandler;Accepts:None - (14:0,14) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[lI];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..19) - FullWidth: 19 - [<li><p>Foo</P></lI>]
+    MarkupTagBlock - [0..4) - FullWidth: 4
+        MarkupTextLiteral - [0..4) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[li];
+            CloseAngle;[>];
+    MarkupTagBlock - [4..7) - FullWidth: 3
+        MarkupTextLiteral - [4..7) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[p];
+            CloseAngle;[>];
+    MarkupTextLiteral - [7..10) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[Foo];
+    MarkupTagBlock - [10..14) - FullWidth: 4
+        MarkupTextLiteral - [10..14) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[P];
+            CloseAngle;[>];
+    MarkupTagBlock - [14..19) - FullWidth: 5
+        MarkupTextLiteral - [14..19) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[lI];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsUnclosedTagsAsLongAsItCanRecoverToAnExpectedEndTag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/AllowsUnclosedTagsAsLongAsItCanRecoverToAnExpectedEndTag.stree.txt
@@ -1,22 +1,22 @@
-Markup block - Gen<None> - 21 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (5:0,5)
-        Markup span - Gen<Markup> - [<bar>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[bar];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (10:0,10)
-        Markup span - Gen<Markup> - [<baz>] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[baz];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (15:0,15)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..21) - FullWidth: 21 - [<foo><bar><baz></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTagBlock - [5..10) - FullWidth: 5
+        MarkupTextLiteral - [5..10) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[bar];
+            CloseAngle;[>];
+    MarkupTagBlock - [10..15) - FullWidth: 5
+        MarkupTextLiteral - [10..15) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[baz];
+            CloseAngle;[>];
+    MarkupTagBlock - [15..21) - FullWidth: 6
+        MarkupTextLiteral - [15..21) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/CanHandleSelfClosingTagsWithinBlock.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/CanHandleSelfClosingTagsWithinBlock.stree.txt
@@ -1,19 +1,19 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 7 - (5:0,5)
-        Markup span - Gen<Markup> - [<bar />] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:5
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[bar];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (12:0,12)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..18) - FullWidth: 18 - [<foo><bar /></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTagBlock - [5..12) - FullWidth: 7
+        MarkupTextLiteral - [5..12) - FullWidth: 7 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[bar];
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];
+    MarkupTagBlock - [12..18) - FullWidth: 6
+        MarkupTextLiteral - [12..18) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/CorrectlyHandlesSingleLineOfMarkupWithEmbeddedStatement.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/CorrectlyHandlesSingleLineOfMarkupWithEmbeddedStatement.stree.txt
@@ -1,29 +1,29 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<div>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [Foo ] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:2
-        SyntaxKind.Text;[Foo];
-        SyntaxKind.Whitespace;[ ];
-    Statement block - Gen<None> - 12 - (9:0,9)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Stmt> - [if(true) {}] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:7
-            SyntaxKind.Keyword;[if];
-            SyntaxKind.LeftParenthesis;[(];
-            SyntaxKind.Keyword;[true];
-            SyntaxKind.RightParenthesis;[)];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.LeftBrace;[{];
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [ Bar] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:2
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[Bar];
-    Tag block - Gen<None> - 6 - (25:0,25)
-        Markup span - Gen<Markup> - [</div>] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..31) - FullWidth: 31 - [<div>Foo @if(true) {} Bar</div>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[div];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..9) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[Foo];
+        Whitespace;[ ];
+    CSharpCodeBlock - [9..21) - FullWidth: 12
+        CSharpTransition - [9..10) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+            Transition;[@];
+        CSharpStatementLiteral - [10..21) - FullWidth: 11 - Gen<Stmt> - SpanEditHandler;Accepts:Any
+            Keyword;[if];
+            LeftParenthesis;[(];
+            Keyword;[true];
+            RightParenthesis;[)];
+            Whitespace;[ ];
+            LeftBrace;[{];
+            RightBrace;[}];
+    MarkupTextLiteral - [21..25) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Whitespace;[ ];
+        Text;[Bar];
+    MarkupTagBlock - [25..31) - FullWidth: 6
+        MarkupTextLiteral - [25..31) - FullWidth: 6 - Gen<None> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[div];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/DoesNotConsiderPsuedoTagWithinMarkupBlock.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/DoesNotConsiderPsuedoTagWithinMarkupBlock.stree.txt
@@ -1,28 +1,28 @@
-Markup block - Gen<None> - 28 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (5:0,5)
-        Markup span - Gen<Markup> - [<text>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[text];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (11:0,11)
-        Markup span - Gen<Markup> - [<bar>] - SpanEditHandler;Accepts:None - (11:0,11) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[bar];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (16:0,16)
-        Markup span - Gen<Markup> - [</bar>] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[bar];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (22:0,22)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (22:0,22) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..28) - FullWidth: 28 - [<foo><text><bar></bar></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTagBlock - [5..11) - FullWidth: 6
+        MarkupTextLiteral - [5..11) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[text];
+            CloseAngle;[>];
+    MarkupTagBlock - [11..16) - FullWidth: 5
+        MarkupTextLiteral - [11..16) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[bar];
+            CloseAngle;[>];
+    MarkupTagBlock - [16..22) - FullWidth: 6
+        MarkupTextLiteral - [16..22) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[bar];
+            CloseAngle;[>];
+    MarkupTagBlock - [22..28) - FullWidth: 6
+        MarkupTextLiteral - [22..28) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/DoesNotTerminateXMLProcInstrAtCloseAngleUnlessPreceededByQuestionMark.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/DoesNotTerminateXMLProcInstrAtCloseAngleUnlessPreceededByQuestionMark.stree.txt
@@ -1,25 +1,25 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<?xml foo bar> baz?>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:12
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.QuestionMark;[?];
-        SyntaxKind.Text;[xml];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[bar];
-        SyntaxKind.CloseAngle;[>];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.QuestionMark;[?];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (25:0,25)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..31) - FullWidth: 31 - [<foo><?xml foo bar> baz?></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..25) - FullWidth: 20 - Gen<Markup> - SpanEditHandler;Accepts:None
+        OpenAngle;[<];
+        QuestionMark;[?];
+        Text;[xml];
+        Whitespace;[ ];
+        Text;[foo];
+        Whitespace;[ ];
+        Text;[bar];
+        CloseAngle;[>];
+        Whitespace;[ ];
+        Text;[baz];
+        QuestionMark;[?];
+        CloseAngle;[>];
+    MarkupTagBlock - [25..31) - FullWidth: 6
+        MarkupTextLiteral - [25..31) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/HandlesOpenAngleAtEof.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/HandlesOpenAngleAtEof.stree.txt
@@ -1,14 +1,20 @@
-Markup block - Gen<None> - 5 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 5 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Code span - Gen<Stmt> - [LF] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[}];AtEOL - (2:0,2) - Tokens:1
-            SyntaxKind.NewLine;[LF];
-        Markup block - Gen<None> - 1 - (4:1,0)
-            Tag block - Gen<None> - 1 - (4:1,0)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (4:1,0) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
+RazorDocument - [0..5) - FullWidth: 5 - [@{LF<]
+    MarkupBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..0) - FullWidth: 0 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..5) - FullWidth: 5
+            CSharpStatement - [0..5) - FullWidth: 5
+                CSharpTransition - [0..1) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..5) - FullWidth: 4
+                    RazorMetaCode - [1..2) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..5) - FullWidth: 3
+                        CSharpStatementLiteral - [2..4) - FullWidth: 2 - Gen<Stmt> - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[}];AtEOL
+                            NewLine;[LF];
+                        MarkupBlock - [4..5) - FullWidth: 1
+                            MarkupTagBlock - [4..5) - FullWidth: 1
+                                MarkupTextLiteral - [4..5) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                    RazorMetaCode - [5..5) - FullWidth: 0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/HandlesOpenAngleWithProperTagFollowingIt.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/HandlesOpenAngleWithProperTagFollowingIt.stree.txt
@@ -1,24 +1,30 @@
-Markup block - Gen<None> - 14 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 14 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Code span - Gen<Stmt> - [LF] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[}];AtEOL - (2:0,2) - Tokens:1
-            SyntaxKind.NewLine;[LF];
-        Markup block - Gen<None> - 3 - (4:1,0)
-            Tag block - Gen<None> - 3 - (4:1,0)
-                Markup span - Gen<Markup> - [<LF] - SpanEditHandler;Accepts:Any - (4:1,0) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.NewLine;[LF];
-        Markup block - Gen<None> - 7 - (7:2,0)
-            Tag block - Gen<None> - 7 - (7:2,0)
-                Markup span - Gen<Markup> - [</html>] - SpanEditHandler;Accepts:None - (7:2,0) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[html];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (14:2,7) - Tokens:1
-            SyntaxKind.Unknown;[];
+RazorDocument - [0..14) - FullWidth: 14 - [@{LF<LF</html>]
+    MarkupBlock - [0..14) - FullWidth: 14
+        MarkupTextLiteral - [0..0) - FullWidth: 0 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..14) - FullWidth: 14
+            CSharpStatement - [0..14) - FullWidth: 14
+                CSharpTransition - [0..1) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..14) - FullWidth: 13
+                    RazorMetaCode - [1..2) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..14) - FullWidth: 12
+                        CSharpStatementLiteral - [2..4) - FullWidth: 2 - Gen<Stmt> - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[}];AtEOL
+                            NewLine;[LF];
+                        MarkupBlock - [4..7) - FullWidth: 3
+                            MarkupTagBlock - [4..7) - FullWidth: 3
+                                MarkupTextLiteral - [4..7) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    NewLine;[LF];
+                        MarkupBlock - [7..14) - FullWidth: 7
+                            MarkupTagBlock - [7..14) - FullWidth: 7
+                                MarkupTextLiteral - [7..14) - FullWidth: 7 - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[html];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [14..14) - FullWidth: 0 - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [14..14) - FullWidth: 0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/HandlesUnbalancedTripleDashHTMLComments.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/HandlesUnbalancedTripleDashHTMLComments.stree.txt
@@ -1,52 +1,56 @@
-Markup block - Gen<None> - 68 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 68 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Code span - Gen<Stmt> - [LF] - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL - (2:0,2) - Tokens:1
-            SyntaxKind.NewLine;[LF];
-        Markup block - Gen<None> - 63 - (4:1,0)
-            Markup span - Gen<Markup> - [    ] - SpanEditHandler;Accepts:Any - (4:1,0) - Tokens:1
-                SyntaxKind.Whitespace;[    ];
-            HtmlComment block - Gen<None> - 57 - (8:1,4)
-                Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (8:1,4) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Bang;[!];
-                    SyntaxKind.DoubleHyphen;[--];
-                Markup span - Gen<Markup> - [ Hello, I'm a comment that shouldn't break razor -] - SpanEditHandler;Accepts:Whitespace - (12:1,8) - Tokens:22
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[Hello,];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[I];
-                    SyntaxKind.SingleQuote;['];
-                    SyntaxKind.Text;[m];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[a];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[comment];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[that];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[shouldn];
-                    SyntaxKind.SingleQuote;['];
-                    SyntaxKind.Text;[t];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[break];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[razor];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[-];
-                Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (62:1,58) - Tokens:2
-                    SyntaxKind.DoubleHyphen;[--];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:None - (65:1,61) - Tokens:1
-                SyntaxKind.NewLine;[LF];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (67:2,0) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (67:2,0) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (68:2,1) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..68) - FullWidth: 68 - [@{LF    <!-- Hello, I'm a comment that shouldn't break razor --->LF}]
+    MarkupBlock - [0..68) - FullWidth: 68
+        MarkupTextLiteral - [0..0) - FullWidth: 0 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..68) - FullWidth: 68
+            CSharpStatement - [0..68) - FullWidth: 68
+                CSharpTransition - [0..1) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..68) - FullWidth: 67
+                    RazorMetaCode - [1..2) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..67) - FullWidth: 65
+                        CSharpStatementLiteral - [2..4) - FullWidth: 2 - Gen<Stmt> - AutoCompleteEditHandler;Accepts:Any,AutoComplete:[<null>];AtEOL
+                            NewLine;[LF];
+                        MarkupBlock - [4..67) - FullWidth: 63
+                            MarkupTextLiteral - [4..8) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Whitespace;[    ];
+                            MarkupCommentBlock - [8..65) - FullWidth: 57
+                                MarkupTextLiteral - [8..12) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    Bang;[!];
+                                    DoubleHyphen;[--];
+                                MarkupTextLiteral - [12..62) - FullWidth: 50 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                                    Whitespace;[ ];
+                                    Text;[Hello,];
+                                    Whitespace;[ ];
+                                    Text;[I];
+                                    SingleQuote;['];
+                                    Text;[m];
+                                    Whitespace;[ ];
+                                    Text;[a];
+                                    Whitespace;[ ];
+                                    Text;[comment];
+                                    Whitespace;[ ];
+                                    Text;[that];
+                                    Whitespace;[ ];
+                                    Text;[shouldn];
+                                    SingleQuote;['];
+                                    Text;[t];
+                                    Whitespace;[ ];
+                                    Text;[break];
+                                    Whitespace;[ ];
+                                    Text;[razor];
+                                    Whitespace;[ ];
+                                    Text;[-];
+                                MarkupTextLiteral - [62..65) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    DoubleHyphen;[--];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [65..67) - FullWidth: 2 - Gen<Markup> - SpanEditHandler;Accepts:None
+                                NewLine;[LF];
+                        CSharpStatementLiteral - [67..67) - FullWidth: 0 - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [67..68) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [68..68) - FullWidth: 0 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/HtmlCommentSupportsMultipleDashes.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/HtmlCommentSupportsMultipleDashes.stree.txt
@@ -1,133 +1,134 @@
-Markup block - Gen<None> - 165 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<div>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    HtmlComment block - Gen<None> - 22 - (5:0,5)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [- Hello World -] - SpanEditHandler;Accepts:Whitespace - (9:0,9) - Tokens:7
-            SyntaxKind.Text;[-];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[Hello];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[World];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[-];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (27:0,27)
-        Markup span - Gen<Markup> - [</div>] - SpanEditHandler;Accepts:Any - (27:0,27) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [LF] - [33..35) - FullWidth: 2 - Slots: 1
-        SyntaxKind.NewLine;[LF];
-    Tag block - Gen<None> - 5 - (35:1,0)
-        Markup span - Gen<Markup> - [<div>] - SpanEditHandler;Accepts:Any - (35:1,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    HtmlComment block - Gen<None> - 24 - (40:1,5)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (40:1,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [-- Hello World --] - SpanEditHandler;Accepts:Whitespace - (44:1,9) - Tokens:7
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[Hello];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[World];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (61:1,26) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (64:1,29)
-        Markup span - Gen<Markup> - [</div>] - SpanEditHandler;Accepts:Any - (64:1,29) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [LF] - [70..72) - FullWidth: 2 - Slots: 1
-        SyntaxKind.NewLine;[LF];
-    Tag block - Gen<None> - 5 - (72:2,0)
-        Markup span - Gen<Markup> - [<div>] - SpanEditHandler;Accepts:Any - (72:2,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    HtmlComment block - Gen<None> - 26 - (77:2,5)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (77:2,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [--- Hello World ---] - SpanEditHandler;Accepts:Whitespace - (81:2,9) - Tokens:9
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.Text;[-];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[Hello];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[World];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.Text;[-];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (100:2,28) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (103:2,31)
-        Markup span - Gen<Markup> - [</div>] - SpanEditHandler;Accepts:Any - (103:2,31) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [LF] - [109..111) - FullWidth: 2 - Slots: 1
-        SyntaxKind.NewLine;[LF];
-    Tag block - Gen<None> - 5 - (111:3,0)
-        Markup span - Gen<Markup> - [<div>] - SpanEditHandler;Accepts:Any - (111:3,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    HtmlComment block - Gen<None> - 41 - (116:3,5)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (116:3,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [--- Hello < --- > World </div> ---] - SpanEditHandler;Accepts:Whitespace - (120:3,9) - Tokens:21
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.Text;[-];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[Hello];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.Text;[-];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.CloseAngle;[>];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[World];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.Text;[-];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (154:3,43) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (157:3,46)
-        Markup span - Gen<Markup> - [</div>] - SpanEditHandler;Accepts:Any - (157:3,46) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:Any - (163:3,52) - Tokens:1
-        SyntaxKind.NewLine;[LF];
+RazorDocument - [0..165) - FullWidth: 165 - [<div><!--- Hello World ---></div>LF<div><!---- Hello World ----></div>LF<div><!----- Hello World -----></div>LF<div><!----- Hello < --- > World </div> -----></div>LF]
+    MarkupBlock - [0..165) - FullWidth: 165
+        MarkupTagBlock - [0..5) - FullWidth: 5
+            MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupCommentBlock - [5..27) - FullWidth: 22
+            MarkupTextLiteral - [5..9) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+                OpenAngle;[<];
+                Bang;[!];
+                DoubleHyphen;[--];
+            MarkupTextLiteral - [9..24) - FullWidth: 15 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                Text;[-];
+                Whitespace;[ ];
+                Text;[Hello];
+                Whitespace;[ ];
+                Text;[World];
+                Whitespace;[ ];
+                Text;[-];
+            MarkupTextLiteral - [24..27) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+                DoubleHyphen;[--];
+                CloseAngle;[>];
+        MarkupTagBlock - [27..33) - FullWidth: 6
+            MarkupTextLiteral - [27..33) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupTextLiteral - [33..35) - FullWidth: 2 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            NewLine;[LF];
+        MarkupTagBlock - [35..40) - FullWidth: 5
+            MarkupTextLiteral - [35..40) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupCommentBlock - [40..64) - FullWidth: 24
+            MarkupTextLiteral - [40..44) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+                OpenAngle;[<];
+                Bang;[!];
+                DoubleHyphen;[--];
+            MarkupTextLiteral - [44..61) - FullWidth: 17 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                DoubleHyphen;[--];
+                Whitespace;[ ];
+                Text;[Hello];
+                Whitespace;[ ];
+                Text;[World];
+                Whitespace;[ ];
+                DoubleHyphen;[--];
+            MarkupTextLiteral - [61..64) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+                DoubleHyphen;[--];
+                CloseAngle;[>];
+        MarkupTagBlock - [64..70) - FullWidth: 6
+            MarkupTextLiteral - [64..70) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupTextLiteral - [70..72) - FullWidth: 2 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            NewLine;[LF];
+        MarkupTagBlock - [72..77) - FullWidth: 5
+            MarkupTextLiteral - [72..77) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupCommentBlock - [77..103) - FullWidth: 26
+            MarkupTextLiteral - [77..81) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+                OpenAngle;[<];
+                Bang;[!];
+                DoubleHyphen;[--];
+            MarkupTextLiteral - [81..100) - FullWidth: 19 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                DoubleHyphen;[--];
+                Text;[-];
+                Whitespace;[ ];
+                Text;[Hello];
+                Whitespace;[ ];
+                Text;[World];
+                Whitespace;[ ];
+                DoubleHyphen;[--];
+                Text;[-];
+            MarkupTextLiteral - [100..103) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+                DoubleHyphen;[--];
+                CloseAngle;[>];
+        MarkupTagBlock - [103..109) - FullWidth: 6
+            MarkupTextLiteral - [103..109) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupTextLiteral - [109..111) - FullWidth: 2 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            NewLine;[LF];
+        MarkupTagBlock - [111..116) - FullWidth: 5
+            MarkupTextLiteral - [111..116) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupCommentBlock - [116..157) - FullWidth: 41
+            MarkupTextLiteral - [116..120) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+                OpenAngle;[<];
+                Bang;[!];
+                DoubleHyphen;[--];
+            MarkupTextLiteral - [120..154) - FullWidth: 34 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                DoubleHyphen;[--];
+                Text;[-];
+                Whitespace;[ ];
+                Text;[Hello];
+                Whitespace;[ ];
+                OpenAngle;[<];
+                Whitespace;[ ];
+                DoubleHyphen;[--];
+                Text;[-];
+                Whitespace;[ ];
+                CloseAngle;[>];
+                Whitespace;[ ];
+                Text;[World];
+                Whitespace;[ ];
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[div];
+                CloseAngle;[>];
+                Whitespace;[ ];
+                DoubleHyphen;[--];
+                Text;[-];
+            MarkupTextLiteral - [154..157) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+                DoubleHyphen;[--];
+                CloseAngle;[>];
+        MarkupTagBlock - [157..163) - FullWidth: 6
+            MarkupTextLiteral - [157..163) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupTextLiteral - [163..165) - FullWidth: 2 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            NewLine;[LF];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/IgnoresTagsInContentsOfScriptTag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/IgnoresTagsInContentsOfScriptTag.stree.txt
@@ -1,28 +1,31 @@
-Markup block - Gen<None> - 36 - (0:0,0)
-    Tag block - Gen<None> - 8 - (0:0,0)
-        Markup span - Gen<Markup> - [<script>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [foo<bar baz='] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:7
-        SyntaxKind.Text;[foo];
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Text;[bar];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.Equals;[=];
-        SyntaxKind.SingleQuote;['];
-    Expression block - Gen<Expr> - 4 - (21:0,21)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [boz] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (22:0,22) - Tokens:1
-            SyntaxKind.Identifier;[boz];
-    Markup span - Gen<Markup> - ['>] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:2
-        SyntaxKind.SingleQuote;['];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (27:0,27)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:None - (27:0,27) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..36) - FullWidth: 36 - [<script>foo<bar baz='@boz'></script>]
+    MarkupTagBlock - [0..8) - FullWidth: 8
+        MarkupTextLiteral - [0..8) - FullWidth: 8 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[script];
+            CloseAngle;[>];
+    MarkupTextLiteral - [8..21) - FullWidth: 13 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[foo];
+        OpenAngle;[<];
+        Text;[bar];
+        Whitespace;[ ];
+        Text;[baz];
+        Equals;[=];
+        SingleQuote;['];
+    CSharpCodeBlock - [21..25) - FullWidth: 4
+        CSharpImplicitExpression - [21..25) - FullWidth: 4
+            CSharpTransition - [21..22) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpImplicitExpressionBody - [22..25) - FullWidth: 3
+                CSharpCodeBlock - [22..25) - FullWidth: 3
+                    CSharpExpressionLiteral - [22..25) - FullWidth: 3 - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                        Identifier;[boz];
+    MarkupTextLiteral - [25..27) - FullWidth: 2 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        SingleQuote;['];
+        CloseAngle;[>];
+    MarkupTagBlock - [27..36) - FullWidth: 9
+        MarkupTextLiteral - [27..36) - FullWidth: 9 - Gen<None> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[script];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/OnlyTerminatesCommentOnFullEndSequence.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/OnlyTerminatesCommentOnFullEndSequence.stree.txt
@@ -1,18 +1,18 @@
-Markup block - Gen<None> - 20 - (0:0,0)
-    HtmlComment block - Gen<None> - 20 - (0:0,0)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [<foo>--</bar>] - SpanEditHandler;Accepts:Whitespace - (4:0,4) - Tokens:8
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[bar];
-            SyntaxKind.CloseAngle;[>];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..20) - FullWidth: 20 - [<!--<foo>--</bar>-->]
+    MarkupCommentBlock - [0..20) - FullWidth: 20
+        MarkupTextLiteral - [0..4) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Bang;[!];
+            DoubleHyphen;[--];
+        MarkupTextLiteral - [4..17) - FullWidth: 13 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+            DoubleHyphen;[--];
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[bar];
+            CloseAngle;[>];
+        MarkupTextLiteral - [17..20) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            DoubleHyphen;[--];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ParsesSGMLDeclarationAsEmptyTag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ParsesSGMLDeclarationAsEmptyTag.stree.txt
@@ -1,23 +1,23 @@
-Markup block - Gen<None> - 33 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<!DOCTYPE foo bar baz>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:10
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Bang;[!];
-        SyntaxKind.Text;[DOCTYPE];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[bar];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (27:0,27)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (27:0,27) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..33) - FullWidth: 33 - [<foo><!DOCTYPE foo bar baz></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..27) - FullWidth: 22 - Gen<Markup> - SpanEditHandler;Accepts:None
+        OpenAngle;[<];
+        Bang;[!];
+        Text;[DOCTYPE];
+        Whitespace;[ ];
+        Text;[foo];
+        Whitespace;[ ];
+        Text;[bar];
+        Whitespace;[ ];
+        Text;[baz];
+        CloseAngle;[>];
+    MarkupTagBlock - [27..33) - FullWidth: 6
+        MarkupTextLiteral - [27..33) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ParsesUntilMatchingEndTagIfFirstNonWhitespaceCharacterIsStartTag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ParsesUntilMatchingEndTagIfFirstNonWhitespaceCharacterIsStartTag.stree.txt
@@ -1,34 +1,34 @@
-Markup block - Gen<None> - 33 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<baz>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[baz];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (5:0,5)
-        Markup span - Gen<Markup> - [<boz>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[boz];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (10:0,10)
-        Markup span - Gen<Markup> - [<biz>] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[biz];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (15:0,15)
-        Markup span - Gen<Markup> - [</biz>] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[biz];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (21:0,21)
-        Markup span - Gen<Markup> - [</boz>] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[boz];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (27:0,27)
-        Markup span - Gen<Markup> - [</baz>] - SpanEditHandler;Accepts:None - (27:0,27) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[baz];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..33) - FullWidth: 33 - [<baz><boz><biz></biz></boz></baz>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[baz];
+            CloseAngle;[>];
+    MarkupTagBlock - [5..10) - FullWidth: 5
+        MarkupTextLiteral - [5..10) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[boz];
+            CloseAngle;[>];
+    MarkupTagBlock - [10..15) - FullWidth: 5
+        MarkupTextLiteral - [10..15) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[biz];
+            CloseAngle;[>];
+    MarkupTagBlock - [15..21) - FullWidth: 6
+        MarkupTextLiteral - [15..21) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[biz];
+            CloseAngle;[>];
+    MarkupTagBlock - [21..27) - FullWidth: 6
+        MarkupTextLiteral - [21..27) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[boz];
+            CloseAngle;[>];
+    MarkupTagBlock - [27..33) - FullWidth: 6
+        MarkupTextLiteral - [27..33) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[baz];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ParsesXMLProcessingInstructionAsEmptyTag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ParsesXMLProcessingInstructionAsEmptyTag.stree.txt
@@ -1,24 +1,24 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<?xml foo bar baz?>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:11
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.QuestionMark;[?];
-        SyntaxKind.Text;[xml];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[bar];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.QuestionMark;[?];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (24:0,24)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..30) - FullWidth: 30 - [<foo><?xml foo bar baz?></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..24) - FullWidth: 19 - Gen<Markup> - SpanEditHandler;Accepts:None
+        OpenAngle;[<];
+        QuestionMark;[?];
+        Text;[xml];
+        Whitespace;[ ];
+        Text;[foo];
+        Whitespace;[ ];
+        Text;[bar];
+        Whitespace;[ ];
+        Text;[baz];
+        QuestionMark;[?];
+        CloseAngle;[>];
+    MarkupTagBlock - [24..30) - FullWidth: 6
+        MarkupTextLiteral - [24..30) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ProperlyBalancesCommentStartAndEndTags.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ProperlyBalancesCommentStartAndEndTags.stree.txt
@@ -1,17 +1,17 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    HtmlComment block - Gen<None> - 18 - (0:0,0)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [<foo></bar>] - SpanEditHandler;Accepts:Whitespace - (4:0,4) - Tokens:7
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[bar];
-            SyntaxKind.CloseAngle;[>];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..18) - FullWidth: 18 - [<!--<foo></bar>-->]
+    MarkupCommentBlock - [0..18) - FullWidth: 18
+        MarkupTextLiteral - [0..4) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Bang;[!];
+            DoubleHyphen;[--];
+        MarkupTextLiteral - [4..15) - FullWidth: 11 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[bar];
+            CloseAngle;[>];
+        MarkupTextLiteral - [15..18) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            DoubleHyphen;[--];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ReadsToEndOfLineIfFirstCharacterAfterTransitionIsColon.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/ReadsToEndOfLineIfFirstCharacterAfterTransitionIsColon.stree.txt
@@ -1,15 +1,15 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-        SyntaxKind.Transition;[@];
-    MetaCode span - Gen<None> - [:] - SpanEditHandler;Accepts:Any - (1:0,1) - Tokens:1
-        SyntaxKind.Colon;[:];
-    Markup span - Gen<Markup> - [<li>Foo Bar BazLF] - SpanEditHandler;Accepts:None - (2:0,2) - Tokens:9
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Text;[li];
-        SyntaxKind.CloseAngle;[>];
-        SyntaxKind.Text;[Foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[Bar];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[Baz];
-        SyntaxKind.NewLine;[LF];
+MarkupBlock - [0..19) - FullWidth: 19 - [@:<li>Foo Bar BazLF]
+    MarkupTransition - [0..1) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+        Transition;[@];
+    RazorMetaCode - [1..2) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+        Colon;[:];
+    MarkupTextLiteral - [2..19) - FullWidth: 17 - Gen<Markup> - SpanEditHandler;Accepts:None
+        OpenAngle;[<];
+        Text;[li];
+        CloseAngle;[>];
+        Text;[Foo];
+        Whitespace;[ ];
+        Text;[Bar];
+        Whitespace;[ ];
+        Text;[Baz];
+        NewLine;[LF];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/RendersLiteralTextTagIfDoubled.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/RendersLiteralTextTagIfDoubled.stree.txt
@@ -1,36 +1,36 @@
-Markup block - Gen<None> - 43 - (0:0,0)
-    Tag block - Gen<None> - 6 - (0:0,0)
-        Transition span - Gen<None> - [<text>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[text];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (6:0,6)
-        Markup span - Gen<Markup> - [<text>] - SpanEditHandler;Accepts:None - (6:0,6) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[text];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [Foo Bar ] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:4
-        SyntaxKind.Text;[Foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[Bar];
-        SyntaxKind.Whitespace;[ ];
-    Tag block - Gen<None> - 5 - (20:0,20)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [ Baz] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:2
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[Baz];
-    Tag block - Gen<None> - 7 - (29:0,29)
-        Markup span - Gen<Markup> - [</text>] - SpanEditHandler;Accepts:None - (29:0,29) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[text];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 7 - (36:0,36)
-        Transition span - Gen<None> - [</text>] - SpanEditHandler;Accepts:None - (36:0,36) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[text];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..43) - FullWidth: 43 - [<text><text>Foo Bar <foo> Baz</text></text>]
+    MarkupTagBlock - [0..6) - FullWidth: 6
+        MarkupTransition - [0..6) - FullWidth: 6 - Gen<None> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[text];
+            CloseAngle;[>];
+    MarkupTagBlock - [6..12) - FullWidth: 6
+        MarkupTextLiteral - [6..12) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[text];
+            CloseAngle;[>];
+    MarkupTextLiteral - [12..20) - FullWidth: 8 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[Foo];
+        Whitespace;[ ];
+        Text;[Bar];
+        Whitespace;[ ];
+    MarkupTagBlock - [20..25) - FullWidth: 5
+        MarkupTextLiteral - [20..25) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [25..29) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Whitespace;[ ];
+        Text;[Baz];
+    MarkupTagBlock - [29..36) - FullWidth: 7
+        MarkupTextLiteral - [29..36) - FullWidth: 7 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[text];
+            CloseAngle;[>];
+    MarkupTagBlock - [36..43) - FullWidth: 7
+        MarkupTransition - [36..43) - FullWidth: 7 - Gen<None> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[text];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/StopsAtMatchingCloseTagToStartTag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/StopsAtMatchingCloseTagToStartTag.stree.txt
@@ -1,23 +1,23 @@
-Markup block - Gen<None> - 14 - (0:0,0)
-    Tag block - Gen<None> - 3 - (0:0,0)
-        Markup span - Gen<Markup> - [<a>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 3 - (3:0,3)
-        Markup span - Gen<Markup> - [<b>] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[b];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 4 - (6:0,6)
-        Markup span - Gen<Markup> - [</b>] - SpanEditHandler;Accepts:None - (6:0,6) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[b];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 4 - (10:0,10)
-        Markup span - Gen<Markup> - [</a>] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[a];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..14) - FullWidth: 14 - [<a><b></b></a>]
+    MarkupTagBlock - [0..3) - FullWidth: 3
+        MarkupTextLiteral - [0..3) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[a];
+            CloseAngle;[>];
+    MarkupTagBlock - [3..6) - FullWidth: 3
+        MarkupTextLiteral - [3..6) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[b];
+            CloseAngle;[>];
+    MarkupTagBlock - [6..10) - FullWidth: 4
+        MarkupTextLiteral - [6..10) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[b];
+            CloseAngle;[>];
+    MarkupTagBlock - [10..14) - FullWidth: 4
+        MarkupTextLiteral - [10..14) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[a];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/StopsParsingMidEmptyTagIfEOFReached.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/StopsParsingMidEmptyTagIfEOFReached.stree.txt
@@ -1,6 +1,6 @@
-Markup block - Gen<None> - 4 - (0:0,0)
-    Tag block - Gen<None> - 4 - (0:0,0)
-        Markup span - Gen<Markup> - [<br/] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[br];
-            SyntaxKind.ForwardSlash;[/];
+MarkupBlock - [0..4) - FullWidth: 4 - [<br/]
+    MarkupTagBlock - [0..4) - FullWidth: 4
+        MarkupTextLiteral - [0..4) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[br];
+            ForwardSlash;[/];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/StopsParsingSingleLineBlockAtEOFIfNoEOLReached.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/StopsParsingSingleLineBlockAtEOFIfNoEOLReached.stree.txt
@@ -1,9 +1,9 @@
-Markup block - Gen<None> - 9 - (0:0,0)
-    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-        SyntaxKind.Transition;[@];
-    MetaCode span - Gen<None> - [:] - SpanEditHandler;Accepts:Any - (1:0,1) - Tokens:1
-        SyntaxKind.Colon;[:];
-    Markup span - Gen<Markup> - [foo bar] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:3
-        SyntaxKind.Text;[foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[bar];
+MarkupBlock - [0..9) - FullWidth: 9 - [@:foo bar]
+    MarkupTransition - [0..1) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:None
+        Transition;[@];
+    RazorMetaCode - [1..2) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+        Colon;[:];
+    MarkupTextLiteral - [2..9) - FullWidth: 7 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[foo];
+        Whitespace;[ ];
+        Text;[bar];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsCommentAsBlock.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsCommentAsBlock.stree.txt
@@ -1,13 +1,13 @@
-Markup block - Gen<None> - 12 - (0:0,0)
-    HtmlComment block - Gen<None> - 12 - (0:0,0)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [ foo ] - SpanEditHandler;Accepts:Whitespace - (4:0,4) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.Whitespace;[ ];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..12) - FullWidth: 12 - [<!-- foo -->]
+    MarkupCommentBlock - [0..12) - FullWidth: 12
+        MarkupTextLiteral - [0..4) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Bang;[!];
+            DoubleHyphen;[--];
+        MarkupTextLiteral - [4..9) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+            Whitespace;[ ];
+            Text;[foo];
+            Whitespace;[ ];
+        MarkupTextLiteral - [9..12) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            DoubleHyphen;[--];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsCommentWithExtraDashAsBlock.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsCommentWithExtraDashAsBlock.stree.txt
@@ -1,14 +1,14 @@
-Markup block - Gen<None> - 13 - (0:0,0)
-    HtmlComment block - Gen<None> - 13 - (0:0,0)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [ foo -] - SpanEditHandler;Accepts:Whitespace - (4:0,4) - Tokens:4
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[-];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..13) - FullWidth: 13 - [<!-- foo --->]
+    MarkupCommentBlock - [0..13) - FullWidth: 13
+        MarkupTextLiteral - [0..4) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Bang;[!];
+            DoubleHyphen;[--];
+        MarkupTextLiteral - [4..10) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+            Whitespace;[ ];
+            Text;[foo];
+            Whitespace;[ ];
+            Text;[-];
+        MarkupTextLiteral - [10..13) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            DoubleHyphen;[--];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsCommentWithinBlock.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsCommentWithinBlock.stree.txt
@@ -1,28 +1,28 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [bar] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:1
-        SyntaxKind.Text;[bar];
-    HtmlComment block - Gen<None> - 13 - (8:0,8)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (8:0,8) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [ zoop ] - SpanEditHandler;Accepts:Whitespace - (12:0,12) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[zoop];
-            SyntaxKind.Whitespace;[ ];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [baz] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:1
-        SyntaxKind.Text;[baz];
-    Tag block - Gen<None> - 6 - (24:0,24)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..30) - FullWidth: 30 - [<foo>bar<!-- zoop -->baz</foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..8) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[bar];
+    MarkupCommentBlock - [8..21) - FullWidth: 13
+        MarkupTextLiteral - [8..12) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Bang;[!];
+            DoubleHyphen;[--];
+        MarkupTextLiteral - [12..18) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+            Whitespace;[ ];
+            Text;[zoop];
+            Whitespace;[ ];
+        MarkupTextLiteral - [18..21) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            DoubleHyphen;[--];
+            CloseAngle;[>];
+    MarkupTextLiteral - [21..24) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+        Text;[baz];
+    MarkupTagBlock - [24..30) - FullWidth: 6
+        MarkupTextLiteral - [24..30) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsScriptTagsWithLessThanSignsInThem.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsScriptTagsWithLessThanSignsInThem.stree.txt
@@ -1,24 +1,24 @@
-Markup block - Gen<None> - 45 - (0:0,0)
-    Tag block - Gen<None> - 8 - (0:0,0)
-        Markup span - Gen<Markup> - [<script>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [if(foo<bar) { alert("baz");)] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:11
-        SyntaxKind.Text;[if(foo];
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Text;[bar)];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[{];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[alert(];
-        SyntaxKind.DoubleQuote;["];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.DoubleQuote;["];
-        SyntaxKind.Text;[);)];
-    Tag block - Gen<None> - 9 - (36:0,36)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:None - (36:0,36) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..45) - FullWidth: 45 - [<script>if(foo<bar) { alert("baz");)</script>]
+    MarkupTagBlock - [0..8) - FullWidth: 8
+        MarkupTextLiteral - [0..8) - FullWidth: 8 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[script];
+            CloseAngle;[>];
+    MarkupTextLiteral - [8..36) - FullWidth: 28 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[if(foo];
+        OpenAngle;[<];
+        Text;[bar)];
+        Whitespace;[ ];
+        Text;[{];
+        Whitespace;[ ];
+        Text;[alert(];
+        DoubleQuote;["];
+        Text;[baz];
+        DoubleQuote;["];
+        Text;[);)];
+    MarkupTagBlock - [36..45) - FullWidth: 9
+        MarkupTextLiteral - [36..45) - FullWidth: 9 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[script];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsScriptTagsWithSpacedLessThanSignsInThem.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsScriptTagsWithSpacedLessThanSignsInThem.stree.txt
@@ -1,26 +1,26 @@
-Markup block - Gen<None> - 47 - (0:0,0)
-    Tag block - Gen<None> - 8 - (0:0,0)
-        Markup span - Gen<Markup> - [<script>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [if(foo < bar) { alert("baz");)] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:13
-        SyntaxKind.Text;[if(foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[bar)];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[{];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[alert(];
-        SyntaxKind.DoubleQuote;["];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.DoubleQuote;["];
-        SyntaxKind.Text;[);)];
-    Tag block - Gen<None> - 9 - (38:0,38)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:None - (38:0,38) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..47) - FullWidth: 47 - [<script>if(foo < bar) { alert("baz");)</script>]
+    MarkupTagBlock - [0..8) - FullWidth: 8
+        MarkupTextLiteral - [0..8) - FullWidth: 8 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[script];
+            CloseAngle;[>];
+    MarkupTextLiteral - [8..38) - FullWidth: 30 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[if(foo];
+        Whitespace;[ ];
+        OpenAngle;[<];
+        Whitespace;[ ];
+        Text;[bar)];
+        Whitespace;[ ];
+        Text;[{];
+        Whitespace;[ ];
+        Text;[alert(];
+        DoubleQuote;["];
+        Text;[baz];
+        DoubleQuote;["];
+        Text;[);)];
+    MarkupTagBlock - [38..47) - FullWidth: 9
+        MarkupTextLiteral - [38..47) - FullWidth: 9 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[script];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsTagsWithAttributes.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/SupportsTagsWithAttributes.stree.txt
@@ -1,48 +1,55 @@
-Markup block - Gen<None> - 48 - (0:0,0)
-    Tag block - Gen<None> - 15 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-        Markup block - Gen<Attr:bar, bar="@(4:0,4),"@(13:0,13)> - 10 - (4:0,4)
-            Markup span - Gen<None> - [ bar="] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[bar];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(10:0,10)> - [baz] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[baz];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (14:0,14) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (15:0,15)
-        Markup span - Gen<Markup> - [<biz>] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[biz];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 16 - (20:0,20)
-        Markup span - Gen<Markup> - [<boz] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[boz];
-        Markup block - Gen<Attr:zoop, zoop=@(24:0,24),@(34:0,34)> - 10 - (24:0,24)
-            Markup span - Gen<None> - [ zoop=] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:3
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[zoop];
-                SyntaxKind.Equals;[=];
-            Markup span - Gen<LitAttr:@(30:0,30)> - [zork] - SpanEditHandler;Accepts:Any - (30:0,30) - Tokens:1
-                SyntaxKind.Text;[zork];
-        Markup span - Gen<Markup> - [/>] - SpanEditHandler;Accepts:None - (34:0,34) - Tokens:2
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (36:0,36)
-        Markup span - Gen<Markup> - [</biz>] - SpanEditHandler;Accepts:None - (36:0,36) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[biz];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (42:0,42)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (42:0,42) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..48) - FullWidth: 48 - [<foo bar="baz"><biz><boz zoop=zork/></biz></foo>]
+    MarkupTagBlock - [0..15) - FullWidth: 15
+        MarkupTextLiteral - [0..4) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[foo];
+        MarkupAttributeBlock - [4..14) - FullWidth: 10
+            MarkupTextLiteral - [4..5) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [5..8) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[bar];
+            Equals;[=];
+            MarkupTextLiteral - [9..10) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+            GenericBlock - [10..13) - FullWidth: 3
+                MarkupLiteralAttributeValue - [10..13) - FullWidth: 3
+                    MarkupTextLiteral - [10..13) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[baz];
+            MarkupTextLiteral - [13..14) - FullWidth: 1 - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+        MarkupTextLiteral - [14..15) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:None
+            CloseAngle;[>];
+    MarkupTagBlock - [15..20) - FullWidth: 5
+        MarkupTextLiteral - [15..20) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[biz];
+            CloseAngle;[>];
+    MarkupTagBlock - [20..36) - FullWidth: 16
+        MarkupTextLiteral - [20..24) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[boz];
+        MarkupAttributeBlock - [24..34) - FullWidth: 10
+            MarkupTextLiteral - [24..25) - FullWidth: 1 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [25..29) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[zoop];
+            Equals;[=];
+            GenericBlock - [30..34) - FullWidth: 4
+                MarkupLiteralAttributeValue - [30..34) - FullWidth: 4
+                    MarkupTextLiteral - [30..34) - FullWidth: 4 - Gen<None> - SpanEditHandler;Accepts:Any
+                        Text;[zork];
+        MarkupTextLiteral - [34..36) - FullWidth: 2 - Gen<Markup> - SpanEditHandler;Accepts:None
+            ForwardSlash;[/];
+            CloseAngle;[>];
+    MarkupTagBlock - [36..42) - FullWidth: 6
+        MarkupTextLiteral - [36..42) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[biz];
+            CloseAngle;[>];
+    MarkupTagBlock - [42..48) - FullWidth: 6
+        MarkupTextLiteral - [42..48) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TagWithoutCloseAngleDoesNotTerminateBlock.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TagWithoutCloseAngleDoesNotTerminateBlock.stree.txt
@@ -1,7 +1,7 @@
-Markup block - Gen<None> - 28 - (0:0,0)
-    Tag block - Gen<None> - 28 - (0:0,0)
-        Markup span - Gen<Markup> - [<                      LF   ] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Whitespace;[                      ];
-            SyntaxKind.NewLine;[LF];
-            SyntaxKind.Whitespace;[   ];
+MarkupBlock - [0..28) - FullWidth: 28 - [<                      LF   ]
+    MarkupTagBlock - [0..28) - FullWidth: 28
+        MarkupTextLiteral - [0..28) - FullWidth: 28 - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Whitespace;[                      ];
+            NewLine;[LF];
+            Whitespace;[   ];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesAtEOF.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesAtEOF.stree.txt
@@ -1,6 +1,6 @@
-Markup block - Gen<None> - 5 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..5) - FullWidth: 5 - [<foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesAtEOFWhenParsingComment.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesAtEOFWhenParsingComment.stree.txt
@@ -1,8 +1,8 @@
-Markup block - Gen<None> - 9 - (0:0,0)
-    Markup span - Gen<Markup> - [<!--<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:6
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Bang;[!];
-        SyntaxKind.DoubleHyphen;[--];
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Text;[foo];
-        SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..9) - FullWidth: 9 - [<!--<foo>]
+    MarkupTextLiteral - [0..9) - FullWidth: 9 - Gen<Markup> - SpanEditHandler;Accepts:None
+        OpenAngle;[<];
+        Bang;[!];
+        DoubleHyphen;[--];
+        OpenAngle;[<];
+        Text;[foo];
+        CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesCommentAtFirstOccurrenceOfEndSequence.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesCommentAtFirstOccurrenceOfEndSequence.stree.txt
@@ -1,30 +1,30 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    HtmlComment block - Gen<None> - 17 - (5:0,5)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [<foo></bar] - SpanEditHandler;Accepts:Whitespace - (9:0,9) - Tokens:6
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[bar];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (19:0,19) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (22:0,22) - Tokens:2
-        SyntaxKind.DoubleHyphen;[--];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (25:0,25)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..31) - FullWidth: 31 - [<foo><!--<foo></bar-->--></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupCommentBlock - [5..22) - FullWidth: 17
+        MarkupTextLiteral - [5..9) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Bang;[!];
+            DoubleHyphen;[--];
+        MarkupTextLiteral - [9..19) - FullWidth: 10 - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[bar];
+        MarkupTextLiteral - [19..22) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+            DoubleHyphen;[--];
+            CloseAngle;[>];
+    MarkupTextLiteral - [22..25) - FullWidth: 3 - Gen<Markup> - SpanEditHandler;Accepts:None
+        DoubleHyphen;[--];
+        CloseAngle;[>];
+    MarkupTagBlock - [25..31) - FullWidth: 6
+        MarkupTextLiteral - [25..31) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesSGMLDeclarationAtFirstCloseAngle.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesSGMLDeclarationAtFirstCloseAngle.stree.txt
@@ -1,25 +1,25 @@
-Markup block - Gen<None> - 34 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<!DOCTYPE foo bar>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:8
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Bang;[!];
-        SyntaxKind.Text;[DOCTYPE];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[bar];
-        SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [ baz>] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:3
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (28:0,28)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (28:0,28) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..34) - FullWidth: 34 - [<foo><!DOCTYPE foo bar> baz></foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..23) - FullWidth: 18 - Gen<Markup> - SpanEditHandler;Accepts:None
+        OpenAngle;[<];
+        Bang;[!];
+        Text;[DOCTYPE];
+        Whitespace;[ ];
+        Text;[foo];
+        Whitespace;[ ];
+        Text;[bar];
+        CloseAngle;[>];
+    MarkupTextLiteral - [23..28) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Whitespace;[ ];
+        Text;[baz];
+        CloseAngle;[>];
+    MarkupTagBlock - [28..34) - FullWidth: 6
+        MarkupTextLiteral - [28..34) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesXMLProcessingInstructionAtQuestionMarkCloseAnglePair.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TerminatesXMLProcessingInstructionAtQuestionMarkCloseAnglePair.stree.txt
@@ -1,27 +1,27 @@
-Markup block - Gen<None> - 34 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<?xml foo bar baz?>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:11
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.QuestionMark;[?];
-        SyntaxKind.Text;[xml];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[foo];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[bar];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.QuestionMark;[?];
-        SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [ baz] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:2
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-    Tag block - Gen<None> - 6 - (28:0,28)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (28:0,28) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..34) - FullWidth: 34 - [<foo><?xml foo bar baz?> baz</foo>]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..24) - FullWidth: 19 - Gen<Markup> - SpanEditHandler;Accepts:None
+        OpenAngle;[<];
+        QuestionMark;[?];
+        Text;[xml];
+        Whitespace;[ ];
+        Text;[foo];
+        Whitespace;[ ];
+        Text;[bar];
+        Whitespace;[ ];
+        Text;[baz];
+        QuestionMark;[?];
+        CloseAngle;[>];
+    MarkupTextLiteral - [24..28) - FullWidth: 4 - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Whitespace;[ ];
+        Text;[baz];
+    MarkupTagBlock - [28..34) - FullWidth: 6
+        MarkupTextLiteral - [28..34) - FullWidth: 6 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TreatsMalformedTagsAsContent.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/TreatsMalformedTagsAsContent.stree.txt
@@ -1,17 +1,17 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 13 - (5:0,5)
-        Markup span - Gen<Markup> - [</!-- bar -->] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:9
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[bar];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..18) - FullWidth: 18 - [<foo></!-- bar -->]
+    MarkupTagBlock - [0..5) - FullWidth: 5
+        MarkupTextLiteral - [0..5) - FullWidth: 5 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTagBlock - [5..18) - FullWidth: 13
+        MarkupTextLiteral - [5..18) - FullWidth: 13 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Bang;[!];
+            DoubleHyphen;[--];
+            Whitespace;[ ];
+            Text;[bar];
+            Whitespace;[ ];
+            DoubleHyphen;[--];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/WithSelfClosingTagJustEmitsTag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlBlockTest/WithSelfClosingTagJustEmitsTag.stree.txt
@@ -1,8 +1,8 @@
-Markup block - Gen<None> - 7 - (0:0,0)
-    Tag block - Gen<None> - 7 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo />] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:5
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..7) - FullWidth: 7 - [<foo />]
+    MarkupTagBlock - [0..7) - FullWidth: 7
+        MarkupTextLiteral - [0..7) - FullWidth: 7 - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];


### PR DESCRIPTION
Most of these tests call `MarkupParser.ParseBlock()` instead of `MarkupParser.ParseDocument()`. So these test a different code path in the HtmlParser. Basically it tests the html inside a csharp block.