### PR TITLE
Change malformed tag handling logic

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Syntax/MarkupElementRewriter.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Syntax/MarkupElementRewriter.cs
@@ -218,15 +218,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax
                     var startTagTracker = _startTagTracker.Pop();
                     var startTag = startTagTracker.TagBlock;
 
-                    // Since this is a start tag with no end tag, treat it as a standalone tag.
-                    // This means its children now belongs to the outer tag.
-                    BuildMarkupElement(rewrittenChildren, startTag, new List<RazorSyntaxNode>(), endTag: null);
-
-                    var tagChildren = startTagTracker.Children;
-                    foreach (var child in tagChildren)
-                    {
-                        TrackChild(child, rewrittenChildren);
-                    }
+                    BuildMarkupElement(rewrittenChildren, startTag, startTagTracker.Children, endTag: null);
                 }
             }
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/MarkupElementRewriterTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Legacy/MarkupElementRewriterTest.cs
@@ -111,6 +111,18 @@ Foo</div>
         }
 
         [Fact]
+        public void Rewrites_MisplacedEndTags_RecoversSuccessfully()
+        {
+            // Arrange
+            var content = @"
+<div>content<span>footer</div></span>
+";
+
+            // Act & Assert
+            RewriterTest(content);
+        }
+
+        [Fact]
         public void Rewrites_MalformedVoidTags_RecoversSuccessfully()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/MarkupElementRewriterTest/Rewrites_MisplacedEndTags_RecoversSuccessfully.cspans.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/MarkupElementRewriterTest/Rewrites_MisplacedEndTags_RecoversSuccessfully.cspans.txt
@@ -1,0 +1,8 @@
+Markup span at (0:0,0 [2] ) (Accepts:Any) - Parent: Markup block at (0:0,0 [41] )
+Markup span at (2:1,0 [5] ) (Accepts:Any) - Parent: Tag block at (2:1,0 [5] )
+Markup span at (7:1,5 [7] ) (Accepts:Any) - Parent: Markup block at (0:0,0 [41] )
+Markup span at (14:1,12 [6] ) (Accepts:Any) - Parent: Tag block at (14:1,12 [6] )
+Markup span at (20:1,18 [6] ) (Accepts:Any) - Parent: Markup block at (0:0,0 [41] )
+Markup span at (26:1,24 [6] ) (Accepts:Any) - Parent: Tag block at (26:1,24 [6] )
+Markup span at (32:1,30 [7] ) (Accepts:Any) - Parent: Tag block at (32:1,30 [7] )
+Markup span at (39:1,37 [2] ) (Accepts:Any) - Parent: Markup block at (0:0,0 [41] )

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/MarkupElementRewriterTest/Rewrites_MisplacedEndTags_RecoversSuccessfully.stree.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/ParserTests/MarkupElementRewriterTest/Rewrites_MisplacedEndTags_RecoversSuccessfully.stree.txt
@@ -1,0 +1,35 @@
+RazorDocument - [0..41)::41 - [LF<div>content<span>footer</div></span>LF]
+    MarkupBlock - [0..41)::41
+        MarkupTextLiteral - [0..2)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            NewLine;[LF];
+        MarkupElement - [2..32)::30
+            MarkupTagBlock - [2..7)::5 - [<div>]
+                MarkupTextLiteral - [2..7)::5 - [<div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    Text;[div];
+                    CloseAngle;[>];
+            MarkupTextLiteral - [7..14)::7 - [content] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                Text;[content];
+            MarkupElement - [14..26)::12
+                MarkupTagBlock - [14..20)::6 - [<span>]
+                    MarkupTextLiteral - [14..20)::6 - [<span>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        OpenAngle;[<];
+                        Text;[span];
+                        CloseAngle;[>];
+                MarkupTextLiteral - [20..26)::6 - [footer] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    Text;[footer];
+            MarkupTagBlock - [26..32)::6 - [</div>]
+                MarkupTextLiteral - [26..32)::6 - [</div>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[div];
+                    CloseAngle;[>];
+        MarkupElement - [32..39)::7
+            MarkupTagBlock - [32..39)::7 - [</span>]
+                MarkupTextLiteral - [32..39)::7 - [</span>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                    OpenAngle;[<];
+                    ForwardSlash;[/];
+                    Text;[span];
+                    CloseAngle;[>];
+        MarkupTextLiteral - [39..41)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
+            NewLine;[LF];


### PR DESCRIPTION
For malformed cases like,
```HTML
<p><strong>Hello</p>
```
`Hello` needs to be a child of `strong` and not `p`. I had the wrong assumption when writing this logic at first.