### PR TITLE
Allow identical DocumentSnapshot sources to trigger output changes.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/GeneratedCodeContainer.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/GeneratedCodeContainer.cs
@@ -106,7 +106,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     return;
                 }
 
-                if (_sourceVersion.HasValue && _sourceVersion == SourceVersion.GetNewerVersion(version))
+                if (_sourceVersion.HasValue &&
+                    _sourceVersion != version &&
+                    _sourceVersion == SourceVersion.GetNewerVersion(version))
                 {
                     // Latest document is newer than the provided document.
                     return;

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedCodeContainerTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedCodeContainerTest.cs
@@ -12,6 +12,31 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     public class GeneratedCodeContainerTest
     {
         [Fact]
+        public void SetOutput_AcceptsSameVersionedDocuments()
+        {
+            // Arrange
+            var csharpDocument = RazorCSharpDocument.Create("...", RazorCodeGenerationOptions.CreateDefault(), Enumerable.Empty<RazorDiagnostic>());
+            var hostProject = new HostProject("C:/project.csproj", RazorConfiguration.Default);
+            var services = TestWorkspace.Create().Services;
+            var projectState = ProjectState.Create(services, hostProject);
+            var project = new DefaultProjectSnapshot(projectState);
+            var hostDocument = new HostDocument("C:/file.cshtml", "C:/file.cshtml");
+            var text = SourceText.From("...");
+            var textAndVersion = TextAndVersion.Create(text, VersionStamp.Default);
+            var documentState = new DocumentState(services, hostDocument, text, VersionStamp.Default, () => Task.FromResult(textAndVersion));
+            var document = new DefaultDocumentSnapshot(project, documentState);
+            var newDocument = new DefaultDocumentSnapshot(project, documentState);
+            var container = new GeneratedCodeContainer();
+            container.SetOutput(csharpDocument, document);
+
+            // Act
+            container.SetOutput(csharpDocument, newDocument);
+
+            // Assert
+            Assert.Same(newDocument, container.LatestDocument);
+        }
+
+        [Fact]
         public void SetOutput_AcceptsInitialOutput()
         {
             // Arrange


### PR DESCRIPTION
- Prior to this project changes would trigger re-parses which would then be thrown away because source versions were identical.
- Added test to verify new SetOutput behavior.

aspnet/Razor.VSCode#184