### PR TITLE
New baselines for HtmlToCodeSwitchTest

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlToCodeSwitchTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlToCodeSwitchTest.cs
@@ -9,6 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     public class HtmlToCodeSwitchTest : CsHtmlMarkupParserTestBase
     {
+        public HtmlToCodeSwitchTest()
+        {
+            UseNewSyntaxTree = true;
+        }
+
         [Fact]
         public void SwitchesWhenCharacterBeforeSwapIsNonAlphanumeric()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/CSharpCodeParserDoesNotAcceptLeadingOrTrailingWhitespaceInDesignMode.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/CSharpCodeParserDoesNotAcceptLeadingOrTrailingWhitespaceInDesignMode.stree.txt
@@ -1,64 +1,67 @@
-Markup block - Gen<None> - 95 - (0:0,0)
-    Markup span - Gen<Markup> - [   ] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Whitespace;[   ];
-    Tag block - Gen<None> - 4 - (3:0,3)
-        Markup span - Gen<Markup> - [<ul>] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[ul];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [LF    ] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:2
-        SyntaxKind.NewLine;[LF];
-        SyntaxKind.Whitespace;[    ];
-    Statement block - Gen<None> - 71 - (13:1,4)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (13:1,4) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Stmt> - [foreach(var p in Products) {LF        ] - SpanEditHandler;Accepts:Any - (14:1,5) - Tokens:14
-            SyntaxKind.Keyword;[foreach];
-            SyntaxKind.LeftParenthesis;[(];
-            SyntaxKind.Identifier;[var];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Identifier;[p];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Keyword;[in];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Identifier;[Products];
-            SyntaxKind.RightParenthesis;[)];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.LeftBrace;[{];
-            SyntaxKind.NewLine;[LF];
-            SyntaxKind.Whitespace;[        ];
-        Markup block - Gen<None> - 25 - (52:2,8)
-            Tag block - Gen<None> - 4 - (52:2,8)
-                Markup span - Gen<Markup> - [<li>] - SpanEditHandler;Accepts:None - (52:2,8) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[li];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [Product: ] - SpanEditHandler;Accepts:Any - (56:2,12) - Tokens:2
-                SyntaxKind.Text;[Product:];
-                SyntaxKind.Whitespace;[ ];
-            Expression block - Gen<Expr> - 7 - (65:2,21)
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (65:2,21) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Expr> - [p.Name] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (66:2,22) - Tokens:3
-                    SyntaxKind.Identifier;[p];
-                    SyntaxKind.Dot;[.];
-                    SyntaxKind.Identifier;[Name];
-            Tag block - Gen<None> - 5 - (72:2,28)
-                Markup span - Gen<Markup> - [</li>] - SpanEditHandler;Accepts:None - (72:2,28) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[li];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [LF    }] - SpanEditHandler;Accepts:None - (77:2,33) - Tokens:3
-            SyntaxKind.NewLine;[LF];
-            SyntaxKind.Whitespace;[    ];
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [LF    ] - SpanEditHandler;Accepts:Any - (84:3,5) - Tokens:2
-        SyntaxKind.NewLine;[LF];
-        SyntaxKind.Whitespace;[    ];
-    Tag block - Gen<None> - 5 - (90:4,4)
-        Markup span - Gen<Markup> - [</ul>] - SpanEditHandler;Accepts:None - (90:4,4) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[ul];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..95)::95 - [   <ul>LF    @foreach(var p in Products) {LF        <li>Product: @p.Name</li>LF    }LF    </ul>]
+    MarkupTextLiteral - [0..3)::3 - [   ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Whitespace;[   ];
+    MarkupTagBlock - [3..7)::4 - [<ul>]
+        MarkupTextLiteral - [3..7)::4 - [<ul>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[ul];
+            CloseAngle;[>];
+    MarkupTextLiteral - [7..13)::6 - [LF    ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        NewLine;[LF];
+        Whitespace;[    ];
+    CSharpCodeBlock - [13..84)::71
+        CSharpTransition - [13..14)::1 - Gen<None> - SpanEditHandler;Accepts:None
+            Transition;[@];
+        CSharpStatementLiteral - [14..52)::38 - [foreach(var p in Products) {LF        ] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+            Keyword;[foreach];
+            LeftParenthesis;[(];
+            Identifier;[var];
+            Whitespace;[ ];
+            Identifier;[p];
+            Whitespace;[ ];
+            Keyword;[in];
+            Whitespace;[ ];
+            Identifier;[Products];
+            RightParenthesis;[)];
+            Whitespace;[ ];
+            LeftBrace;[{];
+            NewLine;[LF];
+            Whitespace;[        ];
+        MarkupBlock - [52..77)::25
+            MarkupTagBlock - [52..56)::4 - [<li>]
+                MarkupTextLiteral - [52..56)::4 - [<li>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    OpenAngle;[<];
+                    Text;[li];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [56..65)::9 - [Product: ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Product:];
+                Whitespace;[ ];
+            CSharpCodeBlock - [65..72)::7
+                CSharpImplicitExpression - [65..72)::7
+                    CSharpTransition - [65..66)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        Transition;[@];
+                    CSharpImplicitExpressionBody - [66..72)::6
+                        CSharpCodeBlock - [66..72)::6
+                            CSharpExpressionLiteral - [66..72)::6 - [p.Name] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                Identifier;[p];
+                                Dot;[.];
+                                Identifier;[Name];
+            MarkupTagBlock - [72..77)::5 - [</li>]
+                MarkupTextLiteral - [72..77)::5 - [</li>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[li];
+                    CloseAngle;[>];
+        CSharpStatementLiteral - [77..84)::7 - [LF    }] - Gen<Stmt> - SpanEditHandler;Accepts:None
+            NewLine;[LF];
+            Whitespace;[    ];
+            RightBrace;[}];
+    MarkupTextLiteral - [84..90)::6 - [LF    ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        NewLine;[LF];
+        Whitespace;[    ];
+    MarkupTagBlock - [90..95)::5 - [</ul>]
+        MarkupTextLiteral - [90..95)::5 - [</ul>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[ul];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/DoesNotSwitchToCodeOnEmailAddressInAttribute.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/DoesNotSwitchToCodeOnEmailAddressInAttribute.stree.txt
@@ -1,27 +1,31 @@
-Markup block - Gen<None> - 50 - (0:0,0)
-    Tag block - Gen<None> - 38 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href="@(2:0,2),"@(36:0,36)> - 35 - (2:0,2)
-            Markup span - Gen<None> - [ href="] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(9:0,9)> - [mailto:anurse@microsoft.com] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:1
-                SyntaxKind.Text;[mailto:anurse@microsoft.com];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (37:0,37) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [Email me] - SpanEditHandler;Accepts:Any - (38:0,38) - Tokens:3
-        SyntaxKind.Text;[Email];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[me];
-    Tag block - Gen<None> - 4 - (46:0,46)
-        Markup span - Gen<Markup> - [</a>] - SpanEditHandler;Accepts:None - (46:0,46) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[a];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..50)::50 - [<a href="mailto:anurse@microsoft.com">Email me</a>]
+    MarkupTagBlock - [0..38)::38 - [<a href="mailto:anurse@microsoft.com">]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..37)::35 - [ href="mailto:anurse@microsoft.com"]
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [8..9)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+            GenericBlock - [9..36)::27
+                MarkupLiteralAttributeValue - [9..36)::27 - [mailto:anurse@microsoft.com]
+                    MarkupTextLiteral - [9..36)::27 - [mailto:anurse@microsoft.com] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[mailto:anurse@microsoft.com];
+            MarkupTextLiteral - [36..37)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+        MarkupTextLiteral - [37..38)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            CloseAngle;[>];
+    MarkupTextLiteral - [38..46)::8 - [Email me] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[Email];
+        Whitespace;[ ];
+        Text;[me];
+    MarkupTagBlock - [46..50)::4 - [</a>]
+        MarkupTextLiteral - [46..50)::4 - [</a>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[a];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/GivesWhitespacePreceedingAtToCodeIfThereIsNoMarkupOnThatLine.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/GivesWhitespacePreceedingAtToCodeIfThereIsNoMarkupOnThatLine.stree.txt
@@ -1,67 +1,70 @@
-Markup block - Gen<None> - 95 - (0:0,0)
-    Markup span - Gen<Markup> - [   ] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Whitespace;[   ];
-    Tag block - Gen<None> - 4 - (3:0,3)
-        Markup span - Gen<Markup> - [<ul>] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[ul];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:1
-        SyntaxKind.NewLine;[LF];
-    Statement block - Gen<None> - 77 - (9:1,0)
-        Code span - Gen<Stmt> - [    ] - SpanEditHandler;Accepts:Any - (9:1,0) - Tokens:1
-            SyntaxKind.Whitespace;[    ];
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (13:1,4) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Stmt> - [foreach(var p in Products) {LF] - SpanEditHandler;Accepts:Any - (14:1,5) - Tokens:13
-            SyntaxKind.Keyword;[foreach];
-            SyntaxKind.LeftParenthesis;[(];
-            SyntaxKind.Identifier;[var];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Identifier;[p];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Keyword;[in];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Identifier;[Products];
-            SyntaxKind.RightParenthesis;[)];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.LeftBrace;[{];
-            SyntaxKind.NewLine;[LF];
-        Markup block - Gen<None> - 35 - (44:2,0)
-            Markup span - Gen<Markup> - [        ] - SpanEditHandler;Accepts:Any - (44:2,0) - Tokens:1
-                SyntaxKind.Whitespace;[        ];
-            Tag block - Gen<None> - 4 - (52:2,8)
-                Markup span - Gen<Markup> - [<li>] - SpanEditHandler;Accepts:None - (52:2,8) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[li];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [Product: ] - SpanEditHandler;Accepts:Any - (56:2,12) - Tokens:2
-                SyntaxKind.Text;[Product:];
-                SyntaxKind.Whitespace;[ ];
-            Expression block - Gen<Expr> - 7 - (65:2,21)
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (65:2,21) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Expr> - [p.Name] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (66:2,22) - Tokens:3
-                    SyntaxKind.Identifier;[p];
-                    SyntaxKind.Dot;[.];
-                    SyntaxKind.Identifier;[Name];
-            Tag block - Gen<None> - 5 - (72:2,28)
-                Markup span - Gen<Markup> - [</li>] - SpanEditHandler;Accepts:None - (72:2,28) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[li];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:None - (77:2,33) - Tokens:1
-                SyntaxKind.NewLine;[LF];
-        Code span - Gen<Stmt> - [    }LF] - SpanEditHandler;Accepts:None - (79:3,0) - Tokens:3
-            SyntaxKind.Whitespace;[    ];
-            SyntaxKind.RightBrace;[}];
-            SyntaxKind.NewLine;[LF];
-    Markup span - Gen<Markup> - [    ] - SpanEditHandler;Accepts:Any - (86:4,0) - Tokens:1
-        SyntaxKind.Whitespace;[    ];
-    Tag block - Gen<None> - 5 - (90:4,4)
-        Markup span - Gen<Markup> - [</ul>] - SpanEditHandler;Accepts:None - (90:4,4) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[ul];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..95)::95 - [   <ul>LF    @foreach(var p in Products) {LF        <li>Product: @p.Name</li>LF    }LF    </ul>]
+    MarkupTextLiteral - [0..3)::3 - [   ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Whitespace;[   ];
+    MarkupTagBlock - [3..7)::4 - [<ul>]
+        MarkupTextLiteral - [3..7)::4 - [<ul>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[ul];
+            CloseAngle;[>];
+    MarkupTextLiteral - [7..9)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        NewLine;[LF];
+    CSharpCodeBlock - [9..86)::77
+        CSharpStatementLiteral - [9..13)::4 - [    ] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+            Whitespace;[    ];
+        CSharpTransition - [13..14)::1 - Gen<None> - SpanEditHandler;Accepts:None
+            Transition;[@];
+        CSharpStatementLiteral - [14..44)::30 - [foreach(var p in Products) {LF] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+            Keyword;[foreach];
+            LeftParenthesis;[(];
+            Identifier;[var];
+            Whitespace;[ ];
+            Identifier;[p];
+            Whitespace;[ ];
+            Keyword;[in];
+            Whitespace;[ ];
+            Identifier;[Products];
+            RightParenthesis;[)];
+            Whitespace;[ ];
+            LeftBrace;[{];
+            NewLine;[LF];
+        MarkupBlock - [44..79)::35
+            MarkupTextLiteral - [44..52)::8 - [        ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[        ];
+            MarkupTagBlock - [52..56)::4 - [<li>]
+                MarkupTextLiteral - [52..56)::4 - [<li>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    OpenAngle;[<];
+                    Text;[li];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [56..65)::9 - [Product: ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Product:];
+                Whitespace;[ ];
+            CSharpCodeBlock - [65..72)::7
+                CSharpImplicitExpression - [65..72)::7
+                    CSharpTransition - [65..66)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        Transition;[@];
+                    CSharpImplicitExpressionBody - [66..72)::6
+                        CSharpCodeBlock - [66..72)::6
+                            CSharpExpressionLiteral - [66..72)::6 - [p.Name] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                Identifier;[p];
+                                Dot;[.];
+                                Identifier;[Name];
+            MarkupTagBlock - [72..77)::5 - [</li>]
+                MarkupTextLiteral - [72..77)::5 - [</li>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[li];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [77..79)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:None
+                NewLine;[LF];
+        CSharpStatementLiteral - [79..86)::7 - [    }LF] - Gen<Stmt> - SpanEditHandler;Accepts:None
+            Whitespace;[    ];
+            RightBrace;[}];
+            NewLine;[LF];
+    MarkupTextLiteral - [86..90)::4 - [    ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Whitespace;[    ];
+    MarkupTagBlock - [90..95)::5 - [</ul>]
+        MarkupTextLiteral - [90..95)::5 - [</ul>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[ul];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParseBlockDoesNotSwitchToCodeOnEmailAddressInText.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParseBlockDoesNotSwitchToCodeOnEmailAddressInText.stree.txt
@@ -1,14 +1,14 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [anurse@microsoft.com] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:1
-        SyntaxKind.Text;[anurse@microsoft.com];
-    Tag block - Gen<None> - 6 - (25:0,25)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..31)::31 - [<foo>anurse@microsoft.com</foo>]
+    MarkupTagBlock - [0..5)::5 - [<foo>]
+        MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..25)::20 - [anurse@microsoft.com] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[anurse@microsoft.com];
+    MarkupTagBlock - [25..31)::6 - [</foo>]
+        MarkupTextLiteral - [25..31)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParseDocumentGivesWhitespacePreceedingAtToCodeIfThereIsNoMarkupOnThatLine.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParseDocumentGivesWhitespacePreceedingAtToCodeIfThereIsNoMarkupOnThatLine.stree.txt
@@ -1,67 +1,71 @@
-Markup block - Gen<None> - 95 - (0:0,0)
-    Markup span - Gen<Markup> - [   ] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Whitespace;[   ];
-    Tag block - Gen<None> - 4 - (3:0,3)
-        Markup span - Gen<Markup> - [<ul>] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[ul];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:1
-        SyntaxKind.NewLine;[LF];
-    Statement block - Gen<None> - 77 - (9:1,0)
-        Code span - Gen<Stmt> - [    ] - SpanEditHandler;Accepts:Any - (9:1,0) - Tokens:1
-            SyntaxKind.Whitespace;[    ];
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (13:1,4) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Stmt> - [foreach(var p in Products) {LF] - SpanEditHandler;Accepts:Any - (14:1,5) - Tokens:13
-            SyntaxKind.Keyword;[foreach];
-            SyntaxKind.LeftParenthesis;[(];
-            SyntaxKind.Identifier;[var];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Identifier;[p];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Keyword;[in];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Identifier;[Products];
-            SyntaxKind.RightParenthesis;[)];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.LeftBrace;[{];
-            SyntaxKind.NewLine;[LF];
-        Markup block - Gen<None> - 35 - (44:2,0)
-            Markup span - Gen<Markup> - [        ] - SpanEditHandler;Accepts:Any - (44:2,0) - Tokens:1
-                SyntaxKind.Whitespace;[        ];
-            Tag block - Gen<None> - 4 - (52:2,8)
-                Markup span - Gen<Markup> - [<li>] - SpanEditHandler;Accepts:None - (52:2,8) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[li];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [Product: ] - SpanEditHandler;Accepts:Any - (56:2,12) - Tokens:2
-                SyntaxKind.Text;[Product:];
-                SyntaxKind.Whitespace;[ ];
-            Expression block - Gen<Expr> - 7 - (65:2,21)
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (65:2,21) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Expr> - [p.Name] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (66:2,22) - Tokens:3
-                    SyntaxKind.Identifier;[p];
-                    SyntaxKind.Dot;[.];
-                    SyntaxKind.Identifier;[Name];
-            Tag block - Gen<None> - 5 - (72:2,28)
-                Markup span - Gen<Markup> - [</li>] - SpanEditHandler;Accepts:None - (72:2,28) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[li];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:None - (77:2,33) - Tokens:1
-                SyntaxKind.NewLine;[LF];
-        Code span - Gen<Stmt> - [    }LF] - SpanEditHandler;Accepts:None - (79:3,0) - Tokens:3
-            SyntaxKind.Whitespace;[    ];
-            SyntaxKind.RightBrace;[}];
-            SyntaxKind.NewLine;[LF];
-    SyntaxKind.HtmlTextLiteral - [    ] - [86..90) - FullWidth: 4 - Slots: 1
-        SyntaxKind.Whitespace;[    ];
-    Tag block - Gen<None> - 5 - (90:4,4)
-        Markup span - Gen<Markup> - [</ul>] - SpanEditHandler;Accepts:Any - (90:4,4) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[ul];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..95)::95 - [   <ul>LF    @foreach(var p in Products) {LF        <li>Product: @p.Name</li>LF    }LF    </ul>]
+    MarkupBlock - [0..95)::95
+        MarkupTextLiteral - [0..3)::3 - [   ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Whitespace;[   ];
+        MarkupTagBlock - [3..7)::4 - [<ul>]
+            MarkupTextLiteral - [3..7)::4 - [<ul>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[ul];
+                CloseAngle;[>];
+        MarkupTextLiteral - [7..9)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            NewLine;[LF];
+        CSharpCodeBlock - [9..86)::77
+            CSharpStatementLiteral - [9..13)::4 - [    ] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                Whitespace;[    ];
+            CSharpTransition - [13..14)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpStatementLiteral - [14..44)::30 - [foreach(var p in Products) {LF] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                Keyword;[foreach];
+                LeftParenthesis;[(];
+                Identifier;[var];
+                Whitespace;[ ];
+                Identifier;[p];
+                Whitespace;[ ];
+                Keyword;[in];
+                Whitespace;[ ];
+                Identifier;[Products];
+                RightParenthesis;[)];
+                Whitespace;[ ];
+                LeftBrace;[{];
+                NewLine;[LF];
+            MarkupBlock - [44..79)::35
+                MarkupTextLiteral - [44..52)::8 - [        ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[        ];
+                MarkupTagBlock - [52..56)::4 - [<li>]
+                    MarkupTextLiteral - [52..56)::4 - [<li>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                        OpenAngle;[<];
+                        Text;[li];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [56..65)::9 - [Product: ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[Product:];
+                    Whitespace;[ ];
+                CSharpCodeBlock - [65..72)::7
+                    CSharpImplicitExpression - [65..72)::7
+                        CSharpTransition - [65..66)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                            Transition;[@];
+                        CSharpImplicitExpressionBody - [66..72)::6
+                            CSharpCodeBlock - [66..72)::6
+                                CSharpExpressionLiteral - [66..72)::6 - [p.Name] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                    Identifier;[p];
+                                    Dot;[.];
+                                    Identifier;[Name];
+                MarkupTagBlock - [72..77)::5 - [</li>]
+                    MarkupTextLiteral - [72..77)::5 - [</li>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[li];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [77..79)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    NewLine;[LF];
+            CSharpStatementLiteral - [79..86)::7 - [    }LF] - Gen<Stmt> - SpanEditHandler;Accepts:None
+                Whitespace;[    ];
+                RightBrace;[}];
+                NewLine;[LF];
+        MarkupTextLiteral - [86..90)::4 - [    ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Whitespace;[    ];
+        MarkupTagBlock - [90..95)::5 - [</ul>]
+            MarkupTextLiteral - [90..95)::5 - [</ul>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[ul];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParseDocumentTreatsPairsOfAtSignsAsEscapeSequence.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParseDocumentTreatsPairsOfAtSignsAsEscapeSequence.stree.txt
@@ -1,25 +1,29 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:1
-        SyntaxKind.Transition;[@];
-    Markup span - Gen<Markup> - [@] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:1
-        SyntaxKind.Transition;[@];
-    Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:1
-        SyntaxKind.Transition;[@];
-    Markup span - Gen<Markup> - [@] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:1
-        SyntaxKind.Transition;[@];
-    Expression block - Gen<Expr> - 4 - (9:0,9)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [bar] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (10:0,10) - Tokens:1
-            SyntaxKind.Identifier;[bar];
-    Tag block - Gen<None> - 6 - (13:0,13)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..19)::19 - [<foo>@@@@@bar</foo>]
+    MarkupBlock - [0..19)::19
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupEphemeralTextLiteral - [5..6)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:Any
+            Transition;[@];
+        MarkupTextLiteral - [6..7)::1 - [@] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Transition;[@];
+        MarkupEphemeralTextLiteral - [7..8)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:Any
+            Transition;[@];
+        MarkupTextLiteral - [8..9)::1 - [@] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Transition;[@];
+        CSharpCodeBlock - [9..13)::4
+            CSharpImplicitExpression - [9..13)::4
+                CSharpTransition - [9..10)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpImplicitExpressionBody - [10..13)::3
+                    CSharpCodeBlock - [10..13)::3
+                        CSharpExpressionLiteral - [10..13)::3 - [bar] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                            Identifier;[bar];
+        MarkupTagBlock - [13..19)::6 - [</foo>]
+            MarkupTextLiteral - [13..19)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParseDocumentTreatsTwoAtSignsAsEscapeSequence.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParseDocumentTreatsTwoAtSignsAsEscapeSequence.stree.txt
@@ -1,18 +1,18 @@
-Markup block - Gen<None> - 16 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:1
-        SyntaxKind.Transition;[@];
-    SyntaxKind.HtmlTextLiteral - [@bar] - [6..10) - FullWidth: 4 - Slots: 1
-        SyntaxKind.List - [@bar] - [6..10) - FullWidth: 4 - Slots: 2
-            SyntaxKind.Transition;[@];
-            SyntaxKind.Text;[bar];
-    Tag block - Gen<None> - 6 - (10:0,10)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..16)::16 - [<foo>@@bar</foo>]
+    MarkupBlock - [0..16)::16
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupEphemeralTextLiteral - [5..6)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:Any
+            Transition;[@];
+        MarkupTextLiteral - [6..10)::4 - [@bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Transition;[@];
+            Text;[bar];
+        MarkupTagBlock - [10..16)::6 - [</foo>]
+            MarkupTextLiteral - [10..16)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParsesCodeWithinSingleLineMarkup.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/ParsesCodeWithinSingleLineMarkup.stree.txt
@@ -1,20 +1,23 @@
-Markup block - Gen<None> - 20 - (0:0,0)
-    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-        SyntaxKind.Transition;[@];
-    MetaCode span - Gen<None> - [:] - SpanEditHandler;Accepts:Any - (1:0,1) - Tokens:1
-        SyntaxKind.Colon;[:];
-    Markup span - Gen<Markup> - [<li>Foo ] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:5
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Text;[li];
-        SyntaxKind.CloseAngle;[>];
-        SyntaxKind.Text;[Foo];
-        SyntaxKind.Whitespace;[ ];
-    Expression block - Gen<Expr> - 4 - (10:0,10)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [Bar] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (11:0,11) - Tokens:1
-            SyntaxKind.Identifier;[Bar];
-    Markup span - Gen<Markup> - [ BazLF] - SpanEditHandler;Accepts:None - (14:0,14) - Tokens:3
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[Baz];
-        SyntaxKind.NewLine;[LF];
+MarkupBlock - [0..20)::20 - [@:<li>Foo @Bar BazLF]
+    MarkupTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+        Transition;[@];
+    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:Any
+        Colon;[:];
+    MarkupTextLiteral - [2..10)::8 - [<li>Foo ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        OpenAngle;[<];
+        Text;[li];
+        CloseAngle;[>];
+        Text;[Foo];
+        Whitespace;[ ];
+    CSharpCodeBlock - [10..14)::4
+        CSharpImplicitExpression - [10..14)::4
+            CSharpTransition - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpImplicitExpressionBody - [11..14)::3
+                CSharpCodeBlock - [11..14)::3
+                    CSharpExpressionLiteral - [11..14)::3 - [Bar] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                        Identifier;[Bar];
+    MarkupTextLiteral - [14..20)::6 - [ BazLF] - Gen<Markup> - SpanEditHandler;Accepts:None
+        Whitespace;[ ];
+        Text;[Baz];
+        NewLine;[LF];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionBodyTreatsPairsOfAtSignsAsEscapeSequence.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionBodyTreatsPairsOfAtSignsAsEscapeSequence.stree.txt
@@ -1,49 +1,56 @@
-Markup block - Gen<None> - 36 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Directive block - Gen<Directive:{section;RazorBlock;Unrestricted}> - 36 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [section] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Identifier;[section];
-        Code span - Gen<None> - [ ] - SpanEditHandler;Accepts:Whitespace - (8:0,8) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        Code span - Gen<DirectiveToken {SectionName;Member;Opt:False}> - [Foo] - DirectiveTokenEditHandler;Accepts:NonWhitespace - (9:0,9) - Tokens:1
-            SyntaxKind.Identifier;[Foo];
-        Markup span - Gen<None> - [ ] - SpanEditHandler;Accepts:AllWhitespace - (12:0,12) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        MetaCode span - Gen<None> - [{] - AutoCompleteEditHandler;Accepts:None,AutoComplete:[<null>];AtEnd - (13:0,13) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 21 - (14:0,14)
-            Markup span - Gen<Markup> - [ ] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.Whitespace;[ ];
-            Tag block - Gen<None> - 5 - (15:0,15)
-                Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[foo];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                SyntaxKind.Transition;[@];
-            Markup span - Gen<Markup> - [@] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.Transition;[@];
-            Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:1
-                SyntaxKind.Transition;[@];
-            Markup span - Gen<Markup> - [@] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:1
-                SyntaxKind.Transition;[@];
-            Expression block - Gen<Expr> - 4 - (24:0,24)
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Expr> - [bar] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K15 - (25:0,25) - Tokens:1
-                    SyntaxKind.Identifier;[bar];
-            Tag block - Gen<None> - 6 - (28:0,28)
-                Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (28:0,28) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[foo];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [ ] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:1
-                SyntaxKind.Whitespace;[ ];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (35:0,35) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..36)::36 - [@section Foo { <foo>@@@@@bar</foo> }]
+    MarkupBlock - [0..36)::36
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..36)::36
+            RazorDirective - [0..36)::36
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                RazorDirectiveBody - [1..36)::35
+                    RazorMetaCode - [1..8)::7 - Gen<None> - SpanEditHandler;Accepts:None
+                        Identifier;[section];
+                    CSharpCodeBlock - [8..36)::28
+                        CSharpStatementLiteral - [8..9)::1 - [ ] - Gen<None> - SpanEditHandler;Accepts:Whitespace
+                            Whitespace;[ ];
+                        CSharpStatementLiteral - [9..12)::3 - [Foo] - Gen<DirectiveToken {SectionName;Member;Opt:False}> - DirectiveTokenEditHandler;Accepts:NonWhitespace
+                            Identifier;[Foo];
+                        MarkupTextLiteral - [12..13)::1 - [ ] - Gen<None> - SpanEditHandler;Accepts:AllWhitespace
+                            Whitespace;[ ];
+                        RazorMetaCode - [13..14)::1 - Gen<None> - AutoCompleteEditHandler;Accepts:None,AutoComplete:[<null>];AtEnd
+                            LeftBrace;[{];
+                        MarkupBlock - [14..35)::21
+                            MarkupTextLiteral - [14..15)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Whitespace;[ ];
+                            MarkupTagBlock - [15..20)::5 - [<foo>]
+                                MarkupTextLiteral - [15..20)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    Text;[foo];
+                                    CloseAngle;[>];
+                            MarkupEphemeralTextLiteral - [20..21)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:Any
+                                Transition;[@];
+                            MarkupTextLiteral - [21..22)::1 - [@] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Transition;[@];
+                            MarkupEphemeralTextLiteral - [22..23)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:Any
+                                Transition;[@];
+                            MarkupTextLiteral - [23..24)::1 - [@] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Transition;[@];
+                            CSharpCodeBlock - [24..28)::4
+                                CSharpImplicitExpression - [24..28)::4
+                                    CSharpTransition - [24..25)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                        Transition;[@];
+                                    CSharpImplicitExpressionBody - [25..28)::3
+                                        CSharpCodeBlock - [25..28)::3
+                                            CSharpExpressionLiteral - [25..28)::3 - [bar] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K15
+                                                Identifier;[bar];
+                            MarkupTagBlock - [28..34)::6 - [</foo>]
+                                MarkupTextLiteral - [28..34)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[foo];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [34..35)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Whitespace;[ ];
+                        RazorMetaCode - [35..36)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                            RightBrace;[}];
+        MarkupTextLiteral - [36..36)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionBodyTreatsTwoAtSignsAsEscapeSequence.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionBodyTreatsTwoAtSignsAsEscapeSequence.stree.txt
@@ -1,42 +1,45 @@
-Markup block - Gen<None> - 33 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Directive block - Gen<Directive:{section;RazorBlock;Unrestricted}> - 33 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [section] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Identifier;[section];
-        Code span - Gen<None> - [ ] - SpanEditHandler;Accepts:Whitespace - (8:0,8) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        Code span - Gen<DirectiveToken {SectionName;Member;Opt:False}> - [Foo] - DirectiveTokenEditHandler;Accepts:NonWhitespace - (9:0,9) - Tokens:1
-            SyntaxKind.Identifier;[Foo];
-        Markup span - Gen<None> - [ ] - SpanEditHandler;Accepts:AllWhitespace - (12:0,12) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        MetaCode span - Gen<None> - [{] - AutoCompleteEditHandler;Accepts:None,AutoComplete:[<null>];AtEnd - (13:0,13) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 18 - (14:0,14)
-            Markup span - Gen<Markup> - [ ] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.Whitespace;[ ];
-            Tag block - Gen<None> - 5 - (15:0,15)
-                Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[foo];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                SyntaxKind.Transition;[@];
-            SyntaxKind.HtmlTextLiteral - [@bar] - [21..25) - FullWidth: 4 - Slots: 1
-                SyntaxKind.List - [@bar] - [21..25) - FullWidth: 4 - Slots: 2
-                    SyntaxKind.Transition;[@];
-                    SyntaxKind.Text;[bar];
-            Tag block - Gen<None> - 6 - (25:0,25)
-                Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[foo];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [ ] - SpanEditHandler;Accepts:Any - (31:0,31) - Tokens:1
-                SyntaxKind.Whitespace;[ ];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (32:0,32) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..33)::33 - [@section Foo { <foo>@@bar</foo> }]
+    MarkupBlock - [0..33)::33
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..33)::33
+            RazorDirective - [0..33)::33
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                RazorDirectiveBody - [1..33)::32
+                    RazorMetaCode - [1..8)::7 - Gen<None> - SpanEditHandler;Accepts:None
+                        Identifier;[section];
+                    CSharpCodeBlock - [8..33)::25
+                        CSharpStatementLiteral - [8..9)::1 - [ ] - Gen<None> - SpanEditHandler;Accepts:Whitespace
+                            Whitespace;[ ];
+                        CSharpStatementLiteral - [9..12)::3 - [Foo] - Gen<DirectiveToken {SectionName;Member;Opt:False}> - DirectiveTokenEditHandler;Accepts:NonWhitespace
+                            Identifier;[Foo];
+                        MarkupTextLiteral - [12..13)::1 - [ ] - Gen<None> - SpanEditHandler;Accepts:AllWhitespace
+                            Whitespace;[ ];
+                        RazorMetaCode - [13..14)::1 - Gen<None> - AutoCompleteEditHandler;Accepts:None,AutoComplete:[<null>];AtEnd
+                            LeftBrace;[{];
+                        MarkupBlock - [14..32)::18
+                            MarkupTextLiteral - [14..15)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Whitespace;[ ];
+                            MarkupTagBlock - [15..20)::5 - [<foo>]
+                                MarkupTextLiteral - [15..20)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    Text;[foo];
+                                    CloseAngle;[>];
+                            MarkupEphemeralTextLiteral - [20..21)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:Any
+                                Transition;[@];
+                            MarkupTextLiteral - [21..25)::4 - [@bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Transition;[@];
+                                Text;[bar];
+                            MarkupTagBlock - [25..31)::6 - [</foo>]
+                                MarkupTextLiteral - [25..31)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[foo];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [31..32)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Whitespace;[ ];
+                        RazorMetaCode - [32..33)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                            RightBrace;[}];
+        MarkupTextLiteral - [33..33)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionContextGivesWhitespacePreceedingAtToCodeIfThereIsNoMarkupOnThatLine.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionContextGivesWhitespacePreceedingAtToCodeIfThereIsNoMarkupOnThatLine.stree.txt
@@ -1,90 +1,97 @@
-Markup block - Gen<None> - 127 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Directive block - Gen<Directive:{section;RazorBlock;Unrestricted}> - 127 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [section] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Identifier;[section];
-        Code span - Gen<None> - [ ] - SpanEditHandler;Accepts:Whitespace - (8:0,8) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        Code span - Gen<DirectiveToken {SectionName;Member;Opt:False}> - [foo] - DirectiveTokenEditHandler;Accepts:NonWhitespace - (9:0,9) - Tokens:1
-            SyntaxKind.Identifier;[foo];
-        Markup span - Gen<None> - [ ] - SpanEditHandler;Accepts:AllWhitespace - (12:0,12) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        MetaCode span - Gen<None> - [{] - AutoCompleteEditHandler;Accepts:None,AutoComplete:[<null>];AtEnd - (13:0,13) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 112 - (14:0,14)
-            Markup span - Gen<Markup> - [LF    ] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:2
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[    ];
-            Tag block - Gen<None> - 4 - (20:1,4)
-                Markup span - Gen<Markup> - [<ul>] - SpanEditHandler;Accepts:Any - (20:1,4) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[ul];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:Any - (24:1,8) - Tokens:1
-                SyntaxKind.NewLine;[LF];
-            Statement block - Gen<None> - 89 - (26:2,0)
-                Code span - Gen<Stmt> - [        ] - SpanEditHandler;Accepts:Any - (26:2,0) - Tokens:1
-                    SyntaxKind.Whitespace;[        ];
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (34:2,8) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Stmt> - [foreach(var p in Products) {LF] - SpanEditHandler;Accepts:Any - (35:2,9) - Tokens:13
-                    SyntaxKind.Keyword;[foreach];
-                    SyntaxKind.LeftParenthesis;[(];
-                    SyntaxKind.Identifier;[var];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Identifier;[p];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Keyword;[in];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Identifier;[Products];
-                    SyntaxKind.RightParenthesis;[)];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.LeftBrace;[{];
-                    SyntaxKind.NewLine;[LF];
-                Markup block - Gen<None> - 39 - (65:3,0)
-                    Markup span - Gen<Markup> - [            ] - SpanEditHandler;Accepts:Any - (65:3,0) - Tokens:1
-                        SyntaxKind.Whitespace;[            ];
-                    Tag block - Gen<None> - 4 - (77:3,12)
-                        Markup span - Gen<Markup> - [<li>] - SpanEditHandler;Accepts:None - (77:3,12) - Tokens:3
-                            SyntaxKind.OpenAngle;[<];
-                            SyntaxKind.Text;[li];
-                            SyntaxKind.CloseAngle;[>];
-                    Markup span - Gen<Markup> - [Product: ] - SpanEditHandler;Accepts:Any - (81:3,16) - Tokens:2
-                        SyntaxKind.Text;[Product:];
-                        SyntaxKind.Whitespace;[ ];
-                    Expression block - Gen<Expr> - 7 - (90:3,25)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (90:3,25) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [p.Name] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K15 - (91:3,26) - Tokens:3
-                            SyntaxKind.Identifier;[p];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Name];
-                    Tag block - Gen<None> - 5 - (97:3,32)
-                        Markup span - Gen<Markup> - [</li>] - SpanEditHandler;Accepts:None - (97:3,32) - Tokens:4
-                            SyntaxKind.OpenAngle;[<];
-                            SyntaxKind.ForwardSlash;[/];
-                            SyntaxKind.Text;[li];
-                            SyntaxKind.CloseAngle;[>];
-                    Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:None - (102:3,37) - Tokens:1
-                        SyntaxKind.NewLine;[LF];
-                Code span - Gen<Stmt> - [        }LF] - SpanEditHandler;Accepts:None - (104:4,0) - Tokens:3
-                    SyntaxKind.Whitespace;[        ];
-                    SyntaxKind.RightBrace;[}];
-                    SyntaxKind.NewLine;[LF];
-            SyntaxKind.HtmlTextLiteral - [    ] - [115..119) - FullWidth: 4 - Slots: 1
-                SyntaxKind.Whitespace;[    ];
-            Tag block - Gen<None> - 5 - (119:5,4)
-                Markup span - Gen<Markup> - [</ul>] - SpanEditHandler;Accepts:Any - (119:5,4) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[ul];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [LF] - SpanEditHandler;Accepts:Any - (124:5,9) - Tokens:1
-                SyntaxKind.NewLine;[LF];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (126:6,0) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (127:6,1) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..127)::127 - [@section foo {LF    <ul>LF        @foreach(var p in Products) {LF            <li>Product: @p.Name</li>LF        }LF    </ul>LF}]
+    MarkupBlock - [0..127)::127
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..127)::127
+            RazorDirective - [0..127)::127
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                RazorDirectiveBody - [1..127)::126
+                    RazorMetaCode - [1..8)::7 - Gen<None> - SpanEditHandler;Accepts:None
+                        Identifier;[section];
+                    CSharpCodeBlock - [8..127)::119
+                        CSharpStatementLiteral - [8..9)::1 - [ ] - Gen<None> - SpanEditHandler;Accepts:Whitespace
+                            Whitespace;[ ];
+                        CSharpStatementLiteral - [9..12)::3 - [foo] - Gen<DirectiveToken {SectionName;Member;Opt:False}> - DirectiveTokenEditHandler;Accepts:NonWhitespace
+                            Identifier;[foo];
+                        MarkupTextLiteral - [12..13)::1 - [ ] - Gen<None> - SpanEditHandler;Accepts:AllWhitespace
+                            Whitespace;[ ];
+                        RazorMetaCode - [13..14)::1 - Gen<None> - AutoCompleteEditHandler;Accepts:None,AutoComplete:[<null>];AtEnd
+                            LeftBrace;[{];
+                        MarkupBlock - [14..126)::112
+                            MarkupTextLiteral - [14..20)::6 - [LF    ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                NewLine;[LF];
+                                Whitespace;[    ];
+                            MarkupTagBlock - [20..24)::4 - [<ul>]
+                                MarkupTextLiteral - [20..24)::4 - [<ul>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    Text;[ul];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [24..26)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                NewLine;[LF];
+                            CSharpCodeBlock - [26..115)::89
+                                CSharpStatementLiteral - [26..34)::8 - [        ] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                                    Whitespace;[        ];
+                                CSharpTransition - [34..35)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Transition;[@];
+                                CSharpStatementLiteral - [35..65)::30 - [foreach(var p in Products) {LF] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                                    Keyword;[foreach];
+                                    LeftParenthesis;[(];
+                                    Identifier;[var];
+                                    Whitespace;[ ];
+                                    Identifier;[p];
+                                    Whitespace;[ ];
+                                    Keyword;[in];
+                                    Whitespace;[ ];
+                                    Identifier;[Products];
+                                    RightParenthesis;[)];
+                                    Whitespace;[ ];
+                                    LeftBrace;[{];
+                                    NewLine;[LF];
+                                MarkupBlock - [65..104)::39
+                                    MarkupTextLiteral - [65..77)::12 - [            ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[            ];
+                                    MarkupTagBlock - [77..81)::4 - [<li>]
+                                        MarkupTextLiteral - [77..81)::4 - [<li>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                            OpenAngle;[<];
+                                            Text;[li];
+                                            CloseAngle;[>];
+                                    MarkupTextLiteral - [81..90)::9 - [Product: ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[Product:];
+                                        Whitespace;[ ];
+                                    CSharpCodeBlock - [90..97)::7
+                                        CSharpImplicitExpression - [90..97)::7
+                                            CSharpTransition - [90..91)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                                Transition;[@];
+                                            CSharpImplicitExpressionBody - [91..97)::6
+                                                CSharpCodeBlock - [91..97)::6
+                                                    CSharpExpressionLiteral - [91..97)::6 - [p.Name] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K15
+                                                        Identifier;[p];
+                                                        Dot;[.];
+                                                        Identifier;[Name];
+                                    MarkupTagBlock - [97..102)::5 - [</li>]
+                                        MarkupTextLiteral - [97..102)::5 - [</li>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                            OpenAngle;[<];
+                                            ForwardSlash;[/];
+                                            Text;[li];
+                                            CloseAngle;[>];
+                                    MarkupTextLiteral - [102..104)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        NewLine;[LF];
+                                CSharpStatementLiteral - [104..115)::11 - [        }LF] - Gen<Stmt> - SpanEditHandler;Accepts:None
+                                    Whitespace;[        ];
+                                    RightBrace;[}];
+                                    NewLine;[LF];
+                            MarkupTextLiteral - [115..119)::4 - [    ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Whitespace;[    ];
+                            MarkupTagBlock - [119..124)::5 - [</ul>]
+                                MarkupTextLiteral - [119..124)::5 - [</ul>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[ul];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [124..126)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                NewLine;[LF];
+                        RazorMetaCode - [126..127)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                            RightBrace;[}];
+        MarkupTextLiteral - [127..127)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SupportsCodeWithinCDataDeclaration.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SupportsCodeWithinCDataDeclaration.stree.txt
@@ -1,32 +1,35 @@
-Markup block - Gen<None> - 36 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<![CDATA[ foo ] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:8
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Bang;[!];
-        SyntaxKind.LeftBracket;[[];
-        SyntaxKind.Text;[CDATA];
-        SyntaxKind.LeftBracket;[[];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[foo];
-        SyntaxKind.Whitespace;[ ];
-    Expression block - Gen<Expr> - 4 - (19:0,19)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (19:0,19) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [bar] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (20:0,20) - Tokens:1
-            SyntaxKind.Identifier;[bar];
-    Markup span - Gen<Markup> - [ baz]]>] - SpanEditHandler;Accepts:None - (23:0,23) - Tokens:5
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.RightBracket;[]];
-        SyntaxKind.RightBracket;[]];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (30:0,30)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (30:0,30) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..36)::36 - [<foo><![CDATA[ foo @bar baz]]></foo>]
+    MarkupTagBlock - [0..5)::5 - [<foo>]
+        MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..19)::14 - [<![CDATA[ foo ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        OpenAngle;[<];
+        Bang;[!];
+        LeftBracket;[[];
+        Text;[CDATA];
+        LeftBracket;[[];
+        Whitespace;[ ];
+        Text;[foo];
+        Whitespace;[ ];
+    CSharpCodeBlock - [19..23)::4
+        CSharpImplicitExpression - [19..23)::4
+            CSharpTransition - [19..20)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpImplicitExpressionBody - [20..23)::3
+                CSharpCodeBlock - [20..23)::3
+                    CSharpExpressionLiteral - [20..23)::3 - [bar] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                        Identifier;[bar];
+    MarkupTextLiteral - [23..30)::7 - [ baz]]>] - Gen<Markup> - SpanEditHandler;Accepts:None
+        Whitespace;[ ];
+        Text;[baz];
+        RightBracket;[]];
+        RightBracket;[]];
+        CloseAngle;[>];
+    MarkupTagBlock - [30..36)::6 - [</foo>]
+        MarkupTextLiteral - [30..36)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SupportsCodeWithinComment.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SupportsCodeWithinComment.stree.txt
@@ -1,29 +1,32 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    HtmlComment block - Gen<None> - 13 - (5:0,5)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [ ] - SpanEditHandler;Accepts:Whitespace - (9:0,9) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        Expression block - Gen<Expr> - 4 - (10:0,10)
-            Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-                SyntaxKind.Transition;[@];
-            Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (11:0,11) - Tokens:1
-                SyntaxKind.Identifier;[foo];
-        Markup span - Gen<Markup> - [ ] - SpanEditHandler;Accepts:Whitespace - (14:0,14) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (18:0,18)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..24)::24 - [<foo><!-- @foo --></foo>]
+    MarkupTagBlock - [0..5)::5 - [<foo>]
+        MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupCommentBlock - [5..18)::13
+        MarkupTextLiteral - [5..9)::4 - [<!--] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Bang;[!];
+            DoubleHyphen;[--];
+        MarkupTextLiteral - [9..10)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+            Whitespace;[ ];
+        CSharpCodeBlock - [10..14)::4
+            CSharpImplicitExpression - [10..14)::4
+                CSharpTransition - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpImplicitExpressionBody - [11..14)::3
+                    CSharpCodeBlock - [11..14)::3
+                        CSharpExpressionLiteral - [11..14)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                            Identifier;[foo];
+        MarkupTextLiteral - [14..15)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+            Whitespace;[ ];
+        MarkupTextLiteral - [15..18)::3 - [-->] - Gen<Markup> - SpanEditHandler;Accepts:None
+            DoubleHyphen;[--];
+            CloseAngle;[>];
+    MarkupTagBlock - [18..24)::6 - [</foo>]
+        MarkupTextLiteral - [18..24)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SupportsCodeWithinSGMLDeclaration.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SupportsCodeWithinSGMLDeclaration.stree.txt
@@ -1,28 +1,31 @@
-Markup block - Gen<None> - 34 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<!DOCTYPE foo ] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:6
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Bang;[!];
-        SyntaxKind.Text;[DOCTYPE];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[foo];
-        SyntaxKind.Whitespace;[ ];
-    Expression block - Gen<Expr> - 4 - (19:0,19)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (19:0,19) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [bar] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (20:0,20) - Tokens:1
-            SyntaxKind.Identifier;[bar];
-    Markup span - Gen<Markup> - [ baz>] - SpanEditHandler;Accepts:None - (23:0,23) - Tokens:3
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (28:0,28)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (28:0,28) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..34)::34 - [<foo><!DOCTYPE foo @bar baz></foo>]
+    MarkupTagBlock - [0..5)::5 - [<foo>]
+        MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..19)::14 - [<!DOCTYPE foo ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        OpenAngle;[<];
+        Bang;[!];
+        Text;[DOCTYPE];
+        Whitespace;[ ];
+        Text;[foo];
+        Whitespace;[ ];
+    CSharpCodeBlock - [19..23)::4
+        CSharpImplicitExpression - [19..23)::4
+            CSharpTransition - [19..20)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpImplicitExpressionBody - [20..23)::3
+                CSharpCodeBlock - [20..23)::3
+                    CSharpExpressionLiteral - [20..23)::3 - [bar] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                        Identifier;[bar];
+    MarkupTextLiteral - [23..28)::5 - [ baz>] - Gen<Markup> - SpanEditHandler;Accepts:None
+        Whitespace;[ ];
+        Text;[baz];
+        CloseAngle;[>];
+    MarkupTagBlock - [28..34)::6 - [</foo>]
+        MarkupTextLiteral - [28..34)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SupportsCodeWithinXMLProcessingInstruction.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SupportsCodeWithinXMLProcessingInstruction.stree.txt
@@ -1,29 +1,32 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<?xml foo ] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:6
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.QuestionMark;[?];
-        SyntaxKind.Text;[xml];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[foo];
-        SyntaxKind.Whitespace;[ ];
-    Expression block - Gen<Expr> - 4 - (15:0,15)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [bar] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (16:0,16) - Tokens:1
-            SyntaxKind.Identifier;[bar];
-    Markup span - Gen<Markup> - [ baz?>] - SpanEditHandler;Accepts:None - (19:0,19) - Tokens:4
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.Text;[baz];
-        SyntaxKind.QuestionMark;[?];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (25:0,25)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..31)::31 - [<foo><?xml foo @bar baz?></foo>]
+    MarkupTagBlock - [0..5)::5 - [<foo>]
+        MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..15)::10 - [<?xml foo ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        OpenAngle;[<];
+        QuestionMark;[?];
+        Text;[xml];
+        Whitespace;[ ];
+        Text;[foo];
+        Whitespace;[ ];
+    CSharpCodeBlock - [15..19)::4
+        CSharpImplicitExpression - [15..19)::4
+            CSharpTransition - [15..16)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpImplicitExpressionBody - [16..19)::3
+                CSharpCodeBlock - [16..19)::3
+                    CSharpExpressionLiteral - [16..19)::3 - [bar] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                        Identifier;[bar];
+    MarkupTextLiteral - [19..25)::6 - [ baz?>] - Gen<Markup> - SpanEditHandler;Accepts:None
+        Whitespace;[ ];
+        Text;[baz];
+        QuestionMark;[?];
+        CloseAngle;[>];
+    MarkupTagBlock - [25..31)::6 - [</foo>]
+        MarkupTextLiteral - [25..31)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SwitchesToCodeWhenSwapCharacterEncounteredInAttributeValue.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SwitchesToCodeWhenSwapCharacterEncounteredInAttributeValue.stree.txt
@@ -1,23 +1,30 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Tag block - Gen<None> - 18 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-        Markup block - Gen<Attr:bar, bar="@(4:0,4),"@(14:0,14)> - 11 - (4:0,4)
-            Markup span - Gen<None> - [ bar="] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[bar];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup block - Gen<DynAttr:@(10:0,10)> - 4 - (10:0,10)
-                Expression block - Gen<Expr> - 4 - (10:0,10)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [baz] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (11:0,11) - Tokens:1
-                        SyntaxKind.Identifier;[baz];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..18)::18 - [<foo bar="@baz" />]
+    MarkupTagBlock - [0..18)::18 - [<foo bar="@baz" />]
+        MarkupTextLiteral - [0..4)::4 - [<foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[foo];
+        MarkupAttributeBlock - [4..15)::11 - [ bar="@baz"]
+            MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [5..8)::3 - [bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[bar];
+            Equals;[=];
+            MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+            GenericBlock - [10..14)::4
+                MarkupDynamicAttributeValue - [10..14)::4 - [@baz]
+                    GenericBlock - [10..14)::4
+                        CSharpCodeBlock - [10..14)::4
+                            CSharpImplicitExpression - [10..14)::4
+                                CSharpTransition - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Transition;[@];
+                                CSharpImplicitExpressionBody - [11..14)::3
+                                    CSharpCodeBlock - [11..14)::3
+                                        CSharpExpressionLiteral - [11..14)::3 - [baz] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                            Identifier;[baz];
+            MarkupTextLiteral - [14..15)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+        MarkupTextLiteral - [15..18)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SwitchesToCodeWhenSwapCharacterEncounteredInTagContent.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SwitchesToCodeWhenSwapCharacterEncounteredInTagContent.stree.txt
@@ -1,37 +1,43 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Expression block - Gen<Expr> - 4 - (5:0,5)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [bar] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (6:0,6) - Tokens:1
-            SyntaxKind.Identifier;[bar];
-    Tag block - Gen<None> - 5 - (9:0,9)
-        Markup span - Gen<Markup> - [<baz>] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[baz];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Expression block - Gen<Expr> - 4 - (14:0,14)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (14:0,14) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [boz] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (15:0,15) - Tokens:1
-            SyntaxKind.Identifier;[boz];
-    Tag block - Gen<None> - 6 - (18:0,18)
-        Markup span - Gen<Markup> - [</baz>] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[baz];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (24:0,24)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..30)::30 - [<foo>@bar<baz>@boz</baz></foo>]
+    MarkupTagBlock - [0..5)::5 - [<foo>]
+        MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupTextLiteral - [5..5)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Marker;[];
+    CSharpCodeBlock - [5..9)::4
+        CSharpImplicitExpression - [5..9)::4
+            CSharpTransition - [5..6)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpImplicitExpressionBody - [6..9)::3
+                CSharpCodeBlock - [6..9)::3
+                    CSharpExpressionLiteral - [6..9)::3 - [bar] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                        Identifier;[bar];
+    MarkupTagBlock - [9..14)::5 - [<baz>]
+        MarkupTextLiteral - [9..14)::5 - [<baz>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[baz];
+            CloseAngle;[>];
+    MarkupTextLiteral - [14..14)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Marker;[];
+    CSharpCodeBlock - [14..18)::4
+        CSharpImplicitExpression - [14..18)::4
+            CSharpTransition - [14..15)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpImplicitExpressionBody - [15..18)::3
+                CSharpCodeBlock - [15..18)::3
+                    CSharpExpressionLiteral - [15..18)::3 - [boz] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                        Identifier;[boz];
+    MarkupTagBlock - [18..24)::6 - [</baz>]
+        MarkupTextLiteral - [18..24)::6 - [</baz>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[baz];
+            CloseAngle;[>];
+    MarkupTagBlock - [24..30)::6 - [</foo>]
+        MarkupTextLiteral - [24..30)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SwitchesToCodeWhenSwapCharacterEncounteredMidTag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SwitchesToCodeWhenSwapCharacterEncounteredMidTag.stree.txt
@@ -1,15 +1,18 @@
-Markup block - Gen<None> - 12 - (0:0,0)
-    Tag block - Gen<None> - 12 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo ] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.Whitespace;[ ];
-        Expression block - Gen<Expr> - 4 - (5:0,5)
-            Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:1
-                SyntaxKind.Transition;[@];
-            Code span - Gen<Expr> - [bar] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (6:0,6) - Tokens:1
-                SyntaxKind.Identifier;[bar];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..12)::12 - [<foo @bar />]
+    MarkupTagBlock - [0..12)::12 - [<foo @bar />]
+        MarkupTextLiteral - [0..5)::5 - [<foo ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[foo];
+            Whitespace;[ ];
+        CSharpCodeBlock - [5..9)::4
+            CSharpImplicitExpression - [5..9)::4
+                CSharpTransition - [5..6)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpImplicitExpressionBody - [6..9)::3
+                    CSharpCodeBlock - [6..9)::3
+                        CSharpExpressionLiteral - [6..9)::3 - [bar] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                            Identifier;[bar];
+        MarkupTextLiteral - [9..12)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SwitchesWhenCharacterBeforeSwapIsNonAlphanumeric.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SwitchesWhenCharacterBeforeSwapIsNonAlphanumeric.stree.txt
@@ -1,19 +1,22 @@
-Markup block - Gen<None> - 13 - (0:0,0)
-    Tag block - Gen<None> - 3 - (0:0,0)
-        Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [foo#] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:1
-        SyntaxKind.Text;[foo#];
-    Expression block - Gen<Expr> - 2 - (7:0,7)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (7:0,7) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [i] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (8:0,8) - Tokens:1
-            SyntaxKind.Identifier;[i];
-    Tag block - Gen<None> - 4 - (9:0,9)
-        Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..13)::13 - [<p>foo#@i</p>]
+    MarkupTagBlock - [0..3)::3 - [<p>]
+        MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[p];
+            CloseAngle;[>];
+    MarkupTextLiteral - [3..7)::4 - [foo#] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Text;[foo#];
+    CSharpCodeBlock - [7..9)::2
+        CSharpImplicitExpression - [7..9)::2
+            CSharpTransition - [7..8)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpImplicitExpressionBody - [8..9)::1
+                CSharpCodeBlock - [8..9)::1
+                    CSharpExpressionLiteral - [8..9)::1 - [i] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                        Identifier;[i];
+    MarkupTagBlock - [9..13)::4 - [</p>]
+        MarkupTextLiteral - [9..13)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[p];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/TreatsPairsOfAtSignsAsEscapeSequence.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/TreatsPairsOfAtSignsAsEscapeSequence.stree.txt
@@ -1,25 +1,28 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:1
-        SyntaxKind.Transition;[@];
-    Markup span - Gen<Markup> - [@] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:1
-        SyntaxKind.Transition;[@];
-    Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:1
-        SyntaxKind.Transition;[@];
-    Markup span - Gen<Markup> - [@] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:1
-        SyntaxKind.Transition;[@];
-    Expression block - Gen<Expr> - 4 - (9:0,9)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [bar] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (10:0,10) - Tokens:1
-            SyntaxKind.Identifier;[bar];
-    Tag block - Gen<None> - 6 - (13:0,13)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (13:0,13) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..19)::19 - [<foo>@@@@@bar</foo>]
+    MarkupTagBlock - [0..5)::5 - [<foo>]
+        MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupEphemeralTextLiteral - [5..6)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:Any
+        Transition;[@];
+    MarkupTextLiteral - [6..7)::1 - [@] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Transition;[@];
+    MarkupEphemeralTextLiteral - [7..8)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:Any
+        Transition;[@];
+    MarkupTextLiteral - [8..9)::1 - [@] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Transition;[@];
+    CSharpCodeBlock - [9..13)::4
+        CSharpImplicitExpression - [9..13)::4
+            CSharpTransition - [9..10)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Transition;[@];
+            CSharpImplicitExpressionBody - [10..13)::3
+                CSharpCodeBlock - [10..13)::3
+                    CSharpExpressionLiteral - [10..13)::3 - [bar] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                        Identifier;[bar];
+    MarkupTagBlock - [13..19)::6 - [</foo>]
+        MarkupTextLiteral - [13..19)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/TreatsTwoAtSignsAsEscapeSequence.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlToCodeSwitchTest/TreatsTwoAtSignsAsEscapeSequence.stree.txt
@@ -1,17 +1,17 @@
-Markup block - Gen<None> - 16 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:1
-        SyntaxKind.Transition;[@];
-    Markup span - Gen<Markup> - [@bar] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:2
-        SyntaxKind.Transition;[@];
-        SyntaxKind.Text;[bar];
-    Tag block - Gen<None> - 6 - (10:0,10)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..16)::16 - [<foo>@@bar</foo>]
+    MarkupTagBlock - [0..5)::5 - [<foo>]
+        MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            Text;[foo];
+            CloseAngle;[>];
+    MarkupEphemeralTextLiteral - [5..6)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:Any
+        Transition;[@];
+    MarkupTextLiteral - [6..10)::4 - [@bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+        Transition;[@];
+        Text;[bar];
+    MarkupTagBlock - [10..16)::6 - [</foo>]
+        MarkupTextLiteral - [10..16)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[foo];
+            CloseAngle;[>];


### PR DESCRIPTION
Mostly testing the same code paths as the previous PRs. No need to review super hard.