### PR TITLE
New baselines for HtmlAttributesTest

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/HtmlAttributeTest.cs
@@ -9,6 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
     public class HtmlAttributeTest : CsHtmlMarkupParserTestBase
     {
+        public HtmlAttributeTest()
+        {
+            UseNewSyntaxTree = true;
+        }
+
         [Fact]
         public void SymbolBoundAttributes_BeforeEqualWhitespace1()
         {
@@ -219,7 +224,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             ParseDocumentTest("<input value=@foo />");
         }
 
-        [Fact]
+        [Fact(Skip = "ConditionalAttributeCollapser doesn't exist in the new tree")]
         public void ConditionalAttributeCollapserDoesNotRewriteEscapedTransitions()
         {
             // Act
@@ -231,7 +236,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             BaselineTest(rewritten);
         }
 
-        [Fact]
+        [Fact(Skip = "ConditionalAttributeCollapser doesn't exist in the new tree")]
         public void ConditionalAttributesDoNotCreateExtraDataForEntirelyLiteralAttribute()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesAreDisabledForDataAttributesInBlock.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesAreDisabledForDataAttributesInBlock.stree.txt
@@ -1,26 +1,32 @@
-Markup block - Gen<None> - 29 - (0:0,0)
-    Tag block - Gen<None> - 22 - (0:0,0)
-        Markup span - Gen<Markup> - [<span] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[span];
-        Markup block - Gen<None> - 16 - (5:0,5)
-            Markup span - Gen<Markup> - [ data-foo='] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[data-foo];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Expression block - Gen<Expr> - 4 - (16:0,16)
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (17:0,17) - Tokens:1
-                    SyntaxKind.Identifier;[foo];
-            Markup span - Gen<Markup> - ['] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 7 - (22:0,22)
-        Markup span - Gen<Markup> - [</span>] - SpanEditHandler;Accepts:None - (22:0,22) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[span];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..29)::29 - [<span data-foo='@foo'></span>]
+    MarkupTagBlock - [0..22)::22 - [<span data-foo='@foo'>]
+        MarkupTextLiteral - [0..5)::5 - [<span] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[span];
+        MarkupAttributeBlock - [5..21)::16 - [ data-foo='@foo']
+            MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [6..14)::8 - [data-foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[data-foo];
+            Equals;[=];
+            MarkupTextLiteral - [15..16)::1 - ['] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [16..20)::4
+                CSharpCodeBlock - [16..20)::4
+                    CSharpImplicitExpression - [16..20)::4
+                        CSharpTransition - [16..17)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                            Transition;[@];
+                        CSharpImplicitExpressionBody - [17..20)::3
+                            CSharpCodeBlock - [17..20)::3
+                                CSharpExpressionLiteral - [17..20)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                    Identifier;[foo];
+            MarkupTextLiteral - [20..21)::1 - ['] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [21..22)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            CloseAngle;[>];
+    MarkupTagBlock - [22..29)::7 - [</span>]
+        MarkupTextLiteral - [22..29)::7 - [</span>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[span];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesAreDisabledForDataAttributesInDocument.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesAreDisabledForDataAttributesInDocument.stree.txt
@@ -1,26 +1,33 @@
-Markup block - Gen<None> - 29 - (0:0,0)
-    Tag block - Gen<None> - 22 - (0:0,0)
-        Markup span - Gen<Markup> - [<span] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[span];
-        Markup block - Gen<None> - 16 - (5:0,5)
-            Markup span - Gen<Markup> - [ data-foo='] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[data-foo];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Expression block - Gen<Expr> - 4 - (16:0,16)
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (17:0,17) - Tokens:1
-                    SyntaxKind.Identifier;[foo];
-            Markup span - Gen<Markup> - ['] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 7 - (22:0,22)
-        Markup span - Gen<Markup> - [</span>] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[span];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..29)::29 - [<span data-foo='@foo'></span>]
+    MarkupBlock - [0..29)::29
+        MarkupTagBlock - [0..22)::22 - [<span data-foo='@foo'>]
+            MarkupTextLiteral - [0..5)::5 - [<span] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[span];
+            MarkupAttributeBlock - [5..21)::16 - [ data-foo='@foo']
+                MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [6..14)::8 - [data-foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[data-foo];
+                Equals;[=];
+                MarkupTextLiteral - [15..16)::1 - ['] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [16..20)::4
+                    CSharpCodeBlock - [16..20)::4
+                        CSharpImplicitExpression - [16..20)::4
+                            CSharpTransition - [16..17)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                Transition;[@];
+                            CSharpImplicitExpressionBody - [17..20)::3
+                                CSharpCodeBlock - [17..20)::3
+                                    CSharpExpressionLiteral - [17..20)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                        Identifier;[foo];
+                MarkupTextLiteral - [20..21)::1 - ['] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupTextLiteral - [21..22)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTagBlock - [22..29)::7 - [</span>]
+            MarkupTextLiteral - [22..29)::7 - [</span>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[span];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesAreEnabledForDataAttributesWithExperimentalFlag.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesAreEnabledForDataAttributesWithExperimentalFlag.stree.txt
@@ -1,27 +1,34 @@
-Markup block - Gen<None> - 29 - (0:0,0)
-    Tag block - Gen<None> - 22 - (0:0,0)
-        Markup span - Gen<Markup> - [<span] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[span];
-        Markup block - Gen<Attr:data-foo, data-foo='@(5:0,5),'@(20:0,20)> - 16 - (5:0,5)
-            Markup span - Gen<None> - [ data-foo='] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[data-foo];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup block - Gen<DynAttr:@(16:0,16)> - 4 - (16:0,16)
-                Expression block - Gen<Expr> - 4 - (16:0,16)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (17:0,17) - Tokens:1
-                        SyntaxKind.Identifier;[foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 7 - (22:0,22)
-        Markup span - Gen<Markup> - [</span>] - SpanEditHandler;Accepts:None - (22:0,22) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[span];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..29)::29 - [<span data-foo='@foo'></span>]
+    MarkupTagBlock - [0..22)::22 - [<span data-foo='@foo'>]
+        MarkupTextLiteral - [0..5)::5 - [<span] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[span];
+        MarkupAttributeBlock - [5..21)::16 - [ data-foo='@foo']
+            MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [6..14)::8 - [data-foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[data-foo];
+            Equals;[=];
+            MarkupTextLiteral - [15..16)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [16..20)::4
+                MarkupDynamicAttributeValue - [16..20)::4 - [@foo]
+                    GenericBlock - [16..20)::4
+                        CSharpCodeBlock - [16..20)::4
+                            CSharpImplicitExpression - [16..20)::4
+                                CSharpTransition - [16..17)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Transition;[@];
+                                CSharpImplicitExpressionBody - [17..20)::3
+                                    CSharpCodeBlock - [17..20)::3
+                                        CSharpExpressionLiteral - [17..20)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                            Identifier;[foo];
+            MarkupTextLiteral - [20..21)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [21..22)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            CloseAngle;[>];
+    MarkupTagBlock - [22..29)::7 - [</span>]
+        MarkupTextLiteral - [22..29)::7 - [</span>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[span];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesWithWeirdSpacingAreDisabledForDataAttributesInBlock.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesWithWeirdSpacingAreDisabledForDataAttributesInBlock.stree.txt
@@ -1,28 +1,35 @@
-Markup block - Gen<None> - 33 - (0:0,0)
-    Tag block - Gen<None> - 26 - (0:0,0)
-        Markup span - Gen<Markup> - [<span] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[span];
-        Markup block - Gen<None> - 20 - (5:0,5)
-            Markup span - Gen<Markup> - [ data-foo  =  '] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:6
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[data-foo];
-                SyntaxKind.Whitespace;[  ];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.Whitespace;[  ];
-                SyntaxKind.SingleQuote;['];
-            Expression block - Gen<Expr> - 4 - (20:0,20)
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (21:0,21) - Tokens:1
-                    SyntaxKind.Identifier;[foo];
-            Markup span - Gen<Markup> - ['] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 7 - (26:0,26)
-        Markup span - Gen<Markup> - [</span>] - SpanEditHandler;Accepts:None - (26:0,26) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[span];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..33)::33 - [<span data-foo  =  '@foo'></span>]
+    MarkupTagBlock - [0..26)::26 - [<span data-foo  =  '@foo'>]
+        MarkupTextLiteral - [0..5)::5 - [<span] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[span];
+        MarkupAttributeBlock - [5..25)::20 - [ data-foo  =  '@foo']
+            MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [6..14)::8 - [data-foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[data-foo];
+            MarkupTextLiteral - [14..16)::2 - [  ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[  ];
+            Equals;[=];
+            MarkupTextLiteral - [17..20)::3 - [  '] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[  ];
+                SingleQuote;['];
+            GenericBlock - [20..24)::4
+                CSharpCodeBlock - [20..24)::4
+                    CSharpImplicitExpression - [20..24)::4
+                        CSharpTransition - [20..21)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                            Transition;[@];
+                        CSharpImplicitExpressionBody - [21..24)::3
+                            CSharpCodeBlock - [21..24)::3
+                                CSharpExpressionLiteral - [21..24)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                    Identifier;[foo];
+            MarkupTextLiteral - [24..25)::1 - ['] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [25..26)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            CloseAngle;[>];
+    MarkupTagBlock - [26..33)::7 - [</span>]
+        MarkupTextLiteral - [26..33)::7 - [</span>] - Gen<Markup> - SpanEditHandler;Accepts:None
+            OpenAngle;[<];
+            ForwardSlash;[/];
+            Text;[span];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesWithWeirdSpacingAreDisabledForDataAttributesInDocument.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/ConditionalAttributesWithWeirdSpacingAreDisabledForDataAttributesInDocument.stree.txt
@@ -1,24 +1,30 @@
-Markup block - Gen<None> - 28 - (0:0,0)
-    Tag block - Gen<None> - 21 - (0:0,0)
-        Markup span - Gen<Markup> - [<span] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[span];
-        Markup block - Gen<None> - 14 - (5:0,5)
-            Markup span - Gen<Markup> - [ data-foo=] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:3
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[data-foo];
-                SyntaxKind.Equals;[=];
-            Expression block - Gen<Expr> - 4 - (15:0,15)
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (16:0,16) - Tokens:1
-                    SyntaxKind.Identifier;[foo];
-        Markup span - Gen<Markup> - [ >] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:2
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 7 - (21:0,21)
-        Markup span - Gen<Markup> - [</span>] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[span];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..28)::28 - [<span data-foo=@foo ></span>]
+    MarkupBlock - [0..28)::28
+        MarkupTagBlock - [0..21)::21 - [<span data-foo=@foo >]
+            MarkupTextLiteral - [0..5)::5 - [<span] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[span];
+            MarkupAttributeBlock - [5..19)::14 - [ data-foo=@foo]
+                MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [6..14)::8 - [data-foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[data-foo];
+                Equals;[=];
+                GenericBlock - [15..19)::4
+                    CSharpCodeBlock - [15..19)::4
+                        CSharpImplicitExpression - [15..19)::4
+                            CSharpTransition - [15..16)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                Transition;[@];
+                            CSharpImplicitExpressionBody - [16..19)::3
+                                CSharpCodeBlock - [16..19)::3
+                                    CSharpExpressionLiteral - [16..19)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                        Identifier;[foo];
+            MarkupTextLiteral - [19..21)::2 - [ >] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                CloseAngle;[>];
+        MarkupTagBlock - [21..28)::7 - [</span>]
+            MarkupTextLiteral - [21..28)::7 - [</span>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[span];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/DoubleQuotedLiteralAttribute.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/DoubleQuotedLiteralAttribute.stree.txt
@@ -1,25 +1,33 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<None> - 24 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href="@(2:0,2),"@(20:0,20)> - 19 - (2:0,2)
-            Markup span - Gen<None> - [ href="] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(9:0,9)> - [Foo] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<LitAttr: @(12:0,12)> - [ Bar] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<LitAttr: @(16:0,16)> - [ Baz] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[Baz];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..24)::24 - [<a href="Foo Bar Baz" />]
+    MarkupTagBlock - [0..24)::24 - [<a href="Foo Bar Baz" />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..21)::19 - [ href="Foo Bar Baz"]
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [8..9)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+            GenericBlock - [9..20)::11
+                MarkupLiteralAttributeValue - [9..12)::3 - [Foo]
+                    MarkupTextLiteral - [9..12)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+                MarkupLiteralAttributeValue - [12..16)::4 - [ Bar]
+                    MarkupTextLiteral - [12..13)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [13..16)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+                MarkupLiteralAttributeValue - [16..20)::4 - [ Baz]
+                    MarkupTextLiteral - [16..17)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [17..20)::3 - [Baz] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Baz];
+            MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                DoubleQuote;["];
+        MarkupTextLiteral - [21..24)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/DynamicAttributeWithWhitespaceSurroundingEquals.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/DynamicAttributeWithWhitespaceSurroundingEquals.stree.txt
@@ -1,27 +1,35 @@
-Markup block - Gen<None> - 23 - (0:0,0)
-    Tag block - Gen<None> - 23 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href LF= LF'@(2:0,2),'@(19:2,5)> - 18 - (2:0,2)
-            Markup span - Gen<None> - [ href LF= LF'] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:8
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.SingleQuote;['];
-            Markup block - Gen<DynAttr:@(15:2,1)> - 4 - (15:2,1)
-                Expression block - Gen<Expr> - 4 - (15:2,1)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (15:2,1) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [Foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (16:2,2) - Tokens:1
-                        SyntaxKind.Identifier;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (19:2,5) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (20:2,6) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..23)::23 - [<a href LF= LF'@Foo' />]
+    MarkupTagBlock - [0..23)::23 - [<a href LF= LF'@Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..20)::18 - [ href LF= LF'@Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            MarkupTextLiteral - [7..10)::3 - [ LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                NewLine;[LF];
+            Equals;[=];
+            MarkupTextLiteral - [11..15)::4 - [ LF'] - Gen<None> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                NewLine;[LF];
+                SingleQuote;['];
+            GenericBlock - [15..19)::4
+                MarkupDynamicAttributeValue - [15..19)::4 - [@Foo]
+                    GenericBlock - [15..19)::4
+                        CSharpCodeBlock - [15..19)::4
+                            CSharpImplicitExpression - [15..19)::4
+                                CSharpTransition - [15..16)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Transition;[@];
+                                CSharpImplicitExpressionBody - [16..19)::3
+                                    CSharpCodeBlock - [16..19)::3
+                                        CSharpExpressionLiteral - [16..19)::3 - [Foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                            Identifier;[Foo];
+            MarkupTextLiteral - [19..20)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [20..23)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/MultiPartLiteralAttribute.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/MultiPartLiteralAttribute.stree.txt
@@ -1,25 +1,33 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<None> - 24 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href='@(2:0,2),'@(20:0,20)> - 19 - (2:0,2)
-            Markup span - Gen<None> - [ href='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(9:0,9)> - [Foo] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<LitAttr: @(12:0,12)> - [ Bar] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<LitAttr: @(16:0,16)> - [ Baz] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[Baz];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..24)::24 - [<a href='Foo Bar Baz' />]
+    MarkupTagBlock - [0..24)::24 - [<a href='Foo Bar Baz' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..21)::19 - [ href='Foo Bar Baz']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [8..9)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [9..20)::11
+                MarkupLiteralAttributeValue - [9..12)::3 - [Foo]
+                    MarkupTextLiteral - [9..12)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+                MarkupLiteralAttributeValue - [12..16)::4 - [ Bar]
+                    MarkupTextLiteral - [12..13)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [13..16)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+                MarkupLiteralAttributeValue - [16..20)::4 - [ Baz]
+                    MarkupTextLiteral - [16..17)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [17..20)::3 - [Baz] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Baz];
+            MarkupTextLiteral - [20..21)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [21..24)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/MultiValueExpressionAttribute.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/MultiValueExpressionAttribute.stree.txt
@@ -1,34 +1,47 @@
-Markup block - Gen<None> - 26 - (0:0,0)
-    Tag block - Gen<None> - 26 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href='@(2:0,2),'@(22:0,22)> - 21 - (2:0,2)
-            Markup span - Gen<None> - [ href='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup block - Gen<DynAttr:@(9:0,9)> - 4 - (9:0,9)
-                Expression block - Gen<Expr> - 4 - (9:0,9)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (10:0,10) - Tokens:1
-                        SyntaxKind.Identifier;[foo];
-            Markup span - Gen<LitAttr: @(13:0,13)> - [ bar] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[bar];
-            Markup block - Gen<DynAttr: @(17:0,17)> - 5 - (17:0,17)
-                Markup span - Gen<None> - [ ] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:1
-                    SyntaxKind.Whitespace;[ ];
-                Expression block - Gen<Expr> - 4 - (18:0,18)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [baz] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (19:0,19) - Tokens:1
-                        SyntaxKind.Identifier;[baz];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (23:0,23) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..26)::26 - [<a href='@foo bar @baz' />]
+    MarkupTagBlock - [0..26)::26 - [<a href='@foo bar @baz' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..23)::21 - [ href='@foo bar @baz']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [8..9)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [9..22)::13
+                MarkupDynamicAttributeValue - [9..13)::4 - [@foo]
+                    GenericBlock - [9..13)::4
+                        CSharpCodeBlock - [9..13)::4
+                            CSharpImplicitExpression - [9..13)::4
+                                CSharpTransition - [9..10)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Transition;[@];
+                                CSharpImplicitExpressionBody - [10..13)::3
+                                    CSharpCodeBlock - [10..13)::3
+                                        CSharpExpressionLiteral - [10..13)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                            Identifier;[foo];
+                MarkupLiteralAttributeValue - [13..17)::4 - [ bar]
+                    MarkupTextLiteral - [13..14)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [14..17)::3 - [bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[bar];
+                MarkupDynamicAttributeValue - [17..22)::5 - [ @baz]
+                    MarkupTextLiteral - [17..18)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    GenericBlock - [18..22)::4
+                        CSharpCodeBlock - [18..22)::4
+                            CSharpImplicitExpression - [18..22)::4
+                                CSharpTransition - [18..19)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Transition;[@];
+                                CSharpImplicitExpressionBody - [19..22)::3
+                                    CSharpCodeBlock - [19..22)::3
+                                        CSharpExpressionLiteral - [19..22)::3 - [baz] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                            Identifier;[baz];
+            MarkupTextLiteral - [22..23)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [23..26)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/NewLineBetweenAttributes.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/NewLineBetweenAttributes.stree.txt
@@ -1,29 +1,37 @@
-Markup block - Gen<None> - 29 - (0:0,0)
-    Tag block - Gen<None> - 29 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href,LFhref='@(2:0,2),'@(13:1,9)> - 12 - (2:0,2)
-            Markup span - Gen<None> - [LFhref='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(10:1,6)> - [Foo] - SpanEditHandler;Accepts:Any - (10:1,6) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (13:1,9) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:abcd,LFabcd='@(14:1,10),'@(25:2,9)> - 12 - (14:1,10)
-            Markup span - Gen<None> - [LFabcd='] - SpanEditHandler;Accepts:Any - (14:1,10) - Tokens:4
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Text;[abcd];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(22:2,6)> - [Bar] - SpanEditHandler;Accepts:Any - (22:2,6) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (25:2,9) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (26:2,10) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..29)::29 - [<aLFhref='Foo'LFabcd='Bar' />]
+    MarkupTagBlock - [0..29)::29 - [<aLFhref='Foo'LFabcd='Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..14)::12 - [LFhref='Foo']
+            MarkupTextLiteral - [2..4)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            MarkupTextLiteral - [4..8)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [9..10)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [10..13)::3
+                MarkupLiteralAttributeValue - [10..13)::3 - [Foo]
+                    MarkupTextLiteral - [10..13)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [14..26)::12 - [LFabcd='Bar']
+            MarkupTextLiteral - [14..16)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            MarkupTextLiteral - [16..20)::4 - [abcd] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[abcd];
+            Equals;[=];
+            MarkupTextLiteral - [21..22)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [22..25)::3
+                MarkupLiteralAttributeValue - [22..25)::3 - [Bar]
+                    MarkupTextLiteral - [22..25)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [25..26)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [26..29)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/NewLinePrecedingAttribute.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/NewLinePrecedingAttribute.stree.txt
@@ -1,19 +1,23 @@
-Markup block - Gen<None> - 17 - (0:0,0)
-    Tag block - Gen<None> - 17 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href,LFhref='@(2:0,2),'@(13:1,9)> - 12 - (2:0,2)
-            Markup span - Gen<None> - [LFhref='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(10:1,6)> - [Foo] - SpanEditHandler;Accepts:Any - (10:1,6) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (13:1,9) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (14:1,10) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..17)::17 - [<aLFhref='Foo' />]
+    MarkupTagBlock - [0..17)::17 - [<aLFhref='Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..14)::12 - [LFhref='Foo']
+            MarkupTextLiteral - [2..4)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            MarkupTextLiteral - [4..8)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [9..10)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [10..13)::3
+                MarkupLiteralAttributeValue - [10..13)::3 - [Foo]
+                    MarkupTextLiteral - [10..13)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [14..17)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SimpleExpressionAttribute.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SimpleExpressionAttribute.stree.txt
@@ -1,23 +1,30 @@
-Markup block - Gen<None> - 17 - (0:0,0)
-    Tag block - Gen<None> - 17 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href='@(2:0,2),'@(13:0,13)> - 12 - (2:0,2)
-            Markup span - Gen<None> - [ href='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup block - Gen<DynAttr:@(9:0,9)> - 4 - (9:0,9)
-                Expression block - Gen<Expr> - 4 - (9:0,9)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (10:0,10) - Tokens:1
-                        SyntaxKind.Identifier;[foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (14:0,14) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..17)::17 - [<a href='@foo' />]
+    MarkupTagBlock - [0..17)::17 - [<a href='@foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..14)::12 - [ href='@foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [8..9)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [9..13)::4
+                MarkupDynamicAttributeValue - [9..13)::4 - [@foo]
+                    GenericBlock - [9..13)::4
+                        CSharpCodeBlock - [9..13)::4
+                            CSharpImplicitExpression - [9..13)::4
+                                CSharpTransition - [9..10)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Transition;[@];
+                                CSharpImplicitExpressionBody - [10..13)::3
+                                    CSharpCodeBlock - [10..13)::3
+                                        CSharpExpressionLiteral - [10..13)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                            Identifier;[foo];
+            MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [14..17)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SimpleLiteralAttribute.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SimpleLiteralAttribute.stree.txt
@@ -1,19 +1,23 @@
-Markup block - Gen<None> - 16 - (0:0,0)
-    Tag block - Gen<None> - 16 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href='@(2:0,2),'@(12:0,12)> - 11 - (2:0,2)
-            Markup span - Gen<None> - [ href='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(9:0,9)> - [Foo] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (13:0,13) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..16)::16 - [<a href='Foo' />]
+    MarkupTagBlock - [0..16)::16 - [<a href='Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..13)::11 - [ href='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [8..9)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [9..12)::3
+                MarkupLiteralAttributeValue - [9..12)::3 - [Foo]
+                    MarkupTextLiteral - [9..12)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [12..13)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [13..16)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SimpleLiteralAttributeWithWhitespaceSurroundingEquals.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SimpleLiteralAttributeWithWhitespaceSurroundingEquals.stree.txt
@@ -1,23 +1,28 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<None> - 24 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href LF= 	LF'@(2:0,2),'@(20:2,4)> - 19 - (2:0,2)
-            Markup span - Gen<None> - [ href LF= 	LF'] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:8
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.Whitespace;[ 	];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(17:2,1)> - [Foo] - SpanEditHandler;Accepts:Any - (17:2,1) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (20:2,4) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (21:2,5) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..24)::24 - [<a href LF= 	LF'Foo' />]
+    MarkupTagBlock - [0..24)::24 - [<a href LF= 	LF'Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..21)::19 - [ href LF= 	LF'Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            MarkupTextLiteral - [7..11)::4 - [ LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                NewLine;[LF];
+            Equals;[=];
+            MarkupTextLiteral - [12..17)::5 - [ 	LF'] - Gen<None> - SpanEditHandler;Accepts:Any
+                Whitespace;[ 	];
+                NewLine;[LF];
+                SingleQuote;['];
+            GenericBlock - [17..20)::3
+                MarkupLiteralAttributeValue - [17..20)::3 - [Foo]
+                    MarkupTextLiteral - [17..20)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [20..21)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [21..24)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes1.stree.txt
@@ -1,21 +1,25 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Tag block - Gen<None> - 18 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:[item], [item]='@(2:0,2),'@(14:0,14)> - 13 - (2:0,2)
-            Markup span - Gen<None> - [ [item]='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:6
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[item];
-                SyntaxKind.RightBracket;[]];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [Foo] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..18)::18 - [<a [item]='Foo' />]
+    MarkupTagBlock - [0..18)::18 - [<a [item]='Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..15)::13 - [ [item]='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..9)::6 - [[item]] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[item];
+                RightBracket;[]];
+            Equals;[=];
+            MarkupTextLiteral - [10..11)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [11..14)::3
+                MarkupLiteralAttributeValue - [11..14)::3 - [Foo]
+                    MarkupTextLiteral - [11..14)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [14..15)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [15..18)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes2.stree.txt
@@ -1,20 +1,24 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Tag block - Gen<None> - 19 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:[(item,, [(item,='@(2:0,2),'@(15:0,15)> - 14 - (2:0,2)
-            Markup span - Gen<None> - [ [(item,='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:5
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[(item,];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(12:0,12)> - [Foo] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..19)::19 - [<a [(item,='Foo' />]
+    MarkupTagBlock - [0..19)::19 - [<a [(item,='Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..16)::14 - [ [(item,='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..10)::7 - [[(item,] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[(item,];
+            Equals;[=];
+            MarkupTextLiteral - [11..12)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [12..15)::3
+                MarkupLiteralAttributeValue - [12..15)::3 - [Foo]
+                    MarkupTextLiteral - [12..15)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [15..16)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [16..19)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes3.stree.txt
@@ -1,19 +1,23 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Tag block - Gen<None> - 19 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:(click), (click)='@(2:0,2),'@(15:0,15)> - 14 - (2:0,2)
-            Markup span - Gen<None> - [ (click)='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[(click)];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(12:0,12)> - [Foo] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..19)::19 - [<a (click)='Foo' />]
+    MarkupTagBlock - [0..19)::19 - [<a (click)='Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..16)::14 - [ (click)='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..10)::7 - [(click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(click)];
+            Equals;[=];
+            MarkupTextLiteral - [11..12)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [12..15)::3
+                MarkupLiteralAttributeValue - [12..15)::3 - [Foo]
+                    MarkupTextLiteral - [12..15)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [15..16)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [16..19)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes4.stree.txt
@@ -1,19 +1,23 @@
-Markup block - Gen<None> - 20 - (0:0,0)
-    Tag block - Gen<None> - 20 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:(^click), (^click)='@(2:0,2),'@(16:0,16)> - 15 - (2:0,2)
-            Markup span - Gen<None> - [ (^click)='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[(^click)];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(13:0,13)> - [Foo] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..20)::20 - [<a (^click)='Foo' />]
+    MarkupTagBlock - [0..20)::20 - [<a (^click)='Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..17)::15 - [ (^click)='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..11)::8 - [(^click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(^click)];
+            Equals;[=];
+            MarkupTextLiteral - [12..13)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [13..16)::3
+                MarkupLiteralAttributeValue - [13..16)::3 - [Foo]
+                    MarkupTextLiteral - [13..16)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [16..17)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [17..20)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes5.stree.txt
@@ -1,19 +1,23 @@
-Markup block - Gen<None> - 22 - (0:0,0)
-    Tag block - Gen<None> - 22 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:*something, *something='@(2:0,2),'@(18:0,18)> - 17 - (2:0,2)
-            Markup span - Gen<None> - [ *something='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[*something];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(15:0,15)> - [Foo] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (19:0,19) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..22)::22 - [<a *something='Foo' />]
+    MarkupTagBlock - [0..22)::22 - [<a *something='Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..19)::17 - [ *something='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..13)::10 - [*something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[*something];
+            Equals;[=];
+            MarkupTextLiteral - [14..15)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [15..18)::3
+                MarkupLiteralAttributeValue - [15..18)::3 - [Foo]
+                    MarkupTextLiteral - [15..18)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [18..19)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [19..22)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes6.stree.txt
@@ -1,19 +1,23 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Tag block - Gen<None> - 18 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:#local, #local='@(2:0,2),'@(14:0,14)> - 13 - (2:0,2)
-            Markup span - Gen<None> - [ #local='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[#local];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [Foo] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..18)::18 - [<a #local='Foo' />]
+    MarkupTagBlock - [0..18)::18 - [<a #local='Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..15)::13 - [ #local='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..9)::6 - [#local] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[#local];
+            Equals;[=];
+            MarkupTextLiteral - [10..11)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [11..14)::3
+                MarkupLiteralAttributeValue - [11..14)::3 - [Foo]
+                    MarkupTextLiteral - [11..14)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [14..15)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [15..18)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace1.stree.txt
@@ -1,35 +1,44 @@
-Markup block - Gen<None> - 35 - (0:0,0)
-    Tag block - Gen<None> - 35 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:[item], [item]LF='@(2:0,2),'@(16:1,5)> - 15 - (2:0,2)
-            Markup span - Gen<None> - [ [item]LF='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:7
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[item];
-                SyntaxKind.RightBracket;[]];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(13:1,2)> - [Foo] - SpanEditHandler;Accepts:Any - (13:1,2) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (16:1,5) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:[item],	[item]=LF'@(17:1,6),'@(31:2,4)> - 15 - (17:1,6)
-            Markup span - Gen<None> - [	[item]=LF'] - SpanEditHandler;Accepts:Any - (17:1,6) - Tokens:7
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[item];
-                SyntaxKind.RightBracket;[]];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(28:2,1)> - [Bar] - SpanEditHandler;Accepts:Any - (28:2,1) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (31:2,4) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (32:2,5) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..35)::35 - [<a [item]LF='Foo'	[item]=LF'Bar' />]
+    MarkupTagBlock - [0..35)::35 - [<a [item]LF='Foo'	[item]=LF'Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..17)::15 - [ [item]LF='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..9)::6 - [[item]] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[item];
+                RightBracket;[]];
+            MarkupTextLiteral - [9..11)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            Equals;[=];
+            MarkupTextLiteral - [12..13)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [13..16)::3
+                MarkupLiteralAttributeValue - [13..16)::3 - [Foo]
+                    MarkupTextLiteral - [13..16)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [16..17)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [17..32)::15 - [	[item]=LF'Bar']
+            MarkupTextLiteral - [17..18)::1 - [	] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+            MarkupTextLiteral - [18..24)::6 - [[item]] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[item];
+                RightBracket;[]];
+            Equals;[=];
+            MarkupTextLiteral - [25..28)::3 - [LF'] - Gen<None> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+                SingleQuote;['];
+            GenericBlock - [28..31)::3
+                MarkupLiteralAttributeValue - [28..31)::3 - [Bar]
+                    MarkupTextLiteral - [28..31)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [31..32)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [32..35)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace2.stree.txt
@@ -1,33 +1,42 @@
-Markup block - Gen<None> - 37 - (0:0,0)
-    Tag block - Gen<None> - 37 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:[(item,, [(item,LF='@(2:0,2),'@(17:1,5)> - 16 - (2:0,2)
-            Markup span - Gen<None> - [ [(item,LF='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:6
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[(item,];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(14:1,2)> - [Foo] - SpanEditHandler;Accepts:Any - (14:1,2) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (17:1,5) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:[(item,,	[(item,=LF'@(18:1,6),'@(33:2,4)> - 16 - (18:1,6)
-            Markup span - Gen<None> - [	[(item,=LF'] - SpanEditHandler;Accepts:Any - (18:1,6) - Tokens:6
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[(item,];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(30:2,1)> - [Bar] - SpanEditHandler;Accepts:Any - (30:2,1) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (33:2,4) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (34:2,5) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..37)::37 - [<a [(item,LF='Foo'	[(item,=LF'Bar' />]
+    MarkupTagBlock - [0..37)::37 - [<a [(item,LF='Foo'	[(item,=LF'Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..18)::16 - [ [(item,LF='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..10)::7 - [[(item,] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[(item,];
+            MarkupTextLiteral - [10..12)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            Equals;[=];
+            MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [14..17)::3
+                MarkupLiteralAttributeValue - [14..17)::3 - [Foo]
+                    MarkupTextLiteral - [14..17)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [17..18)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [18..34)::16 - [	[(item,=LF'Bar']
+            MarkupTextLiteral - [18..19)::1 - [	] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+            MarkupTextLiteral - [19..26)::7 - [[(item,] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[(item,];
+            Equals;[=];
+            MarkupTextLiteral - [27..30)::3 - [LF'] - Gen<None> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+                SingleQuote;['];
+            GenericBlock - [30..33)::3
+                MarkupLiteralAttributeValue - [30..33)::3 - [Bar]
+                    MarkupTextLiteral - [30..33)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [33..34)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [34..37)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace3.stree.txt
@@ -1,31 +1,40 @@
-Markup block - Gen<None> - 37 - (0:0,0)
-    Tag block - Gen<None> - 37 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:(click), (click)LF='@(2:0,2),'@(17:1,5)> - 16 - (2:0,2)
-            Markup span - Gen<None> - [ (click)LF='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:5
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[(click)];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(14:1,2)> - [Foo] - SpanEditHandler;Accepts:Any - (14:1,2) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (17:1,5) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:(click),	(click)=LF'@(18:1,6),'@(33:2,4)> - 16 - (18:1,6)
-            Markup span - Gen<None> - [	(click)=LF'] - SpanEditHandler;Accepts:Any - (18:1,6) - Tokens:5
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.Text;[(click)];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(30:2,1)> - [Bar] - SpanEditHandler;Accepts:Any - (30:2,1) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (33:2,4) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (34:2,5) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..37)::37 - [<a (click)LF='Foo'	(click)=LF'Bar' />]
+    MarkupTagBlock - [0..37)::37 - [<a (click)LF='Foo'	(click)=LF'Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..18)::16 - [ (click)LF='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..10)::7 - [(click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(click)];
+            MarkupTextLiteral - [10..12)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            Equals;[=];
+            MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [14..17)::3
+                MarkupLiteralAttributeValue - [14..17)::3 - [Foo]
+                    MarkupTextLiteral - [14..17)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [17..18)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [18..34)::16 - [	(click)=LF'Bar']
+            MarkupTextLiteral - [18..19)::1 - [	] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+            MarkupTextLiteral - [19..26)::7 - [(click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(click)];
+            Equals;[=];
+            MarkupTextLiteral - [27..30)::3 - [LF'] - Gen<None> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+                SingleQuote;['];
+            GenericBlock - [30..33)::3
+                MarkupLiteralAttributeValue - [30..33)::3 - [Bar]
+                    MarkupTextLiteral - [30..33)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [33..34)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [34..37)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace4.stree.txt
@@ -1,31 +1,40 @@
-Markup block - Gen<None> - 39 - (0:0,0)
-    Tag block - Gen<None> - 39 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:(^click), (^click)LF='@(2:0,2),'@(18:1,5)> - 17 - (2:0,2)
-            Markup span - Gen<None> - [ (^click)LF='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:5
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[(^click)];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(15:1,2)> - [Foo] - SpanEditHandler;Accepts:Any - (15:1,2) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (18:1,5) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:(^click),	(^click)=LF'@(19:1,6),'@(35:2,4)> - 17 - (19:1,6)
-            Markup span - Gen<None> - [	(^click)=LF'] - SpanEditHandler;Accepts:Any - (19:1,6) - Tokens:5
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.Text;[(^click)];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(32:2,1)> - [Bar] - SpanEditHandler;Accepts:Any - (32:2,1) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (35:2,4) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (36:2,5) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..39)::39 - [<a (^click)LF='Foo'	(^click)=LF'Bar' />]
+    MarkupTagBlock - [0..39)::39 - [<a (^click)LF='Foo'	(^click)=LF'Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..19)::17 - [ (^click)LF='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..11)::8 - [(^click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(^click)];
+            MarkupTextLiteral - [11..13)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            Equals;[=];
+            MarkupTextLiteral - [14..15)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [15..18)::3
+                MarkupLiteralAttributeValue - [15..18)::3 - [Foo]
+                    MarkupTextLiteral - [15..18)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [18..19)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [19..36)::17 - [	(^click)=LF'Bar']
+            MarkupTextLiteral - [19..20)::1 - [	] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+            MarkupTextLiteral - [20..28)::8 - [(^click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(^click)];
+            Equals;[=];
+            MarkupTextLiteral - [29..32)::3 - [LF'] - Gen<None> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+                SingleQuote;['];
+            GenericBlock - [32..35)::3
+                MarkupLiteralAttributeValue - [32..35)::3 - [Bar]
+                    MarkupTextLiteral - [32..35)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [35..36)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [36..39)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace5.stree.txt
@@ -1,31 +1,40 @@
-Markup block - Gen<None> - 43 - (0:0,0)
-    Tag block - Gen<None> - 43 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:*something, *somethingLF='@(2:0,2),'@(20:1,5)> - 19 - (2:0,2)
-            Markup span - Gen<None> - [ *somethingLF='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:5
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[*something];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(17:1,2)> - [Foo] - SpanEditHandler;Accepts:Any - (17:1,2) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (20:1,5) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:*something,	*something=LF'@(21:1,6),'@(39:2,4)> - 19 - (21:1,6)
-            Markup span - Gen<None> - [	*something=LF'] - SpanEditHandler;Accepts:Any - (21:1,6) - Tokens:5
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.Text;[*something];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(36:2,1)> - [Bar] - SpanEditHandler;Accepts:Any - (36:2,1) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (39:2,4) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (40:2,5) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..43)::43 - [<a *somethingLF='Foo'	*something=LF'Bar' />]
+    MarkupTagBlock - [0..43)::43 - [<a *somethingLF='Foo'	*something=LF'Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..21)::19 - [ *somethingLF='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..13)::10 - [*something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[*something];
+            MarkupTextLiteral - [13..15)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            Equals;[=];
+            MarkupTextLiteral - [16..17)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [17..20)::3
+                MarkupLiteralAttributeValue - [17..20)::3 - [Foo]
+                    MarkupTextLiteral - [17..20)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [20..21)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [21..40)::19 - [	*something=LF'Bar']
+            MarkupTextLiteral - [21..22)::1 - [	] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+            MarkupTextLiteral - [22..32)::10 - [*something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[*something];
+            Equals;[=];
+            MarkupTextLiteral - [33..36)::3 - [LF'] - Gen<None> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+                SingleQuote;['];
+            GenericBlock - [36..39)::3
+                MarkupLiteralAttributeValue - [36..39)::3 - [Bar]
+                    MarkupTextLiteral - [36..39)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [39..40)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [40..43)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_BeforeEqualWhitespace6.stree.txt
@@ -1,31 +1,40 @@
-Markup block - Gen<None> - 35 - (0:0,0)
-    Tag block - Gen<None> - 35 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:#local, #localLF='@(2:0,2),'@(16:1,5)> - 15 - (2:0,2)
-            Markup span - Gen<None> - [ #localLF='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:5
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[#local];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(13:1,2)> - [Foo] - SpanEditHandler;Accepts:Any - (13:1,2) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (16:1,5) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:#local,	#local=LF'@(17:1,6),'@(31:2,4)> - 15 - (17:1,6)
-            Markup span - Gen<None> - [	#local=LF'] - SpanEditHandler;Accepts:Any - (17:1,6) - Tokens:5
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.Text;[#local];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(28:2,1)> - [Bar] - SpanEditHandler;Accepts:Any - (28:2,1) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (31:2,4) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (32:2,5) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..35)::35 - [<a #localLF='Foo'	#local=LF'Bar' />]
+    MarkupTagBlock - [0..35)::35 - [<a #localLF='Foo'	#local=LF'Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..17)::15 - [ #localLF='Foo']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..9)::6 - [#local] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[#local];
+            MarkupTextLiteral - [9..11)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            Equals;[=];
+            MarkupTextLiteral - [12..13)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [13..16)::3
+                MarkupLiteralAttributeValue - [13..16)::3 - [Foo]
+                    MarkupTextLiteral - [13..16)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [16..17)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [17..32)::15 - [	#local=LF'Bar']
+            MarkupTextLiteral - [17..18)::1 - [	] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+            MarkupTextLiteral - [18..24)::6 - [#local] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[#local];
+            Equals;[=];
+            MarkupTextLiteral - [25..28)::3 - [LF'] - Gen<None> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+                SingleQuote;['];
+            GenericBlock - [28..31)::3
+                MarkupLiteralAttributeValue - [28..31)::3 - [Bar]
+                    MarkupTextLiteral - [28..31)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [31..32)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [32..35)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace1.stree.txt
@@ -1,36 +1,44 @@
-Markup block - Gen<None> - 37 - (0:0,0)
-    Tag block - Gen<None> - 37 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:[item], LF  [item]='@(2:0,2),'@(18:1,13)> - 17 - (2:0,2)
-            Markup span - Gen<None> - [ LF  [item]='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:8
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[  ];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[item];
-                SyntaxKind.RightBracket;[]];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(15:1,10)> - [Foo] - SpanEditHandler;Accepts:Any - (15:1,10) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (18:1,13) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:[item],	LF[item]='@(19:1,14),'@(33:2,11)> - 15 - (19:1,14)
-            Markup span - Gen<None> - [	LF[item]='] - SpanEditHandler;Accepts:Any - (19:1,14) - Tokens:7
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[item];
-                SyntaxKind.RightBracket;[]];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(30:2,8)> - [Bar] - SpanEditHandler;Accepts:Any - (30:2,8) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (33:2,11) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (34:2,12) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..37)::37 - [<a LF  [item]='Foo'	LF[item]='Bar' />]
+    MarkupTagBlock - [0..37)::37 - [<a LF  [item]='Foo'	LF[item]='Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..19)::17 - [ LF  [item]='Foo']
+            MarkupTextLiteral - [2..7)::5 - [ LF  ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                NewLine;[LF];
+                Whitespace;[  ];
+            MarkupTextLiteral - [7..13)::6 - [[item]] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[item];
+                RightBracket;[]];
+            Equals;[=];
+            MarkupTextLiteral - [14..15)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [15..18)::3
+                MarkupLiteralAttributeValue - [15..18)::3 - [Foo]
+                    MarkupTextLiteral - [15..18)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [18..19)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [19..34)::15 - [	LF[item]='Bar']
+            MarkupTextLiteral - [19..22)::3 - [	LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+                NewLine;[LF];
+            MarkupTextLiteral - [22..28)::6 - [[item]] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[item];
+                RightBracket;[]];
+            Equals;[=];
+            MarkupTextLiteral - [29..30)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [30..33)::3
+                MarkupLiteralAttributeValue - [30..33)::3 - [Bar]
+                    MarkupTextLiteral - [30..33)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [33..34)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [34..37)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace2.stree.txt
@@ -1,34 +1,42 @@
-Markup block - Gen<None> - 39 - (0:0,0)
-    Tag block - Gen<None> - 39 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:[(item,, LF  [(item,='@(2:0,2),'@(19:1,14)> - 18 - (2:0,2)
-            Markup span - Gen<None> - [ LF  [(item,='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:7
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[  ];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[(item,];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(16:1,11)> - [Foo] - SpanEditHandler;Accepts:Any - (16:1,11) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (19:1,14) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:[(item,,	LF[(item,='@(20:1,15),'@(35:2,12)> - 16 - (20:1,15)
-            Markup span - Gen<None> - [	LF[(item,='] - SpanEditHandler;Accepts:Any - (20:1,15) - Tokens:6
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.LeftBracket;[[];
-                SyntaxKind.Text;[(item,];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(32:2,9)> - [Bar] - SpanEditHandler;Accepts:Any - (32:2,9) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (35:2,12) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (36:2,13) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..39)::39 - [<a LF  [(item,='Foo'	LF[(item,='Bar' />]
+    MarkupTagBlock - [0..39)::39 - [<a LF  [(item,='Foo'	LF[(item,='Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..20)::18 - [ LF  [(item,='Foo']
+            MarkupTextLiteral - [2..7)::5 - [ LF  ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                NewLine;[LF];
+                Whitespace;[  ];
+            MarkupTextLiteral - [7..14)::7 - [[(item,] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[(item,];
+            Equals;[=];
+            MarkupTextLiteral - [15..16)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [16..19)::3
+                MarkupLiteralAttributeValue - [16..19)::3 - [Foo]
+                    MarkupTextLiteral - [16..19)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [19..20)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [20..36)::16 - [	LF[(item,='Bar']
+            MarkupTextLiteral - [20..23)::3 - [	LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+                NewLine;[LF];
+            MarkupTextLiteral - [23..30)::7 - [[(item,] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                LeftBracket;[[];
+                Text;[(item,];
+            Equals;[=];
+            MarkupTextLiteral - [31..32)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [32..35)::3
+                MarkupLiteralAttributeValue - [32..35)::3 - [Bar]
+                    MarkupTextLiteral - [32..35)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [35..36)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [36..39)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace3.stree.txt
@@ -1,32 +1,40 @@
-Markup block - Gen<None> - 39 - (0:0,0)
-    Tag block - Gen<None> - 39 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:(click), LF  (click)='@(2:0,2),'@(19:1,14)> - 18 - (2:0,2)
-            Markup span - Gen<None> - [ LF  (click)='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:6
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[  ];
-                SyntaxKind.Text;[(click)];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(16:1,11)> - [Foo] - SpanEditHandler;Accepts:Any - (16:1,11) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (19:1,14) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:(click),	LF(click)='@(20:1,15),'@(35:2,12)> - 16 - (20:1,15)
-            Markup span - Gen<None> - [	LF(click)='] - SpanEditHandler;Accepts:Any - (20:1,15) - Tokens:5
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Text;[(click)];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(32:2,9)> - [Bar] - SpanEditHandler;Accepts:Any - (32:2,9) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (35:2,12) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (36:2,13) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..39)::39 - [<a LF  (click)='Foo'	LF(click)='Bar' />]
+    MarkupTagBlock - [0..39)::39 - [<a LF  (click)='Foo'	LF(click)='Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..20)::18 - [ LF  (click)='Foo']
+            MarkupTextLiteral - [2..7)::5 - [ LF  ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                NewLine;[LF];
+                Whitespace;[  ];
+            MarkupTextLiteral - [7..14)::7 - [(click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(click)];
+            Equals;[=];
+            MarkupTextLiteral - [15..16)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [16..19)::3
+                MarkupLiteralAttributeValue - [16..19)::3 - [Foo]
+                    MarkupTextLiteral - [16..19)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [19..20)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [20..36)::16 - [	LF(click)='Bar']
+            MarkupTextLiteral - [20..23)::3 - [	LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+                NewLine;[LF];
+            MarkupTextLiteral - [23..30)::7 - [(click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(click)];
+            Equals;[=];
+            MarkupTextLiteral - [31..32)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [32..35)::3
+                MarkupLiteralAttributeValue - [32..35)::3 - [Bar]
+                    MarkupTextLiteral - [32..35)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [35..36)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [36..39)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace4.stree.txt
@@ -1,32 +1,40 @@
-Markup block - Gen<None> - 41 - (0:0,0)
-    Tag block - Gen<None> - 41 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:(^click), LF  (^click)='@(2:0,2),'@(20:1,15)> - 19 - (2:0,2)
-            Markup span - Gen<None> - [ LF  (^click)='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:6
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[  ];
-                SyntaxKind.Text;[(^click)];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(17:1,12)> - [Foo] - SpanEditHandler;Accepts:Any - (17:1,12) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (20:1,15) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:(^click),	LF(^click)='@(21:1,16),'@(37:2,13)> - 17 - (21:1,16)
-            Markup span - Gen<None> - [	LF(^click)='] - SpanEditHandler;Accepts:Any - (21:1,16) - Tokens:5
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Text;[(^click)];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(34:2,10)> - [Bar] - SpanEditHandler;Accepts:Any - (34:2,10) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (37:2,13) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (38:2,14) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..41)::41 - [<a LF  (^click)='Foo'	LF(^click)='Bar' />]
+    MarkupTagBlock - [0..41)::41 - [<a LF  (^click)='Foo'	LF(^click)='Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..21)::19 - [ LF  (^click)='Foo']
+            MarkupTextLiteral - [2..7)::5 - [ LF  ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                NewLine;[LF];
+                Whitespace;[  ];
+            MarkupTextLiteral - [7..15)::8 - [(^click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(^click)];
+            Equals;[=];
+            MarkupTextLiteral - [16..17)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [17..20)::3
+                MarkupLiteralAttributeValue - [17..20)::3 - [Foo]
+                    MarkupTextLiteral - [17..20)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [20..21)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [21..38)::17 - [	LF(^click)='Bar']
+            MarkupTextLiteral - [21..24)::3 - [	LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+                NewLine;[LF];
+            MarkupTextLiteral - [24..32)::8 - [(^click)] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[(^click)];
+            Equals;[=];
+            MarkupTextLiteral - [33..34)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [34..37)::3
+                MarkupLiteralAttributeValue - [34..37)::3 - [Bar]
+                    MarkupTextLiteral - [34..37)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [37..38)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [38..41)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace5.stree.txt
@@ -1,32 +1,40 @@
-Markup block - Gen<None> - 45 - (0:0,0)
-    Tag block - Gen<None> - 45 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:*something, LF  *something='@(2:0,2),'@(22:1,17)> - 21 - (2:0,2)
-            Markup span - Gen<None> - [ LF  *something='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:6
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[  ];
-                SyntaxKind.Text;[*something];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(19:1,14)> - [Foo] - SpanEditHandler;Accepts:Any - (19:1,14) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (22:1,17) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:*something,	LF*something='@(23:1,18),'@(41:2,15)> - 19 - (23:1,18)
-            Markup span - Gen<None> - [	LF*something='] - SpanEditHandler;Accepts:Any - (23:1,18) - Tokens:5
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Text;[*something];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(38:2,12)> - [Bar] - SpanEditHandler;Accepts:Any - (38:2,12) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (41:2,15) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (42:2,16) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..45)::45 - [<a LF  *something='Foo'	LF*something='Bar' />]
+    MarkupTagBlock - [0..45)::45 - [<a LF  *something='Foo'	LF*something='Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..23)::21 - [ LF  *something='Foo']
+            MarkupTextLiteral - [2..7)::5 - [ LF  ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                NewLine;[LF];
+                Whitespace;[  ];
+            MarkupTextLiteral - [7..17)::10 - [*something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[*something];
+            Equals;[=];
+            MarkupTextLiteral - [18..19)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [19..22)::3
+                MarkupLiteralAttributeValue - [19..22)::3 - [Foo]
+                    MarkupTextLiteral - [19..22)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [22..23)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [23..42)::19 - [	LF*something='Bar']
+            MarkupTextLiteral - [23..26)::3 - [	LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+                NewLine;[LF];
+            MarkupTextLiteral - [26..36)::10 - [*something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[*something];
+            Equals;[=];
+            MarkupTextLiteral - [37..38)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [38..41)::3
+                MarkupLiteralAttributeValue - [38..41)::3 - [Bar]
+                    MarkupTextLiteral - [38..41)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [41..42)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [42..45)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/SymbolBoundAttributes_Whitespace6.stree.txt
@@ -1,32 +1,40 @@
-Markup block - Gen<None> - 37 - (0:0,0)
-    Tag block - Gen<None> - 37 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:#local, LF  #local='@(2:0,2),'@(18:1,13)> - 17 - (2:0,2)
-            Markup span - Gen<None> - [ LF  #local='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:6
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[  ];
-                SyntaxKind.Text;[#local];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(15:1,10)> - [Foo] - SpanEditHandler;Accepts:Any - (15:1,10) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (18:1,13) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:#local,	LF#local='@(19:1,14),'@(33:2,11)> - 15 - (19:1,14)
-            Markup span - Gen<None> - [	LF#local='] - SpanEditHandler;Accepts:Any - (19:1,14) - Tokens:5
-                SyntaxKind.Whitespace;[	];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Text;[#local];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(30:2,8)> - [Bar] - SpanEditHandler;Accepts:Any - (30:2,8) - Tokens:1
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (33:2,11) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (34:2,12) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..37)::37 - [<a LF  #local='Foo'	LF#local='Bar' />]
+    MarkupTagBlock - [0..37)::37 - [<a LF  #local='Foo'	LF#local='Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..19)::17 - [ LF  #local='Foo']
+            MarkupTextLiteral - [2..7)::5 - [ LF  ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                NewLine;[LF];
+                Whitespace;[  ];
+            MarkupTextLiteral - [7..13)::6 - [#local] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[#local];
+            Equals;[=];
+            MarkupTextLiteral - [14..15)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [15..18)::3
+                MarkupLiteralAttributeValue - [15..18)::3 - [Foo]
+                    MarkupTextLiteral - [15..18)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [18..19)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupAttributeBlock - [19..34)::15 - [	LF#local='Bar']
+            MarkupTextLiteral - [19..22)::3 - [	LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[	];
+                NewLine;[LF];
+            MarkupTextLiteral - [22..28)::6 - [#local] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[#local];
+            Equals;[=];
+            MarkupTextLiteral - [29..30)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [30..33)::3
+                MarkupLiteralAttributeValue - [30..33)::3 - [Bar]
+                    MarkupTextLiteral - [30..33)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Bar];
+            MarkupTextLiteral - [33..34)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [34..37)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/UnquotedAttributeWithCodeWithSpacesInBlock.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/UnquotedAttributeWithCodeWithSpacesInBlock.stree.txt
@@ -1,20 +1,26 @@
-Markup block - Gen<None> - 20 - (0:0,0)
-    Tag block - Gen<None> - 20 - (0:0,0)
-        Markup span - Gen<Markup> - [<input] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[input];
-        Markup block - Gen<Attr:value, value=@(6:0,6),@(17:0,17)> - 11 - (6:0,6)
-            Markup span - Gen<None> - [ value=] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:3
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[value];
-                SyntaxKind.Equals;[=];
-            Markup block - Gen<DynAttr:@(13:0,13)> - 4 - (13:0,13)
-                Expression block - Gen<Expr> - 4 - (13:0,13)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (13:0,13) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (14:0,14) - Tokens:1
-                        SyntaxKind.Identifier;[foo];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..20)::20 - [<input value=@foo />]
+    MarkupTagBlock - [0..20)::20 - [<input value=@foo />]
+        MarkupTextLiteral - [0..6)::6 - [<input] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[input];
+        MarkupAttributeBlock - [6..17)::11 - [ value=@foo]
+            MarkupTextLiteral - [6..7)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [7..12)::5 - [value] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[value];
+            Equals;[=];
+            GenericBlock - [13..17)::4
+                MarkupDynamicAttributeValue - [13..17)::4 - [@foo]
+                    GenericBlock - [13..17)::4
+                        CSharpCodeBlock - [13..17)::4
+                            CSharpImplicitExpression - [13..17)::4
+                                CSharpTransition - [13..14)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Transition;[@];
+                                CSharpImplicitExpressionBody - [14..17)::3
+                                    CSharpCodeBlock - [14..17)::3
+                                        CSharpExpressionLiteral - [14..17)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                            Identifier;[foo];
+        MarkupTextLiteral - [17..20)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/UnquotedAttributeWithCodeWithSpacesInDocument.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/UnquotedAttributeWithCodeWithSpacesInDocument.stree.txt
@@ -1,20 +1,27 @@
-Markup block - Gen<None> - 20 - (0:0,0)
-    Tag block - Gen<None> - 20 - (0:0,0)
-        Markup span - Gen<Markup> - [<input] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[input];
-        Markup block - Gen<Attr:value, value=@(6:0,6),@(17:0,17)> - 11 - (6:0,6)
-            Markup span - Gen<None> - [ value=] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:3
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[value];
-                SyntaxKind.Equals;[=];
-            Markup block - Gen<DynAttr:@(13:0,13)> - 4 - (13:0,13)
-                Expression block - Gen<Expr> - 4 - (13:0,13)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (13:0,13) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (14:0,14) - Tokens:1
-                        SyntaxKind.Identifier;[foo];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..20)::20 - [<input value=@foo />]
+    MarkupBlock - [0..20)::20
+        MarkupTagBlock - [0..20)::20 - [<input value=@foo />]
+            MarkupTextLiteral - [0..6)::6 - [<input] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[input];
+            MarkupAttributeBlock - [6..17)::11 - [ value=@foo]
+                MarkupTextLiteral - [6..7)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [7..12)::5 - [value] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[value];
+                Equals;[=];
+                GenericBlock - [13..17)::4
+                    MarkupDynamicAttributeValue - [13..17)::4 - [@foo]
+                        GenericBlock - [13..17)::4
+                            CSharpCodeBlock - [13..17)::4
+                                CSharpImplicitExpression - [13..17)::4
+                                    CSharpTransition - [13..14)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                        Transition;[@];
+                                    CSharpImplicitExpressionBody - [14..17)::3
+                                        CSharpCodeBlock - [14..17)::3
+                                            CSharpExpressionLiteral - [14..17)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                Identifier;[foo];
+            MarkupTextLiteral - [17..20)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                ForwardSlash;[/];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/UnquotedLiteralAttribute.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/UnquotedLiteralAttribute.stree.txt
@@ -1,24 +1,29 @@
-Markup block - Gen<None> - 22 - (0:0,0)
-    Tag block - Gen<None> - 22 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href=@(2:0,2),@(11:0,11)> - 9 - (2:0,2)
-            Markup span - Gen<None> - [ href=] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:3
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-            Markup span - Gen<LitAttr:@(8:0,8)> - [Foo] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:1
-                SyntaxKind.Text;[Foo];
-        Markup block - Gen<None> - 4 - (11:0,11)
-            Markup span - Gen<Markup> - [ Bar] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[Bar];
-        Markup block - Gen<None> - 4 - (15:0,15)
-            Markup span - Gen<Markup> - [ Baz] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[Baz];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (19:0,19) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..22)::22 - [<a href=Foo Bar Baz />]
+    MarkupTagBlock - [0..22)::22 - [<a href=Foo Bar Baz />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..11)::9 - [ href=Foo]
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            GenericBlock - [8..11)::3
+                MarkupLiteralAttributeValue - [8..11)::3 - [Foo]
+                    MarkupTextLiteral - [8..11)::3 - [Foo] - Gen<None> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+        MarkupMinimizedAttributeBlock - [11..15)::4 - [ Bar]
+            MarkupTextLiteral - [11..12)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [12..15)::3 - [Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Bar];
+        MarkupMinimizedAttributeBlock - [15..19)::4 - [ Baz]
+            MarkupTextLiteral - [15..16)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [16..19)::3 - [Baz] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Baz];
+        MarkupTextLiteral - [19..22)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/VirtualPathAttributesWorkWithConditionalAttributes.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/VirtualPathAttributesWorkWithConditionalAttributes.stree.txt
@@ -1,30 +1,39 @@
-Markup block - Gen<None> - 27 - (0:0,0)
-    Tag block - Gen<None> - 27 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, href='@(2:0,2),'@(23:0,23)> - 22 - (2:0,2)
-            Markup span - Gen<None> - [ href='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup block - Gen<DynAttr:@(9:0,9)> - 4 - (9:0,9)
-                Expression block - Gen<Expr> - 4 - (9:0,9)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (10:0,10) - Tokens:1
-                        SyntaxKind.Identifier;[foo];
-            Markup span - Gen<LitAttr: @(13:0,13)> - [ ~/Foo/Bar] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:6
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[~];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[Foo];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[Bar];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..27)::27 - [<a href='@foo ~/Foo/Bar' />]
+    MarkupTagBlock - [0..27)::27 - [<a href='@foo ~/Foo/Bar' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..24)::22 - [ href='@foo ~/Foo/Bar']
+            MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+            MarkupTextLiteral - [3..7)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [8..9)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [9..23)::14
+                MarkupDynamicAttributeValue - [9..13)::4 - [@foo]
+                    GenericBlock - [9..13)::4
+                        CSharpCodeBlock - [9..13)::4
+                            CSharpImplicitExpression - [9..13)::4
+                                CSharpTransition - [9..10)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Transition;[@];
+                                CSharpImplicitExpressionBody - [10..13)::3
+                                    CSharpCodeBlock - [10..13)::3
+                                        CSharpExpressionLiteral - [10..13)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                            Identifier;[foo];
+                MarkupLiteralAttributeValue - [13..23)::10 - [ ~/Foo/Bar]
+                    MarkupTextLiteral - [13..14)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [14..23)::9 - [~/Foo/Bar] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[~];
+                        ForwardSlash;[/];
+                        Text;[Foo];
+                        ForwardSlash;[/];
+                        Text;[Bar];
+            MarkupTextLiteral - [23..24)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [24..27)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/WhitespaceAndNewLinePrecedingAttribute.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/HtmlAttributeTest/WhitespaceAndNewLinePrecedingAttribute.stree.txt
@@ -1,20 +1,24 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Tag block - Gen<None> - 19 - (0:0,0)
-        Markup span - Gen<Markup> - [<a] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[a];
-        Markup block - Gen<Attr:href, 	LFhref='@(2:0,2),'@(15:1,9)> - 14 - (2:0,2)
-            Markup span - Gen<None> - [ 	LFhref='] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:5
-                SyntaxKind.Whitespace;[ 	];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Text;[href];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(12:1,6)> - [Foo] - SpanEditHandler;Accepts:Any - (12:1,6) - Tokens:1
-                SyntaxKind.Text;[Foo];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (15:1,9) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:None - (16:1,10) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+MarkupBlock - [0..19)::19 - [<a 	LFhref='Foo' />]
+    MarkupTagBlock - [0..19)::19 - [<a 	LFhref='Foo' />]
+        MarkupTextLiteral - [0..2)::2 - [<a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[a];
+        MarkupAttributeBlock - [2..16)::14 - [ 	LFhref='Foo']
+            MarkupTextLiteral - [2..6)::4 - [ 	LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ 	];
+                NewLine;[LF];
+            MarkupTextLiteral - [6..10)::4 - [href] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[href];
+            Equals;[=];
+            MarkupTextLiteral - [11..12)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+            GenericBlock - [12..15)::3
+                MarkupLiteralAttributeValue - [12..15)::3 - [Foo]
+                    MarkupTextLiteral - [12..15)::3 - [Foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Foo];
+            MarkupTextLiteral - [15..16)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                SingleQuote;['];
+        MarkupTextLiteral - [16..19)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:None
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];


### PR DESCRIPTION
Attributes have a more defined structure in the new tree. Might be worth a deeper review for a few tests atleast.

Here is the structure of attributes,
``` XML
  <AbstractNode Name="RazorBlockSyntax" Base="RazorSyntaxNode">
    <Field Name="Children" Type="SyntaxList&lt;RazorSyntaxNode&gt;" />
  </AbstractNode>
  <Node Name="MarkupMinimizedAttributeBlockSyntax" Base="MarkupSyntaxNode">
    <Kind Name="MarkupMinimizedAttributeBlock" />
    <Field Name="NamePrefix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="Name" Type="MarkupTextLiteralSyntax" />
  </Node>
  <Node Name="MarkupAttributeBlockSyntax" Base="MarkupSyntaxNode">
    <Kind Name="MarkupAttributeBlock" />
    <Field Name="NamePrefix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="Name" Type="MarkupTextLiteralSyntax" />
    <Field Name="NameSuffix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="EqualsToken" Type="SyntaxToken">
      <Kind Name="Equals" />
    </Field>
    <Field Name="ValuePrefix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="Value" Type="RazorBlockSyntax" />
    <Field Name="ValueSuffix" Type="MarkupTextLiteralSyntax" Optional="true" />
  </Node>
  <Node Name="MarkupLiteralAttributeValueSyntax" Base="MarkupSyntaxNode">
    <Kind Name="MarkupLiteralAttributeValue" />
    <Field Name="Prefix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="Value" Type="MarkupTextLiteralSyntax" />
  </Node>
  <Node Name="MarkupDynamicAttributeValueSyntax" Base="MarkupSyntaxNode">
    <Kind Name="MarkupDynamicAttributeValue" />
    <Field Name="Prefix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="Value" Type="RazorBlockSyntax" />
  </Node>
```

I'm also thinking I should rename `MarkupAttributeBlockSyntax` to be just `MarkupAttributeSyntax` but that can happen later.
