### PR TITLE
Add line numbers for design time directives

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -65,15 +65,17 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
                         }
 
                         // {node.Content} __typeHelper = default({node.Content});
-
-                        context.AddSourceMappingFor(node);
-                        context.CodeWriter
-                            .Write(node.Content)
-                            .Write(" ")
-                            .WriteStartAssignment(TypeHelper)
-                            .Write("default(")
-                            .Write(node.Content)
-                            .WriteLine(");");
+                        using (context.CodeWriter.BuildLinePragma(node.Source))
+                        {
+                            context.AddSourceMappingFor(node);
+                            context.CodeWriter
+                                .Write(node.Content)
+                                .Write(" ")
+                                .WriteStartAssignment(TypeHelper)
+                                .Write("default(")
+                                .Write(node.Content)
+                                .WriteLine(");");
+                        }
                         break;
 
                     case DirectiveTokenKind.Member:
@@ -86,16 +88,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
                         }
 
                         // global::System.Object {node.content} = null;
-
-                        context.CodeWriter
+                        using (context.CodeWriter.BuildLinePragma(node.Source))
+                        {
+                            context.CodeWriter
                             .Write("global::")
                             .Write(typeof(object).FullName)
                             .Write(" ");
 
-                        context.AddSourceMappingFor(node);
-                        context.CodeWriter
-                            .Write(node.Content)
-                            .WriteLine(" = null;");
+                            context.AddSourceMappingFor(node);
+                            context.CodeWriter
+                                .Write(node.Content)
+                                .WriteLine(" = null;");
+                        }
                         break;
 
                     case DirectiveTokenKind.Namespace:
@@ -108,46 +112,50 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
                         }
 
                         // global::System.Object __typeHelper = nameof({node.Content});
-
-                        context.CodeWriter
+                        using (context.CodeWriter.BuildLinePragma(node.Source))
+                        {
+                            context.CodeWriter
                             .Write("global::")
                             .Write(typeof(object).FullName)
                             .Write(" ")
                             .WriteStartAssignment(TypeHelper);
 
-                        context.CodeWriter.Write("nameof(");
+                            context.CodeWriter.Write("nameof(");
 
-                        context.AddSourceMappingFor(node);
-                        context.CodeWriter
-                            .Write(node.Content)
-                            .WriteLine(");");
+                            context.AddSourceMappingFor(node);
+                            context.CodeWriter
+                                .Write(node.Content)
+                                .WriteLine(");");
+                        }
                         break;
 
                     case DirectiveTokenKind.String:
 
                         // global::System.Object __typeHelper = "{node.Content}";
