### PR TITLE
New baselines for TagHelperParseTreeRewriterTest

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Syntax/SyntaxSerializer.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Syntax/SyntaxSerializer.cs
@@ -255,6 +255,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax
                     node.Kind == SyntaxKind.MarkupTagBlock ||
                     node.Kind == SyntaxKind.MarkupAttributeBlock ||
                     node.Kind == SyntaxKind.MarkupMinimizedAttributeBlock ||
+                    node.Kind == SyntaxKind.MarkupTagHelperAttribute ||
+                    node.Kind == SyntaxKind.MarkupMinimizedTagHelperAttribute ||
                     node.Kind == SyntaxKind.MarkupLiteralAttributeValue ||
                     node.Kind == SyntaxKind.MarkupDynamicAttributeValue ||
                     node.Kind == SyntaxKind.CSharpStatementLiteral ||

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -16,15 +16,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             UseNewSyntaxTree = true;
         }
 
-        [Fact]
-        public void TestTagHelpers()
-        {
-            UseNewSyntaxTree = false;
-            var document = "<p class=\"@btn\" />";
-            EvaluateData(PartialRequiredParentTags_Descriptors, document);
-            UseNewSyntaxTree = true;
-        }
-
         public static TheoryData GetAttributeNameValuePairsData
         {
             get

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers1.stree.txt
@@ -1,8 +1,9 @@
-Markup block - Gen<None> - 7 - (0:0,0)
-    Tag block - Gen<None> - 7 - (0:0,0)
-        Markup span - Gen<Markup> - [<th: />] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:5
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[th:];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..7)::7 - [<th: />]
+    MarkupBlock - [0..7)::7
+        MarkupTagBlock - [0..7)::7 - [<th: />]
+            MarkupTextLiteral - [0..7)::7 - [<th: />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[th:];
+                Whitespace;[ ];
+                ForwardSlash;[/];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers10.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers10.stree.txt
@@ -1,13 +1,35 @@
-Markup block - Gen<None> - 47 - (0:0,0)
-    Tag block - Gen<TagHelper> - 47 - (0:0,0) - th:myth - mythTagHelper
-        StartTagAndEndTag - <th:myth class="btn"> ... </th:myth>
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.Text;[btn];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [21..37) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [21..37) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..47)::47 - [<th:myth class="btn">words and spaces</th:myth>]
+    MarkupBlock - [0..47)::47
+        MarkupTagHelperElement - [0..47)::47 - th:myth[StartTagAndEndTag] - mythTagHelper
+            MarkupTagHelperStartTag - [0..21)::21
+                MarkupTextLiteral - [0..8)::8 - [<th:myth] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:myth];
+                MarkupTagHelperAttribute - [8..20)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [16..19)::3
+                        MarkupLiteralAttributeValue - [16..19)::3 - [btn]
+                            MarkupTextLiteral - [16..19)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [19..20)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [20..21)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [21..37)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [37..47)::10
+                MarkupTextLiteral - [37..47)::10 - [</th:myth>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:myth];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers11.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers11.stree.txt
@@ -1,13 +1,34 @@
-Markup block - Gen<None> - 34 - (0:0,0)
-    Tag block - Gen<TagHelper> - 34 - (0:0,0) - th:myth2 - mythTagHelper2
-        SelfClosing - <th:myth2 bound="@DateTime.Now" />
-        bound - DoubleQuotes
-            Markup block - Gen<None> - 13 - (17:0,17)
-                Markup block - Gen<None> - 13 - (17:0,17)
-                    Expression block - Gen<Expr> - 13 - (17:0,17)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:AnyExceptNewline;ImplicitExpression[ATD];K14 - (18:0,18) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
+RazorDocument - [0..34)::34 - [<th:myth2 bound="@DateTime.Now" />]
+    MarkupBlock - [0..34)::34
+        MarkupTagHelperElement - [0..34)::34 - th:myth2[SelfClosing] - mythTagHelper2
+            MarkupTagHelperStartTag - [0..34)::34
+                MarkupTextLiteral - [0..9)::9 - [<th:myth2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:myth2];
+                MarkupTagHelperAttribute - [9..31)::22 - bound - DoubleQuotes - [ bound="@DateTime.Now"]
+                    MarkupTextLiteral - [9..10)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [10..15)::5 - [bound] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[bound];
+                    Equals;[=];
+                    MarkupTextLiteral - [16..17)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [17..30)::13
+                        MarkupDynamicAttributeValue - [17..30)::13 - [@DateTime.Now]
+                            GenericBlock - [17..30)::13
+                                CSharpCodeBlock - [17..30)::13
+                                    CSharpImplicitExpression - [17..30)::13
+                                        CSharpTransition - [17..18)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [18..30)::12
+                                            CSharpCodeBlock - [18..30)::12
+                                                CSharpExpressionLiteral - [18..30)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:AnyExceptNewline;ImplicitExpression[ATD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [30..31)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [31..34)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers2.stree.txt
@@ -1,19 +1,19 @@
-Markup block - Gen<None> - 27 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<th:>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[th:];
-            SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [words and spaces] - [5..21) - FullWidth: 16 - Slots: 1
-        SyntaxKind.List - [words and spaces] - [5..21) - FullWidth: 16 - Slots: 5
-            SyntaxKind.Text;[words];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[and];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[spaces];
-    Tag block - Gen<None> - 6 - (21:0,21)
-        Markup span - Gen<Markup> - [</th:>] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[th:];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..27)::27 - [<th:>words and spaces</th:>]
+    MarkupBlock - [0..27)::27
+        MarkupTagBlock - [0..5)::5 - [<th:>]
+            MarkupTextLiteral - [0..5)::5 - [<th:>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[th:];
+                CloseAngle;[>];
+        MarkupTextLiteral - [5..21)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Text;[words];
+            Whitespace;[ ];
+            Text;[and];
+            Whitespace;[ ];
+            Text;[spaces];
+        MarkupTagBlock - [21..27)::6 - [</th:>]
+            MarkupTextLiteral - [21..27)::6 - [</th:>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[th:];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers3.stree.txt
@@ -1,3 +1,10 @@
-Markup block - Gen<None> - 11 - (0:0,0)
-    Tag block - Gen<TagHelper> - 11 - (0:0,0) - th:myth - mythTagHelper
-        SelfClosing - <th:myth />
+RazorDocument - [0..11)::11 - [<th:myth />]
+    MarkupBlock - [0..11)::11
+        MarkupTagHelperElement - [0..11)::11 - th:myth[SelfClosing] - mythTagHelper
+            MarkupTagHelperStartTag - [0..11)::11
+                MarkupTextLiteral - [0..11)::11 - [<th:myth />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:myth];
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers4.stree.txt
@@ -1,3 +1,14 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Tag block - Gen<TagHelper> - 19 - (0:0,0) - th:myth - mythTagHelper
-        StartTagAndEndTag - <th:myth> ... </th:myth>
+RazorDocument - [0..19)::19 - [<th:myth></th:myth>]
+    MarkupBlock - [0..19)::19
+        MarkupTagHelperElement - [0..19)::19 - th:myth[StartTagAndEndTag] - mythTagHelper
+            MarkupTagHelperStartTag - [0..9)::9
+                MarkupTextLiteral - [0..9)::9 - [<th:myth>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:myth];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [9..19)::10
+                MarkupTextLiteral - [9..19)::10 - [</th:myth>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:myth];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers5.stree.txt
@@ -1,14 +1,25 @@
-Markup block - Gen<None> - 40 - (0:0,0)
-    Tag block - Gen<TagHelper> - 40 - (0:0,0) - th:myth - mythTagHelper
-        StartTagAndEndTag - <th:myth> ... </th:myth>
-        Tag block - Gen<None> - 10 - (9:0,9)
-            Markup span - Gen<Markup> - [<th:my2th>] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[th:my2th];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 11 - (19:0,19)
-            Markup span - Gen<Markup> - [</th:my2th>] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[th:my2th];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..40)::40 - [<th:myth><th:my2th></th:my2th></th:myth>]
+    MarkupBlock - [0..40)::40
+        MarkupTagHelperElement - [0..40)::40 - th:myth[StartTagAndEndTag] - mythTagHelper
+            MarkupTagHelperStartTag - [0..9)::9
+                MarkupTextLiteral - [0..9)::9 - [<th:myth>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:myth];
+                    CloseAngle;[>];
+            MarkupTagBlock - [9..19)::10 - [<th:my2th>]
+                MarkupTextLiteral - [9..19)::10 - [<th:my2th>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:my2th];
+                    CloseAngle;[>];
+            MarkupTagBlock - [19..30)::11 - [</th:my2th>]
+                MarkupTextLiteral - [19..30)::11 - [</th:my2th>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:my2th];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [30..40)::10
+                MarkupTextLiteral - [30..40)::10 - [</th:myth>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:myth];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers6.stree.txt
@@ -1,11 +1,12 @@
-Markup block - Gen<None> - 12 - (0:0,0)
-    Tag block - Gen<None> - 12 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [th:myth />] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:4
-            SyntaxKind.Text;[th:myth];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..12)::12 - [<!th:myth />]
+    MarkupBlock - [0..12)::12
+        MarkupTagBlock - [0..12)::12 - [<!th:myth />]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..12)::10 - [th:myth />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[th:myth];
+                Whitespace;[ ];
+                ForwardSlash;[/];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers7.stree.txt
@@ -1,18 +1,19 @@
-Markup block - Gen<None> - 21 - (0:0,0)
-    Tag block - Gen<None> - 10 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [th:myth>] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:2
-            SyntaxKind.Text;[th:myth];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 11 - (10:0,10)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [th:myth>] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:2
-            SyntaxKind.Text;[th:myth];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..21)::21 - [<!th:myth></!th:myth>]
+    MarkupBlock - [0..21)::21
+        MarkupTagBlock - [0..10)::10 - [<!th:myth>]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..10)::8 - [th:myth>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[th:myth];
+                CloseAngle;[>];
+        MarkupTagBlock - [10..21)::11 - [</!th:myth>]
+            MarkupTextLiteral - [10..12)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [12..13)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [13..21)::8 - [th:myth>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[th:myth];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers8.stree.txt
@@ -1,6 +1,25 @@
-Markup block - Gen<None> - 23 - (0:0,0)
-    Tag block - Gen<TagHelper> - 23 - (0:0,0) - th:myth - mythTagHelper
-        SelfClosing - <th:myth class="btn" />
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..23)::23 - [<th:myth class="btn" />]
+    MarkupBlock - [0..23)::23
+        MarkupTagHelperElement - [0..23)::23 - th:myth[SelfClosing] - mythTagHelper
+            MarkupTagHelperStartTag - [0..23)::23
+                MarkupTextLiteral - [0..8)::8 - [<th:myth] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:myth];
+                MarkupTagHelperAttribute - [8..20)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [16..19)::3
+                        MarkupLiteralAttributeValue - [16..19)::3 - [btn]
+                            MarkupTextLiteral - [16..19)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [19..20)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [20..23)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers9.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsPrefixedTagHelpers9.stree.txt
@@ -1,6 +1,25 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<TagHelper> - 24 - (0:0,0) - th:myth2 - mythTagHelper2
-        SelfClosing - <th:myth2 class="btn" />
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..24)::24 - [<th:myth2 class="btn" />]
+    MarkupBlock - [0..24)::24
+        MarkupTagHelperElement - [0..24)::24 - th:myth2[SelfClosing] - mythTagHelper2
+            MarkupTagHelperStartTag - [0..24)::24
+                MarkupTextLiteral - [0..9)::9 - [<th:myth2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:myth2];
+                MarkupTagHelperAttribute - [9..21)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [9..10)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [10..15)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [16..17)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [17..20)::3
+                        MarkupLiteralAttributeValue - [17..20)::3 - [btn]
+                            MarkupTextLiteral - [17..20)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [21..24)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsRazorCommentsAsChildren.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsRazorCommentsAsChildren.stree.txt
@@ -1,27 +1,33 @@
-Markup block - Gen<None> - 26 - (0:0,0)
-    Tag block - Gen<TagHelper> - 26 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 3 - (3:0,3)
-            Markup span - Gen<Markup> - [<b>] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[b];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [asdf] - [6..10) - FullWidth: 4 - Slots: 1
-            SyntaxKind.Text;[asdf];
-        Tag block - Gen<None> - 4 - (10:0,10)
-            Markup span - Gen<Markup> - [</b>] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[b];
-                SyntaxKind.CloseAngle;[>];
-        Comment block - Gen<RazorComment> - 8 - (14:0,14)
-            Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (14:0,14) - Tokens:1
-                SyntaxKind.RazorCommentTransition;[@];
-            MetaCode span - Gen<None> - [*] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:1
-                SyntaxKind.RazorCommentStar;[*];
-            Comment span - Gen<None> - [asdf] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.RazorCommentLiteral;[asdf];
-            MetaCode span - Gen<None> - [*] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:1
-                SyntaxKind.RazorCommentStar;[*];
-            Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:1
-                SyntaxKind.RazorCommentTransition;[@];
+RazorDocument - [0..26)::26 - [<p><b>asdf</b>@*asdf*@</p>]
+    MarkupBlock - [0..26)::26
+        MarkupTagHelperElement - [0..26)::26 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..6)::3 - [<b>]
+                MarkupTextLiteral - [3..6)::3 - [<b>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[b];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [6..10)::4 - [asdf] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[asdf];
+            MarkupTagBlock - [10..14)::4 - [</b>]
+                MarkupTextLiteral - [10..14)::4 - [</b>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[b];
+                    CloseAngle;[>];
+            RazorComment - [14..22)::8
+                RazorCommentTransition;[@];
+                RazorCommentStar;[*];
+                RazorCommentLiteral;[asdf];
+                RazorCommentStar;[*];
+                RazorCommentTransition;[@];
+            MarkupTagHelperEndTag - [22..26)::4
+                MarkupTextLiteral - [22..26)::4 - [</p>] - Gen<None> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsRazorMarkupInHtmlComment.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsRazorMarkupInHtmlComment.stree.txt
@@ -1,32 +1,46 @@
-Markup block - Gen<None> - 37 - (0:0,0)
-    Tag block - Gen<TagHelper> - 37 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 3 - (3:0,3)
-            Markup span - Gen<Markup> - [<b>] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[b];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [asdf] - [6..10) - FullWidth: 4 - Slots: 1
-            SyntaxKind.Text;[asdf];
-        Tag block - Gen<None> - 4 - (10:0,10)
-            Markup span - Gen<Markup> - [</b>] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[b];
-                SyntaxKind.CloseAngle;[>];
-        HtmlComment block - Gen<None> - 19 - (14:0,14)
-            Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (14:0,14) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Bang;[!];
-                SyntaxKind.DoubleHyphen;[--];
-            Markup span - Gen<Markup> - [Hello ] - SpanEditHandler;Accepts:Whitespace - (18:0,18) - Tokens:2
-                SyntaxKind.Text;[Hello];
-                SyntaxKind.Whitespace;[ ];
-            Expression block - Gen<Expr> - 6 - (24:0,24)
-                Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:1
-                    SyntaxKind.Transition;[@];
-                Code span - Gen<Expr> - [World] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (25:0,25) - Tokens:1
-                    SyntaxKind.Identifier;[World];
-            Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (30:0,30) - Tokens:2
-                SyntaxKind.DoubleHyphen;[--];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..37)::37 - [<p><b>asdf</b><!--Hello @World--></p>]
+    MarkupBlock - [0..37)::37
+        MarkupTagHelperElement - [0..37)::37 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..6)::3 - [<b>]
+                MarkupTextLiteral - [3..6)::3 - [<b>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[b];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [6..10)::4 - [asdf] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[asdf];
+            MarkupTagBlock - [10..14)::4 - [</b>]
+                MarkupTextLiteral - [10..14)::4 - [</b>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[b];
+                    CloseAngle;[>];
+            MarkupCommentBlock - [14..33)::19
+                MarkupTextLiteral - [14..18)::4 - [<!--] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    OpenAngle;[<];
+                    Bang;[!];
+                    DoubleHyphen;[--];
+                MarkupTextLiteral - [18..24)::6 - [Hello ] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                    Text;[Hello];
+                    Whitespace;[ ];
+                CSharpCodeBlock - [24..30)::6
+                    CSharpImplicitExpression - [24..30)::6
+                        CSharpTransition - [24..25)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                            Transition;[@];
+                        CSharpImplicitExpressionBody - [25..30)::5
+                            CSharpCodeBlock - [25..30)::5
+                                CSharpExpressionLiteral - [25..30)::5 - [World] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                    Identifier;[World];
+                MarkupTextLiteral - [30..33)::3 - [-->] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    DoubleHyphen;[--];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [33..37)::4
+                MarkupTextLiteral - [33..37)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsSimpleHtmlCommentsAsChildren.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsSimpleHtmlCommentsAsChildren.stree.txt
@@ -1,28 +1,39 @@
-Markup block - Gen<None> - 36 - (0:0,0)
-    Tag block - Gen<TagHelper> - 36 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 3 - (3:0,3)
-            Markup span - Gen<Markup> - [<b>] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[b];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [asdf] - [6..10) - FullWidth: 4 - Slots: 1
-            SyntaxKind.Text;[asdf];
-        Tag block - Gen<None> - 4 - (10:0,10)
-            Markup span - Gen<Markup> - [</b>] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[b];
-                SyntaxKind.CloseAngle;[>];
-        HtmlComment block - Gen<None> - 18 - (14:0,14)
-            Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (14:0,14) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Bang;[!];
-                SyntaxKind.DoubleHyphen;[--];
-            Markup span - Gen<Markup> - [Hello World] - SpanEditHandler;Accepts:Whitespace - (18:0,18) - Tokens:3
-                SyntaxKind.Text;[Hello];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[World];
-            Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (29:0,29) - Tokens:2
-                SyntaxKind.DoubleHyphen;[--];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..36)::36 - [<p><b>asdf</b><!--Hello World--></p>]
+    MarkupBlock - [0..36)::36
+        MarkupTagHelperElement - [0..36)::36 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..6)::3 - [<b>]
+                MarkupTextLiteral - [3..6)::3 - [<b>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[b];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [6..10)::4 - [asdf] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[asdf];
+            MarkupTagBlock - [10..14)::4 - [</b>]
+                MarkupTextLiteral - [10..14)::4 - [</b>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[b];
+                    CloseAngle;[>];
+            MarkupCommentBlock - [14..32)::18
+                MarkupTextLiteral - [14..18)::4 - [<!--] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    OpenAngle;[<];
+                    Bang;[!];
+                    DoubleHyphen;[--];
+                MarkupTextLiteral - [18..29)::11 - [Hello World] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                    Text;[Hello];
+                    Whitespace;[ ];
+                    Text;[World];
+                MarkupTextLiteral - [29..32)::3 - [-->] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    DoubleHyphen;[--];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [32..36)::4
+                MarkupTextLiteral - [32..36)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag1.stree.txt
@@ -1,30 +1,40 @@
-Markup block - Gen<None> - 22 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 22 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 20 - (2:0,2)
-            Tag block - Gen<None> - 19 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text];
-                Markup block - Gen<Attr:class, class="@(8:0,8),"@(19:0,19)> - 12 - (8:0,8)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(16:0,16)> - [btn] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.Text;[}];
+RazorDocument - [0..22)::22 - [@{<!text class="btn">}]
+    MarkupBlock - [0..22)::22
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..22)::22
+            CSharpStatement - [0..22)::22
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..22)::21
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..22)::20
+                        MarkupBlock - [2..22)::20
+                            MarkupTagBlock - [2..21)::19 - [<!text class="btn">]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..8)::4 - [text] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                MarkupAttributeBlock - [8..20)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [16..19)::3
+                                        MarkupLiteralAttributeValue - [16..19)::3 - [btn]
+                                            MarkupTextLiteral - [16..19)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [19..20)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupTextLiteral - [20..21)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [21..22)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[}];
+                    RazorMetaCode - [22..22)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag2.stree.txt
@@ -1,43 +1,51 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 30 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 27 - (2:0,2)
-            Tag block - Gen<None> - 19 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text];
-                Markup block - Gen<Attr:class, class="@(8:0,8),"@(19:0,19)> - 12 - (8:0,8)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(16:0,16)> - [btn] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 8 - (21:0,21)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (23:0,23) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (29:0,29) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (29:0,29) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (30:0,30) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..30)::30 - [@{<!text class="btn"></!text>}]
+    MarkupBlock - [0..30)::30
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..30)::30
+            CSharpStatement - [0..30)::30
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..30)::29
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..29)::27
+                        MarkupBlock - [2..29)::27
+                            MarkupTagBlock - [2..21)::19 - [<!text class="btn">]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..8)::4 - [text] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                MarkupAttributeBlock - [8..20)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [16..19)::3
+                                        MarkupLiteralAttributeValue - [16..19)::3 - [btn]
+                                            MarkupTextLiteral - [16..19)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [19..20)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupTextLiteral - [20..21)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [21..29)::8 - [</!text>]
+                                MarkupTextLiteral - [21..23)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [23..24)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [24..29)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [29..29)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [29..30)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [30..30)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag3.stree.txt
@@ -1,49 +1,57 @@
-Markup block - Gen<None> - 47 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 47 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 44 - (2:0,2)
-            Tag block - Gen<None> - 19 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text];
-                Markup block - Gen<Attr:class, class="@(8:0,8),"@(19:0,19)> - 12 - (8:0,8)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(16:0,16)> - [btn] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [words with spaces] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[with];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
-            Tag block - Gen<None> - 8 - (38:0,38)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (38:0,38) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (40:0,40) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (41:0,41) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (46:0,46) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (46:0,46) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (47:0,47) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..47)::47 - [@{<!text class="btn">words with spaces</!text>}]
+    MarkupBlock - [0..47)::47
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..47)::47
+            CSharpStatement - [0..47)::47
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..47)::46
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..46)::44
+                        MarkupBlock - [2..46)::44
+                            MarkupTagBlock - [2..21)::19 - [<!text class="btn">]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..8)::4 - [text] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                MarkupAttributeBlock - [8..20)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [16..19)::3
+                                        MarkupLiteralAttributeValue - [16..19)::3 - [btn]
+                                            MarkupTextLiteral - [16..19)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [19..20)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupTextLiteral - [20..21)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [21..38)::17 - [words with spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[words];
+                                Whitespace;[ ];
+                                Text;[with];
+                                Whitespace;[ ];
+                                Text;[spaces];
+                            MarkupTagBlock - [38..46)::8 - [</!text>]
+                                MarkupTextLiteral - [38..40)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [40..41)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [41..46)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [46..46)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [46..47)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [47..47)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag4.stree.txt
@@ -1,53 +1,66 @@
-Markup block - Gen<None> - 47 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 47 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 44 - (2:0,2)
-            Tag block - Gen<None> - 36 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text];
-                Markup block - Gen<Attr:class, class='@(8:0,8),'@(25:0,25)> - 18 - (8:0,8)
-                    Markup span - Gen<None> - [ class='] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.SingleQuote;['];
-                    Markup span - Gen<LitAttr:@(16:0,16)> - [btn1] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.Text;[btn1];
-                    Markup span - Gen<LitAttr: @(20:0,20)> - [ btn2] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:2
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[btn2];
-                    Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:1
-                        SyntaxKind.SingleQuote;['];
-                Markup block - Gen<Attr:class2, class2=@(26:0,26),@(37:0,37)> - 11 - (26:0,26)
-                    Markup span - Gen<None> - [ class2=] - SpanEditHandler;Accepts:Any - (26:0,26) - Tokens:3
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class2];
-                        SyntaxKind.Equals;[=];
-                    Markup span - Gen<LitAttr:@(34:0,34)> - [btn] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (37:0,37) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 8 - (38:0,38)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (38:0,38) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (40:0,40) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (41:0,41) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (46:0,46) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (46:0,46) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (47:0,47) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..47)::47 - [@{<!text class='btn1 btn2' class2=btn></!text>}]
+    MarkupBlock - [0..47)::47
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..47)::47
+            CSharpStatement - [0..47)::47
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..47)::46
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..46)::44
+                        MarkupBlock - [2..46)::44
+                            MarkupTagBlock - [2..38)::36 - [<!text class='btn1 btn2' class2=btn>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..8)::4 - [text] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                MarkupAttributeBlock - [8..26)::18 - [ class='btn1 btn2']
+                                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [15..16)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        SingleQuote;['];
+                                    GenericBlock - [16..25)::9
+                                        MarkupLiteralAttributeValue - [16..20)::4 - [btn1]
+                                            MarkupTextLiteral - [16..20)::4 - [btn1] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn1];
+                                        MarkupLiteralAttributeValue - [20..25)::5 - [ btn2]
+                                            MarkupTextLiteral - [20..21)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Whitespace;[ ];
+                                            MarkupTextLiteral - [21..25)::4 - [btn2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn2];
+                                    MarkupTextLiteral - [25..26)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        SingleQuote;['];
+                                MarkupAttributeBlock - [26..37)::11 - [ class2=btn]
+                                    MarkupTextLiteral - [26..27)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [27..33)::6 - [class2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class2];
+                                    Equals;[=];
+                                    GenericBlock - [34..37)::3
+                                        MarkupLiteralAttributeValue - [34..37)::3 - [btn]
+                                            MarkupTextLiteral - [34..37)::3 - [btn] - Gen<None> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                MarkupTextLiteral - [37..38)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [38..46)::8 - [</!text>]
+                                MarkupTextLiteral - [38..40)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [40..41)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [41..46)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [46..46)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [46..47)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [47..47)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithAttrTextTag5.stree.txt
@@ -1,56 +1,70 @@
-Markup block - Gen<None> - 50 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 50 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 47 - (2:0,2)
-            Tag block - Gen<None> - 39 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text];
-                Markup block - Gen<Attr:class, class='@(8:0,8),'@(39:0,39)> - 32 - (8:0,8)
-                    Markup span - Gen<None> - [ class='] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.SingleQuote;['];
-                    Markup span - Gen<LitAttr:@(16:0,16)> - [btn1] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.Text;[btn1];
-                    Markup block - Gen<DynAttr: @(20:0,20)> - 14 - (20:0,20)
-                        Markup span - Gen<None> - [ ] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                            SyntaxKind.Whitespace;[ ];
-                        Expression block - Gen<Expr> - 13 - (21:0,21)
-                            Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:1
-                                SyntaxKind.Transition;[@];
-                            Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (22:0,22) - Tokens:3
-                                SyntaxKind.Identifier;[DateTime];
-                                SyntaxKind.Dot;[.];
-                                SyntaxKind.Identifier;[Now];
-                    Markup span - Gen<LitAttr: @(34:0,34)> - [ btn2] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:2
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[btn2];
-                    Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (39:0,39) - Tokens:1
-                        SyntaxKind.SingleQuote;['];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (40:0,40) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 8 - (41:0,41)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (41:0,41) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (43:0,43) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (44:0,44) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (49:0,49) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (49:0,49) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (50:0,50) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..50)::50 - [@{<!text class='btn1 @DateTime.Now btn2'></!text>}]
+    MarkupBlock - [0..50)::50
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..50)::50
+            CSharpStatement - [0..50)::50
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..50)::49
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..49)::47
+                        MarkupBlock - [2..49)::47
+                            MarkupTagBlock - [2..41)::39 - [<!text class='btn1 @DateTime.Now btn2'>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..8)::4 - [text] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                MarkupAttributeBlock - [8..40)::32 - [ class='btn1 @DateTime.Now btn2']
+                                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [15..16)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        SingleQuote;['];
+                                    GenericBlock - [16..39)::23
+                                        MarkupLiteralAttributeValue - [16..20)::4 - [btn1]
+                                            MarkupTextLiteral - [16..20)::4 - [btn1] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn1];
+                                        MarkupDynamicAttributeValue - [20..34)::14 - [ @DateTime.Now]
+                                            MarkupTextLiteral - [20..21)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Whitespace;[ ];
+                                            GenericBlock - [21..34)::13
+                                                CSharpCodeBlock - [21..34)::13
+                                                    CSharpImplicitExpression - [21..34)::13
+                                                        CSharpTransition - [21..22)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                                            Transition;[@];
+                                                        CSharpImplicitExpressionBody - [22..34)::12
+                                                            CSharpCodeBlock - [22..34)::12
+                                                                CSharpExpressionLiteral - [22..34)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                                    Identifier;[DateTime];
+                                                                    Dot;[.];
+                                                                    Identifier;[Now];
+                                        MarkupLiteralAttributeValue - [34..39)::5 - [ btn2]
+                                            MarkupTextLiteral - [34..35)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Whitespace;[ ];
+                                            MarkupTextLiteral - [35..39)::4 - [btn2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn2];
+                                    MarkupTextLiteral - [39..40)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        SingleQuote;['];
+                                MarkupTextLiteral - [40..41)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [41..49)::8 - [</!text>]
+                                MarkupTextLiteral - [41..43)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [43..44)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [44..49)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [49..49)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [49..50)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [50..50)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag1.stree.txt
@@ -1,19 +1,25 @@
-Markup block - Gen<None> - 10 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 10 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 8 - (2:0,2)
-            Tag block - Gen<None> - 7 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:1
-                SyntaxKind.Text;[}];
+RazorDocument - [0..10)::10 - [@{<!text>}]
+    MarkupBlock - [0..10)::10
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..10)::10
+            CSharpStatement - [0..10)::10
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..10)::9
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..10)::8
+                        MarkupBlock - [2..10)::8
+                            MarkupTagBlock - [2..9)::7 - [<!text>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..9)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [9..10)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[}];
+                    RazorMetaCode - [10..10)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag2.stree.txt
@@ -1,24 +1,28 @@
-Markup block - Gen<None> - 11 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 11 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 8 - (2:0,2)
-            Tag block - Gen<None> - 8 - (2:0,2)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..11)::11 - [@{</!text>}]
+    MarkupBlock - [0..11)::11
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..11)::11
+            CSharpStatement - [0..11)::11
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..11)::10
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..10)::8
+                        MarkupBlock - [2..10)::8
+                            MarkupTagBlock - [2..10)::8 - [</!text>]
+                                MarkupTextLiteral - [2..4)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [4..5)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [5..10)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [10..10)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [11..11)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag3.stree.txt
@@ -1,32 +1,36 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 18 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 15 - (2:0,2)
-            Tag block - Gen<None> - 7 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 8 - (9:0,9)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (11:0,11) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..18)::18 - [@{<!text></!text>}]
+    MarkupBlock - [0..18)::18
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..18)::18
+            CSharpStatement - [0..18)::18
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..18)::17
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..17)::15
+                        MarkupBlock - [2..17)::15
+                            MarkupTagBlock - [2..9)::7 - [<!text>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..9)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [9..17)::8 - [</!text>]
+                                MarkupTextLiteral - [9..11)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [11..12)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [12..17)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [17..17)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [17..18)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [18..18)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag4.stree.txt
@@ -1,38 +1,42 @@
-Markup block - Gen<None> - 34 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 34 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 31 - (2:0,2)
-            Tag block - Gen<None> - 7 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [words and spaces] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
-            Tag block - Gen<None> - 8 - (25:0,25)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (27:0,27) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (28:0,28) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (33:0,33) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..34)::34 - [@{<!text>words and spaces</!text>}]
+    MarkupBlock - [0..34)::34
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..34)::34
+            CSharpStatement - [0..34)::34
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..34)::33
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..33)::31
+                        MarkupBlock - [2..33)::31
+                            MarkupTagBlock - [2..9)::7 - [<!text>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..9)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [9..25)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[words];
+                                Whitespace;[ ];
+                                Text;[and];
+                                Whitespace;[ ];
+                                Text;[spaces];
+                            MarkupTagBlock - [25..33)::8 - [</!text>]
+                                MarkupTextLiteral - [25..27)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [27..28)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [28..33)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [33..33)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [33..34)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [34..34)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag5.stree.txt
@@ -1,29 +1,33 @@
-Markup block - Gen<None> - 17 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 17 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 14 - (2:0,2)
-            Tag block - Gen<None> - 7 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 7 - (9:0,9)
-                Markup span - Gen<Markup> - [</text>] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..17)::17 - [@{<!text></text>}]
+    MarkupBlock - [0..17)::17
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..17)::17
+            CSharpStatement - [0..17)::17
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..17)::16
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..16)::14
+                        MarkupBlock - [2..16)::14
+                            MarkupTagBlock - [2..9)::7 - [<!text>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..9)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [9..16)::7 - [</text>]
+                                MarkupTextLiteral - [9..16)::7 - [</text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [16..16)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [16..17)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [17..17)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag6.stree.txt
@@ -1,29 +1,33 @@
-Markup block - Gen<None> - 17 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 17 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 14 - (2:0,2)
-            Tag block - Gen<None> - 6 - (2:0,2)
-                Transition span - Gen<None> - [<text>] - SpanEditHandler;Accepts:None - (2:0,2) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 8 - (8:0,8)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:None - (8:0,8) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (11:0,11) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..17)::17 - [@{<text></!text>}]
+    MarkupBlock - [0..17)::17
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..17)::17
+            CSharpStatement - [0..17)::17
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..17)::16
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..16)::14
+                        MarkupBlock - [2..16)::14
+                            MarkupTagBlock - [2..8)::6 - [<text>]
+                                MarkupTransition - [2..8)::6 - Gen<None> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [8..16)::8 - [</!text>]
+                                MarkupTextLiteral - [8..10)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [11..16)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [16..16)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [16..17)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [17..17)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag7.stree.txt
@@ -1,34 +1,48 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 31 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 28 - (2:0,2)
-            Tag block - Gen<None> - 7 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<TagHelper> - 13 - (9:0,9) - text - texttaghelper
-                StartTagAndEndTag - <text> ... </text>
-            Tag block - Gen<None> - 8 - (22:0,22)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (30:0,30) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (30:0,30) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (31:0,31) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..31)::31 - [@{<!text><text></text></!text>}]
+    MarkupBlock - [0..31)::31
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..31)::31
+            CSharpStatement - [0..31)::31
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..31)::30
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..30)::28
+                        MarkupBlock - [2..30)::28
+                            MarkupTagBlock - [2..9)::7 - [<!text>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..9)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTagHelperElement - [9..22)::13 - text[StartTagAndEndTag] - texttaghelper
+                                MarkupTagHelperStartTag - [9..15)::6
+                                    MarkupTextLiteral - [9..15)::6 - [<text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        Text;[text];
+                                        CloseAngle;[>];
+                                MarkupTagHelperEndTag - [15..22)::7
+                                    MarkupTextLiteral - [15..22)::7 - [</text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        ForwardSlash;[/];
+                                        Text;[text];
+                                        CloseAngle;[>];
+                            MarkupTagBlock - [22..30)::8 - [</!text>]
+                                MarkupTextLiteral - [22..24)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [24..25)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [25..30)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [30..30)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [30..31)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [31..31)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag8.stree.txt
@@ -1,33 +1,39 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 24 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 22 - (2:0,2)
-            Tag block - Gen<None> - 6 - (2:0,2)
-                Transition span - Gen<None> - [<text>] - SpanEditHandler;Accepts:None - (2:0,2) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 7 - (8:0,8)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:None - (8:0,8) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 8 - (15:0,15)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:1
-                SyntaxKind.Text;[}];
+RazorDocument - [0..24)::24 - [@{<text><!text></!text>}]
+    MarkupBlock - [0..24)::24
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..24)::24
+            CSharpStatement - [0..24)::24
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..24)::23
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..24)::22
+                        MarkupBlock - [2..24)::22
+                            MarkupTagBlock - [2..8)::6 - [<text>]
+                                MarkupTransition - [2..8)::6 - Gen<None> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [8..15)::7 - [<!text>]
+                                MarkupTextLiteral - [8..9)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                RazorMetaCode - [9..10)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [10..15)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [15..23)::8 - [</!text>]
+                                MarkupTextLiteral - [15..17)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [17..18)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [18..23)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [23..24)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[}];
+                    RazorMetaCode - [24..24)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag9.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTHElementOptForCompleteTextTagInCSharpBlock_WithBlockTextTag9.stree.txt
@@ -1,39 +1,43 @@
-Markup block - Gen<None> - 25 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 25 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 15 - (2:0,2)
-            Tag block - Gen<None> - 7 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 8 - (9:0,9)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (11:0,11) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text>] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Markup block - Gen<None> - 7 - (17:0,17)
-            Tag block - Gen<None> - 7 - (17:0,17)
-                Markup span - Gen<Markup> - [</text>] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..25)::25 - [@{<!text></!text></text>}]
+    MarkupBlock - [0..25)::25
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..25)::25
+            CSharpStatement - [0..25)::25
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..25)::24
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..24)::22
+                        MarkupBlock - [2..17)::15
+                            MarkupTagBlock - [2..9)::7 - [<!text>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..9)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [9..17)::8 - [</!text>]
+                                MarkupTextLiteral - [9..11)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [11..12)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [12..17)::5 - [text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        MarkupBlock - [17..24)::7
+                            MarkupTagBlock - [17..24)::7 - [</text>]
+                                MarkupTextLiteral - [17..24)::7 - [</text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [24..24)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [24..25)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [25..25)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML1.stree.txt
@@ -1,4 +1,5 @@
-Markup block - Gen<None> - 2 - (0:0,0)
-    Markup span - Gen<Markup> - [<!] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Bang;[!];
+RazorDocument - [0..2)::2 - [<!]
+    MarkupBlock - [0..2)::2
+        MarkupTextLiteral - [0..2)::2 - [<!] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Bang;[!];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML2.stree.txt
@@ -1,8 +1,9 @@
-Markup block - Gen<None> - 3 - (0:0,0)
-    Tag block - Gen<None> - 3 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
+RazorDocument - [0..3)::3 - [<!p]
+    MarkupBlock - [0..3)::3
+        MarkupTagBlock - [0..3)::3 - [<!p]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML3.stree.txt
@@ -1,10 +1,11 @@
-Markup block - Gen<None> - 5 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p /] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:3
-            SyntaxKind.Text;[p];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
+RazorDocument - [0..5)::5 - [<!p /]
+    MarkupBlock - [0..5)::5
+        MarkupTagBlock - [0..5)::5 - [<!p /]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..5)::3 - [p /] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                Whitespace;[ ];
+                ForwardSlash;[/];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML4.stree.txt
@@ -1,13 +1,16 @@
-Markup block - Gen<None> - 10 - (0:0,0)
-    Tag block - Gen<None> - 10 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
-        Markup block - Gen<Attr:class, class=@(3:0,3),@(10:0,10)> - 7 - (3:0,3)
-            Markup span - Gen<None> - [ class=] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:3
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
+RazorDocument - [0..10)::10 - [<!p class=]
+    MarkupBlock - [0..10)::10
+        MarkupTagBlock - [0..10)::10 - [<!p class=]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+            MarkupAttributeBlock - [3..10)::7 - [ class=]
+                MarkupTextLiteral - [3..4)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [4..9)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                GenericBlock - [10..10)::0

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML5.stree.txt
@@ -1,16 +1,21 @@
-Markup block - Gen<None> - 14 - (0:0,0)
-    Tag block - Gen<None> - 14 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
-        Markup block - Gen<Attr:class, class="@(3:0,3),@(14:0,14)> - 11 - (3:0,3)
-            Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [btn] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..14)::14 - [<!p class="btn]
+    MarkupBlock - [0..14)::14
+        MarkupTagBlock - [0..14)::14 - [<!p class="btn]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+            MarkupAttributeBlock - [3..14)::11 - [ class="btn]
+                MarkupTextLiteral - [3..4)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [4..9)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [10..11)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+                GenericBlock - [11..14)::3
+                    MarkupLiteralAttributeValue - [11..14)::3 - [btn]
+                        MarkupTextLiteral - [11..14)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML6.stree.txt
@@ -1,18 +1,23 @@
-Markup block - Gen<None> - 15 - (0:0,0)
-    Tag block - Gen<None> - 15 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
-        Markup block - Gen<Attr:class, class="@(3:0,3),"@(14:0,14)> - 12 - (3:0,3)
-            Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [btn] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[btn];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
+RazorDocument - [0..15)::15 - [<!p class="btn"]
+    MarkupBlock - [0..15)::15
+        MarkupTagBlock - [0..15)::15 - [<!p class="btn"]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+            MarkupAttributeBlock - [3..15)::12 - [ class="btn"]
+                MarkupTextLiteral - [3..4)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [4..9)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [10..11)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+                GenericBlock - [11..14)::3
+                    MarkupLiteralAttributeValue - [11..14)::3 - [btn]
+                        MarkupTextLiteral - [11..14)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn];
+                MarkupTextLiteral - [14..15)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTML7.stree.txt
@@ -1,21 +1,26 @@
-Markup block - Gen<None> - 17 - (0:0,0)
-    Tag block - Gen<None> - 17 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
-        Markup block - Gen<Attr:class, class="@(3:0,3),"@(14:0,14)> - 12 - (3:0,3)
-            Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [btn] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[btn];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [ /] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:2
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
+RazorDocument - [0..17)::17 - [<!p class="btn" /]
+    MarkupBlock - [0..17)::17
+        MarkupTagBlock - [0..17)::17 - [<!p class="btn" /]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+            MarkupAttributeBlock - [3..15)::12 - [ class="btn"]
+                MarkupTextLiteral - [3..4)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [4..9)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [10..11)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+                GenericBlock - [11..14)::3
+                    MarkupLiteralAttributeValue - [11..14)::3 - [btn]
+                        MarkupTextLiteral - [11..14)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn];
+                MarkupTextLiteral - [14..15)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+            MarkupTextLiteral - [15..17)::2 - [ /] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                ForwardSlash;[/];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock1.stree.txt
@@ -1,16 +1,22 @@
-Markup block - Gen<None> - 5 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 5 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 3 - (2:0,2)
-            Tag block - Gen<None> - 3 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[}];
+RazorDocument - [0..5)::5 - [@{<!}]
+    MarkupBlock - [0..5)::5
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..5)::5
+            CSharpStatement - [0..5)::5
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..5)::4
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..5)::3
+                        MarkupBlock - [2..5)::3
+                            MarkupTagBlock - [2..5)::3 - [<!}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[}];
+                    RazorMetaCode - [5..5)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock2.stree.txt
@@ -1,16 +1,22 @@
-Markup block - Gen<None> - 6 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 6 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 4 - (2:0,2)
-            Tag block - Gen<None> - 4 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p}] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p}];
+RazorDocument - [0..6)::6 - [@{<!p}]
+    MarkupBlock - [0..6)::6
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..6)::6
+            CSharpStatement - [0..6)::6
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..6)::5
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..6)::4
+                        MarkupBlock - [2..6)::4
+                            MarkupTagBlock - [2..6)::4 - [<!p}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..6)::2 - [p}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p}];
+                    RazorMetaCode - [6..6)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock3.stree.txt
@@ -1,21 +1,27 @@
-Markup block - Gen<None> - 8 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 8 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 6 - (2:0,2)
-            Tag block - Gen<None> - 6 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p /] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:3
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.ForwardSlash;[/];
-                Markup block - Gen<None> - 1 - (7:0,7)
-                    Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:1
-                        SyntaxKind.Text;[}];
+RazorDocument - [0..8)::8 - [@{<!p /}]
+    MarkupBlock - [0..8)::8
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..8)::8
+            CSharpStatement - [0..8)::8
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..8)::7
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..8)::6
+                        MarkupBlock - [2..8)::6
+                            MarkupTagBlock - [2..8)::6 - [<!p /}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..7)::3 - [p /] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                    Whitespace;[ ];
+                                    ForwardSlash;[/];
+                                MarkupMinimizedAttributeBlock - [7..8)::1 - [}]
+                                    MarkupTextLiteral - [7..8)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[}];
+                    RazorMetaCode - [8..8)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock4.stree.txt
@@ -1,23 +1,32 @@
-Markup block - Gen<None> - 13 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 13 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 11 - (2:0,2)
-            Tag block - Gen<None> - 11 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class=@(5:0,5),@(13:0,13)> - 8 - (5:0,5)
-                    Markup span - Gen<None> - [ class=] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:3
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                    Markup span - Gen<LitAttr:@(12:0,12)> - [}] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:1
-                        SyntaxKind.Text;[}];
+RazorDocument - [0..13)::13 - [@{<!p class=}]
+    MarkupBlock - [0..13)::13
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..13)::13
+            CSharpStatement - [0..13)::13
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..13)::12
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..13)::11
+                        MarkupBlock - [2..13)::11
+                            MarkupTagBlock - [2..13)::11 - [<!p class=}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..13)::8 - [ class=}]
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    GenericBlock - [12..13)::1
+                                        MarkupLiteralAttributeValue - [12..13)::1 - [}]
+                                            MarkupTextLiteral - [12..13)::1 - [}] - Gen<None> - SpanEditHandler;Accepts:Any
+                                                Text;[}];
+                    RazorMetaCode - [13..13)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock5.stree.txt
@@ -1,24 +1,34 @@
-Markup block - Gen<None> - 17 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 17 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 15 - (2:0,2)
-            Tag block - Gen<None> - 15 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class="@(5:0,5),@(17:0,17)> - 12 - (5:0,5)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(13:0,13)> - [btn}] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                        SyntaxKind.Text;[btn}];
+RazorDocument - [0..17)::17 - [@{<!p class="btn}]
+    MarkupBlock - [0..17)::17
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..17)::17
+            CSharpStatement - [0..17)::17
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..17)::16
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..17)::15
+                        MarkupBlock - [2..17)::15
+                            MarkupTagBlock - [2..17)::15 - [<!p class="btn}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..17)::12 - [ class="btn}]
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [13..17)::4
+                                        MarkupLiteralAttributeValue - [13..17)::4 - [btn}]
+                                            MarkupTextLiteral - [13..17)::4 - [btn}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn}];
+                    RazorMetaCode - [17..17)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock6.stree.txt
@@ -1,31 +1,42 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 19 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 17 - (2:0,2)
-            Tag block - Gen<None> - 17 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class="@(5:0,5),@(19:0,19)> - 14 - (5:0,5)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(13:0,13)> - [btn] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup block - Gen<None> - 2 - (16:0,16)
-                        Markup span - Gen<LitAttr:@(16:0,16)> - [@] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                    Markup span - Gen<LitAttr:@(18:0,18)> - [}] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                        SyntaxKind.Text;[}];
+RazorDocument - [0..19)::19 - [@{<!p class="btn@@}]
+    MarkupBlock - [0..19)::19
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..19)::19
+            CSharpStatement - [0..19)::19
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..19)::18
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..19)::17
+                        MarkupBlock - [2..19)::17
+                            MarkupTagBlock - [2..19)::17 - [<!p class="btn@@}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..19)::14 - [ class="btn@@}]
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [13..19)::6
+                                        MarkupLiteralAttributeValue - [13..16)::3 - [btn]
+                                            MarkupTextLiteral - [13..16)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                        MarkupBlock - [16..18)::2
+                                            MarkupTextLiteral - [16..17)::1 - [@] - Gen<LitAttr:@(16:0,16)> - SpanEditHandler;Accepts:None
+                                                Transition;[@];
+                                            MarkupEphemeralTextLiteral - [17..18)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:None
+                                                Transition;[@];
+                                        MarkupLiteralAttributeValue - [18..19)::1 - [}]
+                                            MarkupTextLiteral - [18..19)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[}];
+                    RazorMetaCode - [19..19)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock7.stree.txt
@@ -1,29 +1,39 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 18 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 16 - (2:0,2)
-            Tag block - Gen<None> - 16 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class="@(5:0,5),"@(16:0,16)> - 12 - (5:0,5)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(13:0,13)> - [btn] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup block - Gen<None> - 1 - (17:0,17)
-                    Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:1
-                        SyntaxKind.Text;[}];
+RazorDocument - [0..18)::18 - [@{<!p class="btn"}]
+    MarkupBlock - [0..18)::18
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..18)::18
+            CSharpStatement - [0..18)::18
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..18)::17
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..18)::16
+                        MarkupBlock - [2..18)::16
+                            MarkupTagBlock - [2..18)::16 - [<!p class="btn"}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..17)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [13..16)::3
+                                        MarkupLiteralAttributeValue - [13..16)::3 - [btn]
+                                            MarkupTextLiteral - [13..16)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [16..17)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupMinimizedAttributeBlock - [17..18)::1 - [}]
+                                    MarkupTextLiteral - [17..18)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[}];
+                    RazorMetaCode - [18..18)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteHTMLInCSharpBlock8.stree.txt
@@ -1,32 +1,42 @@
-Markup block - Gen<None> - 20 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 20 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 18 - (2:0,2)
-            Tag block - Gen<None> - 18 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class="@(5:0,5),"@(16:0,16)> - 12 - (5:0,5)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(13:0,13)> - [btn] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup span - Gen<Markup> - [ /] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:2
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.ForwardSlash;[/];
-                Markup block - Gen<None> - 1 - (19:0,19)
-                    Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:1
-                        SyntaxKind.Text;[}];
+RazorDocument - [0..20)::20 - [@{<!p class="btn" /}]
+    MarkupBlock - [0..20)::20
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..20)::20
+            CSharpStatement - [0..20)::20
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..20)::19
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..20)::18
+                        MarkupBlock - [2..20)::18
+                            MarkupTagBlock - [2..20)::18 - [<!p class="btn" /}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..17)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [13..16)::3
+                                        MarkupLiteralAttributeValue - [13..16)::3 - [btn]
+                                            MarkupTextLiteral - [13..16)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [16..17)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupTextLiteral - [17..19)::2 - [ /] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Whitespace;[ ];
+                                    ForwardSlash;[/];
+                                MarkupMinimizedAttributeBlock - [19..20)::1 - [}]
+                                    MarkupTextLiteral - [19..20)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[}];
+                    RazorMetaCode - [20..20)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock1.stree.txt
@@ -1,16 +1,22 @@
-Markup block - Gen<None> - 9 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 9 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 7 - (2:0,2)
-            Tag block - Gen<None> - 7 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text}] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text}];
+RazorDocument - [0..9)::9 - [@{<!text}]
+    MarkupBlock - [0..9)::9
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..9)::9
+            CSharpStatement - [0..9)::9
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..9)::8
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..9)::7
+                        MarkupBlock - [2..9)::7
+                            MarkupTagBlock - [2..9)::7 - [<!text}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..9)::5 - [text}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text}];
+                    RazorMetaCode - [9..9)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock2.stree.txt
@@ -1,21 +1,27 @@
-Markup block - Gen<None> - 11 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 11 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 9 - (2:0,2)
-            Tag block - Gen<None> - 9 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text /] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:3
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.ForwardSlash;[/];
-                Markup block - Gen<None> - 1 - (10:0,10)
-                    Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                        SyntaxKind.Text;[}];
+RazorDocument - [0..11)::11 - [@{<!text /}]
+    MarkupBlock - [0..11)::11
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..11)::11
+            CSharpStatement - [0..11)::11
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..11)::10
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..11)::9
+                        MarkupBlock - [2..11)::9
+                            MarkupTagBlock - [2..11)::9 - [<!text /}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..10)::6 - [text /] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                    Whitespace;[ ];
+                                    ForwardSlash;[/];
+                                MarkupMinimizedAttributeBlock - [10..11)::1 - [}]
+                                    MarkupTextLiteral - [10..11)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[}];
+                    RazorMetaCode - [11..11)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock3.stree.txt
@@ -1,23 +1,32 @@
-Markup block - Gen<None> - 16 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 16 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 14 - (2:0,2)
-            Tag block - Gen<None> - 14 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text];
-                Markup block - Gen<Attr:class, class=@(8:0,8),@(16:0,16)> - 8 - (8:0,8)
-                    Markup span - Gen<None> - [ class=] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:3
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                    Markup span - Gen<LitAttr:@(15:0,15)> - [}] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                        SyntaxKind.Text;[}];
+RazorDocument - [0..16)::16 - [@{<!text class=}]
+    MarkupBlock - [0..16)::16
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..16)::16
+            CSharpStatement - [0..16)::16
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..16)::15
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..16)::14
+                        MarkupBlock - [2..16)::14
+                            MarkupTagBlock - [2..16)::14 - [<!text class=}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..8)::4 - [text] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                MarkupAttributeBlock - [8..16)::8 - [ class=}]
+                                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    GenericBlock - [15..16)::1
+                                        MarkupLiteralAttributeValue - [15..16)::1 - [}]
+                                            MarkupTextLiteral - [15..16)::1 - [}] - Gen<None> - SpanEditHandler;Accepts:Any
+                                                Text;[}];
+                    RazorMetaCode - [16..16)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock4.stree.txt
@@ -1,24 +1,34 @@
-Markup block - Gen<None> - 20 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 20 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 18 - (2:0,2)
-            Tag block - Gen<None> - 18 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text];
-                Markup block - Gen<Attr:class, class="@(8:0,8),@(20:0,20)> - 12 - (8:0,8)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(16:0,16)> - [btn}] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.Text;[btn}];
+RazorDocument - [0..20)::20 - [@{<!text class="btn}]
+    MarkupBlock - [0..20)::20
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..20)::20
+            CSharpStatement - [0..20)::20
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..20)::19
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..20)::18
+                        MarkupBlock - [2..20)::18
+                            MarkupTagBlock - [2..20)::18 - [<!text class="btn}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..8)::4 - [text] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                MarkupAttributeBlock - [8..20)::12 - [ class="btn}]
+                                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [16..20)::4
+                                        MarkupLiteralAttributeValue - [16..20)::4 - [btn}]
+                                            MarkupTextLiteral - [16..20)::4 - [btn}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn}];
+                    RazorMetaCode - [20..20)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock5.stree.txt
@@ -1,29 +1,39 @@
-Markup block - Gen<None> - 21 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 21 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 19 - (2:0,2)
-            Tag block - Gen<None> - 19 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text];
-                Markup block - Gen<Attr:class, class="@(8:0,8),"@(19:0,19)> - 12 - (8:0,8)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(16:0,16)> - [btn] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup block - Gen<None> - 1 - (20:0,20)
-                    Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                        SyntaxKind.Text;[}];
+RazorDocument - [0..21)::21 - [@{<!text class="btn"}]
+    MarkupBlock - [0..21)::21
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..21)::21
+            CSharpStatement - [0..21)::21
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..21)::20
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..21)::19
+                        MarkupBlock - [2..21)::19
+                            MarkupTagBlock - [2..21)::19 - [<!text class="btn"}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..8)::4 - [text] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                MarkupAttributeBlock - [8..20)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [16..19)::3
+                                        MarkupLiteralAttributeValue - [16..19)::3 - [btn]
+                                            MarkupTextLiteral - [16..19)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [19..20)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupMinimizedAttributeBlock - [20..21)::1 - [}]
+                                    MarkupTextLiteral - [20..21)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[}];
+                    RazorMetaCode - [21..21)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptForIncompleteTextTagInCSharpBlock6.stree.txt
@@ -1,32 +1,42 @@
-Markup block - Gen<None> - 23 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 23 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 21 - (2:0,2)
-            Tag block - Gen<None> - 21 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [text] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[text];
-                Markup block - Gen<Attr:class, class="@(8:0,8),"@(19:0,19)> - 12 - (8:0,8)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(16:0,16)> - [btn] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup span - Gen<Markup> - [ /] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:2
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.ForwardSlash;[/];
-                Markup block - Gen<None> - 1 - (22:0,22)
-                    Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:1
-                        SyntaxKind.Text;[}];
+RazorDocument - [0..23)::23 - [@{<!text class="btn" /}]
+    MarkupBlock - [0..23)::23
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..23)::23
+            CSharpStatement - [0..23)::23
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..23)::22
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..23)::21
+                        MarkupBlock - [2..23)::21
+                            MarkupTagBlock - [2..23)::21 - [<!text class="btn" /}]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..8)::4 - [text] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[text];
+                                MarkupAttributeBlock - [8..20)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [8..9)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [9..14)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [16..19)::3
+                                        MarkupLiteralAttributeValue - [16..19)::3 - [btn]
+                                            MarkupTextLiteral - [16..19)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [19..20)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupTextLiteral - [20..22)::2 - [ /] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Whitespace;[ ];
+                                    ForwardSlash;[/];
+                                MarkupMinimizedAttributeBlock - [22..23)::1 - [}]
+                                    MarkupTextLiteral - [22..23)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[}];
+                    RazorMetaCode - [23..23)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData1.stree.txt
@@ -1,30 +1,40 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 19 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 17 - (2:0,2)
-            Tag block - Gen<None> - 16 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class="@(5:0,5),"@(16:0,16)> - 12 - (5:0,5)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(13:0,13)> - [btn] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                SyntaxKind.Text;[}];
+RazorDocument - [0..19)::19 - [@{<!p class="btn">}]
+    MarkupBlock - [0..19)::19
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..19)::19
+            CSharpStatement - [0..19)::19
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..19)::18
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..19)::17
+                        MarkupBlock - [2..19)::17
+                            MarkupTagBlock - [2..18)::16 - [<!p class="btn">]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..17)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [13..16)::3
+                                        MarkupLiteralAttributeValue - [13..16)::3 - [btn]
+                                            MarkupTextLiteral - [13..16)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [16..17)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupTextLiteral - [17..18)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [18..19)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[}];
+                    RazorMetaCode - [19..19)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData2.stree.txt
@@ -1,43 +1,51 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 24 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 21 - (2:0,2)
-            Tag block - Gen<None> - 16 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class="@(5:0,5),"@(16:0,16)> - 12 - (5:0,5)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(13:0,13)> - [btn] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 5 - (18:0,18)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (23:0,23) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..24)::24 - [@{<!p class="btn"></!p>}]
+    MarkupBlock - [0..24)::24
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..24)::24
+            CSharpStatement - [0..24)::24
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..24)::23
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..23)::21
+                        MarkupBlock - [2..23)::21
+                            MarkupTagBlock - [2..18)::16 - [<!p class="btn">]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..17)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [13..16)::3
+                                        MarkupLiteralAttributeValue - [13..16)::3 - [btn]
+                                            MarkupTextLiteral - [13..16)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [16..17)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupTextLiteral - [17..18)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [18..23)::5 - [</!p>]
+                                MarkupTextLiteral - [18..20)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [20..21)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [21..23)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [23..23)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [23..24)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [24..24)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData3.stree.txt
@@ -1,49 +1,57 @@
-Markup block - Gen<None> - 41 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 41 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 38 - (2:0,2)
-            Tag block - Gen<None> - 16 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class="@(5:0,5),"@(16:0,16)> - 12 - (5:0,5)
-                    Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.DoubleQuote;["];
-                    Markup span - Gen<LitAttr:@(13:0,13)> - [btn] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                    Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                        SyntaxKind.DoubleQuote;["];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (17:0,17) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [words with spaces] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[with];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
-            Tag block - Gen<None> - 5 - (35:0,35)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (35:0,35) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (37:0,37) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (38:0,38) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (40:0,40) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (40:0,40) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (41:0,41) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..41)::41 - [@{<!p class="btn">words with spaces</!p>}]
+    MarkupBlock - [0..41)::41
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..41)::41
+            CSharpStatement - [0..41)::41
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..41)::40
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..40)::38
+                        MarkupBlock - [2..40)::38
+                            MarkupTagBlock - [2..18)::16 - [<!p class="btn">]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..17)::12 - [ class="btn"]
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                    GenericBlock - [13..16)::3
+                                        MarkupLiteralAttributeValue - [13..16)::3 - [btn]
+                                            MarkupTextLiteral - [13..16)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                    MarkupTextLiteral - [16..17)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        DoubleQuote;["];
+                                MarkupTextLiteral - [17..18)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [18..35)::17 - [words with spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[words];
+                                Whitespace;[ ];
+                                Text;[with];
+                                Whitespace;[ ];
+                                Text;[spaces];
+                            MarkupTagBlock - [35..40)::5 - [</!p>]
+                                MarkupTextLiteral - [35..37)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [37..38)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [38..40)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [40..40)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [40..41)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [41..41)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData4.stree.txt
@@ -1,53 +1,66 @@
-Markup block - Gen<None> - 41 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 41 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 38 - (2:0,2)
-            Tag block - Gen<None> - 33 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class='@(5:0,5),'@(22:0,22)> - 18 - (5:0,5)
-                    Markup span - Gen<None> - [ class='] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.SingleQuote;['];
-                    Markup span - Gen<LitAttr:@(13:0,13)> - [btn1] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                        SyntaxKind.Text;[btn1];
-                    Markup span - Gen<LitAttr: @(17:0,17)> - [ btn2] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:2
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[btn2];
-                    Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:1
-                        SyntaxKind.SingleQuote;['];
-                Markup block - Gen<Attr:class2, class2=@(23:0,23),@(34:0,34)> - 11 - (23:0,23)
-                    Markup span - Gen<None> - [ class2=] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:3
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class2];
-                        SyntaxKind.Equals;[=];
-                    Markup span - Gen<LitAttr:@(31:0,31)> - [btn] - SpanEditHandler;Accepts:Any - (31:0,31) - Tokens:1
-                        SyntaxKind.Text;[btn];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (34:0,34) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 5 - (35:0,35)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (35:0,35) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (37:0,37) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (38:0,38) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (40:0,40) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (40:0,40) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (41:0,41) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..41)::41 - [@{<!p class='btn1 btn2' class2=btn></!p>}]
+    MarkupBlock - [0..41)::41
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..41)::41
+            CSharpStatement - [0..41)::41
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..41)::40
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..40)::38
+                        MarkupBlock - [2..40)::38
+                            MarkupTagBlock - [2..35)::33 - [<!p class='btn1 btn2' class2=btn>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..23)::18 - [ class='btn1 btn2']
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [12..13)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        SingleQuote;['];
+                                    GenericBlock - [13..22)::9
+                                        MarkupLiteralAttributeValue - [13..17)::4 - [btn1]
+                                            MarkupTextLiteral - [13..17)::4 - [btn1] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn1];
+                                        MarkupLiteralAttributeValue - [17..22)::5 - [ btn2]
+                                            MarkupTextLiteral - [17..18)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Whitespace;[ ];
+                                            MarkupTextLiteral - [18..22)::4 - [btn2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn2];
+                                    MarkupTextLiteral - [22..23)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        SingleQuote;['];
+                                MarkupAttributeBlock - [23..34)::11 - [ class2=btn]
+                                    MarkupTextLiteral - [23..24)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [24..30)::6 - [class2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class2];
+                                    Equals;[=];
+                                    GenericBlock - [31..34)::3
+                                        MarkupLiteralAttributeValue - [31..34)::3 - [btn]
+                                            MarkupTextLiteral - [31..34)::3 - [btn] - Gen<None> - SpanEditHandler;Accepts:Any
+                                                Text;[btn];
+                                MarkupTextLiteral - [34..35)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [35..40)::5 - [</!p>]
+                                MarkupTextLiteral - [35..37)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [37..38)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [38..40)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [40..40)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [40..41)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [41..41)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithAttributeData5.stree.txt
@@ -1,56 +1,70 @@
-Markup block - Gen<None> - 44 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 44 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 41 - (2:0,2)
-            Tag block - Gen<None> - 36 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                    SyntaxKind.Text;[p];
-                Markup block - Gen<Attr:class, class='@(5:0,5),'@(36:0,36)> - 32 - (5:0,5)
-                    Markup span - Gen<None> - [ class='] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[class];
-                        SyntaxKind.Equals;[=];
-                        SyntaxKind.SingleQuote;['];
-                    Markup span - Gen<LitAttr:@(13:0,13)> - [btn1] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-                        SyntaxKind.Text;[btn1];
-                    Markup block - Gen<DynAttr: @(17:0,17)> - 14 - (17:0,17)
-                        Markup span - Gen<None> - [ ] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:1
-                            SyntaxKind.Whitespace;[ ];
-                        Expression block - Gen<Expr> - 13 - (18:0,18)
-                            Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:1
-                                SyntaxKind.Transition;[@];
-                            Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (19:0,19) - Tokens:3
-                                SyntaxKind.Identifier;[DateTime];
-                                SyntaxKind.Dot;[.];
-                                SyntaxKind.Identifier;[Now];
-                    Markup span - Gen<LitAttr: @(31:0,31)> - [ btn2] - SpanEditHandler;Accepts:Any - (31:0,31) - Tokens:2
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[btn2];
-                    Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:1
-                        SyntaxKind.SingleQuote;['];
-                Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:None - (37:0,37) - Tokens:1
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 5 - (38:0,38)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (38:0,38) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (40:0,40) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (41:0,41) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (43:0,43) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (43:0,43) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (44:0,44) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..44)::44 - [@{<!p class='btn1 @DateTime.Now btn2'></!p>}]
+    MarkupBlock - [0..44)::44
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..44)::44
+            CSharpStatement - [0..44)::44
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..44)::43
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..43)::41
+                        MarkupBlock - [2..43)::41
+                            MarkupTagBlock - [2..38)::36 - [<!p class='btn1 @DateTime.Now btn2'>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..5)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[p];
+                                MarkupAttributeBlock - [5..37)::32 - [ class='btn1 @DateTime.Now btn2']
+                                    MarkupTextLiteral - [5..6)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Whitespace;[ ];
+                                    MarkupTextLiteral - [6..11)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[class];
+                                    Equals;[=];
+                                    MarkupTextLiteral - [12..13)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        SingleQuote;['];
+                                    GenericBlock - [13..36)::23
+                                        MarkupLiteralAttributeValue - [13..17)::4 - [btn1]
+                                            MarkupTextLiteral - [13..17)::4 - [btn1] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn1];
+                                        MarkupDynamicAttributeValue - [17..31)::14 - [ @DateTime.Now]
+                                            MarkupTextLiteral - [17..18)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Whitespace;[ ];
+                                            GenericBlock - [18..31)::13
+                                                CSharpCodeBlock - [18..31)::13
+                                                    CSharpImplicitExpression - [18..31)::13
+                                                        CSharpTransition - [18..19)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                                            Transition;[@];
+                                                        CSharpImplicitExpressionBody - [19..31)::12
+                                                            CSharpCodeBlock - [19..31)::12
+                                                                CSharpExpressionLiteral - [19..31)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                                    Identifier;[DateTime];
+                                                                    Dot;[.];
+                                                                    Identifier;[Now];
+                                        MarkupLiteralAttributeValue - [31..36)::5 - [ btn2]
+                                            MarkupTextLiteral - [31..32)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Whitespace;[ ];
+                                            MarkupTextLiteral - [32..36)::4 - [btn2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                                Text;[btn2];
+                                    MarkupTextLiteral - [36..37)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                                        SingleQuote;['];
+                                MarkupTextLiteral - [37..38)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [38..43)::5 - [</!p>]
+                                MarkupTextLiteral - [38..40)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [40..41)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [41..43)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [43..43)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [43..44)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [44..44)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData1.stree.txt
@@ -1,19 +1,25 @@
-Markup block - Gen<None> - 7 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 7 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 5 - (2:0,2)
-            Tag block - Gen<None> - 4 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:1
-                SyntaxKind.Text;[}];
+RazorDocument - [0..7)::7 - [@{<!p>}]
+    MarkupBlock - [0..7)::7
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..7)::7
+            CSharpStatement - [0..7)::7
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..7)::6
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..7)::5
+                        MarkupBlock - [2..7)::5
+                            MarkupTagBlock - [2..6)::4 - [<!p>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..6)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [6..7)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[}];
+                    RazorMetaCode - [7..7)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData10.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData10.stree.txt
@@ -1,33 +1,41 @@
-Markup block - Gen<None> - 25 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 25 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 13 - (2:0,2)
-            Tag block - Gen<TagHelper> - 13 - (2:0,2) - strong - strongtaghelper
-                StartTagAndEndTag - <strong>
-                Tag block - Gen<None> - 5 - (10:0,10)
-                    Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:2
-                        SyntaxKind.OpenAngle;[<];
-                        SyntaxKind.ForwardSlash;[/];
-                    MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:1
-                        SyntaxKind.Bang;[!];
-                    Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (13:0,13) - Tokens:2
-                        SyntaxKind.Text;[p];
-                        SyntaxKind.CloseAngle;[>];
-        Markup block - Gen<None> - 9 - (15:0,15)
-            Tag block - Gen<None> - 9 - (15:0,15)
-                Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..25)::25 - [@{<strong></!p></strong>}]
+    MarkupBlock - [0..25)::25
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..25)::25
+            CSharpStatement - [0..25)::25
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..25)::24
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..24)::22
+                        MarkupBlock - [2..15)::13
+                            MarkupTagHelperElement - [2..15)::13 - strong[StartTagAndEndTag] - strongtaghelper
+                                MarkupTagHelperStartTag - [2..10)::8
+                                    MarkupTextLiteral - [2..10)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        Text;[strong];
+                                        CloseAngle;[>];
+                                MarkupTagBlock - [10..15)::5 - [</!p>]
+                                    MarkupTextLiteral - [10..12)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        OpenAngle;[<];
+                                        ForwardSlash;[/];
+                                    RazorMetaCode - [12..13)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                        Bang;[!];
+                                    MarkupTextLiteral - [13..15)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        Text;[p];
+                                        CloseAngle;[>];
+                        MarkupBlock - [15..24)::9
+                            MarkupTagBlock - [15..24)::9 - [</strong>]
+                                MarkupTextLiteral - [15..24)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[strong];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [24..24)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [24..25)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [25..25)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData11.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData11.stree.txt
@@ -1,35 +1,49 @@
-Markup block - Gen<None> - 29 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 29 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 17 - (2:0,2)
-            Tag block - Gen<TagHelper> - 17 - (2:0,2) - strong - strongtaghelper
-                StartTagAndEndTag - <strong> ... </strong>
-        Markup block - Gen<None> - 9 - (19:0,19)
-            Tag block - Gen<None> - 4 - (19:0,19)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (20:0,20) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (21:0,21) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 5 - (23:0,23)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (26:0,26) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (28:0,28) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (28:0,28) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (29:0,29) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..29)::29 - [@{<strong></strong><!p></!p>}]
+    MarkupBlock - [0..29)::29
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..29)::29
+            CSharpStatement - [0..29)::29
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..29)::28
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..28)::26
+                        MarkupBlock - [2..19)::17
+                            MarkupTagHelperElement - [2..19)::17 - strong[StartTagAndEndTag] - strongtaghelper
+                                MarkupTagHelperStartTag - [2..10)::8
+                                    MarkupTextLiteral - [2..10)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        Text;[strong];
+                                        CloseAngle;[>];
+                                MarkupTagHelperEndTag - [10..19)::9
+                                    MarkupTextLiteral - [10..19)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        ForwardSlash;[/];
+                                        Text;[strong];
+                                        CloseAngle;[>];
+                        MarkupBlock - [19..28)::9
+                            MarkupTagBlock - [19..23)::4 - [<!p>]
+                                MarkupTextLiteral - [19..20)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [20..21)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [21..23)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [23..28)::5 - [</!p>]
+                                MarkupTextLiteral - [23..25)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [25..26)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [26..28)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [28..28)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [28..29)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [29..29)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData12.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData12.stree.txt
@@ -1,53 +1,65 @@
-Markup block - Gen<None> - 42 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 42 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 21 - (2:0,2)
-            Tag block - Gen<TagHelper> - 21 - (2:0,2) - p - ptaghelper
-                StartTagAndEndTag - <p>
-                Tag block - Gen<TagHelper> - 18 - (5:0,5) - strong - strongtaghelper
-                    StartTagAndEndTag - <strong>
-                    Tag block - Gen<None> - 10 - (13:0,13)
-                        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:2
-                            SyntaxKind.OpenAngle;[<];
-                            SyntaxKind.ForwardSlash;[/];
-                        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:1
-                            SyntaxKind.Bang;[!];
-                        Markup span - Gen<Markup> - [strong>] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:2
-                            SyntaxKind.Text;[strong];
-                            SyntaxKind.CloseAngle;[>];
-        Markup block - Gen<None> - 13 - (23:0,23)
-            Tag block - Gen<None> - 4 - (23:0,23)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 9 - (27:0,27)
-                Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:None - (27:0,27) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
-        Markup block - Gen<None> - 5 - (36:0,36)
-            Tag block - Gen<None> - 5 - (36:0,36)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (38:0,38) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (39:0,39) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (41:0,41) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (41:0,41) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (42:0,42) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..42)::42 - [@{<p><strong></!strong><!p></strong></!p>}]
+    MarkupBlock - [0..42)::42
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..42)::42
+            CSharpStatement - [0..42)::42
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..42)::41
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..41)::39
+                        MarkupBlock - [2..23)::21
+                            MarkupTagHelperElement - [2..23)::21 - p[StartTagAndEndTag] - ptaghelper
+                                MarkupTagHelperStartTag - [2..5)::3
+                                    MarkupTextLiteral - [2..5)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTagHelperElement - [5..23)::18 - strong[StartTagAndEndTag] - strongtaghelper
+                                    MarkupTagHelperStartTag - [5..13)::8
+                                        MarkupTextLiteral - [5..13)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                            OpenAngle;[<];
+                                            Text;[strong];
+                                            CloseAngle;[>];
+                                    MarkupTagBlock - [13..23)::10 - [</!strong>]
+                                        MarkupTextLiteral - [13..15)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                            OpenAngle;[<];
+                                            ForwardSlash;[/];
+                                        RazorMetaCode - [15..16)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Bang;[!];
+                                        MarkupTextLiteral - [16..23)::7 - [strong>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                            Text;[strong];
+                                            CloseAngle;[>];
+                        MarkupBlock - [23..36)::13
+                            MarkupTagBlock - [23..27)::4 - [<!p>]
+                                MarkupTextLiteral - [23..24)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [24..25)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [25..27)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [27..36)::9 - [</strong>]
+                                MarkupTextLiteral - [27..36)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[strong];
+                                    CloseAngle;[>];
+                        MarkupBlock - [36..41)::5
+                            MarkupTagBlock - [36..41)::5 - [</!p>]
+                                MarkupTextLiteral - [36..38)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [38..39)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [39..41)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [41..41)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [41..42)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [42..42)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData2.stree.txt
@@ -1,24 +1,28 @@
-Markup block - Gen<None> - 8 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 8 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 5 - (2:0,2)
-            Tag block - Gen<None> - 5 - (2:0,2)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (7:0,7) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..8)::8 - [@{</!p>}]
+    MarkupBlock - [0..8)::8
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..8)::8
+            CSharpStatement - [0..8)::8
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..8)::7
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..7)::5
+                        MarkupBlock - [2..7)::5
+                            MarkupTagBlock - [2..7)::5 - [</!p>]
+                                MarkupTextLiteral - [2..4)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [4..5)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [5..7)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [7..7)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [7..8)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [8..8)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData3.stree.txt
@@ -1,32 +1,36 @@
-Markup block - Gen<None> - 12 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 12 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 9 - (2:0,2)
-            Tag block - Gen<None> - 4 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 5 - (6:0,6)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (8:0,8) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (11:0,11) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..12)::12 - [@{<!p></!p>}]
+    MarkupBlock - [0..12)::12
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..12)::12
+            CSharpStatement - [0..12)::12
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..12)::11
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..11)::9
+                        MarkupBlock - [2..11)::9
+                            MarkupTagBlock - [2..6)::4 - [<!p>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..6)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [6..11)::5 - [</!p>]
+                                MarkupTextLiteral - [6..8)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [8..9)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [9..11)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [11..11)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [11..12)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [12..12)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData4.stree.txt
@@ -1,38 +1,42 @@
-Markup block - Gen<None> - 28 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 28 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 25 - (2:0,2)
-            Tag block - Gen<None> - 4 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [words and spaces] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
-            Tag block - Gen<None> - 5 - (22:0,22)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (24:0,24) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (25:0,25) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (27:0,27) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (27:0,27) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (28:0,28) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..28)::28 - [@{<!p>words and spaces</!p>}]
+    MarkupBlock - [0..28)::28
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..28)::28
+            CSharpStatement - [0..28)::28
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..28)::27
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..27)::25
+                        MarkupBlock - [2..27)::25
+                            MarkupTagBlock - [2..6)::4 - [<!p>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..6)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [6..22)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[words];
+                                Whitespace;[ ];
+                                Text;[and];
+                                Whitespace;[ ];
+                                Text;[spaces];
+                            MarkupTagBlock - [22..27)::5 - [</!p>]
+                                MarkupTextLiteral - [22..24)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [24..25)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [25..27)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [27..27)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [27..28)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [28..28)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData5.stree.txt
@@ -1,29 +1,33 @@
-Markup block - Gen<None> - 11 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 11 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 8 - (2:0,2)
-            Tag block - Gen<None> - 4 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 4 - (6:0,6)
-                Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:None - (6:0,6) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..11)::11 - [@{<!p></p>}]
+    MarkupBlock - [0..11)::11
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..11)::11
+            CSharpStatement - [0..11)::11
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..11)::10
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..10)::8
+                        MarkupBlock - [2..10)::8
+                            MarkupTagBlock - [2..6)::4 - [<!p>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..6)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [6..10)::4 - [</p>]
+                                MarkupTextLiteral - [6..10)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [10..10)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [11..11)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData6.stree.txt
@@ -1,26 +1,34 @@
-Markup block - Gen<None> - 11 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 11 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 8 - (2:0,2)
-            Tag block - Gen<TagHelper> - 8 - (2:0,2) - p - ptaghelper
-                StartTagAndEndTag - <p>
-                Tag block - Gen<None> - 5 - (5:0,5)
-                    Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:2
-                        SyntaxKind.OpenAngle;[<];
-                        SyntaxKind.ForwardSlash;[/];
-                    MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (7:0,7) - Tokens:1
-                        SyntaxKind.Bang;[!];
-                    Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (8:0,8) - Tokens:2
-                        SyntaxKind.Text;[p];
-                        SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..11)::11 - [@{<p></!p>}]
+    MarkupBlock - [0..11)::11
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..11)::11
+            CSharpStatement - [0..11)::11
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..11)::10
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..10)::8
+                        MarkupBlock - [2..10)::8
+                            MarkupTagHelperElement - [2..10)::8 - p[StartTagAndEndTag] - ptaghelper
+                                MarkupTagHelperStartTag - [2..5)::3
+                                    MarkupTextLiteral - [2..5)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTagBlock - [5..10)::5 - [</!p>]
+                                    MarkupTextLiteral - [5..7)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        OpenAngle;[<];
+                                        ForwardSlash;[/];
+                                    RazorMetaCode - [7..8)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                        Bang;[!];
+                                    MarkupTextLiteral - [8..10)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        Text;[p];
+                                        CloseAngle;[>];
+                        CSharpStatementLiteral - [10..10)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [11..11)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData7.stree.txt
@@ -1,34 +1,48 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 19 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 16 - (2:0,2)
-            Tag block - Gen<TagHelper> - 16 - (2:0,2) - p - ptaghelper
-                StartTagAndEndTag - <p> ... </p>
-                Tag block - Gen<None> - 4 - (5:0,5)
-                    Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:1
-                        SyntaxKind.OpenAngle;[<];
-                    MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (6:0,6) - Tokens:1
-                        SyntaxKind.Bang;[!];
-                    Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (7:0,7) - Tokens:2
-                        SyntaxKind.Text;[p];
-                        SyntaxKind.CloseAngle;[>];
-                Tag block - Gen<None> - 5 - (9:0,9)
-                    Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:2
-                        SyntaxKind.OpenAngle;[<];
-                        SyntaxKind.ForwardSlash;[/];
-                    MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (11:0,11) - Tokens:1
-                        SyntaxKind.Bang;[!];
-                    Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:2
-                        SyntaxKind.Text;[p];
-                        SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..19)::19 - [@{<p><!p></!p></p>}]
+    MarkupBlock - [0..19)::19
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..19)::19
+            CSharpStatement - [0..19)::19
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..19)::18
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..18)::16
+                        MarkupBlock - [2..18)::16
+                            MarkupTagHelperElement - [2..18)::16 - p[StartTagAndEndTag] - ptaghelper
+                                MarkupTagHelperStartTag - [2..5)::3
+                                    MarkupTextLiteral - [2..5)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTagBlock - [5..9)::4 - [<!p>]
+                                    MarkupTextLiteral - [5..6)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        OpenAngle;[<];
+                                    RazorMetaCode - [6..7)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                        Bang;[!];
+                                    MarkupTextLiteral - [7..9)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTagBlock - [9..14)::5 - [</!p>]
+                                    MarkupTextLiteral - [9..11)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        OpenAngle;[<];
+                                        ForwardSlash;[/];
+                                    RazorMetaCode - [11..12)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                        Bang;[!];
+                                    MarkupTextLiteral - [12..14)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTagHelperEndTag - [14..18)::4
+                                    MarkupTextLiteral - [14..18)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        ForwardSlash;[/];
+                                        Text;[p];
+                                        CloseAngle;[>];
+                        CSharpStatementLiteral - [18..18)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [18..19)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [19..19)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData8.stree.txt
@@ -1,30 +1,40 @@
-Markup block - Gen<None> - 15 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 15 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 13 - (2:0,2)
-            Tag block - Gen<TagHelper> - 13 - (2:0,2) - p - ptaghelper
-                StartTagAndEndTag - <p>
-                Tag block - Gen<None> - 4 - (5:0,5)
-                    Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:1
-                        SyntaxKind.OpenAngle;[<];
-                    MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (6:0,6) - Tokens:1
-                        SyntaxKind.Bang;[!];
-                    Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (7:0,7) - Tokens:2
-                        SyntaxKind.Text;[p];
-                        SyntaxKind.CloseAngle;[>];
-                Tag block - Gen<None> - 5 - (9:0,9)
-                    Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:2
-                        SyntaxKind.OpenAngle;[<];
-                        SyntaxKind.ForwardSlash;[/];
-                    MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (11:0,11) - Tokens:1
-                        SyntaxKind.Bang;[!];
-                    Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:2
-                        SyntaxKind.Text;[p];
-                        SyntaxKind.CloseAngle;[>];
-                Markup span - Gen<Markup> - [}] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                    SyntaxKind.Text;[}];
+RazorDocument - [0..15)::15 - [@{<p><!p></!p>}]
+    MarkupBlock - [0..15)::15
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..15)::15
+            CSharpStatement - [0..15)::15
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..15)::14
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..15)::13
+                        MarkupBlock - [2..15)::13
+                            MarkupTagHelperElement - [2..15)::13 - p[StartTagAndEndTag] - ptaghelper
+                                MarkupTagHelperStartTag - [2..5)::3
+                                    MarkupTextLiteral - [2..5)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTagBlock - [5..9)::4 - [<!p>]
+                                    MarkupTextLiteral - [5..6)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        OpenAngle;[<];
+                                    RazorMetaCode - [6..7)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                        Bang;[!];
+                                    MarkupTextLiteral - [7..9)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTagBlock - [9..14)::5 - [</!p>]
+                                    MarkupTextLiteral - [9..11)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        OpenAngle;[<];
+                                        ForwardSlash;[/];
+                                    RazorMetaCode - [11..12)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                        Bang;[!];
+                                    MarkupTextLiteral - [12..14)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTextLiteral - [14..15)::1 - [}] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[}];
+                    RazorMetaCode - [15..15)::0 - Gen<None> - SpanEditHandler;Accepts:Any
+                        RightBrace;[<Missing>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData9.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutCSharp_WithBlockData9.stree.txt
@@ -1,39 +1,43 @@
-Markup block - Gen<None> - 16 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 16 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 9 - (2:0,2)
-            Tag block - Gen<None> - 4 - (2:0,2)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 5 - (6:0,6)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (8:0,8) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Markup block - Gen<None> - 4 - (11:0,11)
-            Tag block - Gen<None> - 4 - (11:0,11)
-                Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:None - (11:0,11) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..16)::16 - [@{<!p></!p></p>}]
+    MarkupBlock - [0..16)::16
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..16)::16
+            CSharpStatement - [0..16)::16
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..16)::15
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..15)::13
+                        MarkupBlock - [2..11)::9
+                            MarkupTagBlock - [2..6)::4 - [<!p>]
+                                MarkupTextLiteral - [2..3)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                RazorMetaCode - [3..4)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [4..6)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                            MarkupTagBlock - [6..11)::5 - [</!p>]
+                                MarkupTextLiteral - [6..8)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                RazorMetaCode - [8..9)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                    Bang;[!];
+                                MarkupTextLiteral - [9..11)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        MarkupBlock - [11..15)::4
+                            MarkupTagBlock - [11..15)::4 - [</p>]
+                                MarkupTextLiteral - [11..15)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[p];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [15..15)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [15..16)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [16..16)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData1.stree.txt
@@ -1,20 +1,25 @@
-Markup block - Gen<None> - 16 - (0:0,0)
-    Tag block - Gen<None> - 16 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
-        Markup block - Gen<Attr:class, class="@(3:0,3),"@(14:0,14)> - 12 - (3:0,3)
-            Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [btn] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[btn];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..16)::16 - [<!p class="btn">]
+    MarkupBlock - [0..16)::16
+        MarkupTagBlock - [0..16)::16 - [<!p class="btn">]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+            MarkupAttributeBlock - [3..15)::12 - [ class="btn"]
+                MarkupTextLiteral - [3..4)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [4..9)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [10..11)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+                GenericBlock - [11..14)::3
+                    MarkupLiteralAttributeValue - [11..14)::3 - [btn]
+                        MarkupTextLiteral - [11..14)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn];
+                MarkupTextLiteral - [14..15)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+            MarkupTextLiteral - [15..16)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData2.stree.txt
@@ -1,29 +1,34 @@
-Markup block - Gen<None> - 21 - (0:0,0)
-    Tag block - Gen<None> - 16 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
-        Markup block - Gen<Attr:class, class="@(3:0,3),"@(14:0,14)> - 12 - (3:0,3)
-            Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [btn] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[btn];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (16:0,16)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..21)::21 - [<!p class="btn"></!p>]
+    MarkupBlock - [0..21)::21
+        MarkupTagBlock - [0..16)::16 - [<!p class="btn">]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+            MarkupAttributeBlock - [3..15)::12 - [ class="btn"]
+                MarkupTextLiteral - [3..4)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [4..9)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [10..11)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+                GenericBlock - [11..14)::3
+                    MarkupLiteralAttributeValue - [11..14)::3 - [btn]
+                        MarkupTextLiteral - [11..14)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn];
+                MarkupTextLiteral - [14..15)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+            MarkupTextLiteral - [15..16)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTagBlock - [16..21)::5 - [</!p>]
+            MarkupTextLiteral - [16..18)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [18..19)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [19..21)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData3.stree.txt
@@ -1,36 +1,40 @@
-Markup block - Gen<None> - 37 - (0:0,0)
-    Tag block - Gen<None> - 16 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
-        Markup block - Gen<Attr:class, class="@(3:0,3),"@(14:0,14)> - 12 - (3:0,3)
-            Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [btn] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[btn];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [words and spaces] - [16..32) - FullWidth: 16 - Slots: 1
-        SyntaxKind.List - [words and spaces] - [16..32) - FullWidth: 16 - Slots: 5
-            SyntaxKind.Text;[words];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[and];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[spaces];
-    Tag block - Gen<None> - 5 - (32:0,32)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (32:0,32) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (34:0,34) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (35:0,35) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..37)::37 - [<!p class="btn">words and spaces</!p>]
+    MarkupBlock - [0..37)::37
+        MarkupTagBlock - [0..16)::16 - [<!p class="btn">]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+            MarkupAttributeBlock - [3..15)::12 - [ class="btn"]
+                MarkupTextLiteral - [3..4)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [4..9)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [10..11)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+                GenericBlock - [11..14)::3
+                    MarkupLiteralAttributeValue - [11..14)::3 - [btn]
+                        MarkupTextLiteral - [11..14)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn];
+                MarkupTextLiteral - [14..15)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+            MarkupTextLiteral - [15..16)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTextLiteral - [16..32)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Text;[words];
+            Whitespace;[ ];
+            Text;[and];
+            Whitespace;[ ];
+            Text;[spaces];
+        MarkupTagBlock - [32..37)::5 - [</!p>]
+            MarkupTextLiteral - [32..34)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [34..35)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [35..37)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData4.stree.txt
@@ -1,39 +1,49 @@
-Markup block - Gen<None> - 38 - (0:0,0)
-    Tag block - Gen<None> - 33 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
-        Markup block - Gen<Attr:class, class='@(3:0,3),'@(20:0,20)> - 18 - (3:0,3)
-            Markup span - Gen<None> - [ class='] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [btn1] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[btn1];
-            Markup span - Gen<LitAttr: @(15:0,15)> - [ btn2] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[btn2];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:class2, class2=@(21:0,21),@(32:0,32)> - 11 - (21:0,21)
-            Markup span - Gen<None> - [ class2=] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:3
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class2];
-                SyntaxKind.Equals;[=];
-            Markup span - Gen<LitAttr:@(29:0,29)> - [btn] - SpanEditHandler;Accepts:Any - (29:0,29) - Tokens:1
-                SyntaxKind.Text;[btn];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (32:0,32) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (33:0,33)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (35:0,35) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..38)::38 - [<!p class='btn1 btn2' class2=btn></!p>]
+    MarkupBlock - [0..38)::38
+        MarkupTagBlock - [0..33)::33 - [<!p class='btn1 btn2' class2=btn>]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+            MarkupAttributeBlock - [3..21)::18 - [ class='btn1 btn2']
+                MarkupTextLiteral - [3..4)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [4..9)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [10..11)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [11..20)::9
+                    MarkupLiteralAttributeValue - [11..15)::4 - [btn1]
+                        MarkupTextLiteral - [11..15)::4 - [btn1] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn1];
+                    MarkupLiteralAttributeValue - [15..20)::5 - [ btn2]
+                        MarkupTextLiteral - [15..16)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        MarkupTextLiteral - [16..20)::4 - [btn2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn2];
+                MarkupTextLiteral - [20..21)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupAttributeBlock - [21..32)::11 - [ class2=btn]
+                MarkupTextLiteral - [21..22)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [22..28)::6 - [class2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class2];
+                Equals;[=];
+                GenericBlock - [29..32)::3
+                    MarkupLiteralAttributeValue - [29..32)::3 - [btn]
+                        MarkupTextLiteral - [29..32)::3 - [btn] - Gen<None> - SpanEditHandler;Accepts:Any
+                            Text;[btn];
+            MarkupTextLiteral - [32..33)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTagBlock - [33..38)::5 - [</!p>]
+            MarkupTextLiteral - [33..35)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [35..36)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [36..38)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithAttributeData5.stree.txt
@@ -1,42 +1,53 @@
-Markup block - Gen<None> - 41 - (0:0,0)
-    Tag block - Gen<None> - 36 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:1
-            SyntaxKind.Text;[p];
-        Markup block - Gen<Attr:class, class='@(3:0,3),'@(34:0,34)> - 32 - (3:0,3)
-            Markup span - Gen<None> - [ class='] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(11:0,11)> - [btn1] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:1
-                SyntaxKind.Text;[btn1];
-            Markup block - Gen<DynAttr: @(15:0,15)> - 14 - (15:0,15)
-                Markup span - Gen<None> - [ ] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                    SyntaxKind.Whitespace;[ ];
-                Expression block - Gen<Expr> - 13 - (16:0,16)
-                    Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (17:0,17) - Tokens:3
-                        SyntaxKind.Identifier;[DateTime];
-                        SyntaxKind.Dot;[.];
-                        SyntaxKind.Identifier;[Now];
-            Markup span - Gen<LitAttr: @(29:0,29)> - [ btn2] - SpanEditHandler;Accepts:Any - (29:0,29) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[btn2];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (35:0,35) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (36:0,36)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (38:0,38) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (39:0,39) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..41)::41 - [<!p class='btn1 @DateTime.Now btn2'></!p>]
+    MarkupBlock - [0..41)::41
+        MarkupTagBlock - [0..36)::36 - [<!p class='btn1 @DateTime.Now btn2'>]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..3)::1 - [p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+            MarkupAttributeBlock - [3..35)::32 - [ class='btn1 @DateTime.Now btn2']
+                MarkupTextLiteral - [3..4)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [4..9)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [10..11)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [11..34)::23
+                    MarkupLiteralAttributeValue - [11..15)::4 - [btn1]
+                        MarkupTextLiteral - [11..15)::4 - [btn1] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn1];
+                    MarkupDynamicAttributeValue - [15..29)::14 - [ @DateTime.Now]
+                        MarkupTextLiteral - [15..16)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        GenericBlock - [16..29)::13
+                            CSharpCodeBlock - [16..29)::13
+                                CSharpImplicitExpression - [16..29)::13
+                                    CSharpTransition - [16..17)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                        Transition;[@];
+                                    CSharpImplicitExpressionBody - [17..29)::12
+                                        CSharpCodeBlock - [17..29)::12
+                                            CSharpExpressionLiteral - [17..29)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                Identifier;[DateTime];
+                                                Dot;[.];
+                                                Identifier;[Now];
+                    MarkupLiteralAttributeValue - [29..34)::5 - [ btn2]
+                        MarkupTextLiteral - [29..30)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        MarkupTextLiteral - [30..34)::4 - [btn2] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn2];
+                MarkupTextLiteral - [34..35)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupTextLiteral - [35..36)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTagBlock - [36..41)::5 - [</!p>]
+            MarkupTextLiteral - [36..38)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [38..39)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [39..41)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData1.stree.txt
@@ -1,9 +1,10 @@
-Markup block - Gen<None> - 4 - (0:0,0)
-    Tag block - Gen<None> - 4 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..4)::4 - [<!p>]
+    MarkupBlock - [0..4)::4
+        MarkupTagBlock - [0..4)::4 - [<!p>]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..4)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData10.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData10.stree.txt
@@ -1,12 +1,23 @@
-Markup block - Gen<None> - 22 - (0:0,0)
-    Tag block - Gen<TagHelper> - 22 - (0:0,0) - strong - strongtaghelper
-        StartTagAndEndTag - <strong> ... </strong>
-        Tag block - Gen<None> - 5 - (8:0,8)
-            Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-            MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-                SyntaxKind.Bang;[!];
-            Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:2
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..22)::22 - [<strong></!p></strong>]
+    MarkupBlock - [0..22)::22
+        MarkupTagHelperElement - [0..22)::22 - strong[StartTagAndEndTag] - strongtaghelper
+            MarkupTagHelperStartTag - [0..8)::8
+                MarkupTextLiteral - [0..8)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagBlock - [8..13)::5 - [</!p>]
+                MarkupTextLiteral - [8..10)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                RazorMetaCode - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Bang;[!];
+                MarkupTextLiteral - [11..13)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [13..22)::9
+                MarkupTextLiteral - [13..22)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData11.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData11.stree.txt
@@ -1,20 +1,31 @@
-Markup block - Gen<None> - 26 - (0:0,0)
-    Tag block - Gen<TagHelper> - 17 - (0:0,0) - strong - strongtaghelper
-        StartTagAndEndTag - <strong> ... </strong>
-    Tag block - Gen<None> - 4 - (17:0,17)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (21:0,21)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (23:0,23) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..26)::26 - [<strong></strong><!p></!p>]
+    MarkupBlock - [0..26)::26
+        MarkupTagHelperElement - [0..17)::17 - strong[StartTagAndEndTag] - strongtaghelper
+            MarkupTagHelperStartTag - [0..8)::8
+                MarkupTextLiteral - [0..8)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [8..17)::9
+                MarkupTextLiteral - [8..17)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+        MarkupTagBlock - [17..21)::4 - [<!p>]
+            MarkupTextLiteral - [17..18)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [18..19)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [19..21)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];
+        MarkupTagBlock - [21..26)::5 - [</!p>]
+            MarkupTextLiteral - [21..23)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [23..24)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [24..26)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData12.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData12.stree.txt
@@ -1,31 +1,46 @@
-Markup block - Gen<None> - 39 - (0:0,0)
-    Tag block - Gen<TagHelper> - 39 - (0:0,0) - p - ptaghelper
-        StartTagAndEndTag - <p>
-        Tag block - Gen<TagHelper> - 31 - (3:0,3) - strong - strongtaghelper
-            StartTagAndEndTag - <strong> ... </strong>
-            Tag block - Gen<None> - 10 - (11:0,11)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (13:0,13) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [strong>] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:2
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 4 - (21:0,21)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-                MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (22:0,22) - Tokens:1
-                    SyntaxKind.Bang;[!];
-                Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:2
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 5 - (34:0,34)
-            Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-            MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (36:0,36) - Tokens:1
-                SyntaxKind.Bang;[!];
-            Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (37:0,37) - Tokens:2
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..39)::39 - [<p><strong></!strong><!p></strong></!p>]
+    MarkupBlock - [0..39)::39
+        MarkupTagHelperElement - [0..39)::39 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..34)::31 - strong[StartTagAndEndTag] - strongtaghelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagBlock - [11..21)::10 - [</!strong>]
+                    MarkupTextLiteral - [11..13)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                    RazorMetaCode - [13..14)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        Bang;[!];
+                    MarkupTextLiteral - [14..21)::7 - [strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagBlock - [21..25)::4 - [<!p>]
+                    MarkupTextLiteral - [21..22)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                    RazorMetaCode - [22..23)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        Bang;[!];
+                    MarkupTextLiteral - [23..25)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [25..34)::9
+                    MarkupTextLiteral - [25..34)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagBlock - [34..39)::5 - [</!p>]
+                MarkupTextLiteral - [34..36)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                RazorMetaCode - [36..37)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Bang;[!];
+                MarkupTextLiteral - [37..39)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData2.stree.txt
@@ -1,10 +1,11 @@
-Markup block - Gen<None> - 5 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (2:0,2) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..5)::5 - [</!p>]
+    MarkupBlock - [0..5)::5
+        MarkupTagBlock - [0..5)::5 - [</!p>]
+            MarkupTextLiteral - [0..2)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [2..3)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [3..5)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData3.stree.txt
@@ -1,18 +1,19 @@
-Markup block - Gen<None> - 9 - (0:0,0)
-    Tag block - Gen<None> - 4 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (4:0,4)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (6:0,6) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..9)::9 - [<!p></!p>]
+    MarkupBlock - [0..9)::9
+        MarkupTagBlock - [0..4)::4 - [<!p>]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..4)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];
+        MarkupTagBlock - [4..9)::5 - [</!p>]
+            MarkupTextLiteral - [4..6)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [6..7)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [7..9)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData4.stree.txt
@@ -1,25 +1,25 @@
-Markup block - Gen<None> - 25 - (0:0,0)
-    Tag block - Gen<None> - 4 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [words and spaces] - [4..20) - FullWidth: 16 - Slots: 1
-        SyntaxKind.List - [words and spaces] - [4..20) - FullWidth: 16 - Slots: 5
-            SyntaxKind.Text;[words];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[and];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[spaces];
-    Tag block - Gen<None> - 5 - (20:0,20)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (22:0,22) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..25)::25 - [<!p>words and spaces</!p>]
+    MarkupBlock - [0..25)::25
+        MarkupTagBlock - [0..4)::4 - [<!p>]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..4)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];
+        MarkupTextLiteral - [4..20)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Text;[words];
+            Whitespace;[ ];
+            Text;[and];
+            Whitespace;[ ];
+            Text;[spaces];
+        MarkupTagBlock - [20..25)::5 - [</!p>]
+            MarkupTextLiteral - [20..22)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [22..23)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [23..25)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData5.stree.txt
@@ -1,15 +1,16 @@
-Markup block - Gen<None> - 8 - (0:0,0)
-    Tag block - Gen<None> - 4 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 4 - (4:0,4)
-        Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..8)::8 - [<!p></p>]
+    MarkupBlock - [0..8)::8
+        MarkupTagBlock - [0..4)::4 - [<!p>]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..4)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];
+        MarkupTagBlock - [4..8)::4 - [</p>]
+            MarkupTextLiteral - [4..8)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData6.stree.txt
@@ -1,12 +1,17 @@
-Markup block - Gen<None> - 8 - (0:0,0)
-    Tag block - Gen<TagHelper> - 8 - (0:0,0) - p - ptaghelper
-        StartTagAndEndTag - <p>
-        Tag block - Gen<None> - 5 - (3:0,3)
-            Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-            MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:1
-                SyntaxKind.Bang;[!];
-            Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:2
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..8)::8 - [<p></!p>]
+    MarkupBlock - [0..8)::8
+        MarkupTagHelperElement - [0..8)::8 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..8)::5 - [</!p>]
+                MarkupTextLiteral - [3..5)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                RazorMetaCode - [5..6)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Bang;[!];
+                MarkupTextLiteral - [6..8)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData7.stree.txt
@@ -1,20 +1,31 @@
-Markup block - Gen<None> - 16 - (0:0,0)
-    Tag block - Gen<TagHelper> - 16 - (0:0,0) - p - ptaghelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 4 - (3:0,3)
-            Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:1
-                SyntaxKind.OpenAngle;[<];
-            MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:1
-                SyntaxKind.Bang;[!];
-            Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:2
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 5 - (7:0,7)
-            Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-            MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:1
-                SyntaxKind.Bang;[!];
-            Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:2
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..16)::16 - [<p><!p></!p></p>]
+    MarkupBlock - [0..16)::16
+        MarkupTagHelperElement - [0..16)::16 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..7)::4 - [<!p>]
+                MarkupTextLiteral - [3..4)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                RazorMetaCode - [4..5)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Bang;[!];
+                MarkupTextLiteral - [5..7)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [7..12)::5 - [</!p>]
+                MarkupTextLiteral - [7..9)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                RazorMetaCode - [9..10)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Bang;[!];
+                MarkupTextLiteral - [10..12)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [12..16)::4
+                MarkupTextLiteral - [12..16)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData8.stree.txt
@@ -1,20 +1,25 @@
-Markup block - Gen<None> - 12 - (0:0,0)
-    Tag block - Gen<TagHelper> - 12 - (0:0,0) - p - ptaghelper
-        StartTagAndEndTag - <p>
-        Tag block - Gen<None> - 4 - (3:0,3)
-            Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:1
-                SyntaxKind.OpenAngle;[<];
-            MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (4:0,4) - Tokens:1
-                SyntaxKind.Bang;[!];
-            Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:2
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 5 - (7:0,7)
-            Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-            MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (9:0,9) - Tokens:1
-                SyntaxKind.Bang;[!];
-            Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:2
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..12)::12 - [<p><!p></!p>]
+    MarkupBlock - [0..12)::12
+        MarkupTagHelperElement - [0..12)::12 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..7)::4 - [<!p>]
+                MarkupTextLiteral - [3..4)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                RazorMetaCode - [4..5)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Bang;[!];
+                MarkupTextLiteral - [5..7)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [7..12)::5 - [</!p>]
+                MarkupTextLiteral - [7..9)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                RazorMetaCode - [9..10)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Bang;[!];
+                MarkupTextLiteral - [10..12)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData9.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/AllowsTagHelperElementOptOutHTML_WithBlockData9.stree.txt
@@ -1,24 +1,25 @@
-Markup block - Gen<None> - 13 - (0:0,0)
-    Tag block - Gen<None> - 4 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (2:0,2) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 5 - (4:0,4)
-        Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-        MetaCode span - Gen<None> - [!] - SpanEditHandler;Accepts:None - (6:0,6) - Tokens:1
-            SyntaxKind.Bang;[!];
-        Markup span - Gen<Markup> - [p>] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:2
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 4 - (9:0,9)
-        Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (9:0,9) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..13)::13 - [<!p></!p></p>]
+    MarkupBlock - [0..13)::13
+        MarkupTagBlock - [0..4)::4 - [<!p>]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+            RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [2..4)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];
+        MarkupTagBlock - [4..9)::5 - [</!p>]
+            MarkupTextLiteral - [4..6)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+            RazorMetaCode - [6..7)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                Bang;[!];
+            MarkupTextLiteral - [7..9)::2 - [p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[p];
+                CloseAngle;[>];
+        MarkupTagBlock - [9..13)::4 - [</p>]
+            MarkupTextLiteral - [9..13)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CanHandleInvalidChildrenWithWhitespace.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CanHandleInvalidChildrenWithWhitespace.stree.txt
@@ -1,27 +1,36 @@
-Markup block - Gen<None> - 53 - (0:0,0)
-    Tag block - Gen<TagHelper> - 53 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        SyntaxKind.HtmlTextLiteral - [LF    ] - [3..9) - FullWidth: 6 - Slots: 1
-            SyntaxKind.List - [LF    ] - [3..9) - FullWidth: 6 - Slots: 2
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[    ];
-        Tag block - Gen<None> - 8 - (9:1,4)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (9:1,4) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [LF        HelloLF    ] - [17..38) - FullWidth: 21 - Slots: 1
-            SyntaxKind.List - [LF        HelloLF    ] - [17..38) - FullWidth: 21 - Slots: 5
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[        ];
-                SyntaxKind.Text;[Hello];
-                SyntaxKind.NewLine;[LF];
-                SyntaxKind.Whitespace;[    ];
-        Tag block - Gen<None> - 9 - (38:3,4)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (38:3,4) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [LF] - [47..49) - FullWidth: 2 - Slots: 1
-            SyntaxKind.NewLine;[LF];
+RazorDocument - [0..53)::53 - [<p>LF    <strong>LF        HelloLF    </strong>LF</p>]
+    MarkupBlock - [0..53)::53
+        MarkupTagHelperElement - [0..53)::53 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [3..9)::6 - [LF    ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+                Whitespace;[    ];
+            MarkupTagBlock - [9..17)::8 - [<strong>]
+                MarkupTextLiteral - [9..17)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [17..38)::21 - [LF        HelloLF    ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+                Whitespace;[        ];
+                Text;[Hello];
+                NewLine;[LF];
+                Whitespace;[    ];
+            MarkupTagBlock - [38..47)::9 - [</strong>]
+                MarkupTextLiteral - [38..47)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [47..49)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            MarkupTagHelperEndTag - [49..53)::4
+                MarkupTextLiteral - [49..53)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CanHandleMultipleTagHelpersWithAllowedChildren.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CanHandleMultipleTagHelpersWithAllowedChildren.stree.txt
@@ -1,12 +1,36 @@
-Markup block - Gen<None> - 39 - (0:0,0)
-    Tag block - Gen<TagHelper> - 39 - (0:0,0) - p - PTagHelper1 - PTagHelper2
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 28 - (3:0,3) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
-            SyntaxKind.HtmlTextLiteral - [Hello World] - [11..22) - FullWidth: 11 - Slots: 1
-                SyntaxKind.List - [Hello World] - [11..22) - FullWidth: 11 - Slots: 3
-                    SyntaxKind.Text;[Hello];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[World];
-        Tag block - Gen<TagHelper> - 4 - (31:0,31) - br - BRTagHelper
-            StartTagOnly - <br>
+RazorDocument - [0..39)::39 - [<p><strong>Hello World</strong><br></p>]
+    MarkupBlock - [0..39)::39
+        MarkupTagHelperElement - [0..39)::39 - p[StartTagAndEndTag] - PTagHelper1 - PTagHelper2
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..31)::28 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [11..22)::11 - [Hello World] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[Hello];
+                    Whitespace;[ ];
+                    Text;[World];
+                MarkupTagHelperEndTag - [22..31)::9
+                    MarkupTextLiteral - [22..31)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperElement - [31..35)::4 - br[StartTagOnly] - BRTagHelper
+                MarkupTagHelperStartTag - [31..35)::4
+                    MarkupTextLiteral - [31..35)::4 - [<br>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [35..39)::4
+                MarkupTextLiteral - [35..39)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CanHandleMultipleTagHelpersWithAllowedChildren_OneNull.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CanHandleMultipleTagHelpersWithAllowedChildren_OneNull.stree.txt
@@ -1,12 +1,36 @@
-Markup block - Gen<None> - 39 - (0:0,0)
-    Tag block - Gen<TagHelper> - 39 - (0:0,0) - p - PTagHelper1 - PTagHelper2
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 28 - (3:0,3) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
-            SyntaxKind.HtmlTextLiteral - [Hello World] - [11..22) - FullWidth: 11 - Slots: 1
-                SyntaxKind.List - [Hello World] - [11..22) - FullWidth: 11 - Slots: 3
-                    SyntaxKind.Text;[Hello];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[World];
-        Tag block - Gen<TagHelper> - 4 - (31:0,31) - br - BRTagHelper
-            StartTagOnly - <br>
+RazorDocument - [0..39)::39 - [<p><strong>Hello World</strong><br></p>]
+    MarkupBlock - [0..39)::39
+        MarkupTagHelperElement - [0..39)::39 - p[StartTagAndEndTag] - PTagHelper1 - PTagHelper2
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..31)::28 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [11..22)::11 - [Hello World] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[Hello];
+                    Whitespace;[ ];
+                    Text;[World];
+                MarkupTagHelperEndTag - [22..31)::9
+                    MarkupTextLiteral - [22..31)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperElement - [31..35)::4 - br[StartTagOnly] - BRTagHelper
+                MarkupTagHelperStartTag - [31..35)::4
+                    MarkupTextLiteral - [31..35)::4 - [<br>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [35..39)::4
+                MarkupTextLiteral - [35..39)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CanHandleStartTagOnlyTagTagMode.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CanHandleStartTagOnlyTagTagMode.stree.txt
@@ -1,3 +1,8 @@
-Markup block - Gen<None> - 7 - (0:0,0)
-    Tag block - Gen<TagHelper> - 7 - (0:0,0) - input - InputTagHelper
-        StartTagOnly - <input>
+RazorDocument - [0..7)::7 - [<input>]
+    MarkupBlock - [0..7)::7
+        MarkupTagHelperElement - [0..7)::7 - input[StartTagOnly] - InputTagHelper
+            MarkupTagHelperStartTag - [0..7)::7
+                MarkupTextLiteral - [0..7)::7 - [<input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[input];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CreatesErrorForInconsistentTagStructures.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CreatesErrorForInconsistentTagStructures.stree.txt
@@ -1,3 +1,8 @@
-Markup block - Gen<None> - 7 - (0:0,0)
-    Tag block - Gen<TagHelper> - 7 - (0:0,0) - input - InputTagHelper1 - InputTagHelper2
-        StartTagOnly - <input>
+RazorDocument - [0..7)::7 - [<input>]
+    MarkupBlock - [0..7)::7
+        MarkupTagHelperElement - [0..7)::7 - input[StartTagOnly] - InputTagHelper1 - InputTagHelper2
+            MarkupTagHelperStartTag - [0..7)::7
+                MarkupTextLiteral - [0..7)::7 - [<input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[input];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CreatesErrorForWithoutEndTagTagStructureForEndTags.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/CreatesErrorForWithoutEndTagTagStructureForEndTags.stree.txt
@@ -1,7 +1,8 @@
-Markup block - Gen<None> - 8 - (0:0,0)
-    Tag block - Gen<None> - 8 - (0:0,0)
-        Markup span - Gen<Markup> - [</input>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[input];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..8)::8 - [</input>]
+    MarkupBlock - [0..8)::8
+        MarkupTagBlock - [0..8)::8 - [</input>]
+            MarkupTextLiteral - [0..8)::8 - [</input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[input];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers1.diag.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers1.diag.txt
@@ -1,0 +1,5 @@
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!--' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '?xml' because it contains a '?' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '[' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!DOCTYPE' because it contains a '!' character.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers1.stree.txt
@@ -1,26 +1,27 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    HtmlComment block - Gen<None> - 20 - (5:0,5)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [ Hello World ] - SpanEditHandler;Accepts:Whitespace - (9:0,9) - Tokens:5
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[Hello];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[World];
-            SyntaxKind.Whitespace;[ ];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (22:0,22) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (25:0,25)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..31)::31 - [<foo><!-- Hello World --></foo>]
+    MarkupBlock - [0..31)::31
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupCommentBlock - [5..25)::20
+            MarkupTextLiteral - [5..9)::4 - [<!--] - Gen<Markup> - SpanEditHandler;Accepts:None
+                OpenAngle;[<];
+                Bang;[!];
+                DoubleHyphen;[--];
+            MarkupTextLiteral - [9..22)::13 - [ Hello World ] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                Whitespace;[ ];
+                Text;[Hello];
+                Whitespace;[ ];
+                Text;[World];
+                Whitespace;[ ];
+            MarkupTextLiteral - [22..25)::3 - [-->] - Gen<Markup> - SpanEditHandler;Accepts:None
+                DoubleHyphen;[--];
+                CloseAngle;[>];
+        MarkupTagBlock - [25..31)::6 - [</foo>]
+            MarkupTextLiteral - [25..31)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers2.diag.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers2.diag.txt
@@ -1,0 +1,5 @@
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!--' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '?xml' because it contains a '?' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '[' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!DOCTYPE' because it contains a '!' character.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers2.stree.txt
@@ -1,29 +1,33 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    HtmlComment block - Gen<None> - 13 - (5:0,5)
-        Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.DoubleHyphen;[--];
-        Markup span - Gen<Markup> - [ ] - SpanEditHandler;Accepts:Whitespace - (9:0,9) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        Expression block - Gen<Expr> - 4 - (10:0,10)
-            Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-                SyntaxKind.Transition;[@];
-            Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (11:0,11) - Tokens:1
-                SyntaxKind.Identifier;[foo];
-        Markup span - Gen<Markup> - [ ] - SpanEditHandler;Accepts:Whitespace - (14:0,14) - Tokens:1
-            SyntaxKind.Whitespace;[ ];
-        Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:2
-            SyntaxKind.DoubleHyphen;[--];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (18:0,18)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..24)::24 - [<foo><!-- @foo --></foo>]
+    MarkupBlock - [0..24)::24
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupCommentBlock - [5..18)::13
+            MarkupTextLiteral - [5..9)::4 - [<!--] - Gen<Markup> - SpanEditHandler;Accepts:None
+                OpenAngle;[<];
+                Bang;[!];
+                DoubleHyphen;[--];
+            MarkupTextLiteral - [9..10)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                Whitespace;[ ];
+            CSharpCodeBlock - [10..14)::4
+                CSharpImplicitExpression - [10..14)::4
+                    CSharpTransition - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        Transition;[@];
+                    CSharpImplicitExpressionBody - [11..14)::3
+                        CSharpCodeBlock - [11..14)::3
+                            CSharpExpressionLiteral - [11..14)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                Identifier;[foo];
+            MarkupTextLiteral - [14..15)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                Whitespace;[ ];
+            MarkupTextLiteral - [15..18)::3 - [-->] - Gen<Markup> - SpanEditHandler;Accepts:None
+                DoubleHyphen;[--];
+                CloseAngle;[>];
+        MarkupTagBlock - [18..24)::6 - [</foo>]
+            MarkupTextLiteral - [18..24)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers3.diag.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers3.diag.txt
@@ -1,0 +1,5 @@
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!--' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '?xml' because it contains a '?' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '[' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!DOCTYPE' because it contains a '!' character.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers3.stree.txt
@@ -1,24 +1,24 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [<?xml Hello World ?>] - [5..25) - FullWidth: 20 - Slots: 1
-        SyntaxKind.List - [<?xml Hello World ?>] - [5..25) - FullWidth: 20 - Slots: 10
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.QuestionMark;[?];
-            SyntaxKind.Text;[xml];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[Hello];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[World];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.QuestionMark;[?];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (25:0,25)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..31)::31 - [<foo><?xml Hello World ?></foo>]
+    MarkupBlock - [0..31)::31
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupTextLiteral - [5..25)::20 - [<?xml Hello World ?>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            QuestionMark;[?];
+            Text;[xml];
+            Whitespace;[ ];
+            Text;[Hello];
+            Whitespace;[ ];
+            Text;[World];
+            Whitespace;[ ];
+            QuestionMark;[?];
+            CloseAngle;[>];
+        MarkupTagBlock - [25..31)::6 - [</foo>]
+            MarkupTextLiteral - [25..31)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers4.diag.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers4.diag.txt
@@ -1,0 +1,5 @@
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!--' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '?xml' because it contains a '?' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '[' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!DOCTYPE' because it contains a '!' character.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers4.stree.txt
@@ -1,27 +1,30 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<?xml ] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.QuestionMark;[?];
-        SyntaxKind.Text;[xml];
-        SyntaxKind.Whitespace;[ ];
-    Expression block - Gen<Expr> - 4 - (11:0,11)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (11:0,11) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (12:0,12) - Tokens:1
-            SyntaxKind.Identifier;[foo];
-    SyntaxKind.HtmlTextLiteral - [ ?>] - [15..18) - FullWidth: 3 - Slots: 1
-        SyntaxKind.List - [ ?>] - [15..18) - FullWidth: 3 - Slots: 3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.QuestionMark;[?];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (18:0,18)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..24)::24 - [<foo><?xml @foo ?></foo>]
+    MarkupBlock - [0..24)::24
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupTextLiteral - [5..11)::6 - [<?xml ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            QuestionMark;[?];
+            Text;[xml];
+            Whitespace;[ ];
+        CSharpCodeBlock - [11..15)::4
+            CSharpImplicitExpression - [11..15)::4
+                CSharpTransition - [11..12)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpImplicitExpressionBody - [12..15)::3
+                    CSharpCodeBlock - [12..15)::3
+                        CSharpExpressionLiteral - [12..15)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                            Identifier;[foo];
+        MarkupTextLiteral - [15..18)::3 - [ ?>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Whitespace;[ ];
+            QuestionMark;[?];
+            CloseAngle;[>];
+        MarkupTagBlock - [18..24)::6 - [</foo>]
+            MarkupTextLiteral - [18..24)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers5.diag.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers5.diag.txt
@@ -1,0 +1,5 @@
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!--' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '?xml' because it contains a '?' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '[' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!DOCTYPE' because it contains a '!' character.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers5.stree.txt
@@ -1,26 +1,29 @@
-Markup block - Gen<None> - 27 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<!DOCTYPE ] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Bang;[!];
-        SyntaxKind.Text;[DOCTYPE];
-        SyntaxKind.Whitespace;[ ];
-    Expression block - Gen<Expr> - 4 - (15:0,15)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (16:0,16) - Tokens:1
-            SyntaxKind.Identifier;[foo];
-    SyntaxKind.HtmlTextLiteral - [ >] - [19..21) - FullWidth: 2 - Slots: 1
-        SyntaxKind.List - [ >] - [19..21) - FullWidth: 2 - Slots: 2
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (21:0,21)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..27)::27 - [<foo><!DOCTYPE @foo ></foo>]
+    MarkupBlock - [0..27)::27
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupTextLiteral - [5..15)::10 - [<!DOCTYPE ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Bang;[!];
+            Text;[DOCTYPE];
+            Whitespace;[ ];
+        CSharpCodeBlock - [15..19)::4
+            CSharpImplicitExpression - [15..19)::4
+                CSharpTransition - [15..16)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpImplicitExpressionBody - [16..19)::3
+                    CSharpCodeBlock - [16..19)::3
+                        CSharpExpressionLiteral - [16..19)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                            Identifier;[foo];
+        MarkupTextLiteral - [19..21)::2 - [ >] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Whitespace;[ ];
+            CloseAngle;[>];
+        MarkupTagBlock - [21..27)::6 - [</foo>]
+            MarkupTextLiteral - [21..27)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers6.diag.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers6.diag.txt
@@ -1,0 +1,5 @@
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!--' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '?xml' because it contains a '?' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '[' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!DOCTYPE' because it contains a '!' character.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers6.stree.txt
@@ -1,25 +1,25 @@
-Markup block - Gen<None> - 36 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [<!DOCTYPE hello="world" >] - [5..30) - FullWidth: 25 - Slots: 1
-        SyntaxKind.List - [<!DOCTYPE hello="world" >] - [5..30) - FullWidth: 25 - Slots: 11
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.Text;[DOCTYPE];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[hello];
-            SyntaxKind.Equals;[=];
-            SyntaxKind.DoubleQuote;["];
-            SyntaxKind.Text;[world];
-            SyntaxKind.DoubleQuote;["];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (30:0,30)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (30:0,30) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..36)::36 - [<foo><!DOCTYPE hello="world" ></foo>]
+    MarkupBlock - [0..36)::36
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupTextLiteral - [5..30)::25 - [<!DOCTYPE hello="world" >] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Bang;[!];
+            Text;[DOCTYPE];
+            Whitespace;[ ];
+            Text;[hello];
+            Equals;[=];
+            DoubleQuote;["];
+            Text;[world];
+            DoubleQuote;["];
+            Whitespace;[ ];
+            CloseAngle;[>];
+        MarkupTagBlock - [30..36)::6 - [</foo>]
+            MarkupTextLiteral - [30..36)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers7.diag.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers7.diag.txt
@@ -1,0 +1,5 @@
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!--' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '?xml' because it contains a '?' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '[' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!DOCTYPE' because it contains a '!' character.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers7.stree.txt
@@ -1,27 +1,27 @@
-Markup block - Gen<None> - 36 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [<![CDATA[ Hello World ]]>] - [5..30) - FullWidth: 25 - Slots: 1
-        SyntaxKind.List - [<![CDATA[ Hello World ]]>] - [5..30) - FullWidth: 25 - Slots: 13
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Bang;[!];
-            SyntaxKind.LeftBracket;[[];
-            SyntaxKind.Text;[CDATA];
-            SyntaxKind.LeftBracket;[[];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[Hello];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.Text;[World];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.RightBracket;[]];
-            SyntaxKind.RightBracket;[]];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (30:0,30)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (30:0,30) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..36)::36 - [<foo><![CDATA[ Hello World ]]></foo>]
+    MarkupBlock - [0..36)::36
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupTextLiteral - [5..30)::25 - [<![CDATA[ Hello World ]]>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Bang;[!];
+            LeftBracket;[[];
+            Text;[CDATA];
+            LeftBracket;[[];
+            Whitespace;[ ];
+            Text;[Hello];
+            Whitespace;[ ];
+            Text;[World];
+            Whitespace;[ ];
+            RightBracket;[]];
+            RightBracket;[]];
+            CloseAngle;[>];
+        MarkupTagBlock - [30..36)::6 - [</foo>]
+            MarkupTextLiteral - [30..36)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers8.diag.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers8.diag.txt
@@ -1,0 +1,5 @@
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!--' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '?xml' because it contains a '?' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '!' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '![CDATA[' because it contains a '[' character.
+(0,0): Error RZ3008: Tag helpers cannot target tag name '!DOCTYPE' because it contains a '!' character.

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteSpecialTagTagHelpers8.stree.txt
@@ -1,30 +1,33 @@
-Markup block - Gen<None> - 29 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<foo>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<![CDATA[ ] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:6
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Bang;[!];
-        SyntaxKind.LeftBracket;[[];
-        SyntaxKind.Text;[CDATA];
-        SyntaxKind.LeftBracket;[[];
-        SyntaxKind.Whitespace;[ ];
-    Expression block - Gen<Expr> - 4 - (15:0,15)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (15:0,15) - Tokens:1
-            SyntaxKind.Transition;[@];
-        Code span - Gen<Expr> - [foo] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (16:0,16) - Tokens:1
-            SyntaxKind.Identifier;[foo];
-    SyntaxKind.HtmlTextLiteral - [ ]]>] - [19..23) - FullWidth: 4 - Slots: 1
-        SyntaxKind.List - [ ]]>] - [19..23) - FullWidth: 4 - Slots: 4
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.RightBracket;[]];
-            SyntaxKind.RightBracket;[]];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (23:0,23)
-        Markup span - Gen<Markup> - [</foo>] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[foo];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..29)::29 - [<foo><![CDATA[ @foo ]]></foo>]
+    MarkupBlock - [0..29)::29
+        MarkupTagBlock - [0..5)::5 - [<foo>]
+            MarkupTextLiteral - [0..5)::5 - [<foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[foo];
+                CloseAngle;[>];
+        MarkupTextLiteral - [5..15)::10 - [<![CDATA[ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Bang;[!];
+            LeftBracket;[[];
+            Text;[CDATA];
+            LeftBracket;[[];
+            Whitespace;[ ];
+        CSharpCodeBlock - [15..19)::4
+            CSharpImplicitExpression - [15..19)::4
+                CSharpTransition - [15..16)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpImplicitExpressionBody - [16..19)::3
+                    CSharpCodeBlock - [16..19)::3
+                        CSharpExpressionLiteral - [16..19)::3 - [foo] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                            Identifier;[foo];
+        MarkupTextLiteral - [19..23)::4 - [ ]]>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Whitespace;[ ];
+            RightBracket;[]];
+            RightBracket;[]];
+            CloseAngle;[>];
+        MarkupTagBlock - [23..29)::6 - [</foo>]
+            MarkupTextLiteral - [23..29)::6 - [</foo>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[foo];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteTextTagTransitionTagHelpers1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteTextTagTransitionTagHelpers1.stree.txt
@@ -1,8 +1,18 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<TagHelper> - 24 - (0:0,0) - text - texttaghelper
-        StartTagAndEndTag - <text> ... </text>
-        SyntaxKind.HtmlTextLiteral - [Hello World] - [6..17) - FullWidth: 11 - Slots: 1
-            SyntaxKind.List - [Hello World] - [6..17) - FullWidth: 11 - Slots: 3
-                SyntaxKind.Text;[Hello];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[World];
+RazorDocument - [0..24)::24 - [<text>Hello World</text>]
+    MarkupBlock - [0..24)::24
+        MarkupTagHelperElement - [0..24)::24 - text[StartTagAndEndTag] - texttaghelper
+            MarkupTagHelperStartTag - [0..6)::6
+                MarkupTextLiteral - [0..6)::6 - [<text>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[text];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [6..17)::11 - [Hello World] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Hello];
+                Whitespace;[ ];
+                Text;[World];
+            MarkupTagHelperEndTag - [17..24)::7
+                MarkupTextLiteral - [17..24)::7 - [</text>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[text];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteTextTagTransitionTagHelpers2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteTextTagTransitionTagHelpers2.stree.txt
@@ -1,30 +1,34 @@
-Markup block - Gen<None> - 27 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 27 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 24 - (2:0,2)
-            Tag block - Gen<None> - 6 - (2:0,2)
-                Transition span - Gen<None> - [<text>] - SpanEditHandler;Accepts:None - (2:0,2) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Markup span - Gen<Markup> - [Hello World] - SpanEditHandler;Accepts:None - (8:0,8) - Tokens:3
-                SyntaxKind.Text;[Hello];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[World];
-            Tag block - Gen<None> - 7 - (19:0,19)
-                Transition span - Gen<None> - [</text>] - SpanEditHandler;Accepts:None - (19:0,19) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (26:0,26) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (26:0,26) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (27:0,27) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..27)::27 - [@{<text>Hello World</text>}]
+    MarkupBlock - [0..27)::27
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..27)::27
+            CSharpStatement - [0..27)::27
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..27)::26
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..26)::24
+                        MarkupBlock - [2..26)::24
+                            MarkupTagBlock - [2..8)::6 - [<text>]
+                                MarkupTransition - [2..8)::6 - Gen<None> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTextLiteral - [8..19)::11 - [Hello World] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                Text;[Hello];
+                                Whitespace;[ ];
+                                Text;[World];
+                            MarkupTagBlock - [19..26)::7 - [</text>]
+                                MarkupTransition - [19..26)::7 - Gen<None> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [26..26)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [26..27)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [27..27)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteTextTagTransitionTagHelpers3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteTextTagTransitionTagHelpers3.stree.txt
@@ -1,32 +1,46 @@
-Markup block - Gen<None> - 34 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 34 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 31 - (2:0,2)
-            Tag block - Gen<None> - 6 - (2:0,2)
-                Transition span - Gen<None> - [<text>] - SpanEditHandler;Accepts:None - (2:0,2) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<TagHelper> - 18 - (8:0,8) - p - ptaghelper
-                StartTagAndEndTag - <p> ... </p>
-                Markup span - Gen<Markup> - [Hello World] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:3
-                    SyntaxKind.Text;[Hello];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[World];
-            Tag block - Gen<None> - 7 - (26:0,26)
-                Transition span - Gen<None> - [</text>] - SpanEditHandler;Accepts:None - (26:0,26) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (33:0,33) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..34)::34 - [@{<text><p>Hello World</p></text>}]
+    MarkupBlock - [0..34)::34
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..34)::34
+            CSharpStatement - [0..34)::34
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..34)::33
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..33)::31
+                        MarkupBlock - [2..33)::31
+                            MarkupTagBlock - [2..8)::6 - [<text>]
+                                MarkupTransition - [2..8)::6 - Gen<None> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    Text;[text];
+                                    CloseAngle;[>];
+                            MarkupTagHelperElement - [8..26)::18 - p[StartTagAndEndTag] - ptaghelper
+                                MarkupTagHelperStartTag - [8..11)::3
+                                    MarkupTextLiteral - [8..11)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTextLiteral - [11..22)::11 - [Hello World] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[Hello];
+                                    Whitespace;[ ];
+                                    Text;[World];
+                                MarkupTagHelperEndTag - [22..26)::4
+                                    MarkupTextLiteral - [22..26)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        ForwardSlash;[/];
+                                        Text;[p];
+                                        CloseAngle;[>];
+                            MarkupTagBlock - [26..33)::7 - [</text>]
+                                MarkupTransition - [26..33)::7 - Gen<None> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[text];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [33..33)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [33..34)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [34..34)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteTextTagTransitionTagHelpers4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotRewriteTextTagTransitionTagHelpers4.stree.txt
@@ -1,23 +1,47 @@
-Markup block - Gen<None> - 34 - (0:0,0)
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-        SyntaxKind.Unknown;[];
-    Statement block - Gen<None> - 34 - (0:0,0)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (0:0,0) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (1:0,1) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 31 - (2:0,2)
-            Tag block - Gen<TagHelper> - 31 - (2:0,2) - p - ptaghelper
-                StartTagAndEndTag - <p> ... </p>
-                Tag block - Gen<TagHelper> - 24 - (5:0,5) - text - texttaghelper
-                    StartTagAndEndTag - <text> ... </text>
-                    Markup span - Gen<Markup> - [Hello World] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:3
-                        SyntaxKind.Text;[Hello];
-                        SyntaxKind.Whitespace;[ ];
-                        SyntaxKind.Text;[World];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (33:0,33) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..34)::34 - [@{<p><text>Hello World</text></p>}]
+    MarkupBlock - [0..34)::34
+        MarkupTextLiteral - [0..0)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];
+        CSharpCodeBlock - [0..34)::34
+            CSharpStatement - [0..34)::34
+                CSharpTransition - [0..1)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [1..34)::33
+                    RazorMetaCode - [1..2)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [2..33)::31
+                        MarkupBlock - [2..33)::31
+                            MarkupTagHelperElement - [2..33)::31 - p[StartTagAndEndTag] - ptaghelper
+                                MarkupTagHelperStartTag - [2..5)::3
+                                    MarkupTextLiteral - [2..5)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        Text;[p];
+                                        CloseAngle;[>];
+                                MarkupTagHelperElement - [5..29)::24 - text[StartTagAndEndTag] - texttaghelper
+                                    MarkupTagHelperStartTag - [5..11)::6
+                                        MarkupTextLiteral - [5..11)::6 - [<text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                            OpenAngle;[<];
+                                            Text;[text];
+                                            CloseAngle;[>];
+                                    MarkupTextLiteral - [11..22)::11 - [Hello World] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                        Text;[Hello];
+                                        Whitespace;[ ];
+                                        Text;[World];
+                                    MarkupTagHelperEndTag - [22..29)::7
+                                        MarkupTextLiteral - [22..29)::7 - [</text>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                            OpenAngle;[<];
+                                            ForwardSlash;[/];
+                                            Text;[text];
+                                            CloseAngle;[>];
+                                MarkupTagHelperEndTag - [29..33)::4
+                                    MarkupTextLiteral - [29..33)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                        OpenAngle;[<];
+                                        ForwardSlash;[/];
+                                        Text;[p];
+                                        CloseAngle;[>];
+                        CSharpStatementLiteral - [33..33)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [33..34)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [34..34)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotUnderstandTagHelpersInInvalidHtmlTypedScriptTags1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotUnderstandTagHelpersInInvalidHtmlTypedScriptTags1.stree.txt
@@ -1,23 +1,25 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<None> - 13 - (0:0,0)
-        Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-        Markup block - Gen<None> - 5 - (7:0,7)
-            Markup span - Gen<Markup> - [ type] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[type];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<input />] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:5
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Text;[input];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.ForwardSlash;[/];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (22:0,22)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..31)::31 - [<script type><input /></script>]
+    MarkupBlock - [0..31)::31
+        MarkupTagBlock - [0..13)::13 - [<script type>]
+            MarkupTextLiteral - [0..7)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[script];
+            MarkupMinimizedAttributeBlock - [7..12)::5 - [ type]
+                MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [8..12)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[type];
+            MarkupTextLiteral - [12..13)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTextLiteral - [13..22)::9 - [<input />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[input];
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];
+        MarkupTagBlock - [22..31)::9 - [</script>]
+            MarkupTextLiteral - [22..31)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[script];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotUnderstandTagHelpersInInvalidHtmlTypedScriptTags2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotUnderstandTagHelpersInInvalidHtmlTypedScriptTags2.stree.txt
@@ -1,31 +1,36 @@
-Markup block - Gen<None> - 44 - (0:0,0)
-    Tag block - Gen<None> - 26 - (0:0,0)
-        Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-        Markup block - Gen<Attr:types, types='@(7:0,7),'@(24:0,24)> - 18 - (7:0,7)
-            Markup span - Gen<None> - [ types='] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[types];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(15:0,15)> - [text/html] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:3
-                SyntaxKind.Text;[text];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[html];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<input />] - SpanEditHandler;Accepts:Any - (26:0,26) - Tokens:5
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Text;[input];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.ForwardSlash;[/];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (35:0,35)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (35:0,35) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..44)::44 - [<script types='text/html'><input /></script>]
+    MarkupBlock - [0..44)::44
+        MarkupTagBlock - [0..26)::26 - [<script types='text/html'>]
+            MarkupTextLiteral - [0..7)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[script];
+            MarkupAttributeBlock - [7..25)::18 - [ types='text/html']
+                MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [8..13)::5 - [types] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[types];
+                Equals;[=];
+                MarkupTextLiteral - [14..15)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [15..24)::9
+                    MarkupLiteralAttributeValue - [15..24)::9 - [text/html]
+                        MarkupTextLiteral - [15..24)::9 - [text/html] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[text];
+                            ForwardSlash;[/];
+                            Text;[html];
+                MarkupTextLiteral - [24..25)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupTextLiteral - [25..26)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTextLiteral - [26..35)::9 - [<input />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[input];
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];
+        MarkupTagBlock - [35..44)::9 - [</script>]
+            MarkupTextLiteral - [35..44)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[script];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotUnderstandTagHelpersInInvalidHtmlTypedScriptTags3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotUnderstandTagHelpersInInvalidHtmlTypedScriptTags3.stree.txt
@@ -1,34 +1,41 @@
-Markup block - Gen<None> - 51 - (0:0,0)
-    Tag block - Gen<None> - 33 - (0:0,0)
-        Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-        Markup block - Gen<Attr:type, type='@(7:0,7),'@(31:0,31)> - 25 - (7:0,7)
-            Markup span - Gen<None> - [ type='] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[type];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(14:0,14)> - [text/html] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:3
-                SyntaxKind.Text;[text];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[html];
-            Markup span - Gen<LitAttr: @(23:0,23)> - [ invalid] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:2
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[invalid];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (31:0,31) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (32:0,32) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<input />] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:5
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Text;[input];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.ForwardSlash;[/];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (42:0,42)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (42:0,42) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..51)::51 - [<script type='text/html invalid'><input /></script>]
+    MarkupBlock - [0..51)::51
+        MarkupTagBlock - [0..33)::33 - [<script type='text/html invalid'>]
+            MarkupTextLiteral - [0..7)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[script];
+            MarkupAttributeBlock - [7..32)::25 - [ type='text/html invalid']
+                MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [8..12)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[type];
+                Equals;[=];
+                MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [14..31)::17
+                    MarkupLiteralAttributeValue - [14..23)::9 - [text/html]
+                        MarkupTextLiteral - [14..23)::9 - [text/html] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[text];
+                            ForwardSlash;[/];
+                            Text;[html];
+                    MarkupLiteralAttributeValue - [23..31)::8 - [ invalid]
+                        MarkupTextLiteral - [23..24)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        MarkupTextLiteral - [24..31)::7 - [invalid] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[invalid];
+                MarkupTextLiteral - [31..32)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupTextLiteral - [32..33)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTextLiteral - [33..42)::9 - [<input />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[input];
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];
+        MarkupTagBlock - [42..51)::9 - [</script>]
+            MarkupTextLiteral - [42..51)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[script];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotUnderstandTagHelpersInInvalidHtmlTypedScriptTags4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesNotUnderstandTagHelpersInInvalidHtmlTypedScriptTags4.stree.txt
@@ -1,43 +1,52 @@
-Markup block - Gen<None> - 60 - (0:0,0)
-    Tag block - Gen<None> - 42 - (0:0,0)
-        Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-        Markup block - Gen<Attr:type, type='@(7:0,7),'@(23:0,23)> - 17 - (7:0,7)
-            Markup span - Gen<None> - [ type='] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[type];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(14:0,14)> - [text/ng-*] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:3
-                SyntaxKind.Text;[text];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[ng-*];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:type, type='@(24:0,24),'@(40:0,40)> - 17 - (24:0,24)
-            Markup span - Gen<None> - [ type='] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[type];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(31:0,31)> - [text/html] - SpanEditHandler;Accepts:Any - (31:0,31) - Tokens:3
-                SyntaxKind.Text;[text];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[html];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (40:0,40) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (41:0,41) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Markup span - Gen<Markup> - [<input />] - SpanEditHandler;Accepts:Any - (42:0,42) - Tokens:5
-        SyntaxKind.OpenAngle;[<];
-        SyntaxKind.Text;[input];
-        SyntaxKind.Whitespace;[ ];
-        SyntaxKind.ForwardSlash;[/];
-        SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (51:0,51)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (51:0,51) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..60)::60 - [<script type='text/ng-*' type='text/html'><input /></script>]
+    MarkupBlock - [0..60)::60
+        MarkupTagBlock - [0..42)::42 - [<script type='text/ng-*' type='text/html'>]
+            MarkupTextLiteral - [0..7)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[script];
+            MarkupAttributeBlock - [7..24)::17 - [ type='text/ng-*']
+                MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [8..12)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[type];
+                Equals;[=];
+                MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [14..23)::9
+                    MarkupLiteralAttributeValue - [14..23)::9 - [text/ng-*]
+                        MarkupTextLiteral - [14..23)::9 - [text/ng-*] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[text];
+                            ForwardSlash;[/];
+                            Text;[ng-*];
+                MarkupTextLiteral - [23..24)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupAttributeBlock - [24..41)::17 - [ type='text/html']
+                MarkupTextLiteral - [24..25)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [25..29)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[type];
+                Equals;[=];
+                MarkupTextLiteral - [30..31)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [31..40)::9
+                    MarkupLiteralAttributeValue - [31..40)::9 - [text/html]
+                        MarkupTextLiteral - [31..40)::9 - [text/html] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[text];
+                            ForwardSlash;[/];
+                            Text;[html];
+                MarkupTextLiteral - [40..41)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupTextLiteral - [41..42)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTextLiteral - [42..51)::9 - [<input />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            OpenAngle;[<];
+            Text;[input];
+            Whitespace;[ ];
+            ForwardSlash;[/];
+            CloseAngle;[>];
+        MarkupTagBlock - [51..60)::9 - [</script>]
+            MarkupTextLiteral - [51..60)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[script];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesntAllowSimpleHtmlCommentsAsChildrenWhenFeatureFlagIsOff.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/DoesntAllowSimpleHtmlCommentsAsChildrenWhenFeatureFlagIsOff.stree.txt
@@ -1,13 +1,24 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Tag block - Gen<TagHelper> - 19 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        HtmlComment block - Gen<None> - 12 - (3:0,3)
-            Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Bang;[!];
-                SyntaxKind.DoubleHyphen;[--];
-            Markup span - Gen<Markup> - [Hello] - SpanEditHandler;Accepts:Whitespace - (7:0,7) - Tokens:1
-                SyntaxKind.Text;[Hello];
-            Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:2
-                SyntaxKind.DoubleHyphen;[--];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..19)::19 - [<p><!--Hello--></p>]
+    MarkupBlock - [0..19)::19
+        MarkupTagHelperElement - [0..19)::19 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupCommentBlock - [3..15)::12
+                MarkupTextLiteral - [3..7)::4 - [<!--] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    OpenAngle;[<];
+                    Bang;[!];
+                    DoubleHyphen;[--];
+                MarkupTextLiteral - [7..12)::5 - [Hello] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                    Text;[Hello];
+                MarkupTextLiteral - [12..15)::3 - [-->] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    DoubleHyphen;[--];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [15..19)::4
+                MarkupTextLiteral - [15..19)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/FailsForContentWithCommentsAsChildren.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/FailsForContentWithCommentsAsChildren.stree.txt
@@ -1,25 +1,36 @@
-Markup block - Gen<None> - 35 - (0:0,0)
-    Tag block - Gen<TagHelper> - 35 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        HtmlComment block - Gen<None> - 12 - (3:0,3)
-            Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (3:0,3) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Bang;[!];
-                SyntaxKind.DoubleHyphen;[--];
-            Markup span - Gen<Markup> - [Hello] - SpanEditHandler;Accepts:Whitespace - (7:0,7) - Tokens:1
-                SyntaxKind.Text;[Hello];
-            Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:2
-                SyntaxKind.DoubleHyphen;[--];
-                SyntaxKind.CloseAngle;[>];
-        Markup span - Gen<Markup> - [asdf] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-            SyntaxKind.Text;[asdf];
-        HtmlComment block - Gen<None> - 12 - (19:0,19)
-            Markup span - Gen<Markup> - [<!--] - SpanEditHandler;Accepts:None - (19:0,19) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Bang;[!];
-                SyntaxKind.DoubleHyphen;[--];
-            Markup span - Gen<Markup> - [World] - SpanEditHandler;Accepts:Whitespace - (23:0,23) - Tokens:1
-                SyntaxKind.Text;[World];
-            Markup span - Gen<Markup> - [-->] - SpanEditHandler;Accepts:None - (28:0,28) - Tokens:2
-                SyntaxKind.DoubleHyphen;[--];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..35)::35 - [<p><!--Hello-->asdf<!--World--></p>]
+    MarkupBlock - [0..35)::35
+        MarkupTagHelperElement - [0..35)::35 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupCommentBlock - [3..15)::12
+                MarkupTextLiteral - [3..7)::4 - [<!--] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    OpenAngle;[<];
+                    Bang;[!];
+                    DoubleHyphen;[--];
+                MarkupTextLiteral - [7..12)::5 - [Hello] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                    Text;[Hello];
+                MarkupTextLiteral - [12..15)::3 - [-->] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    DoubleHyphen;[--];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [15..19)::4 - [asdf] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[asdf];
+            MarkupCommentBlock - [19..31)::12
+                MarkupTextLiteral - [19..23)::4 - [<!--] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    OpenAngle;[<];
+                    Bang;[!];
+                    DoubleHyphen;[--];
+                MarkupTextLiteral - [23..28)::5 - [World] - Gen<Markup> - SpanEditHandler;Accepts:Whitespace
+                    Text;[World];
+                MarkupTextLiteral - [28..31)::3 - [-->] - Gen<Markup> - SpanEditHandler;Accepts:None
+                    DoubleHyphen;[--];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [31..35)::4
+                MarkupTextLiteral - [31..35)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/HandlesMalformedNestedNonTagHelperTags_Correctly.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/HandlesMalformedNestedNonTagHelperTags_Correctly.stree.txt
@@ -1,24 +1,28 @@
-Markup block - Gen<None> - 14 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<div>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    Statement block - Gen<None> - 9 - (5:0,5)
-        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (5:0,5) - Tokens:1
-            SyntaxKind.Transition;[@];
-        MetaCode span - Gen<None> - [{] - SpanEditHandler;Accepts:None - (6:0,6) - Tokens:1
-            SyntaxKind.LeftBrace;[{];
-        Markup block - Gen<None> - 6 - (7:0,7)
-            Tag block - Gen<None> - 6 - (7:0,7)
-                Markup span - Gen<Markup> - [</div>] - SpanEditHandler;Accepts:None - (7:0,7) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[div];
-                    SyntaxKind.CloseAngle;[>];
-        Code span - Gen<Stmt> - [] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:1
-            SyntaxKind.Unknown;[];
-        MetaCode span - Gen<None> - [}] - SpanEditHandler;Accepts:None - (13:0,13) - Tokens:1
-            SyntaxKind.RightBrace;[}];
-    Markup span - Gen<Markup> - [] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:1
-        SyntaxKind.Unknown;[];
+RazorDocument - [0..14)::14 - [<div>@{</div>}]
+    MarkupBlock - [0..14)::14
+        MarkupTagBlock - [0..5)::5 - [<div>]
+            MarkupTextLiteral - [0..5)::5 - [<div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+                CloseAngle;[>];
+        CSharpCodeBlock - [5..14)::9
+            CSharpStatement - [5..14)::9
+                CSharpTransition - [5..6)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementBody - [6..14)::8
+                    RazorMetaCode - [6..7)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        LeftBrace;[{];
+                    CSharpCodeBlock - [7..13)::6
+                        MarkupBlock - [7..13)::6
+                            MarkupTagBlock - [7..13)::6 - [</div>]
+                                MarkupTextLiteral - [7..13)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                                    OpenAngle;[<];
+                                    ForwardSlash;[/];
+                                    Text;[div];
+                                    CloseAngle;[>];
+                        CSharpStatementLiteral - [13..13)::0 - [] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                            Marker;[];
+                    RazorMetaCode - [13..14)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                        RightBrace;[}];
+        MarkupTextLiteral - [14..14)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Marker;[];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/InvalidStructure_UnderstandsTHPrefixAndAllowedChildrenAndRequireParent.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/InvalidStructure_UnderstandsTHPrefixAndAllowedChildrenAndRequireParent.stree.txt
@@ -1,9 +1,20 @@
-Markup block - Gen<None> - 25 - (0:0,0)
-    Tag block - Gen<TagHelper> - 25 - (0:0,0) - th:p - PTagHelper
-        StartTagAndEndTag - <th:p> ... </th:p>
-        Tag block - Gen<None> - 12 - (6:0,6)
-            Markup span - Gen<Markup> - [</th:strong>] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[th:strong];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..25)::25 - [<th:p></th:strong></th:p>]
+    MarkupBlock - [0..25)::25
+        MarkupTagHelperElement - [0..25)::25 - th:p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..6)::6
+                MarkupTextLiteral - [0..6)::6 - [<th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [6..18)::12 - [</th:strong>]
+                MarkupTextLiteral - [6..18)::12 - [</th:strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [18..25)::7
+                MarkupTextLiteral - [18..25)::7 - [</th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly1.stree.txt
@@ -1,17 +1,40 @@
-Markup block - Gen<None> - 26 - (0:0,0)
-    Tag block - Gen<TagHelper> - 26 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"> ... </p>
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        Tag block - Gen<None> - 3 - (15:0,15)
-            Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 4 - (18:0,18)
-            Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..26)::26 - [<p class="btn"><p></p></p>]
+    MarkupBlock - [0..26)::26
+        MarkupTagHelperElement - [0..26)::26 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagBlock - [15..18)::3 - [<p>]
+                MarkupTextLiteral - [15..18)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [18..22)::4 - [</p>]
+                MarkupTextLiteral - [18..22)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [22..26)::4
+                MarkupTextLiteral - [22..26)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly10.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly10.stree.txt
@@ -1,44 +1,89 @@
-Markup block - Gen<None> - 113 - (0:0,0)
-    Tag block - Gen<TagHelper> - 113 - (0:0,0) - strong - catchAllTagHelper
-        StartTagAndEndTag - <strong catchAll="hi"> ... </strong>
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                SyntaxKind.Text;[hi];
-        Tag block - Gen<None> - 8 - (22:0,22)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 8 - (30:0,30)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (30:0,30) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 48 - (38:0,38) - strong - catchAllTagHelper
-            StartTagAndEndTag - <strong catchAll="hi"> ... </strong>
-            catchAll - DoubleQuotes
-                Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (56:0,56) - Tokens:1
-                    SyntaxKind.Text;[hi];
-            Tag block - Gen<None> - 8 - (60:0,60)
-                Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (60:0,60) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 9 - (68:0,68)
-                Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (68:0,68) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (86:0,86)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (86:0,86) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (95:0,95)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (95:0,95) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..113)::113 - [<strong catchAll="hi"><strong><strong><strong catchAll="hi"><strong></strong></strong></strong></strong></strong>]
+    MarkupBlock - [0..113)::113
+        MarkupTagHelperElement - [0..113)::113 - strong[StartTagAndEndTag] - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..22)::22
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupTagHelperAttribute - [7..21)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [18..20)::2
+                        MarkupLiteralAttributeValue - [18..20)::2 - [hi]
+                            MarkupTextLiteral - [18..20)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [21..22)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagBlock - [22..30)::8 - [<strong>]
+                MarkupTextLiteral - [22..30)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagBlock - [30..38)::8 - [<strong>]
+                MarkupTextLiteral - [30..38)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [38..86)::48 - strong[StartTagAndEndTag] - catchAllTagHelper
+                MarkupTagHelperStartTag - [38..60)::22
+                    MarkupTextLiteral - [38..45)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                    MarkupTagHelperAttribute - [45..59)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                        MarkupTextLiteral - [45..46)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        MarkupTextLiteral - [46..54)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[catchAll];
+                        Equals;[=];
+                        MarkupTextLiteral - [55..56)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                        MarkupTagHelperAttributeValue - [56..58)::2
+                            MarkupLiteralAttributeValue - [56..58)::2 - [hi]
+                                MarkupTextLiteral - [56..58)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[hi];
+                        MarkupTextLiteral - [58..59)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                    MarkupTextLiteral - [59..60)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        CloseAngle;[>];
+                MarkupTagBlock - [60..68)::8 - [<strong>]
+                    MarkupTextLiteral - [60..68)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagBlock - [68..77)::9 - [</strong>]
+                    MarkupTextLiteral - [68..77)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [77..86)::9
+                    MarkupTextLiteral - [77..86)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagBlock - [86..95)::9 - [</strong>]
+                MarkupTextLiteral - [86..95)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagBlock - [95..104)::9 - [</strong>]
+                MarkupTextLiteral - [95..104)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [104..113)::9
+                MarkupTextLiteral - [104..113)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly2.stree.txt
@@ -1,17 +1,40 @@
-Markup block - Gen<None> - 48 - (0:0,0)
-    Tag block - Gen<TagHelper> - 48 - (0:0,0) - strong - catchAllTagHelper
-        StartTagAndEndTag - <strong catchAll="hi"> ... </strong>
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                SyntaxKind.Text;[hi];
-        Tag block - Gen<None> - 8 - (22:0,22)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (30:0,30)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (30:0,30) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..48)::48 - [<strong catchAll="hi"><strong></strong></strong>]
+    MarkupBlock - [0..48)::48
+        MarkupTagHelperElement - [0..48)::48 - strong[StartTagAndEndTag] - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..22)::22
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupTagHelperAttribute - [7..21)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [18..20)::2
+                        MarkupLiteralAttributeValue - [18..20)::2 - [hi]
+                            MarkupTextLiteral - [18..20)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [21..22)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagBlock - [22..30)::8 - [<strong>]
+                MarkupTextLiteral - [22..30)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagBlock - [30..39)::9 - [</strong>]
+                MarkupTextLiteral - [30..39)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [39..48)::9
+                MarkupTextLiteral - [39..48)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly3.stree.txt
@@ -1,28 +1,51 @@
-Markup block - Gen<None> - 43 - (0:0,0)
-    Tag block - Gen<TagHelper> - 43 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"> ... </p>
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        Tag block - Gen<None> - 8 - (15:0,15)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 3 - (23:0,23)
-            Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 4 - (26:0,26)
-            Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (26:0,26) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (30:0,30)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (30:0,30) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..43)::43 - [<p class="btn"><strong><p></p></strong></p>]
+    MarkupBlock - [0..43)::43
+        MarkupTagHelperElement - [0..43)::43 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagBlock - [15..23)::8 - [<strong>]
+                MarkupTextLiteral - [15..23)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagBlock - [23..26)::3 - [<p>]
+                MarkupTextLiteral - [23..26)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [26..30)::4 - [</p>]
+                MarkupTextLiteral - [26..30)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [30..39)::9 - [</strong>]
+                MarkupTextLiteral - [30..39)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [39..43)::4
+                MarkupTextLiteral - [39..43)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly4.stree.txt
@@ -1,28 +1,51 @@
-Markup block - Gen<None> - 55 - (0:0,0)
-    Tag block - Gen<TagHelper> - 55 - (0:0,0) - strong - catchAllTagHelper
-        StartTagAndEndTag - <strong catchAll="hi"> ... </strong>
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                SyntaxKind.Text;[hi];
-        Tag block - Gen<None> - 3 - (22:0,22)
-            Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 8 - (25:0,25)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (33:0,33)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 4 - (42:0,42)
-            Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (42:0,42) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..55)::55 - [<strong catchAll="hi"><p><strong></strong></p></strong>]
+    MarkupBlock - [0..55)::55
+        MarkupTagHelperElement - [0..55)::55 - strong[StartTagAndEndTag] - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..22)::22
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupTagHelperAttribute - [7..21)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [18..20)::2
+                        MarkupLiteralAttributeValue - [18..20)::2 - [hi]
+                            MarkupTextLiteral - [18..20)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [21..22)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagBlock - [22..25)::3 - [<p>]
+                MarkupTextLiteral - [22..25)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [25..33)::8 - [<strong>]
+                MarkupTextLiteral - [25..33)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagBlock - [33..42)::9 - [</strong>]
+                MarkupTextLiteral - [33..42)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagBlock - [42..46)::4 - [</p>]
+                MarkupTextLiteral - [42..46)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [46..55)::9
+                MarkupTextLiteral - [46..55)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly5.stree.txt
@@ -1,22 +1,67 @@
-Markup block - Gen<None> - 57 - (0:0,0)
-    Tag block - Gen<TagHelper> - 57 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"> ... </p>
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        Tag block - Gen<TagHelper> - 38 - (15:0,15) - strong - catchAllTagHelper
-            StartTagAndEndTag - <strong catchAll="hi"> ... </strong>
-            catchAll - DoubleQuotes
-                Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:1
-                    SyntaxKind.Text;[hi];
-            Tag block - Gen<None> - 3 - (37:0,37)
-                Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (37:0,37) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 4 - (40:0,40)
-                Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (40:0,40) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..57)::57 - [<p class="btn"><strong catchAll="hi"><p></p></strong></p>]
+    MarkupBlock - [0..57)::57
+        MarkupTagHelperElement - [0..57)::57 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [15..53)::38 - strong[StartTagAndEndTag] - catchAllTagHelper
+                MarkupTagHelperStartTag - [15..37)::22
+                    MarkupTextLiteral - [15..22)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                    MarkupTagHelperAttribute - [22..36)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                        MarkupTextLiteral - [22..23)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        MarkupTextLiteral - [23..31)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[catchAll];
+                        Equals;[=];
+                        MarkupTextLiteral - [32..33)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                        MarkupTagHelperAttributeValue - [33..35)::2
+                            MarkupLiteralAttributeValue - [33..35)::2 - [hi]
+                                MarkupTextLiteral - [33..35)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[hi];
+                        MarkupTextLiteral - [35..36)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                    MarkupTextLiteral - [36..37)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        CloseAngle;[>];
+                MarkupTagBlock - [37..40)::3 - [<p>]
+                    MarkupTextLiteral - [37..40)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTagBlock - [40..44)::4 - [</p>]
+                    MarkupTextLiteral - [40..44)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [44..53)::9
+                    MarkupTextLiteral - [44..53)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [53..57)::4
+                MarkupTextLiteral - [53..57)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly6.stree.txt
@@ -1,22 +1,67 @@
-Markup block - Gen<None> - 67 - (0:0,0)
-    Tag block - Gen<TagHelper> - 67 - (0:0,0) - strong - catchAllTagHelper
-        StartTagAndEndTag - <strong catchAll="hi"> ... </strong>
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                SyntaxKind.Text;[hi];
-        Tag block - Gen<TagHelper> - 36 - (22:0,22) - p - pTagHelper
-            StartTagAndEndTag - <p class="btn"> ... </p>
-            class - DoubleQuotes
-                Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (32:0,32) - Tokens:1
-                    SyntaxKind.Text;[btn];
-            Tag block - Gen<None> - 8 - (37:0,37)
-                Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (37:0,37) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 9 - (45:0,45)
-                Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (45:0,45) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..67)::67 - [<strong catchAll="hi"><p class="btn"><strong></strong></p></strong>]
+    MarkupBlock - [0..67)::67
+        MarkupTagHelperElement - [0..67)::67 - strong[StartTagAndEndTag] - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..22)::22
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupTagHelperAttribute - [7..21)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [18..20)::2
+                        MarkupLiteralAttributeValue - [18..20)::2 - [hi]
+                            MarkupTextLiteral - [18..20)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [21..22)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [22..58)::36 - p[StartTagAndEndTag] - pTagHelper
+                MarkupTagHelperStartTag - [22..37)::15
+                    MarkupTextLiteral - [22..24)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[p];
+                    MarkupTagHelperAttribute - [24..36)::12 - class - DoubleQuotes - [ class="btn"]
+                        MarkupTextLiteral - [24..25)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        MarkupTextLiteral - [25..30)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[class];
+                        Equals;[=];
+                        MarkupTextLiteral - [31..32)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                        MarkupTagHelperAttributeValue - [32..35)::3
+                            MarkupLiteralAttributeValue - [32..35)::3 - [btn]
+                                MarkupTextLiteral - [32..35)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[btn];
+                        MarkupTextLiteral - [35..36)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                    MarkupTextLiteral - [36..37)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        CloseAngle;[>];
+                MarkupTagBlock - [37..45)::8 - [<strong>]
+                    MarkupTextLiteral - [37..45)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagBlock - [45..54)::9 - [</strong>]
+                    MarkupTextLiteral - [45..54)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [54..58)::4
+                    MarkupTextLiteral - [54..58)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[p];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [58..67)::9
+                MarkupTextLiteral - [58..67)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly7.stree.txt
@@ -1,22 +1,67 @@
-Markup block - Gen<None> - 45 - (0:0,0)
-    Tag block - Gen<TagHelper> - 45 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"> ... </p>
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        Tag block - Gen<TagHelper> - 26 - (15:0,15) - p - pTagHelper
-            StartTagAndEndTag - <p class="btn"> ... </p>
-            class - DoubleQuotes
-                Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:1
-                    SyntaxKind.Text;[btn];
-            Tag block - Gen<None> - 3 - (30:0,30)
-                Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (30:0,30) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 4 - (33:0,33)
-                Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..45)::45 - [<p class="btn"><p class="btn"><p></p></p></p>]
+    MarkupBlock - [0..45)::45
+        MarkupTagHelperElement - [0..45)::45 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [15..41)::26 - p[StartTagAndEndTag] - pTagHelper
+                MarkupTagHelperStartTag - [15..30)::15
+                    MarkupTextLiteral - [15..17)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[p];
+                    MarkupTagHelperAttribute - [17..29)::12 - class - DoubleQuotes - [ class="btn"]
+                        MarkupTextLiteral - [17..18)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        MarkupTextLiteral - [18..23)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[class];
+                        Equals;[=];
+                        MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                        MarkupTagHelperAttributeValue - [25..28)::3
+                            MarkupLiteralAttributeValue - [25..28)::3 - [btn]
+                                MarkupTextLiteral - [25..28)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[btn];
+                        MarkupTextLiteral - [28..29)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                    MarkupTextLiteral - [29..30)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        CloseAngle;[>];
+                MarkupTagBlock - [30..33)::3 - [<p>]
+                    MarkupTextLiteral - [30..33)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTagBlock - [33..37)::4 - [</p>]
+                    MarkupTextLiteral - [33..37)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [37..41)::4
+                    MarkupTextLiteral - [37..41)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[p];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [41..45)::4
+                MarkupTextLiteral - [41..45)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly8.stree.txt
@@ -1,22 +1,67 @@
-Markup block - Gen<None> - 79 - (0:0,0)
-    Tag block - Gen<TagHelper> - 79 - (0:0,0) - strong - catchAllTagHelper
-        StartTagAndEndTag - <strong catchAll="hi"> ... </strong>
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                SyntaxKind.Text;[hi];
-        Tag block - Gen<TagHelper> - 48 - (22:0,22) - strong - catchAllTagHelper
-            StartTagAndEndTag - <strong catchAll="hi"> ... </strong>
-            catchAll - DoubleQuotes
-                Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (40:0,40) - Tokens:1
-                    SyntaxKind.Text;[hi];
-            Tag block - Gen<None> - 8 - (44:0,44)
-                Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (44:0,44) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 9 - (52:0,52)
-                Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (52:0,52) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..79)::79 - [<strong catchAll="hi"><strong catchAll="hi"><strong></strong></strong></strong>]
+    MarkupBlock - [0..79)::79
+        MarkupTagHelperElement - [0..79)::79 - strong[StartTagAndEndTag] - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..22)::22
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupTagHelperAttribute - [7..21)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [18..20)::2
+                        MarkupLiteralAttributeValue - [18..20)::2 - [hi]
+                            MarkupTextLiteral - [18..20)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [21..22)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [22..70)::48 - strong[StartTagAndEndTag] - catchAllTagHelper
+                MarkupTagHelperStartTag - [22..44)::22
+                    MarkupTextLiteral - [22..29)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                    MarkupTagHelperAttribute - [29..43)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                        MarkupTextLiteral - [29..30)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        MarkupTextLiteral - [30..38)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[catchAll];
+                        Equals;[=];
+                        MarkupTextLiteral - [39..40)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                        MarkupTagHelperAttributeValue - [40..42)::2
+                            MarkupLiteralAttributeValue - [40..42)::2 - [hi]
+                                MarkupTextLiteral - [40..42)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[hi];
+                        MarkupTextLiteral - [42..43)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                    MarkupTextLiteral - [43..44)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        CloseAngle;[>];
+                MarkupTagBlock - [44..52)::8 - [<strong>]
+                    MarkupTextLiteral - [44..52)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagBlock - [52..61)::9 - [</strong>]
+                    MarkupTextLiteral - [52..61)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [61..70)::9
+                    MarkupTextLiteral - [61..70)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [70..79)::9
+                MarkupTextLiteral - [70..79)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly9.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly9.stree.txt
@@ -1,44 +1,89 @@
-Markup block - Gen<None> - 59 - (0:0,0)
-    Tag block - Gen<TagHelper> - 59 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"> ... </p>
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        Tag block - Gen<None> - 3 - (15:0,15)
-            Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 3 - (18:0,18)
-            Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 26 - (21:0,21) - p - pTagHelper
-            StartTagAndEndTag - <p class="btn"> ... </p>
-            class - DoubleQuotes
-                Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (31:0,31) - Tokens:1
-                    SyntaxKind.Text;[btn];
-            Tag block - Gen<None> - 3 - (36:0,36)
-                Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 4 - (39:0,39)
-                Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (39:0,39) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[p];
-                    SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 4 - (47:0,47)
-            Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (47:0,47) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 4 - (51:0,51)
-            Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (51:0,51) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..59)::59 - [<p class="btn"><p><p><p class="btn"><p></p></p></p></p></p>]
+    MarkupBlock - [0..59)::59
+        MarkupTagHelperElement - [0..59)::59 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagBlock - [15..18)::3 - [<p>]
+                MarkupTextLiteral - [15..18)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [18..21)::3 - [<p>]
+                MarkupTextLiteral - [18..21)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [21..47)::26 - p[StartTagAndEndTag] - pTagHelper
+                MarkupTagHelperStartTag - [21..36)::15
+                    MarkupTextLiteral - [21..23)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[p];
+                    MarkupTagHelperAttribute - [23..35)::12 - class - DoubleQuotes - [ class="btn"]
+                        MarkupTextLiteral - [23..24)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Whitespace;[ ];
+                        MarkupTextLiteral - [24..29)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[class];
+                        Equals;[=];
+                        MarkupTextLiteral - [30..31)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                        MarkupTagHelperAttributeValue - [31..34)::3
+                            MarkupLiteralAttributeValue - [31..34)::3 - [btn]
+                                MarkupTextLiteral - [31..34)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                    Text;[btn];
+                        MarkupTextLiteral - [34..35)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                            DoubleQuote;["];
+                    MarkupTextLiteral - [35..36)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        CloseAngle;[>];
+                MarkupTagBlock - [36..39)::3 - [<p>]
+                    MarkupTextLiteral - [36..39)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTagBlock - [39..43)::4 - [</p>]
+                    MarkupTextLiteral - [39..43)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [43..47)::4
+                    MarkupTextLiteral - [43..47)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[p];
+                        CloseAngle;[>];
+            MarkupTagBlock - [47..51)::4 - [</p>]
+                MarkupTextLiteral - [47..51)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [51..55)::4 - [</p>]
+                MarkupTextLiteral - [51..55)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [55..59)::4
+                MarkupTextLiteral - [55..59)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NonTagHelperChild_UnderstandsTagHelperPrefixAndAllowedChildren.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/NonTagHelperChild_UnderstandsTagHelperPrefixAndAllowedChildren.stree.txt
@@ -1,14 +1,25 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Tag block - Gen<TagHelper> - 30 - (0:0,0) - th:p - PTagHelper
-        StartTagAndEndTag - <th:p> ... </th:p>
-        Tag block - Gen<None> - 8 - (6:0,6)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (14:0,14)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..30)::30 - [<th:p><strong></strong></th:p>]
+    MarkupBlock - [0..30)::30
+        MarkupTagHelperElement - [0..30)::30 - th:p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..6)::6
+                MarkupTextLiteral - [0..6)::6 - [<th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [6..14)::8 - [<strong>]
+                MarkupTextLiteral - [6..14)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagBlock - [14..23)::9 - [</strong>]
+                MarkupTextLiteral - [14..23)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [23..30)::7
+                MarkupTextLiteral - [23..30)::7 - [</th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RecoversWhenRequiredAttributeMismatchAndRestrictedChildren.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RecoversWhenRequiredAttributeMismatchAndRestrictedChildren.stree.txt
@@ -1,15 +1,31 @@
-Markup block - Gen<None> - 43 - (0:0,0)
-    Tag block - Gen<TagHelper> - 43 - (0:0,0) - strong - StrongTagHelper
-        StartTagAndEndTag - <strong required> ... </strong>
-        required - Minimized
-        Tag block - Gen<None> - 8 - (17:0,17)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (25:0,25)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..43)::43 - [<strong required><strong></strong></strong>]
+    MarkupBlock - [0..43)::43
+        MarkupTagHelperElement - [0..43)::43 - strong[StartTagAndEndTag] - StrongTagHelper
+            MarkupTagHelperStartTag - [0..17)::17
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupMinimizedTagHelperAttribute - [7..16)::9 - [ required]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [required] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[required];
+                MarkupTextLiteral - [16..17)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagBlock - [17..25)::8 - [<strong>]
+                MarkupTextLiteral - [17..25)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagBlock - [25..34)::9 - [</strong>]
+                MarkupTextLiteral - [25..34)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [34..43)::9
+                MarkupTextLiteral - [34..43)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly1.stree.txt
@@ -1,5 +1,6 @@
-Markup block - Gen<None> - 2 - (0:0,0)
-    Tag block - Gen<None> - 2 - (0:0,0)
-        Markup span - Gen<Markup> - [<p] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[p];
+RazorDocument - [0..2)::2 - [<p]
+    MarkupBlock - [0..2)::2
+        MarkupTagBlock - [0..2)::2 - [<p]
+            MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[p];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly10.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly10.stree.txt
@@ -1,9 +1,42 @@
-Markup block - Gen<None> - 35 - (0:0,0)
-    Tag block - Gen<TagHelper> - 35 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p notRequired="hi" class="btn"  ... </p
-        notRequired - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.Text;[hi];
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (27:0,27) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..35)::35 - [<p notRequired="hi" class="btn" </p]
+    MarkupBlock - [0..35)::35
+        MarkupTagHelperElement - [0..35)::35 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..32)::32
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..19)::17 - notRequired - DoubleQuotes - [ notRequired="hi"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..14)::11 - [notRequired] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[notRequired];
+                    Equals;[=];
+                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [16..18)::2
+                        MarkupLiteralAttributeValue - [16..18)::2 - [hi]
+                            MarkupTextLiteral - [16..18)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [18..19)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [19..31)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [19..20)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [20..25)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [26..27)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [27..30)::3
+                        MarkupLiteralAttributeValue - [27..30)::3 - [btn]
+                            MarkupTextLiteral - [27..30)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [30..31)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [31..32)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+            MarkupTagHelperEndTag - [32..35)::3
+                MarkupTextLiteral - [32..35)::3 - [</p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly2.stree.txt
@@ -1,6 +1,21 @@
-Markup block - Gen<None> - 14 - (0:0,0)
-    Tag block - Gen<TagHelper> - 14 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..14)::14 - [<p class="btn"]
+    MarkupBlock - [0..14)::14
+        MarkupTagHelperElement - [0..14)::14 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..14)::14
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly3.stree.txt
@@ -1,9 +1,35 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<TagHelper> - 31 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p notRequired="hi" class="btn"
-        notRequired - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.Text;[hi];
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (27:0,27) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..31)::31 - [<p notRequired="hi" class="btn"]
+    MarkupBlock - [0..31)::31
+        MarkupTagHelperElement - [0..31)::31 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..31)::31
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..19)::17 - notRequired - DoubleQuotes - [ notRequired="hi"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..14)::11 - [notRequired] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[notRequired];
+                    Equals;[=];
+                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [16..18)::2
+                        MarkupLiteralAttributeValue - [16..18)::2 - [hi]
+                            MarkupTextLiteral - [16..18)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [18..19)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [19..31)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [19..20)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [20..25)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [26..27)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [27..30)::3
+                        MarkupLiteralAttributeValue - [27..30)::3 - [btn]
+                            MarkupTextLiteral - [27..30)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [30..31)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly4.stree.txt
@@ -1,11 +1,12 @@
-Markup block - Gen<None> - 6 - (0:0,0)
-    Tag block - Gen<None> - 3 - (0:0,0)
-        Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 3 - (3:0,3)
-        Markup span - Gen<Markup> - [</p] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[p];
+RazorDocument - [0..6)::6 - [<p></p]
+    MarkupBlock - [0..6)::6
+        MarkupTagBlock - [0..3)::3 - [<p>]
+            MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[p];
+                CloseAngle;[>];
+        MarkupTagBlock - [3..6)::3 - [</p]
+            MarkupTextLiteral - [3..6)::3 - [</p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[p];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly5.stree.txt
@@ -1,6 +1,28 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Tag block - Gen<TagHelper> - 18 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"> ... </p
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..18)::18 - [<p class="btn"></p]
+    MarkupBlock - [0..18)::18
+        MarkupTagHelperElement - [0..18)::18 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [15..18)::3
+                MarkupTextLiteral - [15..18)::3 - [</p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly6.stree.txt
@@ -1,9 +1,42 @@
-Markup block - Gen<None> - 35 - (0:0,0)
-    Tag block - Gen<TagHelper> - 35 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p notRequired="hi" class="btn"> ... </p
-        notRequired - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.Text;[hi];
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (27:0,27) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..35)::35 - [<p notRequired="hi" class="btn"></p]
+    MarkupBlock - [0..35)::35
+        MarkupTagHelperElement - [0..35)::35 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..32)::32
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..19)::17 - notRequired - DoubleQuotes - [ notRequired="hi"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..14)::11 - [notRequired] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[notRequired];
+                    Equals;[=];
+                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [16..18)::2
+                        MarkupLiteralAttributeValue - [16..18)::2 - [hi]
+                            MarkupTextLiteral - [16..18)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [18..19)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [19..31)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [19..20)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [20..25)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [26..27)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [27..30)::3
+                        MarkupLiteralAttributeValue - [27..30)::3 - [btn]
+                            MarkupTextLiteral - [27..30)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [30..31)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [31..32)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [32..35)::3
+                MarkupTextLiteral - [32..35)::3 - [</p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly7.stree.txt
@@ -1,11 +1,28 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Tag block - Gen<TagHelper> - 18 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn" 
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        Tag block - Gen<None> - 3 - (15:0,15)
-            Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..18)::18 - [<p class="btn" <p>]
+    MarkupBlock - [0..18)::18
+        MarkupTagHelperElement - [0..18)::18 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+            MarkupTagBlock - [15..18)::3 - [<p>]
+                MarkupTextLiteral - [15..18)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly8.stree.txt
@@ -1,14 +1,42 @@
-Markup block - Gen<None> - 35 - (0:0,0)
-    Tag block - Gen<TagHelper> - 35 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p notRequired="hi" class="btn" 
-        notRequired - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.Text;[hi];
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (27:0,27) - Tokens:1
-                SyntaxKind.Text;[btn];
-        Tag block - Gen<None> - 3 - (32:0,32)
-            Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (32:0,32) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[p];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..35)::35 - [<p notRequired="hi" class="btn" <p>]
+    MarkupBlock - [0..35)::35
+        MarkupTagHelperElement - [0..35)::35 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..32)::32
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..19)::17 - notRequired - DoubleQuotes - [ notRequired="hi"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..14)::11 - [notRequired] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[notRequired];
+                    Equals;[=];
+                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [16..18)::2
+                        MarkupLiteralAttributeValue - [16..18)::2 - [hi]
+                            MarkupTextLiteral - [16..18)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [18..19)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [19..31)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [19..20)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [20..25)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [26..27)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [27..30)::3
+                        MarkupLiteralAttributeValue - [27..30)::3 - [btn]
+                            MarkupTextLiteral - [27..30)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [30..31)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [31..32)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+            MarkupTagBlock - [32..35)::3 - [<p>]
+                MarkupTextLiteral - [32..35)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly9.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly9.stree.txt
@@ -1,6 +1,28 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Tag block - Gen<TagHelper> - 18 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"  ... </p
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..18)::18 - [<p class="btn" </p]
+    MarkupBlock - [0..18)::18
+        MarkupTagHelperElement - [0..18)::18 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+            MarkupTagHelperEndTag - [15..18)::3
+                MarkupTextLiteral - [15..18)::3 - [</p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly1.stree.txt
@@ -1,8 +1,9 @@
-Markup block - Gen<None> - 5 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<p />] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:5
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[p];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..5)::5 - [<p />]
+    MarkupBlock - [0..5)::5
+        MarkupTagBlock - [0..5)::5 - [<p />]
+            MarkupTextLiteral - [0..5)::5 - [<p />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[p];
+                Whitespace;[ ];
+                ForwardSlash;[/];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly10.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly10.stree.txt
@@ -1,6 +1,25 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<TagHelper> - 24 - (0:0,0) - strong - catchAllTagHelper
-        SelfClosing - <strong catchAll="hi" />
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                SyntaxKind.Text;[hi];
+RazorDocument - [0..24)::24 - [<strong catchAll="hi" />]
+    MarkupBlock - [0..24)::24
+        MarkupTagHelperElement - [0..24)::24 - strong[SelfClosing] - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..24)::24
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupTagHelperAttribute - [7..21)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [18..20)::2
+                        MarkupLiteralAttributeValue - [18..20)::2 - [hi]
+                            MarkupTextLiteral - [18..20)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [21..24)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly11.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly11.stree.txt
@@ -1,13 +1,34 @@
-Markup block - Gen<None> - 35 - (0:0,0)
-    Tag block - Gen<TagHelper> - 35 - (0:0,0) - strong - catchAllTagHelper
-        SelfClosing - <strong catchAll="@DateTime.Now" />
-        catchAll - DoubleQuotes
-            Markup block - Gen<None> - 13 - (18:0,18)
-                Markup block - Gen<DynAttr:@(18:0,18)> - 13 - (18:0,18)
-                    Expression block - Gen<Expr> - 13 - (18:0,18)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (19:0,19) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
+RazorDocument - [0..35)::35 - [<strong catchAll="@DateTime.Now" />]
+    MarkupBlock - [0..35)::35
+        MarkupTagHelperElement - [0..35)::35 - strong[SelfClosing] - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..35)::35
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupTagHelperAttribute - [7..32)::25 - catchAll - DoubleQuotes - [ catchAll="@DateTime.Now"]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [18..31)::13
+                        MarkupDynamicAttributeValue - [18..31)::13 - [@DateTime.Now]
+                            GenericBlock - [18..31)::13
+                                CSharpCodeBlock - [18..31)::13
+                                    CSharpImplicitExpression - [18..31)::13
+                                        CSharpTransition - [18..19)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [19..31)::12
+                                            CSharpCodeBlock - [19..31)::12
+                                                CSharpExpressionLiteral - [19..31)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [31..32)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [32..35)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly12.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly12.stree.txt
@@ -1,13 +1,35 @@
-Markup block - Gen<None> - 47 - (0:0,0)
-    Tag block - Gen<TagHelper> - 47 - (0:0,0) - strong - catchAllTagHelper
-        StartTagAndEndTag - <strong catchAll="hi"> ... </strong>
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (18:0,18) - Tokens:1
-                SyntaxKind.Text;[hi];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [22..38) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [22..38) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..47)::47 - [<strong catchAll="hi">words and spaces</strong>]
+    MarkupBlock - [0..47)::47
+        MarkupTagHelperElement - [0..47)::47 - strong[StartTagAndEndTag] - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..22)::22
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupTagHelperAttribute - [7..21)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [18..20)::2
+                        MarkupLiteralAttributeValue - [18..20)::2 - [hi]
+                            MarkupTextLiteral - [18..20)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [21..22)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [22..38)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [38..47)::9
+                MarkupTextLiteral - [38..47)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly13.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly13.stree.txt
@@ -1,20 +1,44 @@
-Markup block - Gen<None> - 58 - (0:0,0)
-    Tag block - Gen<TagHelper> - 58 - (0:0,0) - strong - catchAllTagHelper
-        StartTagAndEndTag - <strong catchAll="@DateTime.Now"> ... </strong>
-        catchAll - DoubleQuotes
-            Markup block - Gen<None> - 13 - (18:0,18)
-                Markup block - Gen<DynAttr:@(18:0,18)> - 13 - (18:0,18)
-                    Expression block - Gen<Expr> - 13 - (18:0,18)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (18:0,18) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (19:0,19) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [33..49) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [33..49) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..58)::58 - [<strong catchAll="@DateTime.Now">words and spaces</strong>]
+    MarkupBlock - [0..58)::58
+        MarkupTagHelperElement - [0..58)::58 - strong[StartTagAndEndTag] - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..33)::33
+                MarkupTextLiteral - [0..7)::7 - [<strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                MarkupTagHelperAttribute - [7..32)::25 - catchAll - DoubleQuotes - [ catchAll="@DateTime.Now"]
+                    MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [8..16)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [18..31)::13
+                        MarkupDynamicAttributeValue - [18..31)::13 - [@DateTime.Now]
+                            GenericBlock - [18..31)::13
+                                CSharpCodeBlock - [18..31)::13
+                                    CSharpImplicitExpression - [18..31)::13
+                                        CSharpTransition - [18..19)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [19..31)::12
+                                            CSharpCodeBlock - [19..31)::12
+                                                CSharpExpressionLiteral - [19..31)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [31..32)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [32..33)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [33..49)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [49..58)::9
+                MarkupTextLiteral - [49..58)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly14.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly14.stree.txt
@@ -1,19 +1,24 @@
-Markup block - Gen<None> - 19 - (0:0,0)
-    Tag block - Gen<None> - 19 - (0:0,0)
-        Markup span - Gen<Markup> - [<div] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-        Markup block - Gen<Attr:class, class="@(4:0,4),"@(15:0,15)> - 12 - (4:0,4)
-            Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(12:0,12)> - [btn] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:1
-                SyntaxKind.Text;[btn];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [ />] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:3
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..19)::19 - [<div class="btn" />]
+    MarkupBlock - [0..19)::19
+        MarkupTagBlock - [0..19)::19 - [<div class="btn" />]
+            MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+            MarkupAttributeBlock - [4..16)::12 - [ class="btn"]
+                MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [5..10)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+                GenericBlock - [12..15)::3
+                    MarkupLiteralAttributeValue - [12..15)::3 - [btn]
+                        MarkupTextLiteral - [12..15)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn];
+                MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+            MarkupTextLiteral - [16..19)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[ ];
+                ForwardSlash;[/];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly15.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly15.stree.txt
@@ -1,23 +1,28 @@
-Markup block - Gen<None> - 23 - (0:0,0)
-    Tag block - Gen<None> - 17 - (0:0,0)
-        Markup span - Gen<Markup> - [<div] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-        Markup block - Gen<Attr:class, class="@(4:0,4),"@(15:0,15)> - 12 - (4:0,4)
-            Markup span - Gen<None> - [ class="] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.DoubleQuote;["];
-            Markup span - Gen<LitAttr:@(12:0,12)> - [btn] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:1
-                SyntaxKind.Text;[btn];
-            Markup span - Gen<None> - ["] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                SyntaxKind.DoubleQuote;["];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (17:0,17)
-        Markup span - Gen<Markup> - [</div>] - SpanEditHandler;Accepts:Any - (17:0,17) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..23)::23 - [<div class="btn"></div>]
+    MarkupBlock - [0..23)::23
+        MarkupTagBlock - [0..17)::17 - [<div class="btn">]
+            MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+            MarkupAttributeBlock - [4..16)::12 - [ class="btn"]
+                MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [5..10)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+                GenericBlock - [12..15)::3
+                    MarkupLiteralAttributeValue - [12..15)::3 - [btn]
+                        MarkupTextLiteral - [12..15)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[btn];
+                MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                    DoubleQuote;["];
+            MarkupTextLiteral - [16..17)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTagBlock - [17..23)::6 - [</div>]
+            MarkupTextLiteral - [17..23)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[div];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly16.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly16.stree.txt
@@ -1,9 +1,39 @@
-Markup block - Gen<None> - 33 - (0:0,0)
-    Tag block - Gen<TagHelper> - 33 - (0:0,0) - p - pTagHelper
-        SelfClosing - <p notRequired="a" class="btn" />
-        notRequired - DoubleQuotes
-            Markup span - Gen<Markup> - [a] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.Text;[a];
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (26:0,26) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..33)::33 - [<p notRequired="a" class="btn" />]
+    MarkupBlock - [0..33)::33
+        MarkupTagHelperElement - [0..33)::33 - p[SelfClosing] - pTagHelper
+            MarkupTagHelperStartTag - [0..33)::33
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..18)::16 - notRequired - DoubleQuotes - [ notRequired="a"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..14)::11 - [notRequired] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[notRequired];
+                    Equals;[=];
+                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [16..17)::1
+                        MarkupLiteralAttributeValue - [16..17)::1 - [a]
+                            MarkupTextLiteral - [16..17)::1 - [a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[a];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [18..30)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [18..19)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [19..24)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [25..26)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [26..29)::3
+                        MarkupLiteralAttributeValue - [26..29)::3 - [btn]
+                            MarkupTextLiteral - [26..29)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [29..30)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [30..33)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly17.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly17.stree.txt
@@ -1,16 +1,48 @@
-Markup block - Gen<None> - 45 - (0:0,0)
-    Tag block - Gen<TagHelper> - 45 - (0:0,0) - p - pTagHelper
-        SelfClosing - <p notRequired="@DateTime.Now" class="btn" />
-        notRequired - DoubleQuotes
-            Markup block - Gen<None> - 13 - (16:0,16)
-                Markup block - Gen<DynAttr:@(16:0,16)> - 13 - (16:0,16)
-                    Expression block - Gen<Expr> - 13 - (16:0,16)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (16:0,16) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (17:0,17) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (38:0,38) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..45)::45 - [<p notRequired="@DateTime.Now" class="btn" />]
+    MarkupBlock - [0..45)::45
+        MarkupTagHelperElement - [0..45)::45 - p[SelfClosing] - pTagHelper
+            MarkupTagHelperStartTag - [0..45)::45
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..30)::28 - notRequired - DoubleQuotes - [ notRequired="@DateTime.Now"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..14)::11 - [notRequired] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[notRequired];
+                    Equals;[=];
+                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [16..29)::13
+                        MarkupDynamicAttributeValue - [16..29)::13 - [@DateTime.Now]
+                            GenericBlock - [16..29)::13
+                                CSharpCodeBlock - [16..29)::13
+                                    CSharpImplicitExpression - [16..29)::13
+                                        CSharpTransition - [16..17)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [17..29)::12
+                                            CSharpCodeBlock - [17..29)::12
+                                                CSharpExpressionLiteral - [17..29)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [29..30)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [30..42)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [30..31)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [31..36)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [37..38)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [38..41)::3
+                        MarkupLiteralAttributeValue - [38..41)::3 - [btn]
+                            MarkupTextLiteral - [38..41)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [41..42)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [42..45)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly18.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly18.stree.txt
@@ -1,16 +1,49 @@
-Markup block - Gen<None> - 51 - (0:0,0)
-    Tag block - Gen<TagHelper> - 51 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p notRequired="a" class="btn"> ... </p>
-        notRequired - DoubleQuotes
-            Markup span - Gen<Markup> - [a] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:1
-                SyntaxKind.Text;[a];
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (26:0,26) - Tokens:1
-                SyntaxKind.Text;[btn];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [31..47) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [31..47) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..51)::51 - [<p notRequired="a" class="btn">words and spaces</p>]
+    MarkupBlock - [0..51)::51
+        MarkupTagHelperElement - [0..51)::51 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..31)::31
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..18)::16 - notRequired - DoubleQuotes - [ notRequired="a"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..14)::11 - [notRequired] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[notRequired];
+                    Equals;[=];
+                    MarkupTextLiteral - [15..16)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [16..17)::1
+                        MarkupLiteralAttributeValue - [16..17)::1 - [a]
+                            MarkupTextLiteral - [16..17)::1 - [a] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[a];
+                    MarkupTextLiteral - [17..18)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [18..30)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [18..19)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [19..24)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [25..26)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [26..29)::3
+                        MarkupLiteralAttributeValue - [26..29)::3 - [btn]
+                            MarkupTextLiteral - [26..29)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [29..30)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [30..31)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [31..47)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [47..51)::4
+                MarkupTextLiteral - [47..51)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly19.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly19.stree.txt
@@ -1,8 +1,36 @@
-Markup block - Gen<None> - 28 - (0:0,0)
-    Tag block - Gen<TagHelper> - 28 - (0:0,0) - div - divTagHelper
-        SelfClosing - <div style="" class="btn" />
-        style - DoubleQuotes
-            Markup block - Gen<None> - 0 - (0:0,0)
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..28)::28 - [<div style="" class="btn" />]
+    MarkupBlock - [0..28)::28
+        MarkupTagHelperElement - [0..28)::28 - div[SelfClosing] - divTagHelper
+            MarkupTagHelperStartTag - [0..28)::28
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..13)::9 - style - DoubleQuotes - [ style=""]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..12)::0
+                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [13..25)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [13..14)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [14..19)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [21..24)::3
+                        MarkupLiteralAttributeValue - [21..24)::3 - [btn]
+                            MarkupTextLiteral - [21..24)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [25..28)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly2.stree.txt
@@ -1,12 +1,13 @@
-Markup block - Gen<None> - 7 - (0:0,0)
-    Tag block - Gen<None> - 3 - (0:0,0)
-        Markup span - Gen<Markup> - [<p>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 4 - (3:0,3)
-        Markup span - Gen<Markup> - [</p>] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[p];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..7)::7 - [<p></p>]
+    MarkupBlock - [0..7)::7
+        MarkupTagBlock - [0..3)::3 - [<p>]
+            MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[p];
+                CloseAngle;[>];
+        MarkupTagBlock - [3..7)::4 - [</p>]
+            MarkupTextLiteral - [3..7)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[p];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly20.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly20.stree.txt
@@ -1,16 +1,48 @@
-Markup block - Gen<None> - 41 - (0:0,0)
-    Tag block - Gen<TagHelper> - 41 - (0:0,0) - div - divTagHelper
-        SelfClosing - <div style="@DateTime.Now" class="btn" />
-        style - DoubleQuotes
-            Markup block - Gen<None> - 13 - (12:0,12)
-                Markup block - Gen<DynAttr:@(12:0,12)> - 13 - (12:0,12)
-                    Expression block - Gen<Expr> - 13 - (12:0,12)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (13:0,13) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..41)::41 - [<div style="@DateTime.Now" class="btn" />]
+    MarkupBlock - [0..41)::41
+        MarkupTagHelperElement - [0..41)::41 - div[SelfClosing] - divTagHelper
+            MarkupTagHelperStartTag - [0..41)::41
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..26)::22 - style - DoubleQuotes - [ style="@DateTime.Now"]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..25)::13
+                        MarkupDynamicAttributeValue - [12..25)::13 - [@DateTime.Now]
+                            GenericBlock - [12..25)::13
+                                CSharpCodeBlock - [12..25)::13
+                                    CSharpImplicitExpression - [12..25)::13
+                                        CSharpTransition - [12..13)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [13..25)::12
+                                            CSharpCodeBlock - [13..25)::12
+                                                CSharpExpressionLiteral - [13..25)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [25..26)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [26..38)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [26..27)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [27..32)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [33..34)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [34..37)::3
+                        MarkupLiteralAttributeValue - [34..37)::3 - [btn]
+                            MarkupTextLiteral - [34..37)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [37..38)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [38..41)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly21.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly21.stree.txt
@@ -1,15 +1,46 @@
-Markup block - Gen<None> - 48 - (0:0,0)
-    Tag block - Gen<TagHelper> - 48 - (0:0,0) - div - divTagHelper
-        StartTagAndEndTag - <div style="" class="btn"> ... </div>
-        style - DoubleQuotes
-            Markup block - Gen<None> - 0 - (0:0,0)
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.Text;[btn];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [26..42) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [26..42) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..48)::48 - [<div style="" class="btn">words and spaces</div>]
+    MarkupBlock - [0..48)::48
+        MarkupTagHelperElement - [0..48)::48 - div[StartTagAndEndTag] - divTagHelper
+            MarkupTagHelperStartTag - [0..26)::26
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..13)::9 - style - DoubleQuotes - [ style=""]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..12)::0
+                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [13..25)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [13..14)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [14..19)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [21..24)::3
+                        MarkupLiteralAttributeValue - [21..24)::3 - [btn]
+                            MarkupTextLiteral - [21..24)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [25..26)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [26..42)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [42..48)::6
+                MarkupTextLiteral - [42..48)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[div];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly22.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly22.stree.txt
@@ -1,30 +1,67 @@
-Markup block - Gen<None> - 71 - (0:0,0)
-    Tag block - Gen<TagHelper> - 71 - (0:0,0) - div - divTagHelper
-        StartTagAndEndTag - <div style="@DateTime.Now" class="@DateTime.Now"> ... </div>
-        style - DoubleQuotes
-            Markup block - Gen<None> - 13 - (12:0,12)
-                Markup block - Gen<DynAttr:@(12:0,12)> - 13 - (12:0,12)
-                    Expression block - Gen<Expr> - 13 - (12:0,12)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (13:0,13) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
-        class - DoubleQuotes
-            Markup block - Gen<None> - 13 - (34:0,34)
-                Markup block - Gen<DynAttr:@(34:0,34)> - 13 - (34:0,34)
-                    Expression block - Gen<Expr> - 13 - (34:0,34)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (34:0,34) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (35:0,35) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [49..65) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [49..65) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..71)::71 - [<div style="@DateTime.Now" class="@DateTime.Now">words and spaces</div>]
+    MarkupBlock - [0..71)::71
+        MarkupTagHelperElement - [0..71)::71 - div[StartTagAndEndTag] - divTagHelper
+            MarkupTagHelperStartTag - [0..49)::49
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..26)::22 - style - DoubleQuotes - [ style="@DateTime.Now"]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..25)::13
+                        MarkupDynamicAttributeValue - [12..25)::13 - [@DateTime.Now]
+                            GenericBlock - [12..25)::13
+                                CSharpCodeBlock - [12..25)::13
+                                    CSharpImplicitExpression - [12..25)::13
+                                        CSharpTransition - [12..13)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [13..25)::12
+                                            CSharpCodeBlock - [13..25)::12
+                                                CSharpExpressionLiteral - [13..25)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [25..26)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [26..48)::22 - class - DoubleQuotes - [ class="@DateTime.Now"]
+                    MarkupTextLiteral - [26..27)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [27..32)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [33..34)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [34..47)::13
+                        MarkupDynamicAttributeValue - [34..47)::13 - [@DateTime.Now]
+                            GenericBlock - [34..47)::13
+                                CSharpCodeBlock - [34..47)::13
+                                    CSharpImplicitExpression - [34..47)::13
+                                        CSharpTransition - [34..35)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [35..47)::12
+                                            CSharpCodeBlock - [35..47)::12
+                                                CSharpExpressionLiteral - [35..47)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [47..48)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [48..49)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [49..65)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [65..71)::6
+                MarkupTextLiteral - [65..71)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[div];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly23.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly23.stree.txt
@@ -1,25 +1,57 @@
-Markup block - Gen<None> - 63 - (0:0,0)
-    Tag block - Gen<TagHelper> - 63 - (0:0,0) - div - divTagHelper
-        StartTagAndEndTag - <div style="" class="btn"> ... </div>
-        style - DoubleQuotes
-            Markup block - Gen<None> - 0 - (0:0,0)
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.Text;[btn];
-        SyntaxKind.HtmlTextLiteral - [words] - [26..31) - FullWidth: 5 - Slots: 1
-            SyntaxKind.Text;[words];
-        Tag block - Gen<None> - 8 - (31:0,31)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (31:0,31) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [and] - [39..42) - FullWidth: 3 - Slots: 1
-            SyntaxKind.Text;[and];
-        Tag block - Gen<None> - 9 - (42:0,42)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (42:0,42) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [spaces] - [51..57) - FullWidth: 6 - Slots: 1
-            SyntaxKind.Text;[spaces];
+RazorDocument - [0..63)::63 - [<div style="" class="btn">words<strong>and</strong>spaces</div>]
+    MarkupBlock - [0..63)::63
+        MarkupTagHelperElement - [0..63)::63 - div[StartTagAndEndTag] - divTagHelper
+            MarkupTagHelperStartTag - [0..26)::26
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..13)::9 - style - DoubleQuotes - [ style=""]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..12)::0
+                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [13..25)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [13..14)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [14..19)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [21..24)::3
+                        MarkupLiteralAttributeValue - [21..24)::3 - [btn]
+                            MarkupTextLiteral - [21..24)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [25..26)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [26..31)::5 - [words] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+            MarkupTagBlock - [31..39)::8 - [<strong>]
+                MarkupTextLiteral - [31..39)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [39..42)::3 - [and] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[and];
+            MarkupTagBlock - [42..51)::9 - [</strong>]
+                MarkupTextLiteral - [42..51)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [51..57)::6 - [spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[spaces];
+            MarkupTagHelperEndTag - [57..63)::6
+                MarkupTextLiteral - [57..63)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[div];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly24.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly24.stree.txt
@@ -1,9 +1,39 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<TagHelper> - 31 - (0:0,0) - p - pTagHelper - catchAllTagHelper
-        SelfClosing - <p class="btn" catchAll="hi" />
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:1
-                SyntaxKind.Text;[hi];
+RazorDocument - [0..31)::31 - [<p class="btn" catchAll="hi" />]
+    MarkupBlock - [0..31)::31
+        MarkupTagHelperElement - [0..31)::31 - p[SelfClosing] - pTagHelper - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..31)::31
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [14..28)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [14..15)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [15..23)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [25..27)::2
+                        MarkupLiteralAttributeValue - [25..27)::2 - [hi]
+                            MarkupTextLiteral - [25..27)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [27..28)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [28..31)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly25.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly25.stree.txt
@@ -1,16 +1,49 @@
-Markup block - Gen<None> - 49 - (0:0,0)
-    Tag block - Gen<TagHelper> - 49 - (0:0,0) - p - pTagHelper - catchAllTagHelper
-        StartTagAndEndTag - <p class="btn" catchAll="hi"> ... </p>
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:1
-                SyntaxKind.Text;[hi];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [29..45) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [29..45) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..49)::49 - [<p class="btn" catchAll="hi">words and spaces</p>]
+    MarkupBlock - [0..49)::49
+        MarkupTagHelperElement - [0..49)::49 - p[StartTagAndEndTag] - pTagHelper - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..29)::29
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [14..28)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [14..15)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [15..23)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [25..27)::2
+                        MarkupLiteralAttributeValue - [25..27)::2 - [hi]
+                            MarkupTextLiteral - [25..27)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [27..28)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [28..29)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [29..45)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [45..49)::4
+                MarkupTextLiteral - [45..49)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly26.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly26.stree.txt
@@ -1,11 +1,50 @@
-Markup block - Gen<None> - 42 - (0:0,0)
-    Tag block - Gen<TagHelper> - 42 - (0:0,0) - div - divTagHelper - catchAllTagHelper
-        SelfClosing - <div style="" class="btn" catchAll="hi" />
-        style - DoubleQuotes
-            Markup block - Gen<None> - 0 - (0:0,0)
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.Text;[btn];
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:1
-                SyntaxKind.Text;[hi];
+RazorDocument - [0..42)::42 - [<div style="" class="btn" catchAll="hi" />]
+    MarkupBlock - [0..42)::42
+        MarkupTagHelperElement - [0..42)::42 - div[SelfClosing] - divTagHelper - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..42)::42
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..13)::9 - style - DoubleQuotes - [ style=""]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..12)::0
+                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [13..25)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [13..14)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [14..19)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [21..24)::3
+                        MarkupLiteralAttributeValue - [21..24)::3 - [btn]
+                            MarkupTextLiteral - [21..24)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [25..39)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [25..26)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [26..34)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [35..36)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [36..38)::2
+                        MarkupLiteralAttributeValue - [36..38)::2 - [hi]
+                            MarkupTextLiteral - [36..38)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [38..39)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [39..42)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly27.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly27.stree.txt
@@ -1,18 +1,61 @@
-Markup block - Gen<None> - 63 - (0:0,0)
-    Tag block - Gen<TagHelper> - 63 - (0:0,0) - div - divTagHelper - catchAllTagHelper
-        StartTagAndEndTag - <div style="" class="btn" catchAll="hi" > ... </div>
-        style - DoubleQuotes
-            Markup block - Gen<None> - 0 - (0:0,0)
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.Text;[btn];
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:1
-                SyntaxKind.Text;[hi];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [41..57) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [41..57) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..63)::63 - [<div style="" class="btn" catchAll="hi" >words and spaces</div>]
+    MarkupBlock - [0..63)::63
+        MarkupTagHelperElement - [0..63)::63 - div[StartTagAndEndTag] - divTagHelper - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..41)::41
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..13)::9 - style - DoubleQuotes - [ style=""]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..12)::0
+                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [13..25)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [13..14)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [14..19)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [21..24)::3
+                        MarkupLiteralAttributeValue - [21..24)::3 - [btn]
+                            MarkupTextLiteral - [21..24)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [25..39)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [25..26)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [26..34)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [35..36)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [36..38)::2
+                        MarkupLiteralAttributeValue - [36..38)::2 - [hi]
+                            MarkupTextLiteral - [36..38)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [38..39)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [39..41)::2 - [ >] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [41..57)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [57..63)::6
+                MarkupTextLiteral - [57..63)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[div];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly28.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly28.stree.txt
@@ -1,24 +1,66 @@
-Markup block - Gen<None> - 65 - (0:0,0)
-    Tag block - Gen<TagHelper> - 65 - (0:0,0) - div - divTagHelper - catchAllTagHelper
-        StartTagAndEndTag - <div style="" class="btn" catchAll="@@hi" > ... </div>
-        style - DoubleQuotes
-            Markup block - Gen<None> - 0 - (0:0,0)
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.Text;[btn];
-        catchAll - DoubleQuotes
-            Markup block - Gen<None> - 4 - (36:0,36)
-                Markup block - Gen<None> - 2 - (36:0,36)
-                    Markup span - Gen<Markup> - [@] - SpanEditHandler;Accepts:None - (36:0,36) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                    Markup span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (37:0,37) - Tokens:1
-                        SyntaxKind.Transition;[@];
-                Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (38:0,38) - Tokens:1
-                    SyntaxKind.Text;[hi];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [43..59) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [43..59) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..65)::65 - [<div style="" class="btn" catchAll="@@hi" >words and spaces</div>]
+    MarkupBlock - [0..65)::65
+        MarkupTagHelperElement - [0..65)::65 - div[StartTagAndEndTag] - divTagHelper - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..43)::43
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..13)::9 - style - DoubleQuotes - [ style=""]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..12)::0
+                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [13..25)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [13..14)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [14..19)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [21..24)::3
+                        MarkupLiteralAttributeValue - [21..24)::3 - [btn]
+                            MarkupTextLiteral - [21..24)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [25..41)::16 - catchAll - DoubleQuotes - [ catchAll="@@hi"]
+                    MarkupTextLiteral - [25..26)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [26..34)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [35..36)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [36..40)::4
+                        MarkupBlock - [36..38)::2
+                            MarkupTextLiteral - [36..37)::1 - [@] - Gen<LitAttr:@(36:0,36)> - SpanEditHandler;Accepts:None
+                                Transition;[@];
+                            MarkupEphemeralTextLiteral - [37..38)::1 - [@] - Gen<None> - SpanEditHandler;Accepts:None
+                                Transition;[@];
+                        MarkupLiteralAttributeValue - [38..40)::2 - [hi]
+                            MarkupTextLiteral - [38..40)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [40..41)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [41..43)::2 - [ >] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [43..59)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [59..65)::6
+                MarkupTextLiteral - [59..65)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[div];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly29.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly29.stree.txt
@@ -1,40 +1,91 @@
-Markup block - Gen<None> - 97 - (0:0,0)
-    Tag block - Gen<TagHelper> - 97 - (0:0,0) - div - divTagHelper - catchAllTagHelper
-        StartTagAndEndTag - <div style="@DateTime.Now" class="@DateTime.Now" catchAll="@DateTime.Now" > ... </div>
-        style - DoubleQuotes
-            Markup block - Gen<None> - 13 - (12:0,12)
-                Markup block - Gen<DynAttr:@(12:0,12)> - 13 - (12:0,12)
-                    Expression block - Gen<Expr> - 13 - (12:0,12)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (12:0,12) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (13:0,13) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
-        class - DoubleQuotes
-            Markup block - Gen<None> - 13 - (34:0,34)
-                Markup block - Gen<DynAttr:@(34:0,34)> - 13 - (34:0,34)
-                    Expression block - Gen<Expr> - 13 - (34:0,34)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (34:0,34) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (35:0,35) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
-        catchAll - DoubleQuotes
-            Markup block - Gen<None> - 13 - (59:0,59)
-                Markup block - Gen<DynAttr:@(59:0,59)> - 13 - (59:0,59)
-                    Expression block - Gen<Expr> - 13 - (59:0,59)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (59:0,59) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (60:0,60) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [75..91) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [75..91) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..97)::97 - [<div style="@DateTime.Now" class="@DateTime.Now" catchAll="@DateTime.Now" >words and spaces</div>]
+    MarkupBlock - [0..97)::97
+        MarkupTagHelperElement - [0..97)::97 - div[StartTagAndEndTag] - divTagHelper - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..75)::75
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..26)::22 - style - DoubleQuotes - [ style="@DateTime.Now"]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..25)::13
+                        MarkupDynamicAttributeValue - [12..25)::13 - [@DateTime.Now]
+                            GenericBlock - [12..25)::13
+                                CSharpCodeBlock - [12..25)::13
+                                    CSharpImplicitExpression - [12..25)::13
+                                        CSharpTransition - [12..13)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [13..25)::12
+                                            CSharpCodeBlock - [13..25)::12
+                                                CSharpExpressionLiteral - [13..25)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [25..26)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [26..48)::22 - class - DoubleQuotes - [ class="@DateTime.Now"]
+                    MarkupTextLiteral - [26..27)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [27..32)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [33..34)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [34..47)::13
+                        MarkupDynamicAttributeValue - [34..47)::13 - [@DateTime.Now]
+                            GenericBlock - [34..47)::13
+                                CSharpCodeBlock - [34..47)::13
+                                    CSharpImplicitExpression - [34..47)::13
+                                        CSharpTransition - [34..35)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [35..47)::12
+                                            CSharpCodeBlock - [35..47)::12
+                                                CSharpExpressionLiteral - [35..47)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [47..48)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [48..73)::25 - catchAll - DoubleQuotes - [ catchAll="@DateTime.Now"]
+                    MarkupTextLiteral - [48..49)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [49..57)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [58..59)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [59..72)::13
+                        MarkupDynamicAttributeValue - [59..72)::13 - [@DateTime.Now]
+                            GenericBlock - [59..72)::13
+                                CSharpCodeBlock - [59..72)::13
+                                    CSharpImplicitExpression - [59..72)::13
+                                        CSharpTransition - [59..60)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [60..72)::12
+                                            CSharpCodeBlock - [60..72)::12
+                                                CSharpExpressionLiteral - [60..72)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [72..73)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [73..75)::2 - [ >] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [75..91)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [91..97)::6
+                MarkupTextLiteral - [91..97)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[div];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly3.stree.txt
@@ -1,8 +1,9 @@
-Markup block - Gen<None> - 7 - (0:0,0)
-    Tag block - Gen<None> - 7 - (0:0,0)
-        Markup span - Gen<Markup> - [<div />] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:5
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..7)::7 - [<div />]
+    MarkupBlock - [0..7)::7
+        MarkupTagBlock - [0..7)::7 - [<div />]
+            MarkupTextLiteral - [0..7)::7 - [<div />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+                Whitespace;[ ];
+                ForwardSlash;[/];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly30.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly30.stree.txt
@@ -1,28 +1,72 @@
-Markup block - Gen<None> - 78 - (0:0,0)
-    Tag block - Gen<TagHelper> - 78 - (0:0,0) - div - divTagHelper - catchAllTagHelper
-        StartTagAndEndTag - <div style="" class="btn" catchAll="hi" > ... </div>
-        style - DoubleQuotes
-            Markup block - Gen<None> - 0 - (0:0,0)
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.Text;[btn];
-        catchAll - DoubleQuotes
-            Markup span - Gen<Markup> - [hi] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:1
-                SyntaxKind.Text;[hi];
-        SyntaxKind.HtmlTextLiteral - [words] - [41..46) - FullWidth: 5 - Slots: 1
-            SyntaxKind.Text;[words];
-        Tag block - Gen<None> - 8 - (46:0,46)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (46:0,46) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [and] - [54..57) - FullWidth: 3 - Slots: 1
-            SyntaxKind.Text;[and];
-        Tag block - Gen<None> - 9 - (57:0,57)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (57:0,57) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [spaces] - [66..72) - FullWidth: 6 - Slots: 1
-            SyntaxKind.Text;[spaces];
+RazorDocument - [0..78)::78 - [<div style="" class="btn" catchAll="hi" >words<strong>and</strong>spaces</div>]
+    MarkupBlock - [0..78)::78
+        MarkupTagHelperElement - [0..78)::78 - div[StartTagAndEndTag] - divTagHelper - catchAllTagHelper
+            MarkupTagHelperStartTag - [0..41)::41
+                MarkupTextLiteral - [0..4)::4 - [<div] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                MarkupTagHelperAttribute - [4..13)::9 - style - DoubleQuotes - [ style=""]
+                    MarkupTextLiteral - [4..5)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [5..10)::5 - [style] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[style];
+                    Equals;[=];
+                    MarkupTextLiteral - [11..12)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [12..12)::0
+                    MarkupTextLiteral - [12..13)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [13..25)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [13..14)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [14..19)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [20..21)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [21..24)::3
+                        MarkupLiteralAttributeValue - [21..24)::3 - [btn]
+                            MarkupTextLiteral - [21..24)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [24..25)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTagHelperAttribute - [25..39)::14 - catchAll - DoubleQuotes - [ catchAll="hi"]
+                    MarkupTextLiteral - [25..26)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [26..34)::8 - [catchAll] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[catchAll];
+                    Equals;[=];
+                    MarkupTextLiteral - [35..36)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [36..38)::2
+                        MarkupLiteralAttributeValue - [36..38)::2 - [hi]
+                            MarkupTextLiteral - [36..38)::2 - [hi] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[hi];
+                    MarkupTextLiteral - [38..39)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [39..41)::2 - [ >] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [41..46)::5 - [words] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+            MarkupTagBlock - [46..54)::8 - [<strong>]
+                MarkupTextLiteral - [46..54)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [54..57)::3 - [and] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[and];
+            MarkupTagBlock - [57..66)::9 - [</strong>]
+                MarkupTextLiteral - [57..66)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [66..72)::6 - [spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[spaces];
+            MarkupTagHelperEndTag - [72..78)::6
+                MarkupTextLiteral - [72..78)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[div];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly4.stree.txt
@@ -1,12 +1,13 @@
-Markup block - Gen<None> - 11 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<div>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 6 - (5:0,5)
-        Markup span - Gen<Markup> - [</div>] - SpanEditHandler;Accepts:Any - (5:0,5) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..11)::11 - [<div></div>]
+    MarkupBlock - [0..11)::11
+        MarkupTagBlock - [0..5)::5 - [<div>]
+            MarkupTextLiteral - [0..5)::5 - [<div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupTagBlock - [5..11)::6 - [</div>]
+            MarkupTextLiteral - [5..11)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[div];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly5.stree.txt
@@ -1,6 +1,25 @@
-Markup block - Gen<None> - 17 - (0:0,0)
-    Tag block - Gen<TagHelper> - 17 - (0:0,0) - p - pTagHelper
-        SelfClosing - <p class="btn" />
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
+RazorDocument - [0..17)::17 - [<p class="btn" />]
+    MarkupBlock - [0..17)::17
+        MarkupTagHelperElement - [0..17)::17 - p[SelfClosing] - pTagHelper
+            MarkupTagHelperStartTag - [0..17)::17
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..17)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly6.stree.txt
@@ -1,13 +1,34 @@
-Markup block - Gen<None> - 27 - (0:0,0)
-    Tag block - Gen<TagHelper> - 27 - (0:0,0) - p - pTagHelper
-        SelfClosing - <p class="@DateTime.Now" />
-        class - DoubleQuotes
-            Markup block - Gen<None> - 13 - (10:0,10)
-                Markup block - Gen<DynAttr:@(10:0,10)> - 13 - (10:0,10)
-                    Expression block - Gen<Expr> - 13 - (10:0,10)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (11:0,11) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
+RazorDocument - [0..27)::27 - [<p class="@DateTime.Now" />]
+    MarkupBlock - [0..27)::27
+        MarkupTagHelperElement - [0..27)::27 - p[SelfClosing] - pTagHelper
+            MarkupTagHelperStartTag - [0..27)::27
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..24)::22 - class - DoubleQuotes - [ class="@DateTime.Now"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..23)::13
+                        MarkupDynamicAttributeValue - [10..23)::13 - [@DateTime.Now]
+                            GenericBlock - [10..23)::13
+                                CSharpCodeBlock - [10..23)::13
+                                    CSharpImplicitExpression - [10..23)::13
+                                        CSharpTransition - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [11..23)::12
+                                            CSharpCodeBlock - [11..23)::12
+                                                CSharpExpressionLiteral - [11..23)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [23..24)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [24..27)::3 - [ />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly7.stree.txt
@@ -1,13 +1,35 @@
-Markup block - Gen<None> - 35 - (0:0,0)
-    Tag block - Gen<TagHelper> - 35 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"> ... </p>
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [15..31) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [15..31) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..35)::35 - [<p class="btn">words and spaces</p>]
+    MarkupBlock - [0..35)::35
+        MarkupTagHelperElement - [0..35)::35 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [15..31)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [31..35)::4
+                MarkupTextLiteral - [31..35)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly8.stree.txt
@@ -1,20 +1,44 @@
-Markup block - Gen<None> - 45 - (0:0,0)
-    Tag block - Gen<TagHelper> - 45 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="@DateTime.Now"> ... </p>
-        class - DoubleQuotes
-            Markup block - Gen<None> - 13 - (10:0,10)
-                Markup block - Gen<DynAttr:@(10:0,10)> - 13 - (10:0,10)
-                    Expression block - Gen<Expr> - 13 - (10:0,10)
-                        Transition span - Gen<None> - [@] - SpanEditHandler;Accepts:None - (10:0,10) - Tokens:1
-                            SyntaxKind.Transition;[@];
-                        Code span - Gen<Expr> - [DateTime.Now] - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14 - (11:0,11) - Tokens:3
-                            SyntaxKind.Identifier;[DateTime];
-                            SyntaxKind.Dot;[.];
-                            SyntaxKind.Identifier;[Now];
-        SyntaxKind.HtmlTextLiteral - [words and spaces] - [25..41) - FullWidth: 16 - Slots: 1
-            SyntaxKind.List - [words and spaces] - [25..41) - FullWidth: 16 - Slots: 5
-                SyntaxKind.Text;[words];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[and];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[spaces];
+RazorDocument - [0..45)::45 - [<p class="@DateTime.Now">words and spaces</p>]
+    MarkupBlock - [0..45)::45
+        MarkupTagHelperElement - [0..45)::45 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..25)::25
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..24)::22 - class - DoubleQuotes - [ class="@DateTime.Now"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..23)::13
+                        MarkupDynamicAttributeValue - [10..23)::13 - [@DateTime.Now]
+                            GenericBlock - [10..23)::13
+                                CSharpCodeBlock - [10..23)::13
+                                    CSharpImplicitExpression - [10..23)::13
+                                        CSharpTransition - [10..11)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                                            Transition;[@];
+                                        CSharpImplicitExpressionBody - [11..23)::12
+                                            CSharpCodeBlock - [11..23)::12
+                                                CSharpExpressionLiteral - [11..23)::12 - [DateTime.Now] - Gen<Expr> - ImplicitExpressionEditHandler;Accepts:NonWhitespace;ImplicitExpression[RTD];K14
+                                                    Identifier;[DateTime];
+                                                    Dot;[.];
+                                                    Identifier;[Now];
+                    MarkupTextLiteral - [23..24)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [24..25)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [25..41)::16 - [words and spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+                Whitespace;[ ];
+                Text;[and];
+                Whitespace;[ ];
+                Text;[spaces];
+            MarkupTagHelperEndTag - [41..45)::4
+                MarkupTextLiteral - [41..45)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly9.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly9.stree.txt
@@ -1,23 +1,46 @@
-Markup block - Gen<None> - 50 - (0:0,0)
-    Tag block - Gen<TagHelper> - 50 - (0:0,0) - p - pTagHelper
-        StartTagAndEndTag - <p class="btn"> ... </p>
-        class - DoubleQuotes
-            Markup span - Gen<Markup> - [btn] - SpanEditHandler;Accepts:Any - (10:0,10) - Tokens:1
-                SyntaxKind.Text;[btn];
-        SyntaxKind.HtmlTextLiteral - [words] - [15..20) - FullWidth: 5 - Slots: 1
-            SyntaxKind.Text;[words];
-        Tag block - Gen<None> - 8 - (20:0,20)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (20:0,20) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [and] - [28..31) - FullWidth: 3 - Slots: 1
-            SyntaxKind.Text;[and];
-        Tag block - Gen<None> - 9 - (31:0,31)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (31:0,31) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [spaces] - [40..46) - FullWidth: 6 - Slots: 1
-            SyntaxKind.Text;[spaces];
+RazorDocument - [0..50)::50 - [<p class="btn">words<strong>and</strong>spaces</p>]
+    MarkupBlock - [0..50)::50
+        MarkupTagHelperElement - [0..50)::50 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15
+                MarkupTextLiteral - [0..2)::2 - [<p] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - DoubleQuotes - [ class="btn"]
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [btn]
+                            MarkupTextLiteral - [10..13)::3 - [btn] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[btn];
+                    MarkupTextLiteral - [13..14)::1 - ["] - Gen<None> - SpanEditHandler;Accepts:Any
+                        DoubleQuote;["];
+                MarkupTextLiteral - [14..15)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [15..20)::5 - [words] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[words];
+            MarkupTagBlock - [20..28)::8 - [<strong>]
+                MarkupTextLiteral - [20..28)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [28..31)::3 - [and] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[and];
+            MarkupTagBlock - [31..40)::9 - [</strong>]
+                MarkupTextLiteral - [31..40)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [40..46)::6 - [spaces] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[spaces];
+            MarkupTagHelperEndTag - [46..50)::4
+                MarkupTextLiteral - [46..50)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RewritesNestedTagHelperTagBlocks1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RewritesNestedTagHelperTagBlocks1.stree.txt
@@ -1,5 +1,26 @@
-Markup block - Gen<None> - 18 - (0:0,0)
-    Tag block - Gen<TagHelper> - 18 - (0:0,0) - p - ptaghelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 11 - (3:0,3) - div - divtaghelper
-            StartTagAndEndTag - <div> ... </div>
+RazorDocument - [0..18)::18 - [<p><div></div></p>]
+    MarkupBlock - [0..18)::18
+        MarkupTagHelperElement - [0..18)::18 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..14)::11 - div[StartTagAndEndTag] - divtaghelper
+                MarkupTagHelperStartTag - [3..8)::5
+                    MarkupTextLiteral - [3..8)::5 - [<div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[div];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [8..14)::6
+                    MarkupTextLiteral - [8..14)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[div];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [14..18)::4
+                MarkupTextLiteral - [14..18)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RewritesNestedTagHelperTagBlocks2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RewritesNestedTagHelperTagBlocks2.stree.txt
@@ -1,11 +1,31 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Tag block - Gen<TagHelper> - 30 - (0:0,0) - p - ptaghelper
-        StartTagAndEndTag - <p> ... </p>
-        SyntaxKind.HtmlTextLiteral - [Hello World ] - [3..15) - FullWidth: 12 - Slots: 1
-            SyntaxKind.List - [Hello World ] - [3..15) - FullWidth: 12 - Slots: 4
-                SyntaxKind.Text;[Hello];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[World];
-                SyntaxKind.Whitespace;[ ];
-        Tag block - Gen<TagHelper> - 11 - (15:0,15) - div - divtaghelper
-            StartTagAndEndTag - <div> ... </div>
+RazorDocument - [0..30)::30 - [<p>Hello World <div></div></p>]
+    MarkupBlock - [0..30)::30
+        MarkupTagHelperElement - [0..30)::30 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [3..15)::12 - [Hello World ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Hello];
+                Whitespace;[ ];
+                Text;[World];
+                Whitespace;[ ];
+            MarkupTagHelperElement - [15..26)::11 - div[StartTagAndEndTag] - divtaghelper
+                MarkupTagHelperStartTag - [15..20)::5
+                    MarkupTextLiteral - [15..20)::5 - [<div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[div];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [20..26)::6
+                    MarkupTextLiteral - [20..26)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[div];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [26..30)::4
+                MarkupTextLiteral - [26..30)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RewritesNestedTagHelperTagBlocks3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RewritesNestedTagHelperTagBlocks3.stree.txt
@@ -1,17 +1,58 @@
-Markup block - Gen<None> - 43 - (0:0,0)
-    Tag block - Gen<TagHelper> - 19 - (0:0,0) - p - ptaghelper
-        StartTagAndEndTag - <p> ... </p>
-        SyntaxKind.HtmlTextLiteral - [Hel] - [3..6) - FullWidth: 3 - Slots: 1
-            SyntaxKind.Text;[Hel];
-        Tag block - Gen<TagHelper> - 9 - (6:0,6) - p - ptaghelper
-            StartTagAndEndTag - <p> ... </p>
-            SyntaxKind.HtmlTextLiteral - [lo] - [9..11) - FullWidth: 2 - Slots: 1
-                SyntaxKind.Text;[lo];
-    SyntaxKind.HtmlTextLiteral - [ ] - [19..20) - FullWidth: 1 - Slots: 1
-        SyntaxKind.Whitespace;[ ];
-    Tag block - Gen<TagHelper> - 23 - (20:0,20) - p - ptaghelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 16 - (23:0,23) - div - divtaghelper
-            StartTagAndEndTag - <div> ... </div>
-            SyntaxKind.HtmlTextLiteral - [World] - [28..33) - FullWidth: 5 - Slots: 1
-                SyntaxKind.Text;[World];
+RazorDocument - [0..43)::43 - [<p>Hel<p>lo</p></p> <p><div>World</div></p>]
+    MarkupBlock - [0..43)::43
+        MarkupTagHelperElement - [0..19)::19 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [3..6)::3 - [Hel] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Hel];
+            MarkupTagHelperElement - [6..15)::9 - p[StartTagAndEndTag] - ptaghelper
+                MarkupTagHelperStartTag - [6..9)::3
+                    MarkupTextLiteral - [6..9)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [9..11)::2 - [lo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[lo];
+                MarkupTagHelperEndTag - [11..15)::4
+                    MarkupTextLiteral - [11..15)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[p];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [15..19)::4
+                MarkupTextLiteral - [15..19)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+        MarkupTextLiteral - [19..20)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Whitespace;[ ];
+        MarkupTagHelperElement - [20..43)::23 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [20..23)::3
+                MarkupTextLiteral - [20..23)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [23..39)::16 - div[StartTagAndEndTag] - divtaghelper
+                MarkupTagHelperStartTag - [23..28)::5
+                    MarkupTextLiteral - [23..28)::5 - [<div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[div];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [28..33)::5 - [World] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[World];
+                MarkupTagHelperEndTag - [33..39)::6
+                    MarkupTextLiteral - [33..39)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[div];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [39..43)::4
+                MarkupTextLiteral - [39..43)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RewritesNestedTagHelperTagBlocks4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RewritesNestedTagHelperTagBlocks4.stree.txt
@@ -1,35 +1,56 @@
-Markup block - Gen<None> - 55 - (0:0,0)
-    Tag block - Gen<TagHelper> - 29 - (0:0,0) - p - ptaghelper
-        StartTagAndEndTag - <p> ... </p>
-        SyntaxKind.HtmlTextLiteral - [Hel] - [3..6) - FullWidth: 3 - Slots: 1
-            SyntaxKind.Text;[Hel];
-        Tag block - Gen<None> - 8 - (6:0,6)
-            Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [lo] - [14..16) - FullWidth: 2 - Slots: 1
-            SyntaxKind.Text;[lo];
-        Tag block - Gen<None> - 9 - (16:0,16)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
-    SyntaxKind.HtmlTextLiteral - [ ] - [29..30) - FullWidth: 1 - Slots: 1
-        SyntaxKind.Whitespace;[ ];
-    Tag block - Gen<TagHelper> - 25 - (30:0,30) - p - ptaghelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 6 - (33:0,33)
-            Markup span - Gen<Markup> - [<span>] - SpanEditHandler;Accepts:Any - (33:0,33) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[span];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [World] - [39..44) - FullWidth: 5 - Slots: 1
-            SyntaxKind.Text;[World];
-        Tag block - Gen<None> - 7 - (44:0,44)
-            Markup span - Gen<Markup> - [</span>] - SpanEditHandler;Accepts:Any - (44:0,44) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[span];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..55)::55 - [<p>Hel<strong>lo</strong></p> <p><span>World</span></p>]
+    MarkupBlock - [0..55)::55
+        MarkupTagHelperElement - [0..29)::29 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [3..6)::3 - [Hel] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Hel];
+            MarkupTagBlock - [6..14)::8 - [<strong>]
+                MarkupTextLiteral - [6..14)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [14..16)::2 - [lo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[lo];
+            MarkupTagBlock - [16..25)::9 - [</strong>]
+                MarkupTextLiteral - [16..25)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [25..29)::4
+                MarkupTextLiteral - [25..29)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+        MarkupTextLiteral - [29..30)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            Whitespace;[ ];
+        MarkupTagHelperElement - [30..55)::25 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [30..33)::3
+                MarkupTextLiteral - [30..33)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [33..39)::6 - [<span>]
+                MarkupTextLiteral - [33..39)::6 - [<span>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[span];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [39..44)::5 - [World] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[World];
+            MarkupTagBlock - [44..51)::7 - [</span>]
+                MarkupTextLiteral - [44..51)::7 - [</span>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[span];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [51..55)::4
+                MarkupTextLiteral - [51..55)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren1.stree.txt
@@ -1,5 +1,22 @@
-Markup block - Gen<None> - 13 - (0:0,0)
-    Tag block - Gen<TagHelper> - 13 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 6 - (3:0,3) - br - BRTagHelper
-            SelfClosing - <br />
+RazorDocument - [0..13)::13 - [<p><br /></p>]
+    MarkupBlock - [0..13)::13
+        MarkupTagHelperElement - [0..13)::13 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..9)::6 - br[SelfClosing] - BRTagHelper
+                MarkupTagHelperStartTag - [3..9)::6
+                    MarkupTextLiteral - [3..9)::6 - [<br />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [9..13)::4
+                MarkupTextLiteral - [9..13)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren10.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren10.stree.txt
@@ -1,31 +1,61 @@
-Markup block - Gen<None> - 69 - (0:0,0)
-    Tag block - Gen<TagHelper> - 69 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 47 - (3:0,3) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
-            SyntaxKind.HtmlTextLiteral - [Title:] - [11..17) - FullWidth: 6 - Slots: 1
-                SyntaxKind.Text;[Title:];
-            Tag block - Gen<TagHelper> - 4 - (17:0,17) - br - BRTagHelper
-                StartTagOnly - <br>
-            Tag block - Gen<None> - 4 - (21:0,21)
-                Markup span - Gen<Markup> - [<em>] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[em];
-                    SyntaxKind.CloseAngle;[>];
-            SyntaxKind.HtmlTextLiteral - [A Very Cool] - [25..36) - FullWidth: 11 - Slots: 1
-                SyntaxKind.List - [A Very Cool] - [25..36) - FullWidth: 11 - Slots: 5
-                    SyntaxKind.Text;[A];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[Very];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[Cool];
-            Tag block - Gen<None> - 5 - (36:0,36)
-                Markup span - Gen<Markup> - [</em>] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[em];
-                    SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 6 - (50:0,50) - br - BRTagHelper
-            SelfClosing - <br />
-        SyntaxKind.HtmlTextLiteral - [Something] - [56..65) - FullWidth: 9 - Slots: 1
-            SyntaxKind.Text;[Something];
+RazorDocument - [0..69)::69 - [<p><strong>Title:<br><em>A Very Cool</em></strong><br />Something</p>]
+    MarkupBlock - [0..69)::69
+        MarkupTagHelperElement - [0..69)::69 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..50)::47 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [11..17)::6 - [Title:] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[Title:];
+                MarkupTagHelperElement - [17..21)::4 - br[StartTagOnly] - BRTagHelper
+                    MarkupTagHelperStartTag - [17..21)::4
+                        MarkupTextLiteral - [17..21)::4 - [<br>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            OpenAngle;[<];
+                            Text;[br];
+                            CloseAngle;[>];
+                MarkupTagBlock - [21..25)::4 - [<em>]
+                    MarkupTextLiteral - [21..25)::4 - [<em>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[em];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [25..36)::11 - [A Very Cool] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[A];
+                    Whitespace;[ ];
+                    Text;[Very];
+                    Whitespace;[ ];
+                    Text;[Cool];
+                MarkupTagBlock - [36..41)::5 - [</em>]
+                    MarkupTextLiteral - [36..41)::5 - [</em>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[em];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [41..50)::9
+                    MarkupTextLiteral - [41..50)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperElement - [50..56)::6 - br[SelfClosing] - BRTagHelper
+                MarkupTagHelperStartTag - [50..56)::6
+                    MarkupTextLiteral - [50..56)::6 - [<br />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [56..65)::9 - [Something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Something];
+            MarkupTagHelperEndTag - [65..69)::4
+                MarkupTextLiteral - [65..69)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren11.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren11.stree.txt
@@ -1,40 +1,60 @@
-Markup block - Gen<None> - 69 - (0:0,0)
-    Tag block - Gen<TagHelper> - 69 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 8 - (3:0,3)
-            Markup span - Gen<Markup> - [<custom>] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[custom];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [Title:] - [11..17) - FullWidth: 6 - Slots: 1
-            SyntaxKind.Text;[Title:];
-        Tag block - Gen<TagHelper> - 4 - (17:0,17) - br - BRTagHelper
-            StartTagOnly - <br>
-        Tag block - Gen<None> - 4 - (21:0,21)
-            Markup span - Gen<Markup> - [<em>] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[em];
-                SyntaxKind.CloseAngle;[>];
-        SyntaxKind.HtmlTextLiteral - [A Very Cool] - [25..36) - FullWidth: 11 - Slots: 1
-            SyntaxKind.List - [A Very Cool] - [25..36) - FullWidth: 11 - Slots: 5
-                SyntaxKind.Text;[A];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[Very];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[Cool];
-        Tag block - Gen<None> - 5 - (36:0,36)
-            Markup span - Gen<Markup> - [</em>] - SpanEditHandler;Accepts:Any - (36:0,36) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[em];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (41:0,41)
-            Markup span - Gen<Markup> - [</custom>] - SpanEditHandler;Accepts:Any - (41:0,41) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[custom];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 6 - (50:0,50) - br - BRTagHelper
-            SelfClosing - <br />
-        SyntaxKind.HtmlTextLiteral - [Something] - [56..65) - FullWidth: 9 - Slots: 1
-            SyntaxKind.Text;[Something];
+RazorDocument - [0..69)::69 - [<p><custom>Title:<br><em>A Very Cool</em></custom><br />Something</p>]
+    MarkupBlock - [0..69)::69
+        MarkupTagHelperElement - [0..69)::69 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..11)::8 - [<custom>]
+                MarkupTextLiteral - [3..11)::8 - [<custom>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[custom];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [11..17)::6 - [Title:] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Title:];
+            MarkupTagHelperElement - [17..21)::4 - br[StartTagOnly] - BRTagHelper
+                MarkupTagHelperStartTag - [17..21)::4
+                    MarkupTextLiteral - [17..21)::4 - [<br>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        CloseAngle;[>];
+            MarkupTagBlock - [21..25)::4 - [<em>]
+                MarkupTextLiteral - [21..25)::4 - [<em>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[em];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [25..36)::11 - [A Very Cool] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[A];
+                Whitespace;[ ];
+                Text;[Very];
+                Whitespace;[ ];
+                Text;[Cool];
+            MarkupTagBlock - [36..41)::5 - [</em>]
+                MarkupTextLiteral - [36..41)::5 - [</em>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[em];
+                    CloseAngle;[>];
+            MarkupTagBlock - [41..50)::9 - [</custom>]
+                MarkupTextLiteral - [41..50)::9 - [</custom>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[custom];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [50..56)::6 - br[SelfClosing] - BRTagHelper
+                MarkupTagHelperStartTag - [50..56)::6
+                    MarkupTextLiteral - [50..56)::6 - [<br />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [56..65)::9 - [Something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Something];
+            MarkupTagHelperEndTag - [65..69)::4
+                MarkupTextLiteral - [65..69)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren12.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren12.stree.txt
@@ -1,7 +1,18 @@
-Markup block - Gen<None> - 9 - (0:0,0)
-    Tag block - Gen<TagHelper> - 9 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 2 - (3:0,3)
-            Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
+RazorDocument - [0..9)::9 - [<p></</p>]
+    MarkupBlock - [0..9)::9
+        MarkupTagHelperElement - [0..9)::9 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..5)::2 - [</]
+                MarkupTextLiteral - [3..5)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+            MarkupTagHelperEndTag - [5..9)::4
+                MarkupTextLiteral - [5..9)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren13.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren13.stree.txt
@@ -1,6 +1,17 @@
-Markup block - Gen<None> - 8 - (0:0,0)
-    Tag block - Gen<TagHelper> - 8 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 1 - (3:0,3)
-            Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:1
-                SyntaxKind.OpenAngle;[<];
+RazorDocument - [0..8)::8 - [<p><</p>]
+    MarkupBlock - [0..8)::8
+        MarkupTagHelperElement - [0..8)::8 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..4)::1 - [<]
+                MarkupTextLiteral - [3..4)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+            MarkupTagHelperEndTag - [4..8)::4
+                MarkupTextLiteral - [4..8)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren14.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren14.stree.txt
@@ -1,31 +1,66 @@
-Markup block - Gen<None> - 76 - (0:0,0)
-    Tag block - Gen<TagHelper> - 76 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 8 - (3:0,3)
-            Markup span - Gen<Markup> - [<custom>] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[custom];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 4 - (11:0,11) - br - BRTagHelper
-            StartTagOnly - <br>
-        SyntaxKind.HtmlTextLiteral - [:] - [15..16) - FullWidth: 1 - Slots: 1
-            SyntaxKind.Text;[:];
-        Tag block - Gen<TagHelper> - 39 - (16:0,16) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
-            Tag block - Gen<TagHelper> - 22 - (24:0,24) - strong - StrongTagHelper
-                StartTagAndEndTag - <strong> ... </strong>
-                SyntaxKind.HtmlTextLiteral - [Hello] - [32..37) - FullWidth: 5 - Slots: 1
-                    SyntaxKind.Text;[Hello];
-        SyntaxKind.HtmlTextLiteral - [:] - [55..56) - FullWidth: 1 - Slots: 1
-            SyntaxKind.Text;[:];
-        Tag block - Gen<None> - 7 - (56:0,56)
-            Markup span - Gen<Markup> - [<input>] - SpanEditHandler;Accepts:Any - (56:0,56) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[input];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (63:0,63)
-            Markup span - Gen<Markup> - [</custom>] - SpanEditHandler;Accepts:Any - (63:0,63) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[custom];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..76)::76 - [<p><custom><br>:<strong><strong>Hello</strong></strong>:<input></custom></p>]
+    MarkupBlock - [0..76)::76
+        MarkupTagHelperElement - [0..76)::76 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..11)::8 - [<custom>]
+                MarkupTextLiteral - [3..11)::8 - [<custom>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[custom];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [11..15)::4 - br[StartTagOnly] - BRTagHelper
+                MarkupTagHelperStartTag - [11..15)::4
+                    MarkupTextLiteral - [11..15)::4 - [<br>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [15..16)::1 - [:] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[:];
+            MarkupTagHelperElement - [16..55)::39 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [16..24)::8
+                    MarkupTextLiteral - [16..24)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperElement - [24..46)::22 - strong[StartTagAndEndTag] - StrongTagHelper
+                    MarkupTagHelperStartTag - [24..32)::8
+                        MarkupTextLiteral - [24..32)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            OpenAngle;[<];
+                            Text;[strong];
+                            CloseAngle;[>];
+                    MarkupTextLiteral - [32..37)::5 - [Hello] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[Hello];
+                    MarkupTagHelperEndTag - [37..46)::9
+                        MarkupTextLiteral - [37..46)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            OpenAngle;[<];
+                            ForwardSlash;[/];
+                            Text;[strong];
+                            CloseAngle;[>];
+                MarkupTagHelperEndTag - [46..55)::9
+                    MarkupTextLiteral - [46..55)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [55..56)::1 - [:] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[:];
+            MarkupTagBlock - [56..63)::7 - [<input>]
+                MarkupTextLiteral - [56..63)::7 - [<input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[input];
+                    CloseAngle;[>];
+            MarkupTagBlock - [63..72)::9 - [</custom>]
+                MarkupTextLiteral - [63..72)::9 - [</custom>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[custom];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [72..76)::4
+                MarkupTextLiteral - [72..76)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren2.stree.txt
@@ -1,9 +1,26 @@
-Markup block - Gen<None> - 17 - (0:0,0)
-    Tag block - Gen<TagHelper> - 17 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        SyntaxKind.HtmlTextLiteral - [LF] - [3..5) - FullWidth: 2 - Slots: 1
-            SyntaxKind.NewLine;[LF];
-        Tag block - Gen<TagHelper> - 6 - (5:1,0) - br - BRTagHelper
-            SelfClosing - <br />
-        SyntaxKind.HtmlTextLiteral - [LF] - [11..13) - FullWidth: 2 - Slots: 1
-            SyntaxKind.NewLine;[LF];
+RazorDocument - [0..17)::17 - [<p>LF<br />LF</p>]
+    MarkupBlock - [0..17)::17
+        MarkupTagHelperElement - [0..17)::17 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [3..5)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            MarkupTagHelperElement - [5..11)::6 - br[SelfClosing] - BRTagHelper
+                MarkupTagHelperStartTag - [5..11)::6
+                    MarkupTextLiteral - [5..11)::6 - [<br />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [11..13)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                NewLine;[LF];
+            MarkupTagHelperEndTag - [13..17)::4
+                MarkupTextLiteral - [13..17)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren3.stree.txt
@@ -1,5 +1,20 @@
-Markup block - Gen<None> - 11 - (0:0,0)
-    Tag block - Gen<TagHelper> - 11 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 4 - (3:0,3) - br - BRTagHelper
-            StartTagOnly - <br>
+RazorDocument - [0..11)::11 - [<p><br></p>]
+    MarkupBlock - [0..11)::11
+        MarkupTagHelperElement - [0..11)::11 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..7)::4 - br[StartTagOnly] - BRTagHelper
+                MarkupTagHelperStartTag - [3..7)::4
+                    MarkupTextLiteral - [3..7)::4 - [<br>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [7..11)::4
+                MarkupTextLiteral - [7..11)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren4.stree.txt
@@ -1,5 +1,16 @@
-Markup block - Gen<None> - 12 - (0:0,0)
-    Tag block - Gen<TagHelper> - 12 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        SyntaxKind.HtmlTextLiteral - [Hello] - [3..8) - FullWidth: 5 - Slots: 1
-            SyntaxKind.Text;[Hello];
+RazorDocument - [0..12)::12 - [<p>Hello</p>]
+    MarkupBlock - [0..12)::12
+        MarkupTagHelperElement - [0..12)::12 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [3..8)::5 - [Hello] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Hello];
+            MarkupTagHelperEndTag - [8..12)::4
+                MarkupTextLiteral - [8..12)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren5.stree.txt
@@ -1,10 +1,21 @@
-Markup block - Gen<None> - 13 - (0:0,0)
-    Tag block - Gen<TagHelper> - 13 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 6 - (3:0,3)
-            Markup span - Gen<Markup> - [<hr />] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:5
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[hr];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..13)::13 - [<p><hr /></p>]
+    MarkupBlock - [0..13)::13
+        MarkupTagHelperElement - [0..13)::13 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..9)::6 - [<hr />]
+                MarkupTextLiteral - [3..9)::6 - [<hr />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[hr];
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [9..13)::4
+                MarkupTextLiteral - [9..13)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren6.stree.txt
@@ -1,7 +1,22 @@
-Markup block - Gen<None> - 16 - (0:0,0)
-    Tag block - Gen<TagHelper> - 16 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 4 - (3:0,3) - br - BRTagHelper
-            StartTagOnly - <br>
-        SyntaxKind.HtmlTextLiteral - [Hello] - [7..12) - FullWidth: 5 - Slots: 1
-            SyntaxKind.Text;[Hello];
+RazorDocument - [0..16)::16 - [<p><br>Hello</p>]
+    MarkupBlock - [0..16)::16
+        MarkupTagHelperElement - [0..16)::16 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..7)::4 - br[StartTagOnly] - BRTagHelper
+                MarkupTagHelperStartTag - [3..7)::4
+                    MarkupTextLiteral - [3..7)::4 - [<br>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [7..12)::5 - [Hello] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Hello];
+            MarkupTagHelperEndTag - [12..16)::4
+                MarkupTextLiteral - [12..16)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren7.stree.txt
@@ -1,11 +1,38 @@
-Markup block - Gen<None> - 45 - (0:0,0)
-    Tag block - Gen<TagHelper> - 45 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 23 - (3:0,3) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
-            SyntaxKind.HtmlTextLiteral - [Title:] - [11..17) - FullWidth: 6 - Slots: 1
-                SyntaxKind.Text;[Title:];
-        Tag block - Gen<TagHelper> - 6 - (26:0,26) - br - BRTagHelper
-            SelfClosing - <br />
-        SyntaxKind.HtmlTextLiteral - [Something] - [32..41) - FullWidth: 9 - Slots: 1
-            SyntaxKind.Text;[Something];
+RazorDocument - [0..45)::45 - [<p><strong>Title:</strong><br />Something</p>]
+    MarkupBlock - [0..45)::45
+        MarkupTagHelperElement - [0..45)::45 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..26)::23 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [11..17)::6 - [Title:] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[Title:];
+                MarkupTagHelperEndTag - [17..26)::9
+                    MarkupTextLiteral - [17..26)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperElement - [26..32)::6 - br[SelfClosing] - BRTagHelper
+                MarkupTagHelperStartTag - [26..32)::6
+                    MarkupTextLiteral - [26..32)::6 - [<br />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [32..41)::9 - [Something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Something];
+            MarkupTagHelperEndTag - [41..45)::4
+                MarkupTextLiteral - [41..45)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren8.stree.txt
@@ -1,11 +1,38 @@
-Markup block - Gen<None> - 45 - (0:0,0)
-    Tag block - Gen<TagHelper> - 45 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 23 - (3:0,3) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
-            SyntaxKind.HtmlTextLiteral - [Title:] - [11..17) - FullWidth: 6 - Slots: 1
-                SyntaxKind.Text;[Title:];
-        Tag block - Gen<TagHelper> - 6 - (26:0,26) - br - BRTagHelper
-            SelfClosing - <br />
-        SyntaxKind.HtmlTextLiteral - [Something] - [32..41) - FullWidth: 9 - Slots: 1
-            SyntaxKind.Text;[Something];
+RazorDocument - [0..45)::45 - [<p><strong>Title:</strong><br />Something</p>]
+    MarkupBlock - [0..45)::45
+        MarkupTagHelperElement - [0..45)::45 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..26)::23 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [11..17)::6 - [Title:] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[Title:];
+                MarkupTagHelperEndTag - [17..26)::9
+                    MarkupTextLiteral - [17..26)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperElement - [26..32)::6 - br[SelfClosing] - BRTagHelper
+                MarkupTagHelperStartTag - [26..32)::6
+                    MarkupTextLiteral - [26..32)::6 - [<br />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [32..41)::9 - [Something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[Something];
+            MarkupTagHelperEndTag - [41..45)::4
+                MarkupTextLiteral - [41..45)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren9.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsAllowedChildren9.stree.txt
@@ -1,17 +1,43 @@
-Markup block - Gen<None> - 51 - (0:0,0)
-    Tag block - Gen<TagHelper> - 51 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        SyntaxKind.HtmlTextLiteral - [  ] - [3..5) - FullWidth: 2 - Slots: 1
-            SyntaxKind.Whitespace;[  ];
-        Tag block - Gen<TagHelper> - 23 - (5:0,5) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
-            SyntaxKind.HtmlTextLiteral - [Title:] - [13..19) - FullWidth: 6 - Slots: 1
-                SyntaxKind.Text;[Title:];
-        SyntaxKind.HtmlTextLiteral - [  ] - [28..30) - FullWidth: 2 - Slots: 1
-            SyntaxKind.Whitespace;[  ];
-        Tag block - Gen<TagHelper> - 6 - (30:0,30) - br - BRTagHelper
-            SelfClosing - <br />
-        SyntaxKind.HtmlTextLiteral - [  Something] - [36..47) - FullWidth: 11 - Slots: 1
-            SyntaxKind.List - [  Something] - [36..47) - FullWidth: 11 - Slots: 2
-                SyntaxKind.Whitespace;[  ];
-                SyntaxKind.Text;[Something];
+RazorDocument - [0..51)::51 - [<p>  <strong>Title:</strong>  <br />  Something</p>]
+    MarkupBlock - [0..51)::51
+        MarkupTagHelperElement - [0..51)::51 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [3..5)::2 - [  ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[  ];
+            MarkupTagHelperElement - [5..28)::23 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [5..13)::8
+                    MarkupTextLiteral - [5..13)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [13..19)::6 - [Title:] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[Title:];
+                MarkupTagHelperEndTag - [19..28)::9
+                    MarkupTextLiteral - [19..28)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [28..30)::2 - [  ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[  ];
+            MarkupTagHelperElement - [30..36)::6 - br[SelfClosing] - BRTagHelper
+                MarkupTagHelperStartTag - [30..36)::6
+                    MarkupTextLiteral - [30..36)::6 - [<br />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTextLiteral - [36..47)::11 - [  Something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Whitespace;[  ];
+                Text;[Something];
+            MarkupTagHelperEndTag - [47..51)::4
+                MarkupTextLiteral - [47..51)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent1.stree.txt
@@ -1,12 +1,13 @@
-Markup block - Gen<None> - 17 - (0:0,0)
-    Tag block - Gen<None> - 8 - (0:0,0)
-        Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (8:0,8)
-        Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..17)::17 - [<strong></strong>]
+    MarkupBlock - [0..17)::17
+        MarkupTagBlock - [0..8)::8 - [<strong>]
+            MarkupTextLiteral - [0..8)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[strong];
+                CloseAngle;[>];
+        MarkupTagBlock - [8..17)::9 - [</strong>]
+            MarkupTextLiteral - [8..17)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[strong];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent2.stree.txt
@@ -1,5 +1,26 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<TagHelper> - 24 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 17 - (3:0,3) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
+RazorDocument - [0..24)::24 - [<p><strong></strong></p>]
+    MarkupBlock - [0..24)::24
+        MarkupTagHelperElement - [0..24)::24 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..20)::17 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [11..20)::9
+                    MarkupTextLiteral - [11..20)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [20..24)::4
+                MarkupTextLiteral - [20..24)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent3.stree.txt
@@ -1,14 +1,25 @@
-Markup block - Gen<None> - 28 - (0:0,0)
-    Tag block - Gen<None> - 5 - (0:0,0)
-        Markup span - Gen<Markup> - [<div>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<TagHelper> - 17 - (5:0,5) - strong - StrongTagHelper
-        StartTagAndEndTag - <strong> ... </strong>
-    Tag block - Gen<None> - 6 - (22:0,22)
-        Markup span - Gen<Markup> - [</div>] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[div];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..28)::28 - [<div><strong></strong></div>]
+    MarkupBlock - [0..28)::28
+        MarkupTagBlock - [0..5)::5 - [<div>]
+            MarkupTextLiteral - [0..5)::5 - [<div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[div];
+                CloseAngle;[>];
+        MarkupTagHelperElement - [5..22)::17 - strong[StartTagAndEndTag] - StrongTagHelper
+            MarkupTagHelperStartTag - [5..13)::8
+                MarkupTextLiteral - [5..13)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [13..22)::9
+                MarkupTextLiteral - [13..22)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+        MarkupTagBlock - [22..28)::6 - [</div>]
+            MarkupTextLiteral - [22..28)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[div];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent4.stree.txt
@@ -1,23 +1,24 @@
-Markup block - Gen<None> - 34 - (0:0,0)
-    Tag block - Gen<None> - 8 - (0:0,0)
-        Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 8 - (8:0,8)
-        Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (8:0,8) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (16:0,16)
-        Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (16:0,16) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (25:0,25)
-        Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..34)::34 - [<strong><strong></strong></strong>]
+    MarkupBlock - [0..34)::34
+        MarkupTagBlock - [0..8)::8 - [<strong>]
+            MarkupTextLiteral - [0..8)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[strong];
+                CloseAngle;[>];
+        MarkupTagBlock - [8..16)::8 - [<strong>]
+            MarkupTextLiteral - [8..16)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[strong];
+                CloseAngle;[>];
+        MarkupTagBlock - [16..25)::9 - [</strong>]
+            MarkupTextLiteral - [16..25)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[strong];
+                CloseAngle;[>];
+        MarkupTagBlock - [25..34)::9 - [</strong>]
+            MarkupTextLiteral - [25..34)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[strong];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedRequiredParent5.stree.txt
@@ -1,16 +1,37 @@
-Markup block - Gen<None> - 41 - (0:0,0)
-    Tag block - Gen<TagHelper> - 41 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 34 - (3:0,3) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
-            Tag block - Gen<None> - 8 - (11:0,11)
-                Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (11:0,11) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
-            Tag block - Gen<None> - 9 - (19:0,19)
-                Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (19:0,19) - Tokens:4
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[strong];
-                    SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..41)::41 - [<p><strong><strong></strong></strong></p>]
+    MarkupBlock - [0..41)::41
+        MarkupTagHelperElement - [0..41)::41 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..37)::34 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagBlock - [11..19)::8 - [<strong>]
+                    MarkupTextLiteral - [11..19)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagBlock - [19..28)::9 - [</strong>]
+                    MarkupTextLiteral - [19..28)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [28..37)::9
+                    MarkupTextLiteral - [28..37)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [37..41)::4
+                MarkupTextLiteral - [37..41)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent1.stree.txt
@@ -1,14 +1,19 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<TagHelper> - 7 - (0:0,0) - input - InputTagHelper
-        StartTagOnly - <input>
-    Tag block - Gen<None> - 8 - (7:0,7)
-        Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (15:0,15)
-        Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..24)::24 - [<input><strong></strong>]
+    MarkupBlock - [0..24)::24
+        MarkupTagHelperElement - [0..7)::7 - input[StartTagOnly] - InputTagHelper
+            MarkupTagHelperStartTag - [0..7)::7
+                MarkupTextLiteral - [0..7)::7 - [<input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[input];
+                    CloseAngle;[>];
+        MarkupTagBlock - [7..15)::8 - [<strong>]
+            MarkupTextLiteral - [7..15)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[strong];
+                CloseAngle;[>];
+        MarkupTagBlock - [15..24)::9 - [</strong>]
+            MarkupTextLiteral - [15..24)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[strong];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent2.stree.txt
@@ -1,7 +1,32 @@
-Markup block - Gen<None> - 31 - (0:0,0)
-    Tag block - Gen<TagHelper> - 31 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 7 - (3:0,3) - input - InputTagHelper
-            StartTagOnly - <input>
-        Tag block - Gen<TagHelper> - 17 - (10:0,10) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
+RazorDocument - [0..31)::31 - [<p><input><strong></strong></p>]
+    MarkupBlock - [0..31)::31
+        MarkupTagHelperElement - [0..31)::31 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..10)::7 - input[StartTagOnly] - InputTagHelper
+                MarkupTagHelperStartTag - [3..10)::7
+                    MarkupTextLiteral - [3..10)::7 - [<input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[input];
+                        CloseAngle;[>];
+            MarkupTagHelperElement - [10..27)::17 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [10..18)::8
+                    MarkupTextLiteral - [10..18)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [18..27)::9
+                    MarkupTextLiteral - [18..27)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [27..31)::4
+                MarkupTextLiteral - [27..31)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent3.stree.txt
@@ -1,10 +1,31 @@
-Markup block - Gen<None> - 28 - (0:0,0)
-    Tag block - Gen<TagHelper> - 28 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 4 - (3:0,3)
-            Markup span - Gen<Markup> - [<br>] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:3
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[br];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 17 - (7:0,7) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
+RazorDocument - [0..28)::28 - [<p><br><strong></strong></p>]
+    MarkupBlock - [0..28)::28
+        MarkupTagHelperElement - [0..28)::28 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..7)::4 - [<br>]
+                MarkupTextLiteral - [3..7)::4 - [<br>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[br];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [7..24)::17 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [7..15)::8
+                    MarkupTextLiteral - [7..15)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [15..24)::9
+                    MarkupTextLiteral - [15..24)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [24..28)::4
+                MarkupTextLiteral - [24..28)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent4.stree.txt
@@ -1,12 +1,43 @@
-Markup block - Gen<None> - 35 - (0:0,0)
-    Tag block - Gen<TagHelper> - 35 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 11 - (3:0,3) - p - PTagHelper
-            StartTagAndEndTag - <p> ... </p>
-            Tag block - Gen<None> - 4 - (6:0,6)
-                Markup span - Gen<Markup> - [<br>] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:3
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[br];
-                    SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 17 - (14:0,14) - strong - StrongTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
+RazorDocument - [0..35)::35 - [<p><p><br></p><strong></strong></p>]
+    MarkupBlock - [0..35)::35
+        MarkupTagHelperElement - [0..35)::35 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..14)::11 - p[StartTagAndEndTag] - PTagHelper
+                MarkupTagHelperStartTag - [3..6)::3
+                    MarkupTextLiteral - [3..6)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTagBlock - [6..10)::4 - [<br>]
+                    MarkupTextLiteral - [6..10)::4 - [<br>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [10..14)::4
+                    MarkupTextLiteral - [10..14)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[p];
+                        CloseAngle;[>];
+            MarkupTagHelperElement - [14..31)::17 - strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [14..22)::8
+                    MarkupTextLiteral - [14..22)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [22..31)::9
+                    MarkupTextLiteral - [22..31)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [31..35)::4
+                MarkupTextLiteral - [31..35)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent5.stree.txt
@@ -1,14 +1,19 @@
-Markup block - Gen<None> - 24 - (0:0,0)
-    Tag block - Gen<TagHelper> - 7 - (0:0,0) - input - InputTagHelper
-        StartTagOnly - <input>
-    Tag block - Gen<None> - 8 - (7:0,7)
-        Markup span - Gen<Markup> - [<strong>] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:3
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (15:0,15)
-        Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[strong];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..24)::24 - [<input><strong></strong>]
+    MarkupBlock - [0..24)::24
+        MarkupTagHelperElement - [0..7)::7 - input[StartTagOnly] - InputTagHelper
+            MarkupTagHelperStartTag - [0..7)::7
+                MarkupTextLiteral - [0..7)::7 - [<input>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[input];
+                    CloseAngle;[>];
+        MarkupTagBlock - [7..15)::8 - [<strong>]
+            MarkupTextLiteral - [7..15)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[strong];
+                CloseAngle;[>];
+        MarkupTagBlock - [15..24)::9 - [</strong>]
+            MarkupTextLiteral - [15..24)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[strong];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent6.stree.txt
@@ -1,7 +1,30 @@
-Markup block - Gen<None> - 26 - (0:0,0)
-    Tag block - Gen<TagHelper> - 26 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 9 - (3:0,3) - input - InputTagHelper
-            SelfClosing - <input />
-        Tag block - Gen<TagHelper> - 10 - (12:0,12) - strong - StrongTagHelper
-            SelfClosing - <strong />
+RazorDocument - [0..26)::26 - [<p><input /><strong /></p>]
+    MarkupBlock - [0..26)::26
+        MarkupTagHelperElement - [0..26)::26 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..12)::9 - input[SelfClosing] - InputTagHelper
+                MarkupTagHelperStartTag - [3..12)::9
+                    MarkupTextLiteral - [3..12)::9 - [<input />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[input];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTagHelperElement - [12..22)::10 - strong[SelfClosing] - StrongTagHelper
+                MarkupTagHelperStartTag - [12..22)::10
+                    MarkupTextLiteral - [12..22)::10 - [<strong />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [22..26)::4
+                MarkupTextLiteral - [22..26)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent7.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent7.stree.txt
@@ -1,12 +1,29 @@
-Markup block - Gen<None> - 23 - (0:0,0)
-    Tag block - Gen<TagHelper> - 23 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 6 - (3:0,3)
-            Markup span - Gen<Markup> - [<br />] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:5
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[br];
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 10 - (9:0,9) - strong - StrongTagHelper
-            SelfClosing - <strong />
+RazorDocument - [0..23)::23 - [<p><br /><strong /></p>]
+    MarkupBlock - [0..23)::23
+        MarkupTagHelperElement - [0..23)::23 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..9)::6 - [<br />]
+                MarkupTextLiteral - [3..9)::6 - [<br />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[br];
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [9..19)::10 - strong[SelfClosing] - StrongTagHelper
+                MarkupTagHelperStartTag - [9..19)::10
+                    MarkupTextLiteral - [9..19)::10 - [<strong />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [19..23)::4
+                MarkupTextLiteral - [19..23)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent8.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNestedVoidSelfClosingRequiredParent8.stree.txt
@@ -1,14 +1,41 @@
-Markup block - Gen<None> - 30 - (0:0,0)
-    Tag block - Gen<TagHelper> - 30 - (0:0,0) - p - PTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 13 - (3:0,3) - p - PTagHelper
-            StartTagAndEndTag - <p> ... </p>
-            Tag block - Gen<None> - 6 - (6:0,6)
-                Markup span - Gen<Markup> - [<br />] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:5
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.Text;[br];
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 10 - (16:0,16) - strong - StrongTagHelper
-            SelfClosing - <strong />
+RazorDocument - [0..30)::30 - [<p><p><br /></p><strong /></p>]
+    MarkupBlock - [0..30)::30
+        MarkupTagHelperElement - [0..30)::30 - p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..16)::13 - p[StartTagAndEndTag] - PTagHelper
+                MarkupTagHelperStartTag - [3..6)::3
+                    MarkupTextLiteral - [3..6)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[p];
+                        CloseAngle;[>];
+                MarkupTagBlock - [6..12)::6 - [<br />]
+                    MarkupTextLiteral - [6..12)::6 - [<br />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[br];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [12..16)::4
+                    MarkupTextLiteral - [12..16)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[p];
+                        CloseAngle;[>];
+            MarkupTagHelperElement - [16..26)::10 - strong[SelfClosing] - StrongTagHelper
+                MarkupTagHelperStartTag - [16..26)::10
+                    MarkupTextLiteral - [16..26)::10 - [<strong />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [26..30)::4
+                MarkupTextLiteral - [26..30)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNullTagNameWithAllowedChildrenForCatchAll.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNullTagNameWithAllowedChildrenForCatchAll.stree.txt
@@ -1,7 +1,18 @@
-Markup block - Gen<None> - 9 - (0:0,0)
-    Tag block - Gen<TagHelper> - 9 - (0:0,0) - p - PTagHelper - CatchAllTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 2 - (3:0,3)
-            Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (3:0,3) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
+RazorDocument - [0..9)::9 - [<p></</p>]
+    MarkupBlock - [0..9)::9
+        MarkupTagHelperElement - [0..9)::9 - p[StartTagAndEndTag] - PTagHelper - CatchAllTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [3..5)::2 - [</]
+                MarkupTextLiteral - [3..5)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+            MarkupTagHelperEndTag - [5..9)::4
+                MarkupTextLiteral - [5..9)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNullTagNameWithAllowedChildrenForCatchAllWithPrefix.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsNullTagNameWithAllowedChildrenForCatchAllWithPrefix.stree.txt
@@ -1,7 +1,18 @@
-Markup block - Gen<None> - 15 - (0:0,0)
-    Tag block - Gen<TagHelper> - 15 - (0:0,0) - th:p - PTagHelper - CatchAllTagHelper
-        StartTagAndEndTag - <th:p> ... </th:p>
-        Tag block - Gen<None> - 2 - (6:0,6)
-            Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (6:0,6) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
+RazorDocument - [0..15)::15 - [<th:p></</th:p>]
+    MarkupBlock - [0..15)::15
+        MarkupTagHelperElement - [0..15)::15 - th:p[StartTagAndEndTag] - PTagHelper - CatchAllTagHelper
+            MarkupTagHelperStartTag - [0..6)::6
+                MarkupTextLiteral - [0..6)::6 - [<th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [6..8)::2 - [</]
+                MarkupTextLiteral - [6..8)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+            MarkupTagHelperEndTag - [8..15)::7
+                MarkupTextLiteral - [8..15)::7 - [</th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags1.stree.txt
@@ -1,5 +1,14 @@
-Markup block - Gen<None> - 11 - (0:0,0)
-    Tag block - Gen<TagHelper> - 11 - (0:0,0) - p - PTagHelper - CatchALlTagHelper
-        StartTagAndEndTag - <p>
-        Tag block - Gen<TagHelper> - 8 - (3:0,3) - strong - StrongTagHelper - CatchALlTagHelper
-            StartTagAndEndTag - <strong>
+RazorDocument - [0..11)::11 - [<p><strong>]
+    MarkupBlock - [0..11)::11
+        MarkupTagHelperElement - [0..11)::11 - p[StartTagAndEndTag] - PTagHelper - CatchALlTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..11)::8 - strong[StartTagAndEndTag] - StrongTagHelper - CatchALlTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags2.stree.txt
@@ -1,5 +1,20 @@
-Markup block - Gen<None> - 20 - (0:0,0)
-    Tag block - Gen<TagHelper> - 20 - (0:0,0) - p - PTagHelper - CatchALlTagHelper
-        StartTagAndEndTag - <p>
-        Tag block - Gen<TagHelper> - 17 - (3:0,3) - strong - StrongTagHelper - CatchALlTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
+RazorDocument - [0..20)::20 - [<p><strong></strong>]
+    MarkupBlock - [0..20)::20
+        MarkupTagHelperElement - [0..20)::20 - p[StartTagAndEndTag] - PTagHelper - CatchALlTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..20)::17 - strong[StartTagAndEndTag] - StrongTagHelper - CatchALlTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [11..20)::9
+                    MarkupTextLiteral - [11..20)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags3.stree.txt
@@ -1,7 +1,26 @@
-Markup block - Gen<None> - 23 - (0:0,0)
-    Tag block - Gen<TagHelper> - 15 - (0:0,0) - p - PTagHelper - CatchALlTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<TagHelper> - 8 - (3:0,3) - strong - StrongTagHelper - CatchALlTagHelper
-            StartTagAndEndTag - <strong>
-    Tag block - Gen<TagHelper> - 8 - (15:0,15) - strong - StrongTagHelper - CatchALlTagHelper
-        StartTagAndEndTag - <strong>
+RazorDocument - [0..23)::23 - [<p><strong></p><strong>]
+    MarkupBlock - [0..23)::23
+        MarkupTagHelperElement - [0..15)::15 - p[StartTagAndEndTag] - PTagHelper - CatchALlTagHelper
+            MarkupTagHelperStartTag - [0..3)::3
+                MarkupTextLiteral - [0..3)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [3..11)::8 - strong[StartTagAndEndTag] - StrongTagHelper - CatchALlTagHelper
+                MarkupTagHelperStartTag - [3..11)::8
+                    MarkupTextLiteral - [3..11)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [11..15)::4
+                MarkupTextLiteral - [11..15)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+        MarkupTagHelperElement - [15..23)::8 - strong[StartTagAndEndTag] - StrongTagHelper - CatchALlTagHelper
+            MarkupTagHelperStartTag - [15..23)::8
+                MarkupTextLiteral - [15..23)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[strong];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags4.stree.txt
@@ -1,21 +1,41 @@
-Markup block - Gen<None> - 36 - (0:0,0)
-    Tag block - Gen<None> - 1 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-    Tag block - Gen<TagHelper> - 35 - (1:0,1) - p - PTagHelper - CatchALlTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 1 - (4:0,4)
-            Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                SyntaxKind.OpenAngle;[<];
-        Tag block - Gen<TagHelper> - 18 - (5:0,5) - strong - StrongTagHelper - CatchALlTagHelper
-            StartTagAndEndTag - <strong> ... </strong
-            Tag block - Gen<None> - 2 - (13:0,13)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-        Tag block - Gen<None> - 9 - (23:0,23)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..36)::36 - [<<p><<strong></</strong</strong></p>]
+    MarkupBlock - [0..36)::36
+        MarkupTagBlock - [0..1)::1 - [<]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+        MarkupTagHelperElement - [1..36)::35 - p[StartTagAndEndTag] - PTagHelper - CatchALlTagHelper
+            MarkupTagHelperStartTag - [1..4)::3
+                MarkupTextLiteral - [1..4)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [4..5)::1 - [<]
+                MarkupTextLiteral - [4..5)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+            MarkupTagHelperElement - [5..23)::18 - strong[StartTagAndEndTag] - StrongTagHelper - CatchALlTagHelper
+                MarkupTagHelperStartTag - [5..13)::8
+                    MarkupTextLiteral - [5..13)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagBlock - [13..15)::2 - [</]
+                    MarkupTextLiteral - [13..15)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                MarkupTagHelperEndTag - [15..23)::8
+                    MarkupTextLiteral - [15..23)::8 - [</strong] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+            MarkupTagBlock - [23..32)::9 - [</strong>]
+                MarkupTextLiteral - [23..32)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [32..36)::4
+                MarkupTextLiteral - [32..36)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags5.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags5.stree.txt
@@ -1,21 +1,42 @@
-Markup block - Gen<None> - 37 - (0:0,0)
-    Tag block - Gen<None> - 1 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-    Tag block - Gen<TagHelper> - 36 - (1:0,1) - p - PTagHelper - CatchALlTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 1 - (4:0,4)
-            Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                SyntaxKind.OpenAngle;[<];
-        Tag block - Gen<TagHelper> - 19 - (5:0,5) - strong - StrongTagHelper - CatchALlTagHelper
-            StartTagAndEndTag - <strong> ... </strong>
-            Tag block - Gen<None> - 2 - (13:0,13)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-        Tag block - Gen<None> - 9 - (24:0,24)
-            Markup span - Gen<Markup> - [</strong>] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[strong];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..37)::37 - [<<p><<strong></</strong></strong></p>]
+    MarkupBlock - [0..37)::37
+        MarkupTagBlock - [0..1)::1 - [<]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+        MarkupTagHelperElement - [1..37)::36 - p[StartTagAndEndTag] - PTagHelper - CatchALlTagHelper
+            MarkupTagHelperStartTag - [1..4)::3
+                MarkupTextLiteral - [1..4)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [4..5)::1 - [<]
+                MarkupTextLiteral - [4..5)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+            MarkupTagHelperElement - [5..24)::19 - strong[StartTagAndEndTag] - StrongTagHelper - CatchALlTagHelper
+                MarkupTagHelperStartTag - [5..13)::8
+                    MarkupTextLiteral - [5..13)::8 - [<strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[strong];
+                        CloseAngle;[>];
+                MarkupTagBlock - [13..15)::2 - [</]
+                    MarkupTextLiteral - [13..15)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                MarkupTagHelperEndTag - [15..24)::9
+                    MarkupTextLiteral - [15..24)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[strong];
+                        CloseAngle;[>];
+            MarkupTagBlock - [24..33)::9 - [</strong>]
+                MarkupTextLiteral - [24..33)::9 - [</strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[strong];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [33..37)::4
+                MarkupTextLiteral - [33..37)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags6.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsPartialRequiredParentTags6.stree.txt
@@ -1,24 +1,45 @@
-Markup block - Gen<None> - 38 - (0:0,0)
-    Tag block - Gen<None> - 1 - (0:0,0)
-        Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:1
-            SyntaxKind.OpenAngle;[<];
-    Tag block - Gen<TagHelper> - 37 - (1:0,1) - p - PTagHelper - CatchALlTagHelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 1 - (4:0,4)
-            Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (4:0,4) - Tokens:1
-                SyntaxKind.OpenAngle;[<];
-        Tag block - Gen<TagHelper> - 20 - (5:0,5) - custom - CatchALlTagHelper
-            StartTagAndEndTag - <custom> ... </custom>
-            Tag block - Gen<None> - 2 - (13:0,13)
-                Markup span - Gen<Markup> - [</] - SpanEditHandler;Accepts:Any - (13:0,13) - Tokens:2
-                    SyntaxKind.OpenAngle;[<];
-                    SyntaxKind.ForwardSlash;[/];
-            Tag block - Gen<None> - 1 - (15:0,15)
-                Markup span - Gen<Markup> - [<] - SpanEditHandler;Accepts:Any - (15:0,15) - Tokens:1
-                    SyntaxKind.OpenAngle;[<];
-        Tag block - Gen<None> - 9 - (25:0,25)
-            Markup span - Gen<Markup> - [</custom>] - SpanEditHandler;Accepts:Any - (25:0,25) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[custom];
-                SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..38)::38 - [<<p><<custom></<</custom></custom></p>]
+    MarkupBlock - [0..38)::38
+        MarkupTagBlock - [0..1)::1 - [<]
+            MarkupTextLiteral - [0..1)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+        MarkupTagHelperElement - [1..38)::37 - p[StartTagAndEndTag] - PTagHelper - CatchALlTagHelper
+            MarkupTagHelperStartTag - [1..4)::3
+                MarkupTextLiteral - [1..4)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [4..5)::1 - [<]
+                MarkupTextLiteral - [4..5)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+            MarkupTagHelperElement - [5..25)::20 - custom[StartTagAndEndTag] - CatchALlTagHelper
+                MarkupTagHelperStartTag - [5..13)::8
+                    MarkupTextLiteral - [5..13)::8 - [<custom>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[custom];
+                        CloseAngle;[>];
+                MarkupTagBlock - [13..15)::2 - [</]
+                    MarkupTextLiteral - [13..15)::2 - [</] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                MarkupTagBlock - [15..16)::1 - [<]
+                    MarkupTextLiteral - [15..16)::1 - [<] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                MarkupTagHelperEndTag - [16..25)::9
+                    MarkupTextLiteral - [16..25)::9 - [</custom>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[custom];
+                        CloseAngle;[>];
+            MarkupTagBlock - [25..34)::9 - [</custom>]
+                MarkupTextLiteral - [25..34)::9 - [</custom>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[custom];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [34..38)::4
+                MarkupTextLiteral - [34..38)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelperPrefixAndAllowedChildren.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelperPrefixAndAllowedChildren.stree.txt
@@ -1,5 +1,26 @@
-Markup block - Gen<None> - 36 - (0:0,0)
-    Tag block - Gen<TagHelper> - 36 - (0:0,0) - th:p - PTagHelper
-        StartTagAndEndTag - <th:p> ... </th:p>
-        Tag block - Gen<TagHelper> - 23 - (6:0,6) - th:strong - StrongTagHelper
-            StartTagAndEndTag - <th:strong> ... </th:strong>
+RazorDocument - [0..36)::36 - [<th:p><th:strong></th:strong></th:p>]
+    MarkupBlock - [0..36)::36
+        MarkupTagHelperElement - [0..36)::36 - th:p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..6)::6
+                MarkupTextLiteral - [0..6)::6 - [<th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [6..29)::23 - th:strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [6..17)::11
+                    MarkupTextLiteral - [6..17)::11 - [<th:strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[th:strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [17..29)::12
+                    MarkupTextLiteral - [17..29)::12 - [</th:strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[th:strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [29..36)::7
+                MarkupTextLiteral - [29..36)::7 - [</th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelperPrefixAndAllowedChildrenAndRequireParent.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelperPrefixAndAllowedChildrenAndRequireParent.stree.txt
@@ -1,5 +1,26 @@
-Markup block - Gen<None> - 36 - (0:0,0)
-    Tag block - Gen<TagHelper> - 36 - (0:0,0) - th:p - PTagHelper
-        StartTagAndEndTag - <th:p> ... </th:p>
-        Tag block - Gen<TagHelper> - 23 - (6:0,6) - th:strong - StrongTagHelper
-            StartTagAndEndTag - <th:strong> ... </th:strong>
+RazorDocument - [0..36)::36 - [<th:p><th:strong></th:strong></th:p>]
+    MarkupBlock - [0..36)::36
+        MarkupTagHelperElement - [0..36)::36 - th:p[StartTagAndEndTag] - PTagHelper
+            MarkupTagHelperStartTag - [0..6)::6
+                MarkupTextLiteral - [0..6)::6 - [<th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[th:p];
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [6..29)::23 - th:strong[StartTagAndEndTag] - StrongTagHelper
+                MarkupTagHelperStartTag - [6..17)::11
+                    MarkupTextLiteral - [6..17)::11 - [<th:strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[th:strong];
+                        CloseAngle;[>];
+                MarkupTagHelperEndTag - [17..29)::12
+                    MarkupTextLiteral - [17..29)::12 - [</th:strong>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        ForwardSlash;[/];
+                        Text;[th:strong];
+                        CloseAngle;[>];
+            MarkupTagHelperEndTag - [29..36)::7
+                MarkupTextLiteral - [29..36)::7 - [</th:p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[th:p];
+                    CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelpersInHtmlTypedScriptTags1.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelpersInHtmlTypedScriptTags1.stree.txt
@@ -1,27 +1,38 @@
-Markup block - Gen<None> - 43 - (0:0,0)
-    Tag block - Gen<None> - 25 - (0:0,0)
-        Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-        Markup block - Gen<Attr:type, type='@(7:0,7),'@(23:0,23)> - 17 - (7:0,7)
-            Markup span - Gen<None> - [ type='] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[type];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(14:0,14)> - [text/html] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:3
-                SyntaxKind.Text;[text];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[html];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<TagHelper> - 9 - (25:0,25) - input - inputtaghelper
-        SelfClosing - <input />
-    Tag block - Gen<None> - 9 - (34:0,34)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (34:0,34) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..43)::43 - [<script type='text/html'><input /></script>]
+    MarkupBlock - [0..43)::43
+        MarkupTagBlock - [0..25)::25 - [<script type='text/html'>]
+            MarkupTextLiteral - [0..7)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[script];
+            MarkupAttributeBlock - [7..24)::17 - [ type='text/html']
+                MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [8..12)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[type];
+                Equals;[=];
+                MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [14..23)::9
+                    MarkupLiteralAttributeValue - [14..23)::9 - [text/html]
+                        MarkupTextLiteral - [14..23)::9 - [text/html] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[text];
+                            ForwardSlash;[/];
+                            Text;[html];
+                MarkupTextLiteral - [23..24)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupTextLiteral - [24..25)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTagHelperElement - [25..34)::9 - input[SelfClosing] - inputtaghelper
+            MarkupTagHelperStartTag - [25..34)::9
+                MarkupTextLiteral - [25..34)::9 - [<input />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[input];
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];
+        MarkupTagBlock - [34..43)::9 - [</script>]
+            MarkupTextLiteral - [34..43)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[script];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelpersInHtmlTypedScriptTags2.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelpersInHtmlTypedScriptTags2.stree.txt
@@ -1,47 +1,66 @@
-Markup block - Gen<None> - 76 - (0:0,0)
-    Tag block - Gen<None> - 58 - (0:0,0)
-        Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-        Markup block - Gen<Attr:id, id='@(7:0,7),'@(21:0,21)> - 15 - (7:0,7)
-            Markup span - Gen<None> - [ id='] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[id];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(12:0,12)> - [scriptTag] - SpanEditHandler;Accepts:Any - (12:0,12) - Tokens:1
-                SyntaxKind.Text;[scriptTag];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (21:0,21) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:type, type='@(22:0,22),'@(38:0,38)> - 17 - (22:0,22)
-            Markup span - Gen<None> - [ type='] - SpanEditHandler;Accepts:Any - (22:0,22) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[type];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(29:0,29)> - [text/html] - SpanEditHandler;Accepts:Any - (29:0,29) - Tokens:3
-                SyntaxKind.Text;[text];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[html];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (38:0,38) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup block - Gen<Attr:class, class='@(39:0,39),'@(56:0,56)> - 18 - (39:0,39)
-            Markup span - Gen<None> - [ class='] - SpanEditHandler;Accepts:Any - (39:0,39) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[class];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(47:0,47)> - [something] - SpanEditHandler;Accepts:Any - (47:0,47) - Tokens:1
-                SyntaxKind.Text;[something];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (56:0,56) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (57:0,57) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<TagHelper> - 9 - (58:0,58) - input - inputtaghelper
-        SelfClosing - <input />
-    Tag block - Gen<None> - 9 - (67:0,67)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (67:0,67) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..76)::76 - [<script id='scriptTag' type='text/html' class='something'><input /></script>]
+    MarkupBlock - [0..76)::76
+        MarkupTagBlock - [0..58)::58 - [<script id='scriptTag' type='text/html' class='something'>]
+            MarkupTextLiteral - [0..7)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[script];
+            MarkupAttributeBlock - [7..22)::15 - [ id='scriptTag']
+                MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [8..10)::2 - [id] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[id];
+                Equals;[=];
+                MarkupTextLiteral - [11..12)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [12..21)::9
+                    MarkupLiteralAttributeValue - [12..21)::9 - [scriptTag]
+                        MarkupTextLiteral - [12..21)::9 - [scriptTag] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[scriptTag];
+                MarkupTextLiteral - [21..22)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupAttributeBlock - [22..39)::17 - [ type='text/html']
+                MarkupTextLiteral - [22..23)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [23..27)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[type];
+                Equals;[=];
+                MarkupTextLiteral - [28..29)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [29..38)::9
+                    MarkupLiteralAttributeValue - [29..38)::9 - [text/html]
+                        MarkupTextLiteral - [29..38)::9 - [text/html] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[text];
+                            ForwardSlash;[/];
+                            Text;[html];
+                MarkupTextLiteral - [38..39)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupAttributeBlock - [39..57)::18 - [ class='something']
+                MarkupTextLiteral - [39..40)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [40..45)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[class];
+                Equals;[=];
+                MarkupTextLiteral - [46..47)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [47..56)::9
+                    MarkupLiteralAttributeValue - [47..56)::9 - [something]
+                        MarkupTextLiteral - [47..56)::9 - [something] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[something];
+                MarkupTextLiteral - [56..57)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupTextLiteral - [57..58)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTagHelperElement - [58..67)::9 - input[SelfClosing] - inputtaghelper
+            MarkupTagHelperStartTag - [58..67)::9
+                MarkupTextLiteral - [58..67)::9 - [<input />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[input];
+                    Whitespace;[ ];
+                    ForwardSlash;[/];
+                    CloseAngle;[>];
+        MarkupTagBlock - [67..76)::9 - [</script>]
+            MarkupTextLiteral - [67..76)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[script];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelpersInHtmlTypedScriptTags3.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelpersInHtmlTypedScriptTags3.stree.txt
@@ -1,53 +1,78 @@
-Markup block - Gen<None> - 84 - (0:0,0)
-    Tag block - Gen<None> - 25 - (0:0,0)
-        Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-        Markup block - Gen<Attr:type, type='@(7:0,7),'@(23:0,23)> - 17 - (7:0,7)
-            Markup span - Gen<None> - [ type='] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[type];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(14:0,14)> - [text/html] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:3
-                SyntaxKind.Text;[text];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[html];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<TagHelper> - 50 - (25:0,25) - p - ptaghelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 25 - (28:0,28)
-            Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (28:0,28) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[script];
-            Markup block - Gen<Attr:type, type='@(35:0,35),'@(51:0,51)> - 17 - (35:0,35)
-                Markup span - Gen<None> - [ type='] - SpanEditHandler;Accepts:Any - (35:0,35) - Tokens:4
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[type];
-                    SyntaxKind.Equals;[=];
-                    SyntaxKind.SingleQuote;['];
-                Markup span - Gen<LitAttr:@(42:0,42)> - [text/html] - SpanEditHandler;Accepts:Any - (42:0,42) - Tokens:3
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.ForwardSlash;[/];
-                    SyntaxKind.Text;[html];
-                Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (51:0,51) - Tokens:1
-                    SyntaxKind.SingleQuote;['];
-            Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (52:0,52) - Tokens:1
-                SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<TagHelper> - 9 - (53:0,53) - input - inputtaghelper
-            SelfClosing - <input />
-        Tag block - Gen<None> - 9 - (62:0,62)
-            Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (62:0,62) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[script];
-                SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (75:0,75)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (75:0,75) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..84)::84 - [<script type='text/html'><p><script type='text/html'><input /></script></p></script>]
+    MarkupBlock - [0..84)::84
+        MarkupTagBlock - [0..25)::25 - [<script type='text/html'>]
+            MarkupTextLiteral - [0..7)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[script];
+            MarkupAttributeBlock - [7..24)::17 - [ type='text/html']
+                MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [8..12)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[type];
+                Equals;[=];
+                MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [14..23)::9
+                    MarkupLiteralAttributeValue - [14..23)::9 - [text/html]
+                        MarkupTextLiteral - [14..23)::9 - [text/html] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[text];
+                            ForwardSlash;[/];
+                            Text;[html];
+                MarkupTextLiteral - [23..24)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupTextLiteral - [24..25)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTagHelperElement - [25..75)::50 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [25..28)::3
+                MarkupTextLiteral - [25..28)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [28..53)::25 - [<script type='text/html'>]
+                MarkupTextLiteral - [28..35)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[script];
+                MarkupAttributeBlock - [35..52)::17 - [ type='text/html']
+                    MarkupTextLiteral - [35..36)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [36..40)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[type];
+                    Equals;[=];
+                    MarkupTextLiteral - [41..42)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                        SingleQuote;['];
+                    GenericBlock - [42..51)::9
+                        MarkupLiteralAttributeValue - [42..51)::9 - [text/html]
+                            MarkupTextLiteral - [42..51)::9 - [text/html] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[text];
+                                ForwardSlash;[/];
+                                Text;[html];
+                    MarkupTextLiteral - [51..52)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                        SingleQuote;['];
+                MarkupTextLiteral - [52..53)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTagHelperElement - [53..62)::9 - input[SelfClosing] - inputtaghelper
+                MarkupTagHelperStartTag - [53..62)::9
+                    MarkupTextLiteral - [53..62)::9 - [<input />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[input];
+                        Whitespace;[ ];
+                        ForwardSlash;[/];
+                        CloseAngle;[>];
+            MarkupTagBlock - [62..71)::9 - [</script>]
+                MarkupTextLiteral - [62..71)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[script];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [71..75)::4
+                MarkupTextLiteral - [71..75)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+        MarkupTagBlock - [75..84)::9 - [</script>]
+            MarkupTextLiteral - [75..84)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[script];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelpersInHtmlTypedScriptTags4.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/UnderstandsTagHelpersInHtmlTypedScriptTags4.stree.txt
@@ -1,59 +1,80 @@
-Markup block - Gen<None> - 85 - (0:0,0)
-    Tag block - Gen<None> - 25 - (0:0,0)
-        Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (0:0,0) - Tokens:2
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[script];
-        Markup block - Gen<Attr:type, type='@(7:0,7),'@(23:0,23)> - 17 - (7:0,7)
-            Markup span - Gen<None> - [ type='] - SpanEditHandler;Accepts:Any - (7:0,7) - Tokens:4
-                SyntaxKind.Whitespace;[ ];
-                SyntaxKind.Text;[type];
-                SyntaxKind.Equals;[=];
-                SyntaxKind.SingleQuote;['];
-            Markup span - Gen<LitAttr:@(14:0,14)> - [text/html] - SpanEditHandler;Accepts:Any - (14:0,14) - Tokens:3
-                SyntaxKind.Text;[text];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[html];
-            Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (23:0,23) - Tokens:1
-                SyntaxKind.SingleQuote;['];
-        Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (24:0,24) - Tokens:1
-            SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<TagHelper> - 51 - (25:0,25) - p - ptaghelper
-        StartTagAndEndTag - <p> ... </p>
-        Tag block - Gen<None> - 26 - (28:0,28)
-            Markup span - Gen<Markup> - [<script] - SpanEditHandler;Accepts:Any - (28:0,28) - Tokens:2
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.Text;[script];
-            Markup block - Gen<Attr:type, type='@(35:0,35),'@(52:0,52)> - 18 - (35:0,35)
-                Markup span - Gen<None> - [ type='] - SpanEditHandler;Accepts:Any - (35:0,35) - Tokens:4
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[type];
-                    SyntaxKind.Equals;[=];
-                    SyntaxKind.SingleQuote;['];
-                Markup span - Gen<LitAttr:@(42:0,42)> - [text/] - SpanEditHandler;Accepts:Any - (42:0,42) - Tokens:2
-                    SyntaxKind.Text;[text];
-                    SyntaxKind.ForwardSlash;[/];
-                Markup span - Gen<LitAttr: @(47:0,47)> - [ html] - SpanEditHandler;Accepts:Any - (47:0,47) - Tokens:2
-                    SyntaxKind.Whitespace;[ ];
-                    SyntaxKind.Text;[html];
-                Markup span - Gen<None> - ['] - SpanEditHandler;Accepts:Any - (52:0,52) - Tokens:1
-                    SyntaxKind.SingleQuote;['];
-            Markup span - Gen<Markup> - [>] - SpanEditHandler;Accepts:Any - (53:0,53) - Tokens:1
-                SyntaxKind.CloseAngle;[>];
-        Markup span - Gen<Markup> - [<input />] - SpanEditHandler;Accepts:Any - (54:0,54) - Tokens:5
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.Text;[input];
-            SyntaxKind.Whitespace;[ ];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.CloseAngle;[>];
-        Tag block - Gen<None> - 9 - (63:0,63)
-            Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (63:0,63) - Tokens:4
-                SyntaxKind.OpenAngle;[<];
-                SyntaxKind.ForwardSlash;[/];
-                SyntaxKind.Text;[script];
-                SyntaxKind.CloseAngle;[>];
-    Tag block - Gen<None> - 9 - (76:0,76)
-        Markup span - Gen<Markup> - [</script>] - SpanEditHandler;Accepts:Any - (76:0,76) - Tokens:4
-            SyntaxKind.OpenAngle;[<];
-            SyntaxKind.ForwardSlash;[/];
-            SyntaxKind.Text;[script];
-            SyntaxKind.CloseAngle;[>];
+RazorDocument - [0..85)::85 - [<script type='text/html'><p><script type='text/ html'><input /></script></p></script>]
+    MarkupBlock - [0..85)::85
+        MarkupTagBlock - [0..25)::25 - [<script type='text/html'>]
+            MarkupTextLiteral - [0..7)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[script];
+            MarkupAttributeBlock - [7..24)::17 - [ type='text/html']
+                MarkupTextLiteral - [7..8)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Whitespace;[ ];
+                MarkupTextLiteral - [8..12)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[type];
+                Equals;[=];
+                MarkupTextLiteral - [13..14)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+                GenericBlock - [14..23)::9
+                    MarkupLiteralAttributeValue - [14..23)::9 - [text/html]
+                        MarkupTextLiteral - [14..23)::9 - [text/html] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                            Text;[text];
+                            ForwardSlash;[/];
+                            Text;[html];
+                MarkupTextLiteral - [23..24)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                    SingleQuote;['];
+            MarkupTextLiteral - [24..25)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                CloseAngle;[>];
+        MarkupTagHelperElement - [25..76)::51 - p[StartTagAndEndTag] - ptaghelper
+            MarkupTagHelperStartTag - [25..28)::3
+                MarkupTextLiteral - [25..28)::3 - [<p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[p];
+                    CloseAngle;[>];
+            MarkupTagBlock - [28..54)::26 - [<script type='text/ html'>]
+                MarkupTextLiteral - [28..35)::7 - [<script] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[script];
+                MarkupAttributeBlock - [35..53)::18 - [ type='text/ html']
+                    MarkupTextLiteral - [35..36)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [36..40)::4 - [type] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[type];
+                    Equals;[=];
+                    MarkupTextLiteral - [41..42)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                        SingleQuote;['];
+                    GenericBlock - [42..52)::10
+                        MarkupLiteralAttributeValue - [42..47)::5 - [text/]
+                            MarkupTextLiteral - [42..47)::5 - [text/] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[text];
+                                ForwardSlash;[/];
+                        MarkupLiteralAttributeValue - [47..52)::5 - [ html]
+                            MarkupTextLiteral - [47..48)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Whitespace;[ ];
+                            MarkupTextLiteral - [48..52)::4 - [html] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[html];
+                    MarkupTextLiteral - [52..53)::1 - ['] - Gen<None> - SpanEditHandler;Accepts:Any
+                        SingleQuote;['];
+                MarkupTextLiteral - [53..54)::1 - [>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    CloseAngle;[>];
+            MarkupTextLiteral - [54..63)::9 - [<input />] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[input];
+                Whitespace;[ ];
+                ForwardSlash;[/];
+                CloseAngle;[>];
+            MarkupTagBlock - [63..72)::9 - [</script>]
+                MarkupTextLiteral - [63..72)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[script];
+                    CloseAngle;[>];
+            MarkupTagHelperEndTag - [72..76)::4
+                MarkupTextLiteral - [72..76)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[p];
+                    CloseAngle;[>];
+        MarkupTagBlock - [76..85)::9 - [</script>]
+            MarkupTextLiteral - [76..85)::9 - [</script>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[script];
+                CloseAngle;[>];

--- a/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/SyntaxNodeWriter.cs
+++ b/test/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/SyntaxNodeWriter.cs
@@ -171,6 +171,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax
                 node.Kind == SyntaxKind.MarkupTagBlock ||
                 node.Kind == SyntaxKind.MarkupAttributeBlock ||
                 node.Kind == SyntaxKind.MarkupMinimizedAttributeBlock ||
+                node.Kind == SyntaxKind.MarkupTagHelperAttribute ||
+                node.Kind == SyntaxKind.MarkupMinimizedTagHelperAttribute ||
                 node.Kind == SyntaxKind.MarkupLiteralAttributeValue ||
                 node.Kind == SyntaxKind.MarkupDynamicAttributeValue ||
                 node.Kind == SyntaxKind.CSharpStatementLiteral ||


### PR DESCRIPTION
Part of #2584 

Converted all of the TagHelperParseTreeRewriter tests. I understand it is impossible to look through each and every test. I suggest looking at as many different types of test as possible.

I'm only including the test changes here because the source may change a lot and it isn't worth reviewing at this point. If anyone is interested the source is [here](https://github.com/aspnet/Razor/commit/67bc5eb22e0e98a30f5db25e70bcb1dba1de9d57).

Here is the syntax for tag helpers,
``` XML
  <Node Name="MarkupTagHelperElementSyntax" Base="MarkupSyntaxNode">
    <Kind Name="MarkupTagHelperElement" />
    <Field Name="StartTag" Type="MarkupTagHelperStartTagSyntax" />
    <Field Name="Body" Type="SyntaxList&lt;RazorSyntaxNode&gt;" Optional="true" />
    <Field Name="EndTag" Type="MarkupTagHelperEndTagSyntax" Optional="true" />
  </Node>
  <Node Name="MarkupTagHelperStartTagSyntax" Base="RazorBlockSyntax">
    <Kind Name="MarkupTagHelperStartTag" />
    <Field Name="Children" Type="SyntaxList&lt;RazorSyntaxNode&gt;" Override="true" />
  </Node>
  <Node Name="MarkupTagHelperEndTagSyntax" Base="RazorBlockSyntax">
    <Kind Name="MarkupTagHelperEndTag" />
    <Field Name="Children" Type="SyntaxList&lt;RazorSyntaxNode&gt;" Override="true" />
  </Node>
  <Node Name="MarkupTagHelperAttributeSyntax" Base="MarkupSyntaxNode">
    <Kind Name="MarkupTagHelperAttribute" />
    <Field Name="NamePrefix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="Name" Type="MarkupTextLiteralSyntax" />
    <Field Name="NameSuffix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="EqualsToken" Type="SyntaxToken">
      <Kind Name="Equals" />
    </Field>
    <Field Name="ValuePrefix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="Value" Type="MarkupTagHelperAttributeValueSyntax" />
    <Field Name="ValueSuffix" Type="MarkupTextLiteralSyntax" Optional="true" />
  </Node>
  <Node Name="MarkupMinimizedTagHelperAttributeSyntax" Base="MarkupSyntaxNode">
    <Kind Name="MarkupMinimizedTagHelperAttribute" />
    <Field Name="NamePrefix" Type="MarkupTextLiteralSyntax" Optional="true" />
    <Field Name="Name" Type="MarkupTextLiteralSyntax" />
  </Node>
  <Node Name="MarkupTagHelperAttributeValueSyntax" Base="RazorBlockSyntax">
    <Kind Name="MarkupTagHelperAttributeValue" />
    <Field Name="Children" Type="SyntaxList&lt;RazorSyntaxNode&gt;" Override="true" />
  </Node>
```