-
-                        context.CodeWriter
+                        using (context.CodeWriter.BuildLinePragma(node.Source))
+                        {
+                            context.CodeWriter
                             .Write("global::")
                             .Write(typeof(object).FullName)
                             .Write(" ")
                             .WriteStartAssignment(TypeHelper);
 
-                        if (node.Content.StartsWith("\"", StringComparison.Ordinal))
-                        {
-                            context.AddSourceMappingFor(node);
-                            context.CodeWriter.Write(node.Content);
-                        }
-                        else
-                        {
-                            context.CodeWriter.Write("\"");
-                            context.AddSourceMappingFor(node);
-                            context.CodeWriter
-                                .Write(node.Content)
-                                .Write("\"");
-                        }
+                            if (node.Content.StartsWith("\"", StringComparison.Ordinal))
+                            {
+                                context.AddSourceMappingFor(node);
+                                context.CodeWriter.Write(node.Content);
+                            }
+                            else
+                            {
+                                context.CodeWriter.Write("\"");
+                                context.AddSourceMappingFor(node);
+                                context.CodeWriter
+                                    .Write(node.Content)
+                                    .Write("\"");
+                            }
 
-                        context.CodeWriter.WriteLine(";");
+                            context.CodeWriter.WriteLine(";");
+                        }
                         break;
                 }
                 context.CodeWriter.CurrentIndent = originalIndent;

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/Experiment/SpanMapResult.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/Experiment/SpanMapResult.cs
@@ -11,7 +11,6 @@ namespace Microsoft.CodeAnalysis.Experiment
     {
         public SpanMapResult(Document document, LinePositionSpan linePositionSpan)
         {
-
         }
 
     }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -28,7 +28,11 @@ namespace AspNetCore
  }
         ))();
         ((System.Action)(() => {
+#line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 MyService<TModel> __typeHelper = default(MyService<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -20,21 +20,21 @@ Generated Location: (830:27,0 [0] )
 
 Source Location: (159:11,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (883:30,0 [17] )
+Generated Location: (980:31,0 [17] )
 |MyService<TModel>|
 
 Source Location: (176:11,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1005:34,0 [0] )
+Generated Location: (1133:38,0 [0] )
 ||
 
 Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1058:37,0 [0] )
+Generated Location: (1186:41,0 [0] )
 ||
 
 Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1111:40,0 [0] )
+Generated Location: (1239:44,0 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
@@ -16,11 +16,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
 MyBasePageForViews<TModel> __typeHelper = default(MyBasePageForViews<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
 MyModel __typeHelper = default(MyModel);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (10:0,10 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
 |MyBasePageForViews<TModel>|
-Generated Location: (647:18,0 [26] )
+Generated Location: (740:19,0 [26] )
 |MyBasePageForViews<TModel>|
 
 Source Location: (45:1,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
 |MyModel|
-Generated Location: (787:22,0 [7] )
+Generated Location: (1004:27,0 [7] )
 |MyModel|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
@@ -16,7 +16,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports.cshtml"
 MyModel __typeHelper = default(MyModel);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:1,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports.cshtml)
 |MyModel|
-Generated Location: (646:18,0 [7] )
+Generated Location: (745:19,0 [7] )
 |MyModel|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
@@ -16,23 +16,43 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 MyModel __typeHelper = default(MyModel);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 MyApp __typeHelper = default(MyApp);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 global::System.Object MyPropertyName = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 MyService<TModel> __typeHelper = default(MyService<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 global::System.Object Html = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (7:0,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyModel|
-Generated Location: (675:18,0 [7] )
+Generated Location: (766:19,0 [7] )
 |MyModel|
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyApp|
-Generated Location: (777:22,0 [5] )
+Generated Location: (990:27,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyPropertyName|
-Generated Location: (897:26,22 [14] )
+Generated Location: (1232:35,22 [14] )
 |MyPropertyName|
 
 Source Location: (54:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyService<TModel>|
-Generated Location: (981:30,0 [17] )
+Generated Location: (1438:43,0 [17] )
 |MyService<TModel>|
 
 Source Location: (72:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |Html|
-Generated Location: (1125:34,22 [4] )
+Generated Location: (1704:51,22 [4] )
 |Html|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
@@ -16,39 +16,75 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyModel __typeHelper = default(MyModel);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyApp __typeHelper = default(MyApp);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 global::System.Object MyPropertyName = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyService<TModel> __typeHelper = default(MyService<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 global::System.Object Html = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyApp __typeHelper = default(MyApp);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 global::System.Object MyPropertyName2 = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyService<TModel> __typeHelper = default(MyService<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 global::System.Object Html2 = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
@@ -1,45 +1,45 @@
 Source Location: (7:0,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyModel|
-Generated Location: (679:18,0 [7] )
+Generated Location: (774:19,0 [7] )
 |MyModel|
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (781:22,0 [5] )
+Generated Location: (1002:27,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName|
-Generated Location: (901:26,22 [14] )
+Generated Location: (1248:35,22 [14] )
 |MyPropertyName|
 
 Source Location: (58:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (985:30,0 [17] )
+Generated Location: (1458:43,0 [17] )
 |MyService<TModel>|
 
 Source Location: (76:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html|
-Generated Location: (1129:34,22 [4] )
+Generated Location: (1728:51,22 [4] )
 |Html|
 
 Source Location: (93:3,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1203:38,0 [5] )
+Generated Location: (1928:59,0 [5] )
 |MyApp|
 
 Source Location: (99:3,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName2|
-Generated Location: (1323:42,22 [15] )
+Generated Location: (2174:67,22 [15] )
 |MyPropertyName2|
 
 Source Location: (129:4,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (1408:46,0 [17] )
+Generated Location: (2385:75,0 [17] )
 |MyService<TModel>|
 
 Source Location: (147:4,26 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html2|
-Generated Location: (1552:50,22 [5] )
+Generated Location: (2655:83,22 [5] )
 |Html2|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
@@ -16,11 +16,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml"
 MyApp __typeHelper = default(MyApp);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml"
 global::System.Object MyPropertyName = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (8:0,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyApp|
-Generated Location: (666:18,0 [5] )
+Generated Location: (748:19,0 [5] )
 |MyApp|
 
 Source Location: (14:0,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyPropertyName|
-Generated Location: (786:22,22 [14] )
+Generated Location: (981:27,22 [14] )
 |MyPropertyName|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -17,11 +17,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
 DateTime __typeHelper = default(DateTime);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
 global::System.Object __typeHelper = "InputTestTagHelper, AppCode";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |DateTime|
-Generated Location: (751:19,0 [8] )
+Generated Location: (851:20,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (892:23,37 [29] )
+Generated Location: (1123:28,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (83:4,17 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Date|
-Generated Location: (1540:36,102 [4] )
+Generated Location: (1802:44,102 [4] )
 |Date|
 
 Source Location: (111:5,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (1856:42,94 [5] )
+Generated Location: (2118:50,94 [5] )
 |Model|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
@@ -16,7 +16,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model.cshtml"
 System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (7:0,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (688:18,0 [30] )
+Generated Location: (769:19,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -16,11 +16,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
 ThisShouldBeGenerated __typeHelper = default(ThisShouldBeGenerated);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
 System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (7:0,7 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |ThisShouldBeGenerated|
-Generated Location: (688:18,0 [21] )
+Generated Location: (778:19,0 [21] )
 |ThisShouldBeGenerated|
 
 Source Location: (37:1,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (818:22,0 [30] )
+Generated Location: (1029:27,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.codegen.cs
@@ -16,7 +16,11 @@ namespace Test.Namespace
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace.cshtml"
 global::System.Object __typeHelper = nameof(Test.Namespace);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (18:1,11 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PageWithNamespace.cshtml)
 |Test.Namespace|
-Generated Location: (716:18,44 [14] )
+Generated Location: (809:19,44 [14] )
 |Test.Namespace|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.codegen.cs
@@ -22,11 +22,19 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml"
 global::System.Object __typeHelper = "/About";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml"
 NewModel __typeHelper = default(NewModel);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_DesignTime.mappings.txt
@@ -5,17 +5,17 @@ Generated Location: (492:14,0 [41] )
 
 Source Location: (6:0,6 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |"/About"|
-Generated Location: (1005:24,37 [8] )
+Generated Location: (1108:25,37 [8] )
 |"/About"|
 
 Source Location: (25:2,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |NewModel|
-Generated Location: (1076:28,0 [8] )
+Generated Location: (1313:33,0 [8] )
 |NewModel|
 
 Source Location: (213:12,18 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
 |Model.Name|
-Generated Location: (1573:40,18 [10] )
+Generated Location: (1841:48,18 [10] )
 |Model.Name|
 
 Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml)
@@ -25,7 +25,7 @@ Source Location: (93:5,12 [97] TestFiles/IntegrationTests/CodeGenerationIntegrat
         public string Name { get; set; }
     }
 |
-Generated Location: (1781:47,12 [97] )
+Generated Location: (2049:55,12 [97] )
 |
     public class NewModel : PageModel
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.codegen.cs
@@ -22,7 +22,11 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml"
 global::System.Object __typeHelper = "*, AppCode";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel_DesignTime.mappings.txt
@@ -5,12 +5,12 @@ Generated Location: (487:14,0 [41] )
 
 Source Location: (23:2,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |"*, AppCode"|
-Generated Location: (937:24,37 [12] )
+Generated Location: (1035:25,37 [12] )
 |"*, AppCode"|
 
 Source Location: (566:24,47 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
 |Name|
-Generated Location: (1500:37,47 [4] )
+Generated Location: (1629:41,47 [4] )
 |Name|
 
 Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithoutModel.cshtml)
@@ -28,7 +28,7 @@ Source Location: (95:5,12 [283] TestFiles/IntegrationTests/CodeGenerationIntegra
         public string Name { get; set; }
     }
 |
-Generated Location: (1981:48,12 [283] )
+Generated Location: (2110:52,12 [283] )
 |
     public IActionResult OnPost(Customer customer)
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.codegen.cs
@@ -22,11 +22,19 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"
 NewModel __typeHelper = default(NewModel);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml"
 global::System.Object __typeHelper = "*, AppCode";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages_DesignTime.mappings.txt
@@ -5,17 +5,17 @@ Generated Location: (475:14,0 [41] )
 
 Source Location: (16:2,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |NewModel|
-Generated Location: (876:24,0 [8] )
+Generated Location: (962:25,0 [8] )
 |NewModel|
 
 Source Location: (40:3,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |"*, AppCode"|
-Generated Location: (1017:28,37 [12] )
+Generated Location: (1220:33,37 [12] )
 |"*, AppCode"|
 
 Source Location: (661:28,47 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
 |Model.Name|
-Generated Location: (1568:41,47 [10] )
+Generated Location: (1802:49,47 [10] )
 |Model.Name|
 
 Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPages.cshtml)
@@ -36,7 +36,7 @@ Source Location: (112:6,12 [360] TestFiles/IntegrationTests/CodeGenerationIntegr
         public string Name { get; set; }
     }
 |
-Generated Location: (2043:52,12 [360] )
+Generated Location: (2277:60,12 [360] )
 |
     public class NewModel : PageModel
     {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -17,15 +17,27 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
 DateTime __typeHelper = default(DateTime);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
 global::System.Object __typeHelper = "InputTestTagHelper, AppCode";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
 global::System.Object Section1 = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -1,29 +1,29 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |DateTime|
-Generated Location: (735:19,0 [8] )
+Generated Location: (819:20,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (876:23,37 [29] )
+Generated Location: (1075:28,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (152:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (990:27,22 [8] )
+Generated Location: (1305:36,22 [8] )
 |Section1|
 
 Source Location: (68:4,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
-Generated Location: (1425:39,2 [46] )
+Generated Location: (1771:51,2 [46] )
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
 
 Source Location: (222:12,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Date|
-Generated Location: (1850:47,102 [4] )
+Generated Location: (2196:59,102 [4] )
 |Date|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
@@ -18,7 +18,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml"
 global::System.Object __typeHelper = "*, AppCode";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (14:0,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |"*, AppCode"|
-Generated Location: (959:20,37 [12] )
+Generated Location: (1057:21,37 [12] )
 |"*, AppCode"|
 
 Source Location: (30:1,2 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |
     var foo = "Hello";
 |
-Generated Location: (1405:32,2 [26] )
+Generated Location: (1534:36,2 [26] )
 |
     var foo = "Hello";
 |
 
 Source Location: (83:5,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |foo|
-Generated Location: (1856:40,22 [3] )
+Generated Location: (1985:44,22 [3] )
 |foo|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.codegen.cs
@@ -16,7 +16,11 @@ namespace Test.Namespace
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace.cshtml"
 global::System.Object __typeHelper = nameof(Test.Namespace);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (11:0,11 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewWithNamespace.cshtml)
 |Test.Namespace|
-Generated Location: (725:18,44 [14] )
+Generated Location: (818:19,44 [14] )
 |Test.Namespace|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
@@ -16,11 +16,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml"
 IHtmlHelper<TModel> __typeHelper = default(IHtmlHelper<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml"
 global::System.Object Helper = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (8:0,8 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |IHtmlHelper<TModel>|
-Generated Location: (672:18,0 [19] )
+Generated Location: (760:19,0 [19] )
 |IHtmlHelper<TModel>|
 
 Source Location: (28:0,28 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |Helper|
-Generated Location: (820:22,22 [6] )
+Generated Location: (1027:27,22 [6] )
 |Helper|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -28,7 +28,11 @@ namespace AspNetCore
  }
         ))();
         ((System.Action)(() => {
+#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 MyService<TModel> __typeHelper = default(MyService<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -20,11 +20,11 @@ Generated Location: (839:27,0 [0] )
 
 Source Location: (133:7,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (892:30,0 [17] )
+Generated Location: (988:31,0 [17] )
 |MyService<TModel>|
 
 Source Location: (150:7,25 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1014:34,0 [0] )
+Generated Location: (1141:38,0 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.codegen.cs
@@ -16,11 +16,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
 MyBasePageForViews<TModel> __typeHelper = default(MyBasePageForViews<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml"
 MyModel __typeHelper = default(MyModel);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (10:0,10 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
 |MyBasePageForViews<TModel>|
-Generated Location: (647:18,0 [26] )
+Generated Location: (740:19,0 [26] )
 |MyBasePageForViews<TModel>|
 
 Source Location: (45:1,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsViewModel.cshtml)
 |MyModel|
-Generated Location: (787:22,0 [7] )
+Generated Location: (1004:27,0 [7] )
 |MyModel|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.codegen.cs
@@ -16,7 +16,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports.cshtml"
 MyModel __typeHelper = default(MyModel);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (7:0,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InheritsWithViewImports.cshtml)
 |MyModel|
-Generated Location: (653:18,0 [7] )
+Generated Location: (752:19,0 [7] )
 |MyModel|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.codegen.cs
@@ -16,23 +16,43 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 MyModel __typeHelper = default(MyModel);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 MyApp __typeHelper = default(MyApp);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 global::System.Object MyPropertyName = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 MyService<TModel> __typeHelper = default(MyService<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml"
 global::System.Object Html = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (7:0,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyModel|
-Generated Location: (675:18,0 [7] )
+Generated Location: (766:19,0 [7] )
 |MyModel|
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyApp|
-Generated Location: (777:22,0 [5] )
+Generated Location: (990:27,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyPropertyName|
-Generated Location: (897:26,22 [14] )
+Generated Location: (1232:35,22 [14] )
 |MyPropertyName|
 
 Source Location: (54:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |MyService<TModel>|
-Generated Location: (981:30,0 [17] )
+Generated Location: (1438:43,0 [17] )
 |MyService<TModel>|
 
 Source Location: (72:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithModel.cshtml)
 |Html|
-Generated Location: (1125:34,22 [4] )
+Generated Location: (1704:51,22 [4] )
 |Html|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.codegen.cs
@@ -16,39 +16,75 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyModel __typeHelper = default(MyModel);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyApp __typeHelper = default(MyApp);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 global::System.Object MyPropertyName = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyService<TModel> __typeHelper = default(MyService<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 global::System.Object Html = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyApp __typeHelper = default(MyApp);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 global::System.Object MyPropertyName2 = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 MyService<TModel> __typeHelper = default(MyService<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml"
 global::System.Object Html2 = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon_DesignTime.mappings.txt
@@ -1,45 +1,45 @@
 Source Location: (7:0,7 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyModel|
-Generated Location: (679:18,0 [7] )
+Generated Location: (774:19,0 [7] )
 |MyModel|
 
 Source Location: (24:1,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (781:22,0 [5] )
+Generated Location: (1002:27,0 [5] )
 |MyApp|
 
 Source Location: (30:1,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName|
-Generated Location: (901:26,22 [14] )
+Generated Location: (1248:35,22 [14] )
 |MyPropertyName|
 
 Source Location: (58:2,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (985:30,0 [17] )
+Generated Location: (1458:43,0 [17] )
 |MyService<TModel>|
 
 Source Location: (76:2,26 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html|
-Generated Location: (1129:34,22 [4] )
+Generated Location: (1728:51,22 [4] )
 |Html|
 
 Source Location: (93:3,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyApp|
-Generated Location: (1203:38,0 [5] )
+Generated Location: (1928:59,0 [5] )
 |MyApp|
 
 Source Location: (99:3,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyPropertyName2|
-Generated Location: (1323:42,22 [15] )
+Generated Location: (2174:67,22 [15] )
 |MyPropertyName2|
 
 Source Location: (129:4,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |MyService<TModel>|
-Generated Location: (1408:46,0 [17] )
+Generated Location: (2385:75,0 [17] )
 |MyService<TModel>|
 
 Source Location: (147:4,26 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InjectWithSemicolon.cshtml)
 |Html2|
-Generated Location: (1552:50,22 [5] )
+Generated Location: (2655:83,22 [5] )
 |Html2|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.codegen.cs
@@ -16,11 +16,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml"
 MyApp __typeHelper = default(MyApp);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml"
 global::System.Object MyPropertyName = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (8:0,8 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyApp|
-Generated Location: (666:18,0 [5] )
+Generated Location: (748:19,0 [5] )
 |MyApp|
 
 Source Location: (14:0,14 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inject.cshtml)
 |MyPropertyName|
-Generated Location: (786:22,22 [14] )
+Generated Location: (981:27,22 [14] )
 |MyPropertyName|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.codegen.cs
@@ -17,11 +17,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
 DateTime __typeHelper = default(DateTime);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml"
 global::System.Object __typeHelper = "InputTestTagHelper, AppCode";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |DateTime|
-Generated Location: (751:19,0 [8] )
+Generated Location: (851:20,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (892:23,37 [29] )
+Generated Location: (1123:28,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (83:4,17 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Date|
-Generated Location: (1540:36,102 [4] )
+Generated Location: (1802:44,102 [4] )
 |Date|
 
 Source Location: (111:5,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ModelExpressionTagHelper.cshtml)
 |Model|
-Generated Location: (1856:42,94 [5] )
+Generated Location: (2118:50,94 [5] )
 |Model|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.codegen.cs
@@ -16,7 +16,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model.cshtml"
 System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (7:0,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Model.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (688:18,0 [30] )
+Generated Location: (769:19,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.codegen.cs
@@ -16,11 +16,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
 ThisShouldBeGenerated __typeHelper = default(ThisShouldBeGenerated);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml"
 System.Collections.IEnumerable __typeHelper = default(System.Collections.IEnumerable);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (7:0,7 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |ThisShouldBeGenerated|
-Generated Location: (688:18,0 [21] )
+Generated Location: (778:19,0 [21] )
 |ThisShouldBeGenerated|
 
 Source Location: (37:1,7 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MultipleModels.cshtml)
 |System.Collections.IEnumerable|
-Generated Location: (818:22,0 [30] )
+Generated Location: (1029:27,0 [30] )
 |System.Collections.IEnumerable|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -17,15 +17,27 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
 DateTime __typeHelper = default(DateTime);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
 global::System.Object __typeHelper = "InputTestTagHelper, AppCode";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
 global::System.Object Section1 = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -1,29 +1,29 @@
 Source Location: (7:0,7 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |DateTime|
-Generated Location: (735:19,0 [8] )
+Generated Location: (819:20,0 [8] )
 |DateTime|
 
 Source Location: (33:2,14 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |"InputTestTagHelper, AppCode"|
-Generated Location: (876:23,37 [29] )
+Generated Location: (1075:28,37 [29] )
 |"InputTestTagHelper, AppCode"|
 
 Source Location: (152:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (990:27,22 [8] )
+Generated Location: (1305:36,22 [8] )
 |Section1|
 
 Source Location: (68:4,2 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
-Generated Location: (1425:39,2 [46] )
+Generated Location: (1771:51,2 [46] )
 | 
     Layout = "_SectionTestLayout.cshtml";
 |
 
 Source Location: (222:12,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Date|
-Generated Location: (1850:47,102 [4] )
+Generated Location: (2196:59,102 [4] )
 |Date|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
@@ -18,7 +18,11 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml"
 global::System.Object __typeHelper = "*, AppCode";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.mappings.txt
@@ -1,19 +1,19 @@
 Source Location: (14:0,14 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |"*, AppCode"|
-Generated Location: (959:20,37 [12] )
+Generated Location: (1057:21,37 [12] )
 |"*, AppCode"|
 
 Source Location: (30:1,2 [26] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |
     var foo = "Hello";
 |
-Generated Location: (1405:32,2 [26] )
+Generated Location: (1534:36,2 [26] )
 |
     var foo = "Hello";
 |
 
 Source Location: (83:5,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper.cshtml)
 |foo|
-Generated Location: (1856:40,22 [3] )
+Generated Location: (1985:44,22 [3] )
 |foo|
 

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.codegen.cs
@@ -16,11 +16,19 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml"
 IHtmlHelper<TModel> __typeHelper = default(IHtmlHelper<TModel>);
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml"
 global::System.Object Helper = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (8:0,8 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |IHtmlHelper<TModel>|
-Generated Location: (672:18,0 [19] )
+Generated Location: (760:19,0 [19] )
 |IHtmlHelper<TModel>|
 
 Source Location: (28:0,28 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/_ViewImports.cshtml)
 |Helper|
-Generated Location: (820:22,22 [6] )
+Generated Location: (1027:27,22 [6] )
 |Helper|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/DesignTimeDirectiveTargetExtensionTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/Extensions/DesignTimeDirectiveTargetExtensionTest.cs
@@ -58,7 +58,11 @@ private void __RazorDirectiveTokenHelpers__() {
 @"#pragma warning disable 219
 private void __RazorDirectiveTokenHelpers__() {
 ((System.Action)(() => {
+#line 1 ""test.cshtml""
 System.String __typeHelper = default(System.String);
+
+#line default
+#line hidden
 }
 ))();
 }
@@ -93,7 +97,11 @@ System.String __typeHelper = default(System.String);
 @"#pragma warning disable 219
 private void __RazorDirectiveTokenHelpers__() {
 ((System.Action)(() => {
+#line 1 ""test.cshtml""
 global::System.Object __typeHelper = nameof(System.Collections.Generic);
+
+#line default
+#line hidden
 }
 ))();
 }
@@ -128,7 +136,11 @@ global::System.Object __typeHelper = nameof(System.Collections.Generic);
 @"#pragma warning disable 219
 private void __RazorDirectiveTokenHelpers__() {
 ((System.Action)(() => {
+#line 1 ""test.cshtml""
 global::System.Object Foo = null;
+
+#line default
+#line hidden
 }
 ))();
 }
@@ -170,11 +182,19 @@ global::System.Object Foo = null;
 @"#pragma warning disable 219
 private void __RazorDirectiveTokenHelpers__() {
 ((System.Action)(() => {
+#line 1 ""test.cshtml""
 global::System.Object __typeHelper = ""Value"";
+
+#line default
+#line hidden
 }
 ))();
 ((System.Action)(() => {
+#line 1 ""test.cshtml""
 global::System.Object __typeHelper = ""Value"";
+
+#line default
+#line hidden
 }
 ))();
 }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 {
     public class CodeGenerationIntegrationTest : IntegrationTestBase
     {
-
+        public CodeGenerationIntegrationTest()
+            : base(generateBaselines: null)
+        {
+        }
+        
         #region Runtime
         [Fact]
         public void IncompleteDirectives_Runtime()

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ExtensibleDirectiveTest.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/IntegrationTests/ExtensibleDirectiveTest.cs
@@ -8,6 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
     // Extensible directives only have codegen for design time, so we're only testing that.
     public class ExtensibleDirectiveTest : IntegrationTestBase
     {
+        public ExtensibleDirectiveTest()
+            : base(generateBaselines: null)
+        {
+        }
+
         [Fact]
         public void NamespaceToken()
         {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.codegen.cs
@@ -8,7 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AddTagHelperDirective.cshtml)
 |"*, TestAssembly"|
-Generated Location: (427:10,37 [17] )
+Generated Location: (524:11,37 [17] )
 |"*, TestAssembly"|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.codegen.cs
@@ -12,7 +12,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (779:14,38 [15] )
+Generated Location: (883:15,38 [15] )
 |*, TestAssembly|
 
 Source Location: (187:5,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (1727:31,42 [4] )
+Generated Location: (1862:35,42 [4] )
 |true|
 
 Source Location: (233:6,36 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/AttributeTargetingTagHelpers.cshtml)
 |true|
-Generated Location: (2380:41,42 [4] )
+Generated Location: (2515:45,42 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.codegen.cs
@@ -11,7 +11,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (673:13,37 [17] )
+Generated Location: (764:14,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (220:5,38 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1439:28,38 [23] )
+Generated Location: (1561:32,38 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (303:6,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers.cshtml)
 |true|
-Generated Location: (2137:39,42 [4] )
+Generated Location: (2259:43,42 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.codegen.cs
@@ -11,11 +11,19 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml"
 global::System.Object __typeHelper = "THS";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (17:0,17 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |"THS"|
-Generated Location: (682:13,37 [5] )
+Generated Location: (782:14,37 [5] )
 |"THS"|
 
 Source Location: (38:1,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |"*, TestAssembly"|
-Generated Location: (787:17,37 [17] )
+Generated Location: (1018:22,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (226:7,43 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicTagHelpers_Prefixed.cshtml)
 |true|
-Generated Location: (1624:33,43 [4] )
+Generated Location: (1886:41,43 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.codegen.cs
@@ -11,7 +11,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (675:13,37 [17] )
+Generated Location: (768:14,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (36:2,1 [52] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
@@ -9,7 +9,7 @@ Source Location: (36:2,1 [52] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var checkbox = "checkbox";
 
     |
-Generated Location: (1103:25,1 [52] )
+Generated Location: (1227:29,1 [52] )
 |if (true)
 {
     var checkbox = "checkbox";
@@ -18,39 +18,39 @@ Generated Location: (1103:25,1 [52] )
 
 Source Location: (147:7,16 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (1409:35,33 [1] )
+Generated Location: (1533:39,33 [1] )
 |@|
 
 Source Location: (149:7,18 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 ||
-Generated Location: (1410:35,34 [0] )
+Generated Location: (1534:39,34 [0] )
 ||
 
 Source Location: (149:7,18 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (1410:35,34 [1] )
+Generated Location: (1534:39,34 [1] )
 |@|
 
 Source Location: (150:7,19 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (1411:35,35 [1] )
+Generated Location: (1535:39,35 [1] )
 |(|
 
 Source Location: (151:7,20 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |1+2|
-Generated Location: (1412:35,36 [3] )
+Generated Location: (1536:39,36 [3] )
 |1+2|
 
 Source Location: (154:7,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (1415:35,39 [1] )
+Generated Location: (1539:39,39 [1] )
 |)|
 
 Source Location: (273:10,13 [43] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if (false)
             {
                 |
-Generated Location: (1557:40,13 [43] )
+Generated Location: (1681:44,13 [43] )
 |if (false)
             {
                 |
@@ -61,7 +61,7 @@ Source Location: (399:12,99 [66] TestFiles/IntegrationTests/CodeGenerationIntegr
             else
             {
                 |
-Generated Location: (2277:52,99 [66] )
+Generated Location: (2401:56,99 [66] )
 |
             }
             else
@@ -70,224 +70,224 @@ Generated Location: (2277:52,99 [66] )
 
 Source Location: (495:16,46 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checkbox|
-Generated Location: (2724:63,46 [8] )
+Generated Location: (2848:67,46 [8] )
 |checkbox|
 
 Source Location: (512:16,63 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true|
-Generated Location: (3077:70,63 [4] )
+Generated Location: (3201:74,63 [4] )
 |true|
 
 Source Location: (523:16,74 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (3378:76,74 [18] )
+Generated Location: (3502:80,74 [18] )
 |
                 |
 
 Source Location: (556:17,31 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |true ? "checkbox" : "anything"|
-Generated Location: (3762:84,31 [30] )
+Generated Location: (3886:88,31 [30] )
 |true ? "checkbox" : "anything"|
 
 Source Location: (591:17,66 [18] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
                 |
-Generated Location: (4140:91,66 [18] )
+Generated Location: (4264:95,66 [18] )
 |
                 |
 
 Source Location: (623:18,30 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |if(true) { |
-Generated Location: (4523:99,30 [11] )
+Generated Location: (4647:103,30 [11] )
 |if(true) { |
 
 Source Location: (655:18,62 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | } else { |
-Generated Location: (4723:104,62 [10] )
+Generated Location: (4847:108,62 [10] )
 | } else { |
 
 Source Location: (686:18,93 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | }|
-Generated Location: (4953:109,93 [2] )
+Generated Location: (5077:113,93 [2] )
 | }|
 
 Source Location: (690:18,97 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
             }|
-Generated Location: (5333:116,97 [15] )
+Generated Location: (5457:120,97 [15] )
 |
             }|
 
 Source Location: (212:8,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (5601:123,32 [12] )
+Generated Location: (5725:127,32 [12] )
 |DateTime.Now|
 
 Source Location: (832:22,14 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | var @object = false;|
-Generated Location: (5755:128,14 [21] )
+Generated Location: (5879:132,14 [21] )
 | var @object = false;|
 
 Source Location: (885:23,29 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (6153:135,42 [1] )
+Generated Location: (6277:139,42 [1] )
 |(|
 
 Source Location: (886:23,30 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@object|
-Generated Location: (6154:135,43 [7] )
+Generated Location: (6278:139,43 [7] )
 |@object|
 
 Source Location: (893:23,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (6161:135,50 [1] )
+Generated Location: (6285:139,50 [1] )
 |)|
 
 Source Location: (760:21,39 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (6423:141,38 [23] )
+Generated Location: (6547:145,38 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (783:21,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | -|
-Generated Location: (6446:141,61 [2] )
+Generated Location: (6570:145,61 [2] )
 | -|
 
 Source Location: (785:21,64 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 1970|
-Generated Location: (6448:141,63 [5] )
+Generated Location: (6572:145,63 [5] )
 | 1970|
 
 Source Location: (1025:26,61 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (6849:148,60 [1] )
+Generated Location: (6973:152,60 [1] )
 |(|
 
 Source Location: (1026:26,62 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (6850:148,61 [30] )
+Generated Location: (6974:152,61 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1056:26,92 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (6880:148,91 [1] )
+Generated Location: (7004:152,91 [1] )
 |)|
 
 Source Location: (928:25,16 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |-1970|
-Generated Location: (7137:154,33 [5] )
+Generated Location: (7261:158,33 [5] )
 |-1970|
 
 Source Location: (933:25,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | +|
-Generated Location: (7142:154,38 [2] )
+Generated Location: (7266:158,38 [2] )
 | +|
 
 Source Location: (935:25,23 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | |
-Generated Location: (7144:154,40 [1] )
+Generated Location: (7268:158,40 [1] )
 | |
 
 Source Location: (936:25,24 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (7145:154,41 [1] )
+Generated Location: (7269:158,41 [1] )
 |@|
 
 Source Location: (937:25,25 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year|
-Generated Location: (7146:154,42 [23] )
+Generated Location: (7270:158,42 [23] )
 |DateTimeOffset.Now.Year|
 
 Source Location: (1155:29,28 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year > 2014|
-Generated Location: (7547:161,42 [30] )
+Generated Location: (7671:165,42 [30] )
 |DateTimeOffset.Now.Year > 2014|
 
 Source Location: (1093:28,16 [30] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |DateTimeOffset.Now.Year - 1970|
-Generated Location: (7833:167,33 [30] )
+Generated Location: (7957:171,33 [30] )
 |DateTimeOffset.Now.Year - 1970|
 
 Source Location: (1283:32,28 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (8241:174,42 [3] )
+Generated Location: (8365:178,42 [3] )
 |   |
 
 Source Location: (1286:32,31 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |@|
-Generated Location: (8244:174,45 [1] )
+Generated Location: (8368:178,45 [1] )
 |@|
 
 Source Location: (1287:32,32 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (8245:174,46 [1] )
+Generated Location: (8369:178,46 [1] )
 |(|
 
 Source Location: (1288:32,33 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |  DateTimeOffset.Now.Year  |
-Generated Location: (8246:174,47 [27] )
+Generated Location: (8370:178,47 [27] )
 |  DateTimeOffset.Now.Year  |
 
 Source Location: (1315:32,60 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (8273:174,74 [1] )
+Generated Location: (8397:178,74 [1] )
 |)|
 
 Source Location: (1316:32,61 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | >|
-Generated Location: (8274:174,75 [2] )
+Generated Location: (8398:178,75 [2] )
 | >|
 
 Source Location: (1318:32,63 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 | 2014|
-Generated Location: (8276:174,77 [5] )
+Generated Location: (8400:178,77 [5] )
 | 2014|
 
 Source Location: (1323:32,68 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |   |
-Generated Location: (8281:174,82 [3] )
+Generated Location: (8405:178,82 [3] )
 |   |
 
 Source Location: (1220:31,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |(|
-Generated Location: (8540:180,33 [1] )
+Generated Location: (8664:184,33 [1] )
 |(|
 
 Source Location: (1221:31,18 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |"My age is this long.".Length|
-Generated Location: (8541:180,34 [29] )
+Generated Location: (8665:184,34 [29] )
 |"My age is this long.".Length|
 
 Source Location: (1250:31,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (8570:180,63 [1] )
+Generated Location: (8694:184,63 [1] )
 |)|
 
 Source Location: (1355:34,9 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |someMethod(|
-Generated Location: (8708:185,9 [11] )
+Generated Location: (8832:189,9 [11] )
 |someMethod(|
 
 Source Location: (1410:34,64 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |checked|
-Generated Location: (9126:189,63 [7] )
+Generated Location: (9250:193,63 [7] )
 |checked|
 
 Source Location: (1375:34,29 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |123|
-Generated Location: (9381:195,33 [3] )
+Generated Location: (9505:199,33 [3] )
 |123|
 
 Source Location: (1424:34,78 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |)|
-Generated Location: (9422:200,1 [1] )
+Generated Location: (9546:204,1 [1] )
 |)|
 
 Source Location: (1437:35,10 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ComplexTagHelpers.cshtml)
 |
 }|
-Generated Location: (9561:205,10 [3] )
+Generated Location: (9685:209,10 [3] )
 |
 }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.codegen.cs
@@ -8,7 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml"
 global::System.Object Footer = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime_DesignTime.mappings.txt
@@ -1,49 +1,49 @@
 Source Location: (173:11,9 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Footer|
-Generated Location: (401:10,22 [6] )
+Generated Location: (488:11,22 [6] )
 |Footer|
 
 Source Location: (20:1,13 [36] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |for(int i = 1; i <= 10; i++) {
     |
-Generated Location: (830:22,13 [36] )
+Generated Location: (948:26,13 [36] )
 |for(int i = 1; i <= 10; i++) {
     |
 
 Source Location: (74:2,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |i|
-Generated Location: (1007:28,22 [1] )
+Generated Location: (1125:32,22 [1] )
 |i|
 
 Source Location: (79:2,27 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |
             }|
-Generated Location: (1155:33,27 [15] )
+Generated Location: (1273:37,27 [15] )
 |
             }|
 
 Source Location: (113:7,2 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(Bar.Baz)|
-Generated Location: (1295:39,6 [12] )
+Generated Location: (1413:43,6 [12] )
 |Foo(Bar.Baz)|
 
 Source Location: (129:8,1 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |Foo(|
-Generated Location: (1433:44,6 [4] )
+Generated Location: (1551:48,6 [4] )
 |Foo(|
 
 Source Location: (142:8,14 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |baz|
-Generated Location: (1595:46,14 [3] )
+Generated Location: (1713:50,14 [3] )
 |baz|
 
 Source Location: (153:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |)|
-Generated Location: (1636:51,1 [1] )
+Generated Location: (1754:55,1 [1] )
 |)|
 
 Source Location: (204:13,5 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DesignTime.cshtml)
 |bar|
-Generated Location: (1836:57,6 [3] )
+Generated Location: (1954:61,6 [3] )
 |bar|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.codegen.cs
@@ -11,7 +11,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (686:13,37 [17] )
+Generated Location: (790:14,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (146:4,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (1882:33,42 [4] )
+Generated Location: (2017:37,42 [4] )
 |true|
 
 Source Location: (222:5,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |true|
-Generated Location: (2424:42,42 [4] )
+Generated Location: (2559:46,42 [4] )
 |true|
 
 Source Location: (43:2,8 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateAttributeTagHelpers.cshtml)
 |3|
-Generated Location: (2694:48,33 [1] )
+Generated Location: (2829:52,33 [1] )
 |3|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.codegen.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (608:12,37 [17] )
+Generated Location: (708:13,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (67:2,32 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DuplicateTargetTagHelper.cshtml)
 |true|
-Generated Location: (1449:28,41 [4] )
+Generated Location: (1580:32,41 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.codegen.cs
@@ -9,7 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,155 +1,155 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (518:11,37 [17] )
+Generated Location: (620:12,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (59:2,24 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1081:24,24 [12] )
+Generated Location: (1214:28,24 [12] )
 |DateTime.Now|
 
 Source Location: (96:4,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (1349:30,17 [12] )
+Generated Location: (1482:34,17 [12] )
 |if (true) { |
 
 Source Location: (109:4,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (1526:35,30 [12] )
+Generated Location: (1659:39,30 [12] )
 |string.Empty|
 
 Source Location: (121:4,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (1716:40,42 [10] )
+Generated Location: (1849:44,42 [10] )
 | } else { |
 
 Source Location: (132:4,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (1914:45,53 [5] )
+Generated Location: (2047:49,53 [5] )
 |false|
 
 Source Location: (137:4,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (2113:50,58 [2] )
+Generated Location: (2246:54,58 [2] )
 | }|
 
 Source Location: (176:6,22 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (2375:56,22 [12] )
+Generated Location: (2508:60,22 [12] )
 |DateTime.Now|
 
 Source Location: (214:6,60 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (2649:62,60 [12] )
+Generated Location: (2782:66,60 [12] )
 |DateTime.Now|
 
 Source Location: (256:8,15 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (2915:68,15 [13] )
+Generated Location: (3048:72,15 [13] )
 |long.MinValue|
 
 Source Location: (271:8,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (3094:73,30 [12] )
+Generated Location: (3227:77,30 [12] )
 |if (true) { |
 
 Source Location: (284:8,43 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (3284:78,43 [12] )
+Generated Location: (3417:82,43 [12] )
 |string.Empty|
 
 Source Location: (296:8,55 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (3487:83,55 [10] )
+Generated Location: (3620:87,55 [10] )
 | } else { |
 
 Source Location: (307:8,66 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (3698:88,66 [5] )
+Generated Location: (3831:92,66 [5] )
 |false|
 
 Source Location: (312:8,71 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (3910:93,71 [2] )
+Generated Location: (4043:97,71 [2] )
 | }|
 
 Source Location: (316:8,75 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (4122:98,75 [12] )
+Generated Location: (4255:102,75 [12] )
 |int.MaxValue|
 
 Source Location: (348:9,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (4354:104,17 [13] )
+Generated Location: (4487:108,17 [13] )
 |long.MinValue|
 
 Source Location: (363:9,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (4536:109,32 [12] )
+Generated Location: (4669:113,32 [12] )
 |if (true) { |
 
 Source Location: (376:9,45 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (4729:114,45 [12] )
+Generated Location: (4862:118,45 [12] )
 |string.Empty|
 
 Source Location: (388:9,57 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (4935:119,57 [10] )
+Generated Location: (5068:123,57 [10] )
 | } else { |
 
 Source Location: (399:9,68 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (5149:124,68 [5] )
+Generated Location: (5282:128,68 [5] )
 |false|
 
 Source Location: (404:9,73 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (5364:129,73 [2] )
+Generated Location: (5497:133,73 [2] )
 | }|
 
 Source Location: (408:9,77 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (5579:134,77 [12] )
+Generated Location: (5712:138,77 [12] )
 |int.MaxValue|
 
 Source Location: (445:11,17 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |long.MinValue|
-Generated Location: (5848:140,17 [13] )
+Generated Location: (5981:144,17 [13] )
 |long.MinValue|
 
 Source Location: (460:11,32 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (6030:145,32 [12] )
+Generated Location: (6163:149,32 [12] )
 |DateTime.Now|
 
 Source Location: (492:11,64 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |int.MaxValue|
-Generated Location: (6243:150,64 [12] )
+Generated Location: (6376:154,64 [12] )
 |int.MaxValue|
 
 Source Location: (529:13,17 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |if (true) { |
-Generated Location: (6512:156,17 [12] )
+Generated Location: (6645:160,17 [12] )
 |if (true) { |
 
 Source Location: (542:13,30 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |string.Empty|
-Generated Location: (6690:161,30 [12] )
+Generated Location: (6823:165,30 [12] )
 |string.Empty|
 
 Source Location: (554:13,42 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | } else { |
-Generated Location: (6881:166,42 [10] )
+Generated Location: (7014:170,42 [10] )
 | } else { |
 
 Source Location: (565:13,53 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 |false|
-Generated Location: (7080:171,53 [5] )
+Generated Location: (7213:175,53 [5] )
 |false|
 
 Source Location: (570:13,58 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/DynamicAttributeTagHelpers.cshtml)
 | }|
-Generated Location: (7280:176,58 [2] )
+Generated Location: (7413:180,58 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.codegen.cs
@@ -11,7 +11,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (683:13,38 [15] )
+Generated Location: (783:14,38 [15] )
 |*, TestAssembly|
 
 Source Location: (66:3,26 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (1510:29,42 [0] )
+Generated Location: (1641:33,42 [0] )
 ||
 
 Source Location: (126:5,30 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (2038:38,42 [0] )
+Generated Location: (2169:42,42 [0] )
 ||
 
 Source Location: (92:4,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EmptyAttributeTagHelpers.cshtml)
 ||
-Generated Location: (2300:44,33 [0] )
+Generated Location: (2431:48,33 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.codegen.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers_DesignTime.mappings.txt
@@ -1,49 +1,49 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (598:12,37 [17] )
+Generated Location: (688:13,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (37:2,2 [39] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |
     var enumValue = MyEnum.MyValue;
 |
-Generated Location: (1024:24,2 [39] )
+Generated Location: (1145:28,2 [39] )
 |
     var enumValue = MyEnum.MyValue;
 |
 
 Source Location: (96:6,15 [14] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MyValue|
-Generated Location: (1435:32,39 [14] )
+Generated Location: (1556:36,39 [14] )
 |MyEnum.MyValue|
 
 Source Location: (131:7,15 [20] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyEnum.MySecondValue|
-Generated Location: (1800:39,15 [20] )
+Generated Location: (1921:43,15 [20] )
 |MyEnum.MySecondValue|
 
 Source Location: (171:8,14 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (2288:46,132 [7] )
+Generated Location: (2409:50,132 [7] )
 |MyValue|
 
 Source Location: (198:9,14 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MySecondValue|
-Generated Location: (2764:53,132 [13] )
+Generated Location: (2885:57,132 [13] )
 |MySecondValue|
 
 Source Location: (224:9,40 [7] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |MyValue|
-Generated Location: (3040:58,138 [7] )
+Generated Location: (3161:62,138 [7] )
 |MyValue|
 
 Source Location: (251:10,15 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (3423:65,39 [9] )
+Generated Location: (3544:69,39 [9] )
 |enumValue|
 
 Source Location: (274:10,38 [9] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EnumTagHelpers.cshtml)
 |enumValue|
-Generated Location: (3602:70,45 [9] )
+Generated Location: (3723:74,45 [9] )
 |enumValue|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.codegen.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (598:12,38 [15] )
+Generated Location: (691:13,38 [15] )
 |*, TestAssembly|
 
 Source Location: (106:3,29 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1053:24,29 [12] )
+Generated Location: (1177:28,29 [12] )
 |DateTime.Now|
 
 Source Location: (204:5,51 [12] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |DateTime.Now|
-Generated Location: (1451:31,51 [12] )
+Generated Location: (1575:35,51 [12] )
 |DateTime.Now|
 
 Source Location: (227:5,74 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/EscapedTagHelpers.cshtml)
 |true|
-Generated Location: (1818:38,74 [4] )
+Generated Location: (1942:42,74 [4] )
 |true|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -8,39 +8,75 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 global::System.Object __typeHelper = "";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 global::System.Object __typeHelper = "";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 5 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 global::System.Object __typeHelper = ";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 global::System.Object __typeHelper = "";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 global::System.Object __typeHelper = "";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 9 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 global::System.Object __typeHelper = ";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 global::System.Object __typeHelper = "";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 12 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 global::System.Object __typeHelper = "";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
 global::System.Object __typeHelper = ";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,70 +1,70 @@
 Source Location: (100:2,13 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (427:10,38 [0] )
+Generated Location: (523:11,38 [0] )
 ||
 
 Source Location: (116:3,14 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (529:14,38 [0] )
+Generated Location: (752:19,38 [0] )
 ||
 
 Source Location: (132:4,14 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |"|
-Generated Location: (630:18,37 [1] )
+Generated Location: (980:27,37 [1] )
 |"|
 
 Source Location: (153:6,16 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (732:22,38 [0] )
+Generated Location: (1209:35,38 [0] )
 ||
 
 Source Location: (172:7,17 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (834:26,38 [0] )
+Generated Location: (1438:43,38 [0] )
 ||
 
 Source Location: (191:8,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |"|
-Generated Location: (935:30,37 [1] )
+Generated Location: (1666:51,37 [1] )
 |"|
 
 Source Location: (212:10,16 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1037:34,38 [0] )
+Generated Location: (1896:59,38 [0] )
 ||
 
 Source Location: (231:11,17 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1139:38,38 [0] )
+Generated Location: (2126:67,38 [0] )
 ||
 
 Source Location: (250:12,17 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |"|
-Generated Location: (1240:42,37 [1] )
+Generated Location: (2355:75,37 [1] )
 |"|
 
 Source Location: (264:14,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1304:46,0 [0] )
+Generated Location: (2450:82,0 [0] )
 ||
 
 Source Location: (276:15,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1357:49,0 [0] )
+Generated Location: (2503:85,0 [0] )
 ||
 
 Source Location: (315:20,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1410:52,0 [0] )
+Generated Location: (2556:88,0 [0] )
 ||
 
 Source Location: (326:21,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1463:55,0 [0] )
+Generated Location: (2609:91,0 [0] )
 ||
 
 Source Location: (354:24,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1879:66,12 [0] )
+Generated Location: (3025:102,12 [0] )
 ||
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.codegen.cs
@@ -9,7 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (503:11,37 [17] )
+Generated Location: (598:12,37 [17] )
 |"*, TestAssembly"|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.codegen.cs
@@ -8,7 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml"
 foo.bar<baz<biz>>.boz __typeHelper = default(foo.bar<baz<biz>>.boz);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (10:0,10 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
 |foo.bar<baz<biz>>.boz|
-Generated Location: (401:10,0 [21] )
+Generated Location: (485:11,0 [21] )
 |foo.bar<baz<biz>>.boz|
 
 Source Location: (36:2,1 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Inherits.cshtml)
 |foo()|
-Generated Location: (875:22,6 [5] )
+Generated Location: (990:26,6 [5] )
 |foo()|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.codegen.cs
@@ -8,7 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml"
 global::System.Object Link = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (9:0,9 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |Link|
-Generated Location: (403:10,22 [4] )
+Generated Location: (491:11,22 [4] )
 |Link|
 
 Source Location: (44:1,14 [19] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |if(link != null) { |
-Generated Location: (833:22,14 [19] )
+Generated Location: (952:26,14 [19] )
 |if(link != null) { |
 
 Source Location: (64:1,34 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 |link|
-Generated Location: (1007:27,34 [4] )
+Generated Location: (1126:31,34 [4] )
 |link|
 
 Source Location: (68:1,38 [10] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | } else { |
-Generated Location: (1171:32,38 [10] )
+Generated Location: (1290:36,38 [10] )
 | } else { |
 
 Source Location: (92:1,62 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/InlineBlocks.cshtml)
 | }|
-Generated Location: (1364:37,62 [2] )
+Generated Location: (1483:41,62 [2] )
 | }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.codegen.cs
@@ -11,7 +11,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MinimizedTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (657:13,37 [17] )
+Generated Location: (752:14,37 [17] )
 |"*, TestAssembly"|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.codegen.cs
@@ -11,7 +11,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers_DesignTime.mappings.txt
@@ -1,29 +1,29 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (683:13,37 [17] )
+Generated Location: (784:14,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (195:5,13 [46] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |for(var i = 0; i < 5; i++) {
                 |
-Generated Location: (1131:25,13 [46] )
+Generated Location: (1263:29,13 [46] )
 |for(var i = 0; i < 5; i++) {
                 |
 
 Source Location: (339:7,50 [23] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |ViewBag.DefaultInterval|
-Generated Location: (1569:33,50 [23] )
+Generated Location: (1701:37,50 [23] )
 |ViewBag.DefaultInterval|
 
 Source Location: (389:7,100 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |true|
-Generated Location: (1975:40,100 [4] )
+Generated Location: (2107:44,100 [4] )
 |true|
 
 Source Location: (422:8,25 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedScriptTagTagHelpers.cshtml)
 |
             }|
-Generated Location: (2139:45,25 [15] )
+Generated Location: (2271:49,25 [15] )
 |
             }|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.codegen.cs
@@ -11,7 +11,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/NestedTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (591:13,38 [15] )
+Generated Location: (683:14,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.codegen.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |"*, TestAssembly"|
-Generated Location: (609:12,37 [17] )
+Generated Location: (712:13,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (37:2,2 [242] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
@@ -15,7 +15,7 @@ Source Location: (37:2,2 [242] TestFiles/IntegrationTests/CodeGenerationIntegrat
         { "name", "value" },
     };
 |
-Generated Location: (1048:24,2 [242] )
+Generated Location: (1182:28,2 [242] )
 |
     var literate = "or illiterate";
     var intDictionary = new Dictionary<string, int>
@@ -30,51 +30,51 @@ Generated Location: (1048:24,2 [242] )
 
 Source Location: (370:15,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (1691:40,56 [13] )
+Generated Location: (1825:44,56 [13] )
 |intDictionary|
 
 Source Location: (404:15,77 [16] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |stringDictionary|
-Generated Location: (2043:46,77 [16] )
+Generated Location: (2177:50,77 [16] )
 |stringDictionary|
 
 Source Location: (468:16,43 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |intDictionary|
-Generated Location: (2593:54,56 [13] )
+Generated Location: (2727:58,56 [13] )
 |intDictionary|
 
 Source Location: (502:16,77 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (2945:60,77 [2] )
+Generated Location: (3079:64,77 [2] )
 |37|
 
 Source Location: (526:16,101 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (3330:66,101 [2] )
+Generated Location: (3464:70,101 [2] )
 |42|
 
 Source Location: (590:18,31 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |42|
-Generated Location: (3851:74,46 [2] )
+Generated Location: (3985:78,46 [2] )
 |42|
 
 Source Location: (611:18,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (4180:80,64 [2] )
+Generated Location: (4314:84,64 [2] )
 |37|
 
 Source Location: (634:18,75 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |98|
-Generated Location: (4535:86,75 [2] )
+Generated Location: (4669:90,75 [2] )
 |98|
 
 Source Location: (783:20,42 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |literate|
-Generated Location: (5317:96,42 [8] )
+Generated Location: (5451:100,42 [8] )
 |literate|
 
 Source Location: (826:21,29 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/PrefixedAttributeTagHelpers.cshtml)
 |37|
-Generated Location: (5981:105,65 [2] )
+Generated Location: (6115:109,65 [2] )
 |37|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.codegen.cs
@@ -8,7 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (17:0,17 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RemoveTagHelperDirective.cshtml)
 |*, TestAssembly|
-Generated Location: (431:10,38 [15] )
+Generated Location: (531:11,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.codegen.cs
@@ -8,15 +8,27 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
 global::System.Object Section2 = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 11 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
 global::System.Object Section1 = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml"
 global::System.Object NestedDelegates = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections_DesignTime.mappings.txt
@@ -1,44 +1,44 @@
 Source Location: (89:6,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section2|
-Generated Location: (399:10,22 [8] )
+Generated Location: (483:11,22 [8] )
 |Section2|
 
 Source Location: (172:10,9 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |Section1|
-Generated Location: (499:14,22 [8] )
+Generated Location: (699:19,22 [8] )
 |Section1|
 
 Source Location: (235:14,9 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |NestedDelegates|
-Generated Location: (599:18,22 [15] )
+Generated Location: (915:27,22 [15] )
 |NestedDelegates|
 
 Source Location: (2:0,2 [44] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |
     Layout = "_SectionTestLayout.cshtml"
 |
-Generated Location: (1024:30,2 [44] )
+Generated Location: (1371:42,2 [44] )
 |
     Layout = "_SectionTestLayout.cshtml"
 |
 
 Source Location: (123:7,22 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |thing|
-Generated Location: (1279:37,22 [5] )
+Generated Location: (1626:49,22 [5] )
 |thing|
 
 Source Location: (260:15,6 [27] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 | Func<dynamic, object> f = |
-Generated Location: (1626:48,6 [27] )
+Generated Location: (1973:60,6 [27] )
 | Func<dynamic, object> f = |
 
 Source Location: (295:15,41 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |item|
-Generated Location: (1886:54,41 [4] )
+Generated Location: (2233:66,41 [4] )
 |item|
 
 Source Location: (306:15,52 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Sections.cshtml)
 |; |
-Generated Location: (2099:61,52 [2] )
+Generated Location: (2446:73,52 [2] )
 |; |
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.codegen.cs
@@ -9,7 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers_DesignTime.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SimpleTagHelpers.cshtml)
 |*, TestAssembly|
-Generated Location: (481:11,38 [15] )
+Generated Location: (573:12,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.codegen.cs
@@ -9,7 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (526:11,37 [17] )
+Generated Location: (644:12,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (67:3,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelperWithNewlineBeforeAttributes.cshtml)
 |1337|
-Generated Location: (1106:24,33 [4] )
+Generated Location: (1255:28,33 [4] )
 |1337|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.codegen.cs
@@ -9,7 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml)
 |"*, TestAssembly"|
-Generated Location: (499:11,37 [17] )
+Generated Location: (590:12,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (63:2,28 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SingleTagHelper.cshtml)
 |1337|
-Generated Location: (1052:24,33 [4] )
+Generated Location: (1174:28,33 [4] )
 |1337|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.codegen.cs
@@ -8,11 +8,19 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 86 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml"
 global::System.Object WriteLiteralsToInHere = null;
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 206 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml"
 global::System.Object WriteLiteralsToInHereAlso = null;
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (2022:85,9 [21] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml)
 |WriteLiteralsToInHere|
-Generated Location: (405:10,22 [21] )
+Generated Location: (496:11,22 [21] )
 |WriteLiteralsToInHere|
 
 Source Location: (5701:205,9 [25] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/StringLiterals.cshtml)
 |WriteLiteralsToInHereAlso|
-Generated Location: (518:14,22 [25] )
+Generated Location: (732:19,22 [25] )
 |WriteLiteralsToInHereAlso|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.codegen.cs
@@ -9,7 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes_DesignTime.mappings.txt
@@ -1,25 +1,25 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |*, TestAssembly|
-Generated Location: (520:11,38 [15] )
+Generated Location: (617:12,38 [15] )
 |*, TestAssembly|
 
 Source Location: (302:11,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1106:24,46 [5] )
+Generated Location: (1234:28,46 [5] )
 |items|
 
 Source Location: (351:12,20 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |items|
-Generated Location: (1399:30,47 [5] )
+Generated Location: (1527:34,47 [5] )
 |items|
 
 Source Location: (405:13,23 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (1688:36,43 [13] )
+Generated Location: (1816:40,43 [13] )
 |doSomething()|
 
 Source Location: (487:14,24 [13] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/SymbolBoundAttributes.cshtml)
 |doSomething()|
-Generated Location: (1985:42,43 [13] )
+Generated Location: (2113:46,43 [13] )
 |doSomething()|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.codegen.cs
@@ -9,7 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes_DesignTime.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml)
 |*, TestAssembly|
-Generated Location: (494:11,38 [15] )
+Generated Location: (599:12,38 [15] )
 |*, TestAssembly|
 
 Source Location: (57:2,18 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithBoundAttributes.cshtml)
 |Hello|
-Generated Location: (1025:24,18 [5] )
+Generated Location: (1161:28,18 [5] )
 |Hello|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.codegen.cs
@@ -9,11 +9,19 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         ((System.Action)(() => {
+#line 2 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml"
 global::System.Object __typeHelper = "cool:";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix_DesignTime.mappings.txt
@@ -1,15 +1,15 @@
 Source Location: (14:0,14 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |*, TestAssembly|
-Generated Location: (485:11,38 [15] )
+Generated Location: (581:12,38 [15] )
 |*, TestAssembly|
 
 Source Location: (48:1,17 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |cool:|
-Generated Location: (602:15,38 [5] )
+Generated Location: (825:20,38 [5] )
 |cool:|
 
 Source Location: (86:3,23 [5] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithPrefix.cshtml)
 |Hello|
-Generated Location: (1119:28,23 [5] )
+Generated Location: (1373:36,23 [5] )
 |Hello|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.codegen.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |"*, TestAssembly"|
-Generated Location: (540:12,37 [17] )
+Generated Location: (638:13,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (333:12,6 [66] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
@@ -8,7 +8,7 @@ Source Location: (333:12,6 [66] TestFiles/IntegrationTests/CodeGenerationIntegra
         RenderTemplate(
             "Template: ",
             |
-Generated Location: (979:24,6 [66] )
+Generated Location: (1108:28,6 [66] )
 |
         RenderTemplate(
             "Template: ",
@@ -16,13 +16,13 @@ Generated Location: (979:24,6 [66] )
 
 Source Location: (427:15,40 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |item|
-Generated Location: (1287:33,40 [4] )
+Generated Location: (1416:37,40 [4] )
 |item|
 
 Source Location: (482:15,95 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithTemplate.cshtml)
 |);
     |
-Generated Location: (1703:42,95 [8] )
+Generated Location: (1832:46,95 [8] )
 |);
     |
 
@@ -35,7 +35,7 @@ Source Location: (47:2,12 [268] TestFiles/IntegrationTests/CodeGenerationIntegra
         helperResult.WriteTo(Output, HtmlEncoder);
     }
 |
-Generated Location: (1974:51,12 [268] )
+Generated Location: (2103:55,12 [268] )
 |
     public void RenderTemplate(string title, Func<string, HelperResult> template)
     {

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.codegen.cs
@@ -11,7 +11,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes_DesignTime.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (695:13,37 [17] )
+Generated Location: (808:14,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (74:5,21 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1337|
-Generated Location: (1270:26,33 [4] )
+Generated Location: (1414:30,33 [4] )
 |1337|
 
 Source Location: (99:6,19 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |true|
-Generated Location: (1440:31,19 [4] )
+Generated Location: (1584:35,19 [4] )
 |true|
 
 Source Location: (186:10,11 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TagHelpersWithWeirdlySpacedAttributes.cshtml)
 |1234|
-Generated Location: (2076:41,33 [4] )
+Generated Location: (2220:45,33 [4] )
 |1234|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.codegen.cs
@@ -9,7 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml"
 global::System.Object __typeHelper = "*, TestAssembly";
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes_DesignTime.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (14:0,14 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |"*, TestAssembly"|
-Generated Location: (516:11,37 [17] )
+Generated Location: (624:12,37 [17] )
 |"*, TestAssembly"|
 
 Source Location: (35:1,2 [59] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
@@ -8,7 +8,7 @@ Source Location: (35:1,2 [59] TestFiles/IntegrationTests/CodeGenerationIntegrati
     var @class = "container-fluid";
     var @int = 1;
 |
-Generated Location: (960:23,2 [59] )
+Generated Location: (1099:27,2 [59] )
 | 
     var @class = "container-fluid";
     var @int = 1;
@@ -16,101 +16,101 @@ Generated Location: (960:23,2 [59] )
 
 Source Location: (122:6,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |1337|
-Generated Location: (1286:31,33 [4] )
+Generated Location: (1425:35,33 [4] )
 |1337|
 
 Source Location: (157:7,12 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (1539:37,12 [6] )
+Generated Location: (1678:41,12 [6] )
 |@class|
 
 Source Location: (171:7,26 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42|
-Generated Location: (1720:42,33 [2] )
+Generated Location: (1859:46,33 [2] )
 |42|
 
 Source Location: (202:8,21 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |42|
-Generated Location: (1992:48,33 [2] )
+Generated Location: (2131:52,33 [2] )
 |42|
 
 Source Location: (204:8,23 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | +|
-Generated Location: (1994:48,35 [2] )
+Generated Location: (2133:52,35 [2] )
 | +|
 
 Source Location: (206:8,25 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | |
-Generated Location: (1996:48,37 [1] )
+Generated Location: (2135:52,37 [1] )
 | |
 
 Source Location: (207:8,26 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
-Generated Location: (1997:48,38 [1] )
+Generated Location: (2136:52,38 [1] )
 |@|
 
 Source Location: (208:8,27 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (1998:48,39 [3] )
+Generated Location: (2137:52,39 [3] )
 |int|
 
 Source Location: (241:9,22 [3] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |int|
-Generated Location: (2272:54,33 [3] )
+Generated Location: (2411:58,33 [3] )
 |int|
 
 Source Location: (274:10,22 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |(|
-Generated Location: (2546:60,33 [1] )
+Generated Location: (2685:64,33 [1] )
 |(|
 
 Source Location: (275:10,23 [4] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int|
-Generated Location: (2547:60,34 [4] )
+Generated Location: (2686:64,34 [4] )
 |@int|
 
 Source Location: (279:10,27 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (2551:60,38 [1] )
+Generated Location: (2690:64,38 [1] )
 |)|
 
 Source Location: (307:11,19 [6] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@class|
-Generated Location: (2809:66,19 [6] )
+Generated Location: (2948:70,19 [6] )
 |@class|
 
 Source Location: (321:11,33 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |4|
-Generated Location: (2991:71,33 [1] )
+Generated Location: (3130:75,33 [1] )
 |4|
 
 Source Location: (322:11,34 [2] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | *|
-Generated Location: (2992:71,34 [2] )
+Generated Location: (3131:75,34 [2] )
 | *|
 
 Source Location: (324:11,36 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 | |
-Generated Location: (2994:71,36 [1] )
+Generated Location: (3133:75,36 [1] )
 | |
 
 Source Location: (325:11,37 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@|
-Generated Location: (2995:71,37 [1] )
+Generated Location: (3134:75,37 [1] )
 |@|
 
 Source Location: (326:11,38 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |(|
-Generated Location: (2996:71,38 [1] )
+Generated Location: (3135:75,38 [1] )
 |(|
 
 Source Location: (327:11,39 [8] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |@int + 2|
-Generated Location: (2997:71,39 [8] )
+Generated Location: (3136:75,39 [8] )
 |@int + 2|
 
 Source Location: (335:11,47 [1] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/TransitionsInTagHelperAttributes.cshtml)
 |)|
-Generated Location: (3005:71,47 [1] )
+Generated Location: (3144:75,47 [1] )
 |)|
 

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.codegen.cs
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.codegen.cs
@@ -8,7 +8,11 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestFiles
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
+#line 1 "TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.cshtml"
 global::System.Object __typeHelper = nameof(System.Globalization);
+
+#line default
+#line hidden
         }
         ))();
         }

--- a/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.mappings.txt
+++ b/test/Microsoft.AspNetCore.Razor.Language.Test/TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (8:0,8 [20] TestFiles/IntegrationTests/ExtensibleDirectiveTest/NamespaceToken.cshtml)
 |System.Globalization|
-Generated Location: (410:10,44 [20] )
+Generated Location: (494:11,44 [20] )
 |System.Globalization|
 

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedCodeContainerTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedCodeContainerTest.cs
@@ -60,6 +60,62 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         [Fact]
+        public void TryGetLinePositionSpan_SpanMatchesSourceMapping_ReturnsTrue()
+        {
+            // Arrange
+            var content = @"
+@SomeProperty
+";
+            var sourceText = SourceText.From(content);
+            var codeDocument = GetCodeDocument(content);
+            var csharpDocument = codeDocument.GetCSharpDocument();
+            var generatedCode = csharpDocument.GeneratedCode;
+
+            var symbol = "SomeProperty";
+            var span = new TextSpan(generatedCode.IndexOf(symbol), symbol.Length);
+
+            // Position of `SomeProperty` in the source code.
+            var expectedLineSpan = new LinePositionSpan(new LinePosition(1, 1), new LinePosition(1, 13));
+
+            // Act
+            var result = GeneratedCodeContainer.TryGetLinePositionSpan(span, sourceText, csharpDocument, out var lineSpan);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedLineSpan, lineSpan);
+        }
+
+        [Fact]
+        public void TryGetLinePositionSpan_SpanMatchesSourceMapping_MatchingOnPosition_ReturnsTrue()
+        {
+            // Arrange
+            var content = @"
+@SomeProperty
+@SomeProperty
+@SomeProperty
+";
+            var sourceText = SourceText.From(content);
+            var codeDocument = GetCodeDocument(content);
+            var csharpDocument = codeDocument.GetCSharpDocument();
+            var generatedCode = csharpDocument.GeneratedCode;
+
+            var symbol = "SomeProperty";
+
+            // Second occurrence
+            var span = new TextSpan(generatedCode.IndexOf(symbol, generatedCode.IndexOf(symbol) + symbol.Length), symbol.Length);
+
+            // Position of `SomeProperty` in the source code.
+            var expectedLineSpan = new LinePositionSpan(new LinePosition(2, 1), new LinePosition(2, 13));
+
+            // Act
+            var result = GeneratedCodeContainer.TryGetLinePositionSpan(span, sourceText, csharpDocument, out var lineSpan);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expectedLineSpan, lineSpan);
+        }
+
+        [Fact]
         public void TryGetLinePositionSpan_SpanWithinSourceMapping_ReturnsTrue()
         {
             // Arrange
@@ -73,8 +129,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var csharpDocument = codeDocument.GetCSharpDocument();
             var generatedCode = csharpDocument.GeneratedCode;
 
-            // TODO: Make writing these tests a little less manual.
-            // Position of `SomeProperty` in the generated code.
             var symbol = "SomeProperty";
             var span = new TextSpan(generatedCode.IndexOf(symbol), symbol.Length);
 


### PR DESCRIPTION
Addresses a blocking issue for FAR of types when used in user-code in a
directive. The FAR infrastructure is skipping over the directive code
because it's mapped to `#hidden`. As you can see in the code, the token
provided by the user is already included in the projection mappings.

I think we didn't do this before because we didn't expect this code to
need line numbers - it's not really debuggable, and design-time codegen
doesn't happen when you build the project.

I think it's OK for now that we don't line-map (or include) directives
based on view imports. If you trigger FAR on an `@inject ...` in an
import for instance, you'll find the reference for the view import file.
That seems pretty good, and the only cases I can really imagine it being
broken would be for go-to-definition (within a Razor view). Lets revisit
in the future based on feedback.