### PR TITLE
Add and process notifications for Imports

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Razor.Performance/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
+++ b/benchmarks/Microsoft.AspNetCore.Razor.Performance/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
@@ -132,14 +132,6 @@ namespace Microsoft.AspNetCore.Razor.Performance
 
         private class StaticProjectSnapshotProjectEngineFactory : ProjectSnapshotProjectEngineFactory
         {
-            public override RazorProjectEngine Create(ProjectSnapshot project, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
-            {
-                return RazorProjectEngine.Create(project.Configuration, fileSystem, b =>
-                {
-                    RazorExtensions.Register(b);
-                });
-            }
-
             public override IProjectEngineFactory FindFactory(ProjectSnapshot project)
             {
                 throw new NotImplementedException();
@@ -148,6 +140,14 @@ namespace Microsoft.AspNetCore.Razor.Performance
             public override IProjectEngineFactory FindSerializableFactory(ProjectSnapshot project)
             {
                 throw new NotImplementedException();
+            }
+
+            public override RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+            {
+                return RazorProjectEngine.Create(configuration, fileSystem, b =>
+                {
+                    RazorExtensions.Register(b);
+                });
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
+++ b/src/Microsoft.AspNetCore.Razor.Language/DefaultRazorProjectFileSystem.cs
@@ -49,6 +49,10 @@ namespace Microsoft.AspNetCore.Razor.Language
             var absolutePath = NormalizeAndEnsureValidPath(path);
 
             var file = new FileInfo(absolutePath);
+            if (!absolutePath.StartsWith(absoluteBasePath))
+            {
+                throw new InvalidOperationException($"The file '{file.FullName}' is not a descendent of the base path '{absoluteBasePath}'.");
+            }
 
             var relativePhysicalPath = file.FullName.Substring(absoluteBasePath.Length + 1); // Include leading separator
             var filePath = "/" + relativePhysicalPath.Replace(Path.DirectorySeparatorChar, '/');

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectSnapshotProjectEngineFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultProjectSnapshotProjectEngineFactory.cs
@@ -32,13 +32,8 @@ namespace Microsoft.CodeAnalysis.Razor
             _factories = factories;
         }
 
-        public override RazorProjectEngine Create(ProjectSnapshot project, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        public override RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {
-            if (project == null)
-            {
-                throw new ArgumentNullException(nameof(project));
-            }
-
             if (fileSystem == null)
             {
                 throw new ArgumentNullException(nameof(fileSystem));
@@ -55,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Razor
             //
             // We typically want this because the language adds features over time - we don't want to a bunch of errors
             // to show up when a document is first opened, and then go away when the configuration loads, we'd prefer the opposite.
-            var configuration = project.Configuration ?? DefaultConfiguration;
+            configuration = configuration ?? DefaultConfiguration;
 
             // If there's no factory to handle the configuration then fall back to a very basic configuration.
             //

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotProjectEngineFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotProjectEngineFactory.cs
@@ -60,6 +60,21 @@ namespace Microsoft.CodeAnalysis.Razor
             return Create(project.Configuration, fileSystem, configure);
         }
 
+        public RazorProjectEngine Create(RazorConfiguration configuration, string directoryPath, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            if (directoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(directoryPath));
+            }
+
+            return Create(configuration, RazorProjectFileSystem.Create(directoryPath), configure);
+        }
+
         public abstract RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure);
     }
 }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotProjectEngineFactory.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSnapshotProjectEngineFactory.cs
@@ -45,7 +45,21 @@ namespace Microsoft.CodeAnalysis.Razor
             return Create(project, RazorProjectFileSystem.Create(Path.GetDirectoryName(project.FilePath)), configure);
         }
 
-        public abstract RazorProjectEngine Create(ProjectSnapshot project, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure);
+        public RazorProjectEngine Create(ProjectSnapshot project, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
 
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(fileSystem));
+            }
+
+            return Create(project.Configuration, fileSystem, configure);
+        }
+
+        public abstract RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure);
     }
 }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshot.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshot.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 
@@ -58,9 +59,37 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             }
         }
 
+        public override bool IsImportDocument(DocumentSnapshot document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+            
+            return State.ImportsToIncludingDocuments.ContainsKey(document.TargetPath);
+        }
+
+        public override IEnumerable<DocumentSnapshot> GetRelatedDocuments(DocumentSnapshot document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            if (State.ImportsToIncludingDocuments.TryGetValue(document.TargetPath, out var relatedDocuments))
+            {
+                lock (_lock)
+                {
+                    return relatedDocuments.Select(GetDocument).ToArray();
+                }
+            }
+
+            return Array.Empty<DocumentSnapshot>();
+        }
+
         public override RazorProjectEngine GetProjectEngine()
         {
-            return State.ProjectEngine.GetProjectEngine(this);
+            return State.ProjectEngine.GetProjectEngine(this.State);
         }
 
         public override Task<IReadOnlyList<TagHelperDescriptor>> GetTagHelpersAsync()

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshot.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshot.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 throw new ArgumentNullException(nameof(document));
             }
             
-            return State.ImportsToIncludingDocuments.ContainsKey(document.TargetPath);
+            return State.ImportsToRelatedDocuments.ContainsKey(document.TargetPath);
         }
 
         public override IEnumerable<DocumentSnapshot> GetRelatedDocuments(DocumentSnapshot document)
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 throw new ArgumentNullException(nameof(document));
             }
 
-            if (State.ImportsToIncludingDocuments.TryGetValue(document.TargetPath, out var relatedDocuments))
+            if (State.ImportsToRelatedDocuments.TryGetValue(document.TargetPath, out var relatedDocuments))
             {
                 lock (_lock)
                 {

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -183,6 +183,18 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return state;
         }
 
+        public virtual DocumentState WithImportsChange()
+        {
+            var state = new DocumentState(Services, HostDocument, _sourceText, _version, _loader);
+
+            // The source could not have possibly changed.
+            state._sourceText = _sourceText;
+            state._version = _version;
+            state._loaderTask = _loaderTask;
+
+            return state;
+        }
+
         public virtual DocumentState WithWorkspaceProjectChange()
         {
             var state = new DocumentState(Services, HostDocument, _sourceText, _version, _loader);

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/EphemeralProjectSnapshot.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/EphemeralProjectSnapshot.cs
@@ -56,6 +56,26 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return null;
         }
 
+        public override bool IsImportDocument(DocumentSnapshot document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            return false;
+        }
+
+        public override IEnumerable<DocumentSnapshot> GetRelatedDocuments(DocumentSnapshot document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            return Array.Empty<DocumentSnapshot>();
+        }
+
         public override RazorProjectEngine GetProjectEngine()
         {
             return _projectEngine.Value;

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/LiveShareProjectSnapshotBase.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/LiveShareProjectSnapshotBase.cs
@@ -27,6 +27,10 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces.ProjectSystem
 
         public override DocumentSnapshot GetDocument(string filePath) => throw new NotImplementedException();
 
+        public override bool IsImportDocument(DocumentSnapshot document) => throw new NotImplementedException();
+
+        public override IEnumerable<DocumentSnapshot> GetRelatedDocuments(DocumentSnapshot document) => throw new NotImplementedException();
+
         public override RazorProjectEngine GetProjectEngine() => throw new NotImplementedException();
 
         public override Task<IReadOnlyList<TagHelperDescriptor>> GetTagHelpersAsync() => throw new NotImplementedException();

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
@@ -14,6 +14,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 throw new ArgumentException("Both projects cannot be null.");
             }
 
+            Older = older;
+            Newer = newer;
             Kind = kind;
 
             ProjectFilePath = older?.FilePath ?? newer.FilePath;
@@ -26,6 +28,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 throw new ArgumentException("Both projects cannot be null.");
             }
 
+            Older = older;
+            Newer = newer;
             DocumentFilePath = documentFilePath;
             Kind = kind;
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
@@ -7,28 +7,34 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal class ProjectChangeEventArgs : EventArgs
     {
-        public ProjectChangeEventArgs(string projectFilePath, ProjectChangeKind kind)
+        public ProjectChangeEventArgs(ProjectSnapshot older, ProjectSnapshot newer, ProjectChangeKind kind)
         {
-            if (projectFilePath == null)
+            if (older == null && newer == null)
             {
-                throw new ArgumentNullException(nameof(projectFilePath));
+                throw new ArgumentException("Both projects cannot be null.");
             }
 
-            ProjectFilePath = projectFilePath;
             Kind = kind;
+
+            ProjectFilePath = older?.FilePath ?? newer.FilePath;
         }
 
-        public ProjectChangeEventArgs(string projectFilePath, string documentFilePath, ProjectChangeKind kind)
+        public ProjectChangeEventArgs(ProjectSnapshot older, ProjectSnapshot newer, string documentFilePath, ProjectChangeKind kind)
         {
-            if (projectFilePath == null)
+            if (older == null && newer == null)
             {
-                throw new ArgumentNullException(nameof(projectFilePath));
+                throw new ArgumentException("Both projects cannot be null.");
             }
 
-            ProjectFilePath = projectFilePath;
             DocumentFilePath = documentFilePath;
             Kind = kind;
+
+            ProjectFilePath = older?.FilePath ?? newer.FilePath;
         }
+
+        public ProjectSnapshot Older { get; }
+
+        public ProjectSnapshot Newer { get; }
 
         public string ProjectFilePath { get; }
 

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectEngineTracker.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectEngineTracker.cs
@@ -59,10 +59,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     if (_projectEngine == null)
                     {
                         var factory = _services.GetRequiredService<ProjectSnapshotProjectEngineFactory>();
-                        _projectEngine = factory.Create(
-                            state.HostProject.Configuration, 
-                            RazorProjectFileSystem.Create(Path.GetDirectoryName(state.HostProject.FilePath)), 
-                            configure: null);
+                        _projectEngine = factory.Create(state.HostProject.Configuration, Path.GetDirectoryName(state.HostProject.FilePath), configure: null);
                     }
                 }
             }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectEngineTracker.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectEngineTracker.cs
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Host;
 
@@ -41,11 +45,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             return this;
         }
 
-        public RazorProjectEngine GetProjectEngine(ProjectSnapshot snapshot)
+        public RazorProjectEngine GetProjectEngine(ProjectState state)
         {
-            if (snapshot == null)
+            if (state == null)
             {
-                throw new ArgumentNullException(nameof(snapshot));
+                throw new ArgumentNullException(nameof(state));
             }
 
             if (_projectEngine == null)
@@ -55,12 +59,33 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     if (_projectEngine == null)
                     {
                         var factory = _services.GetRequiredService<ProjectSnapshotProjectEngineFactory>();
-                        _projectEngine = factory.Create(snapshot);
+                        _projectEngine = factory.Create(
+                            state.HostProject.Configuration, 
+                            RazorProjectFileSystem.Create(Path.GetDirectoryName(state.HostProject.FilePath)), 
+                            configure: null);
                     }
                 }
             }
 
             return _projectEngine;
+        }
+
+        public List<string> GetImportDocumentTargetPaths(ProjectState state, string targetPath)
+        {
+            var projectEngine = GetProjectEngine(state);
+            var importFeature = projectEngine.ProjectFeatures.OfType<IImportProjectFeature>().FirstOrDefault();
+            var projectItem = projectEngine.FileSystem.GetItem(targetPath);
+            var importItems = importFeature?.GetImports(projectItem).Where(i => i.FilePath != null);
+
+            // Target path looks like `Foo\\Bar.cshtml`
+            var targetPaths = new List<string>();
+            foreach (var importItem in importItems)
+            {
+                var itemTargetPath = importItem.FilePath.Replace('/', '\\').TrimStart('\\');
+                targetPaths.Add(itemTargetPath);
+            }
+
+            return targetPaths;
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
@@ -25,6 +25,17 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         public abstract DocumentSnapshot GetDocument(string filePath);
 
+        public abstract bool IsImportDocument(DocumentSnapshot document);
+
+        /// <summary>
+        /// If the provided document is an import document, gets the other documents in the project
+        /// that include directives specified by the provided document. Otherwise returns an empty
+        /// list.
+        /// </summary>
+        /// <param name="document">The document.</param>
+        /// <returns>A list of related documents.</returns>
+        public abstract IEnumerable<DocumentSnapshot> GetRelatedDocuments(DocumentSnapshot document);
+
         public abstract Task<IReadOnlyList<TagHelperDescriptor>> GetTagHelpersAsync();
 
         public abstract bool TryGetTagHelpers(out IReadOnlyList<TagHelperDescriptor> result);

--- a/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceBase.cs
+++ b/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceBase.cs
@@ -76,6 +76,16 @@ namespace Microsoft.CodeAnalysis.Remote.Razor
                 return null;
             }
 
+            public override bool IsImportDocument(DocumentSnapshot document)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override IEnumerable<DocumentSnapshot> GetRelatedDocuments(DocumentSnapshot document)
+            {
+                throw new NotImplementedException();
+            }
+
             public override RazorProjectEngine GetProjectEngine()
             {
                 throw new NotImplementedException();

--- a/src/Microsoft.VisualStudio.LanguageServices.Razor/BackgroundDocumentGenerator.cs
+++ b/src/Microsoft.VisualStudio.LanguageServices.Razor/BackgroundDocumentGenerator.cs
@@ -143,33 +143,6 @@ namespace Microsoft.CodeAnalysis.Razor
             }
         }
 
-        public void EnqueueRelatedDocuments(ProjectSnapshot project, DocumentSnapshot document)
-        {
-            if (project == null)
-            {
-                throw new ArgumentNullException(nameof(project));
-            }
-
-            if (document == null)
-            {
-                throw new ArgumentNullException(nameof(document));
-            }
-
-            _foregroundDispatcher.AssertForegroundThread();
-
-            lock (_work)
-            {
-                // We only want to store the last 'seen' version of any given document. That way when we pick one to process
-                // it's always the best version to use.
-                foreach (var relatedDocument in project.GetRelatedDocuments(document))
-                {
-                    _work[new DocumentKey(project.FilePath, relatedDocument.FilePath)] = relatedDocument;
-                }
-
-                StartWorker();
-            }
-        }
-
         protected virtual void StartWorker()
         {
             // Access to the timer is protected by the lock in Enqueue and in Timer_Tick

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Host;
@@ -9,14 +10,10 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
-    public class DefaultDocumentSnapshotTest
+    public class DefaultDocumentSnapshotTest : WorkspaceTestBase
     {
         public DefaultDocumentSnapshotTest()
         {
-            var services = TestServices.Create(
-                new[] { new TestProjectSnapshotProjectEngineFactory() },
-                new[] { new TestTagHelperResolver() });
-            Workspace = TestWorkspace.Create(services);
             var hostProject = new HostProject("C:/some/path/project.csproj", RazorConfiguration.Default);
             var projectState = ProjectState.Create(Workspace.Services, hostProject);
             var project = new DefaultProjectSnapshot(projectState);
@@ -26,10 +23,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var textAndVersion = TextAndVersion.Create(SourceText, Version);
             var documentState = DocumentState.Create(Workspace.Services, HostDocument, () => Task.FromResult(textAndVersion));
             Document = new DefaultDocumentSnapshot(project, documentState);
-
         }
-
-        private Workspace Workspace { get; }
 
         private SourceText SourceText { get; }
 
@@ -38,6 +32,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         private HostDocument HostDocument { get; }
 
         private DefaultDocumentSnapshot Document { get; }
+
+        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        {
+            services.Add(new TestTagHelperResolver());
+        }
 
         [Fact]
         public async Task GetGeneratedOutputAsync_SetsHostDocumentOutput()

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
@@ -14,11 +13,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     {
         public DefaultDocumentSnapshotTest()
         {
-            var hostProject = new HostProject("C:/some/path/project.csproj", RazorConfiguration.Default);
-            var projectState = ProjectState.Create(Workspace.Services, hostProject);
+            var projectState = ProjectState.Create(Workspace.Services, TestProjectData.SomeProject);
             var project = new DefaultProjectSnapshot(projectState);
-            HostDocument = new HostDocument("C:/some/path/file.cshtml", "C:/some/path/file.cshtml");
-            SourceText = Text.SourceText.From("<p>Hello World</p>");
+            HostDocument = TestProjectData.SomeProjectFile1;
+            SourceText = SourceText.From("<p>Hello World</p>");
             Version = VersionStamp.Default.GetNewerVersion();
             var textAndVersion = TextAndVersion.Create(SourceText, Version);
             var documentState = DocumentState.Create(Workspace.Services, HostDocument, () => Task.FromResult(textAndVersion));

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotTest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Host;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Host;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         {
             TagHelperResolver = new TestTagHelperResolver();
 
-            HostProject = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_2_0);
-            HostProjectWithConfigurationChange = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_1_0);
+            HostProject = new HostProject(TestProjectData.SomeProject.FilePath, FallbackRazorConfiguration.MVC_2_0);
+            HostProjectWithConfigurationChange = new HostProject(TestProjectData.SomeProject.FilePath, FallbackRazorConfiguration.MVC_1_0);
 
             var projectId = ProjectId.CreateNewId("Test");
             var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
@@ -26,19 +26,21 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 "Test",
                 "Test",
                 LanguageNames.CSharp,
-                "c:\\MyProject\\Test.csproj"));
+                TestProjectData.SomeProject.FilePath));
             WorkspaceProject = solution.GetProject(projectId);
 
-            SomeTagHelpers = new List<TagHelperDescriptor>();
-            SomeTagHelpers.Add(TagHelperDescriptorBuilder.Create("Test1", "TestAssembly").Build());
+            SomeTagHelpers = new List<TagHelperDescriptor>
+            {
+                TagHelperDescriptorBuilder.Create("Test1", "TestAssembly").Build()
+            };
 
             Documents = new HostDocument[]
             {
-                new HostDocument("c:\\MyProject\\File.cshtml", "File.cshtml"),
-                new HostDocument("c:\\MyProject\\Index.cshtml", "Index.cshtml"),
+                TestProjectData.SomeProjectFile1,
+                TestProjectData.SomeProjectFile2,
 
                 // linked file
-                new HostDocument("c:\\SomeOtherProject\\Index.cshtml", "Pages\\Index.cshtml"),
+                TestProjectData.AnotherProjectNestedFile3,
             };
         }
 
@@ -139,10 +141,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Arrange
             var state = ProjectState.Create(Workspace.Services, HostProject, WorkspaceProject)
                 .WithAddedHostDocument(Documents[0], DocumentState.EmptyLoader)
-                .WithAddedHostDocument(new HostDocument("c:\\SomeImport.cshtml", "_Imports.cshtml"), DocumentState.EmptyLoader);
+                .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
             var snapshot = new DefaultProjectSnapshot(state);
 
-            var document = snapshot.GetDocument("c:\\SomeImport.cshtml");
+            var document = snapshot.GetDocument(TestProjectData.SomeProjectImportFile.FilePath);
 
             // Act
             var result = snapshot.IsImportDocument(document);
@@ -175,10 +177,10 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var state = ProjectState.Create(Workspace.Services, HostProject, WorkspaceProject)
                 .WithAddedHostDocument(Documents[0], DocumentState.EmptyLoader)
                 .WithAddedHostDocument(Documents[1], DocumentState.EmptyLoader)
-                .WithAddedHostDocument(new HostDocument("c:\\SomeImport.cshtml", "_Imports.cshtml"), DocumentState.EmptyLoader);
+                .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
             var snapshot = new DefaultProjectSnapshot(state);
 
-            var document = snapshot.GetDocument("c:\\SomeImport.cshtml");
+            var document = snapshot.GetDocument(TestProjectData.SomeProjectImportFile.FilePath);
 
             // Act
             var documents = snapshot.GetRelatedDocuments(document);

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
@@ -14,26 +14,14 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
-    public class DocumentStateTest
+    public class DocumentStateTest : WorkspaceTestBase
     {
         public DocumentStateTest()
         {
             TagHelperResolver = new TestTagHelperResolver();
 
-            HostServices = TestServices.Create(
-                new IWorkspaceService[]
-                {
-                    new TestProjectSnapshotProjectEngineFactory(),
-                },
-                new ILanguageService[]
-                {
-                    TagHelperResolver,
-                });
-
             HostProject = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_2_0);
             HostProjectWithConfigurationChange = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_1_0);
-
-            Workspace = TestWorkspace.Create(HostServices);
 
             var projectId = ProjectId.CreateNewId("Test");
             var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
@@ -64,15 +52,16 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private TestTagHelperResolver TagHelperResolver { get; }
 
-        private HostServices HostServices { get; }
-
-        private Workspace Workspace { get; }
-
         private List<TagHelperDescriptor> SomeTagHelpers { get; }
 
         private Func<Task<TextAndVersion>> TextLoader { get; }
 
         private SourceText Text { get; }
+
+        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        {
+            services.Add(TagHelperResolver);
+        }
 
         [Fact]
         public async Task DocumentState_CreatedNew_HasEmptyText()
@@ -146,6 +135,38 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         }
 
         [Fact]
+        public void DocumentState_WithImportsChange_CachesSnapshotText()
+        {
+            // Arrange
+            var original = DocumentState.Create(Workspace.Services, Document, DocumentState.EmptyLoader)
+                .WithText(Text, VersionStamp.Create());
+
+            // Act
+            var state = original.WithImportsChange();
+
+            // Assert
+            Assert.True(state.TryGetText(out _));
+            Assert.True(state.TryGetTextVersion(out _));
+        }
+
+        [Fact]
+        public async Task DocumentState_WithImportsChange_CachesLoadedText()
+        {
+            // Arrange
+            var original = DocumentState.Create(Workspace.Services, Document, DocumentState.EmptyLoader)
+                .WithTextLoader(TextLoader);
+
+            await original.GetTextAsync();
+
+            // Act
+            var state = original.WithImportsChange();
+
+            // Assert
+            Assert.True(state.TryGetText(out _));
+            Assert.True(state.TryGetTextVersion(out _));
+        }
+
+        [Fact]
         public void DocumentState_WithWorkspaceProjectChange_CachesSnapshotText()
         {
             // Arrange
@@ -159,7 +180,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             Assert.True(state.TryGetText(out _));
             Assert.True(state.TryGetTextVersion(out _));
         }
-
 
         [Fact]
         public async Task DocumentState_WithWorkspaceProjectChange_CachesLoadedText()

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
@@ -3,13 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
-using Moq;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
@@ -19,9 +16,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public DocumentStateTest()
         {
             TagHelperResolver = new TestTagHelperResolver();
-
-            HostProject = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_2_0);
-            HostProjectWithConfigurationChange = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_1_0);
+            
+            HostProject = new HostProject(TestProjectData.SomeProject.FilePath, FallbackRazorConfiguration.MVC_2_0);
+            HostProjectWithConfigurationChange = new HostProject(TestProjectData.SomeProject.FilePath, FallbackRazorConfiguration.MVC_1_0);
 
             var projectId = ProjectId.CreateNewId("Test");
             var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
@@ -30,13 +27,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 "Test",
                 "Test",
                 LanguageNames.CSharp,
-                "c:\\MyProject\\Test.csproj"));
+                TestProjectData.SomeProject.FilePath));
             WorkspaceProject = solution.GetProject(projectId);
 
             SomeTagHelpers = new List<TagHelperDescriptor>();
             SomeTagHelpers.Add(TagHelperDescriptorBuilder.Create("Test1", "TestAssembly").Build());
 
-            Document = new HostDocument("c:\\MyProject\\File.cshtml", "File.cshtml");
+            Document = TestProjectData.SomeProjectFile1;
 
             Text = SourceText.From("Hello, world!");
             TextLoader = () => Task.FromResult(TextAndVersion.Create(Text, VersionStamp.Create()));

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -398,13 +399,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         {
             // Arrange
             var callCount = 0;
-
-            var documents = new Dictionary<string, DocumentState>();
+            
+            var documents = ImmutableDictionary.CreateBuilder<string, DocumentState>(FilePathComparer.Instance);
             documents[Documents[1].FilePath] = TestDocumentState.Create(Workspace.Services, Documents[1], onConfigurationChange: () => callCount++);
             documents[Documents[2].FilePath] = TestDocumentState.Create(Workspace.Services, Documents[2], onConfigurationChange: () => callCount++);
 
             var original = ProjectState.Create(Workspace.Services, HostProject, WorkspaceProject);
-            original.Documents = documents;
+            original.Documents = documents.ToImmutable();
 
             var changed = WorkspaceProject.WithAssemblyName("Test1");
 
@@ -503,12 +504,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Arrange
             var callCount = 0;
 
-            var documents = new Dictionary<string, DocumentState>();
+            var documents = ImmutableDictionary.CreateBuilder<string, DocumentState>(FilePathComparer.Instance);
             documents[Documents[1].FilePath] = TestDocumentState.Create(Workspace.Services, Documents[1], onWorkspaceProjectChange: () => callCount++);
             documents[Documents[2].FilePath] = TestDocumentState.Create(Workspace.Services, Documents[2], onWorkspaceProjectChange: () => callCount++);
 
             var original = ProjectState.Create(Workspace.Services, HostProject, WorkspaceProject);
-            original.Documents = documents;
+            original.Documents = documents.ToImmutable();
 
             var changed = WorkspaceProject.WithAssemblyName("Test1");
 

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestImportProjectFeature.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestImportProjectFeature.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class TestImportProjectFeature : RazorProjectEngineFeatureBase, IImportProjectFeature
+    {
+        public IReadOnlyList<RazorProjectItem> GetImports(RazorProjectItem projectItem)
+        {
+            if (projectItem == null)
+            {
+                throw new ArgumentNullException(nameof(projectItem));
+            }
+
+            var imports = new List<RazorProjectItem>();
+            AddHierarchicalImports(projectItem, imports);
+
+            return imports;
+        }
+
+        private void AddHierarchicalImports(RazorProjectItem projectItem, List<RazorProjectItem> imports)
+        {
+            // We want items in descending order. FindHierarchicalItems returns items in ascending order.
+            var importProjectItems = ProjectEngine.FileSystem.FindHierarchicalItems(projectItem.FilePath, "_Imports.cshtml").Reverse();
+            imports.AddRange(importProjectItems);
+        }
+    }
+}

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectData.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectData.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    // Used to abstract away platform-specific file/directory path information.
+    //
+    // The System.IO.Path methods don't processes Windows paths in a Windows way 
+    // on *nix (rightly so), so we need to use platform-specific paths.
+    //
+    // Target paths are always Windows style.
+    internal static class TestProjectData
+    {
+        static TestProjectData()
+        {
+            var baseDirectory = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "c:\\users\\example\\src" : "/home/example";
+
+            SomeProject = new HostProject(Path.Combine(baseDirectory, "SomeProject", "SomeProject.csproj"), RazorConfiguration.Default);
+            SomeProjectFile1 = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "File1.cshtml"), "File1.cshtml");
+            SomeProjectFile2 = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "File2.cshtml"), "File2.cshtml");
+            SomeProjectImportFile = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "_Imports.cshtml"), "_Imports.cshtml");
+            SomeProjectNestedFile3 = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "Nested", "File3.cshtml"), "Nested\\File1.cshtml");
+            SomeProjectNestedFile4 = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "Nested", "File4.cshtml"), "Nested\\File2.cshtml");
+            SomeProjectNestedImportFile = new HostDocument(Path.Combine(baseDirectory, "SomeProject", "Nested", "_Imports.cshtml"), "Nested\\_Imports.cshtml");
+
+            AnotherProject = new HostProject(Path.Combine(baseDirectory, "AnotherProject", "AnotherProject.csproj"), RazorConfiguration.Default);
+            AnotherProjectFile1 = new HostDocument(Path.Combine(baseDirectory, "AnotherProject", "File1.cshtml"), "File1.cshtml");
+            AnotherProjectFile2 = new HostDocument(Path.Combine(baseDirectory, "AnotherProject", "File2.cshtml"), "File2.cshtml");
+            AnotherProjectImportFile = new HostDocument(Path.Combine(baseDirectory, "AnotherProject", "_Imports.cshtml"), "_Imports.cshtml");
+            AnotherProjectNestedFile3 = new HostDocument(Path.Combine(baseDirectory, "AnotherProject", "Nested", "File3.cshtml"), "Nested\\File1.cshtml");
+            AnotherProjectNestedFile4 = new HostDocument(Path.Combine(baseDirectory, "AnotherProject", "Nested", "File4.cshtml"), "Nested\\File2.cshtml");
+            AnotherProjectNestedImportFile = new HostDocument(Path.Combine(baseDirectory, "AnotherProject", "Nested", "_Imports.cshtml"), "Nested\\_Imports.cshtml");
+        }
+
+        public static readonly HostProject SomeProject;
+        public static readonly HostDocument SomeProjectFile1;
+        public static readonly HostDocument SomeProjectFile2;
+        public static readonly HostDocument SomeProjectImportFile;
+        public static readonly HostDocument SomeProjectNestedFile3;
+        public static readonly HostDocument SomeProjectNestedFile4;
+        public static readonly HostDocument SomeProjectNestedImportFile;
+
+        public static readonly HostProject AnotherProject;
+        public static readonly HostDocument AnotherProjectFile1;
+        public static readonly HostDocument AnotherProjectFile2;
+        public static readonly HostDocument AnotherProjectImportFile;
+        public static readonly HostDocument AnotherProjectNestedFile3;
+        public static readonly HostDocument AnotherProjectNestedFile4;
+        public static readonly HostDocument AnotherProjectNestedImportFile;
+    }
+}

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectSnapshotProjectEngineFactory.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectSnapshotProjectEngineFactory.cs
@@ -8,11 +8,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal class TestProjectSnapshotProjectEngineFactory : ProjectSnapshotProjectEngineFactory
     {
+        public Action<RazorProjectEngineBuilder> Configure { get; set; }
+
         public RazorProjectEngine Engine { get; set; }
 
         public override RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {
-            return Engine ?? RazorProjectEngine.Create(configuration, fileSystem, configure);
+            return Engine ?? RazorProjectEngine.Create(configuration, fileSystem, configure ?? Configure);
         }
 
         public override IProjectEngineFactory FindFactory(ProjectSnapshot project)

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectSnapshotProjectEngineFactory.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectSnapshotProjectEngineFactory.cs
@@ -10,9 +10,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
     {
         public RazorProjectEngine Engine { get; set; }
 
-        public override RazorProjectEngine Create(ProjectSnapshot project, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
+        public override RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
         {
-            return Engine ?? RazorProjectEngine.Create(project.Configuration, fileSystem, configure);
+            return Engine ?? RazorProjectEngine.Create(configuration, fileSystem, configure);
         }
 
         public override IProjectEngineFactory FindFactory(ProjectSnapshot project)

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/WorkspaceTestBase.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/WorkspaceTestBase.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    public abstract class WorkspaceTestBase
+    {
+        private bool _initialized;
+        private HostServices _hostServices;
+        private Workspace _workspace;
+
+        protected WorkspaceTestBase()
+        {
+        }
+
+        protected HostServices HostServices
+        {
+            get
+            {
+                EnsureInitialized();
+                return _hostServices;
+            }
+        }
+
+        protected Workspace Workspace
+        {
+            get
+            {
+                EnsureInitialized();
+                return _workspace;
+            }
+        }
+
+        protected virtual void ConfigureWorkspaceServices(List<IWorkspaceService> services)
+        {
+        }
+
+        protected virtual void ConfigureLanguageServices(List<ILanguageService> services)
+        {
+        }
+
+        protected virtual void ConfigureWorkspace(AdhocWorkspace workspace)
+        {
+        }
+
+        protected virtual void ConfigureProjectEngine(RazorProjectEngineBuilder builder)
+        {
+        }
+
+        private void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            var workspaceServices = new List<IWorkspaceService>()
+            {
+                new TestProjectSnapshotProjectEngineFactory()
+                {
+                    Configure = ConfigureProjectEngine,
+                },
+            };
+            ConfigureWorkspaceServices(workspaceServices);
+
+            var languageServices = new List<ILanguageService>();
+            ConfigureLanguageServices(languageServices);
+
+            _hostServices = TestServices.Create(workspaceServices, languageServices);
+            _workspace = TestWorkspace.Create(_hostServices, ConfigureWorkspace);
+            _initialized = true;
+        }
+    }
+}

--- a/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/WorkspaceTestBase.cs
+++ b/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/WorkspaceTestBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Razor
                 return _workspace;
             }
         }
-
+        
         protected virtual void ConfigureWorkspaceServices(List<IWorkspaceService> services)
         {
         }

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/SingleThreadedForegroundDispatcher.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/SingleThreadedForegroundDispatcher.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Razor
+{
+    internal class SingleThreadedForegroundDispatcher : ForegroundDispatcher
+    {
+        public SingleThreadedForegroundDispatcher()
+        {
+            ForegroundScheduler = SynchronizationContext.Current == null ? new ThrowingTaskScheduler() : TaskScheduler.FromCurrentSynchronizationContext();
+            BackgroundScheduler = TaskScheduler.Default;
+        }
+
+        public override TaskScheduler ForegroundScheduler { get; }
+
+        public override TaskScheduler BackgroundScheduler { get; }
+
+        private Thread Thread { get; } = Thread.CurrentThread;
+
+        public override bool IsForegroundThread => Thread.CurrentThread == Thread;
+
+        private class ThrowingTaskScheduler : TaskScheduler
+        {
+            protected override IEnumerable<Task> GetScheduledTasks()
+            {
+                return Enumerable.Empty<Task>();
+            }
+
+            protected override void QueueTask(Task task)
+            {
+                throw new InvalidOperationException($"Use [{nameof(ForegroundFactAttribute)}]");
+            }
+
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+            {
+                throw new InvalidOperationException($"Use [{nameof(ForegroundFactAttribute)}]");
+            }
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultImportDocumentManagerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultImportDocumentManagerTest.cs
@@ -16,7 +16,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
     {
         public DefaultImportDocumentManagerTest()
         {
-            ProjectPath = "C:\\path\\to\\project\\project.csproj";
+            ProjectPath = TestProjectData.SomeProject.FilePath;
+            DirectoryPath = Path.GetDirectoryName(ProjectPath);
 
             FileSystem = RazorProjectFileSystem.Create(Path.GetDirectoryName(ProjectPath));
             ProjectEngine = RazorProjectEngine.Create(FallbackRazorConfiguration.MVC_2_1, FileSystem, b =>
@@ -26,9 +27,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
             });
         }
 
-        private string FilePath { get; }
-
         private string ProjectPath { get; }
+
+        private string DirectoryPath { get; }
 
         private RazorProjectFileSystem FileSystem { get; }
 
@@ -39,17 +40,17 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var tracker = Mock.Of<VisualStudioDocumentTracker>(
-                t => t.FilePath == "C:\\path\\to\\project\\Views\\Home\\file.cshtml" && 
+                t => t.FilePath == Path.Combine(DirectoryPath, "Views", "Home", "file.cshtml") && 
                 t.ProjectPath == ProjectPath &&
                 t.ProjectSnapshot == Mock.Of<ProjectSnapshot>(p => p.GetProjectEngine() == ProjectEngine));
-
+            
             var fileChangeTrackerFactory = new Mock<FileChangeTrackerFactory>();
             var fileChangeTracker1 = new Mock<FileChangeTracker>();
             fileChangeTracker1
                 .Setup(f => f.StartListening())
                 .Verifiable();
             fileChangeTrackerFactory
-                .Setup(f => f.Create("C:\\path\\to\\project\\Views\\Home\\_ViewImports.cshtml"))
+                .Setup(f => f.Create(Path.Combine(DirectoryPath, "Views", "Home", "_ViewImports.cshtml")))
                 .Returns(fileChangeTracker1.Object)
                 .Verifiable();
             var fileChangeTracker2 = new Mock<FileChangeTracker>();
@@ -57,13 +58,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 .Setup(f => f.StartListening())
                 .Verifiable();
             fileChangeTrackerFactory
-                .Setup(f => f.Create("C:\\path\\to\\project\\Views\\_ViewImports.cshtml"))
+                .Setup(f => f.Create(Path.Combine(DirectoryPath, "Views", "_ViewImports.cshtml")))
                 .Returns(fileChangeTracker2.Object)
                 .Verifiable();
             var fileChangeTracker3 = new Mock<FileChangeTracker>();
             fileChangeTracker3.Setup(f => f.StartListening()).Verifiable();
             fileChangeTrackerFactory
-                .Setup(f => f.Create("C:\\path\\to\\project\\_ViewImports.cshtml"))
+                .Setup(f => f.Create(Path.Combine(DirectoryPath, "_ViewImports.cshtml")))
                 .Returns(fileChangeTracker3.Object)
                 .Verifiable();
 
@@ -84,12 +85,12 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var tracker = Mock.Of<VisualStudioDocumentTracker>(
-                t => t.FilePath == "C:\\path\\to\\project\\file.cshtml" &&
+                t => t.FilePath == Path.Combine(DirectoryPath, "file.cshtml") &&
                 t.ProjectPath == ProjectPath &&
                 t.ProjectSnapshot == Mock.Of<ProjectSnapshot>(p => p.GetProjectEngine() == ProjectEngine));
 
             var anotherTracker = Mock.Of<VisualStudioDocumentTracker>(
-                t => t.FilePath == "C:\\path\\to\\project\\anotherFile.cshtml" && 
+                t => t.FilePath == Path.Combine(DirectoryPath, "anotherFile.cshtml") && 
                 t.ProjectPath == ProjectPath &&
                 t.ProjectSnapshot == Mock.Of<ProjectSnapshot>(p => p.GetProjectEngine() == ProjectEngine));
 
@@ -115,7 +116,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var tracker = Mock.Of<VisualStudioDocumentTracker>(
-                t => t.FilePath == "C:\\path\\to\\project\\file.cshtml" &&
+                t => t.FilePath == Path.Combine(DirectoryPath, "file.cshtml") &&
                 t.ProjectPath == ProjectPath &&
                 t.ProjectSnapshot == Mock.Of<ProjectSnapshot>(p => p.GetProjectEngine() == ProjectEngine));
 
@@ -125,7 +126,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
                 .Setup(f => f.StopListening())
                 .Verifiable();
             fileChangeTrackerFactory
-                .Setup(f => f.Create("C:\\path\\to\\project\\_ViewImports.cshtml"))
+                .Setup(f => f.Create(Path.Combine(DirectoryPath, "_ViewImports.cshtml")))
                 .Returns(fileChangeTracker.Object)
                 .Verifiable();
 
@@ -145,12 +146,12 @@ namespace Microsoft.VisualStudio.Editor.Razor
         {
             // Arrange
             var tracker = Mock.Of<VisualStudioDocumentTracker>(
-                t => t.FilePath == "C:\\path\\to\\project\\file.cshtml" && 
+                t => t.FilePath == Path.Combine(DirectoryPath, "file.cshtml") && 
                 t.ProjectPath == ProjectPath &&
                 t.ProjectSnapshot == Mock.Of<ProjectSnapshot>(p => p.GetProjectEngine() == ProjectEngine));
 
             var anotherTracker = Mock.Of<VisualStudioDocumentTracker>(
-                t => t.FilePath == "C:\\path\\to\\project\\anotherFile.cshtml" &&
+                t => t.FilePath == Path.Combine(DirectoryPath, "anotherFile.cshtml") &&
                 t.ProjectPath == ProjectPath &&
                 t.ProjectSnapshot == Mock.Of<ProjectSnapshot>(p => p.GetProjectEngine() == ProjectEngine));
 

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
@@ -56,7 +56,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             ProjectManager = new TestProjectSnapshotManager(Dispatcher, Workspace) { AllowNotifyListeners = true };
 
             HostProject = new HostProject(ProjectPath, FallbackRazorConfiguration.MVC_2_1);
-            OtherHostProject = new HostProject(ProjectPath, FallbackRazorConfiguration.MVC_2_0);
+            UpdatedHostProject = new HostProject(ProjectPath, FallbackRazorConfiguration.MVC_2_0);
+            OtherHostProject = new HostProject("C:/Some/Other/Path/TestProject.csproj", FallbackRazorConfiguration.MVC_2_0);
 
             DocumentTracker = new DefaultVisualStudioDocumentTracker(
                 Dispatcher,
@@ -78,6 +79,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
         private string ProjectPath { get; }
 
         private HostProject HostProject { get; }
+
+        private HostProject UpdatedHostProject { get; }
 
         private HostProject OtherHostProject { get; }
 
@@ -191,7 +194,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             ProjectManager.HostProjectAdded(HostProject);
             ProjectManager.WorkspaceProjectAdded(WorkspaceProject);
 
-            var e = new ProjectChangeEventArgs(ProjectPath, ProjectChangeKind.ProjectAdded);
+            var e = new ProjectChangeEventArgs(null, ProjectManager.GetLoadedProject(HostProject.FilePath), ProjectChangeKind.ProjectAdded);
 
             var called = false;
             DocumentTracker.ContextChanged += (sender, args) =>
@@ -215,8 +218,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             // Arrange
             ProjectManager.HostProjectAdded(HostProject);
             ProjectManager.WorkspaceProjectAdded(WorkspaceProject);
-
-            var e = new ProjectChangeEventArgs(ProjectPath, ProjectChangeKind.ProjectChanged);
+            
+            var e = new ProjectChangeEventArgs(null, ProjectManager.GetLoadedProject(HostProject.FilePath), ProjectChangeKind.ProjectChanged);
 
             var called = false;
             DocumentTracker.ContextChanged += (sender, args) =>
@@ -238,7 +241,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public void ProjectManager_Changed_ProjectRemoved_TriggersContextChanged_WithEphemeralProject()
         {
             // Arrange
-            var e = new ProjectChangeEventArgs(ProjectPath, ProjectChangeKind.ProjectRemoved);
+            ProjectManager.HostProjectAdded(HostProject);
+            ProjectManager.WorkspaceProjectAdded(WorkspaceProject);
+
+            var project = ProjectManager.GetLoadedProject(HostProject.FilePath);
+            ProjectManager.HostProjectRemoved(HostProject);
+
+            var e = new ProjectChangeEventArgs(project, null, ProjectChangeKind.ProjectRemoved);
 
             var called = false;
             DocumentTracker.ContextChanged += (sender, args) =>
@@ -260,7 +269,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
         public void ProjectManager_Changed_IgnoresUnknownProject()
         {
             // Arrange
-            var e = new ProjectChangeEventArgs("c:/OtherPath/OtherProject.csproj", ProjectChangeKind.ProjectChanged);
+            ProjectManager.HostProjectAdded(OtherHostProject);
+
+            var e = new ProjectChangeEventArgs(null, ProjectManager.GetLoadedProject(OtherHostProject.FilePath), ProjectChangeKind.ProjectChanged);
 
             var called = false;
             DocumentTracker.ContextChanged += (sender, args) =>
@@ -488,13 +499,13 @@ namespace Microsoft.VisualStudio.Editor.Razor
             DocumentTracker.ContextChanged += (sender, e) => { args.Add(e); };
             
             // Act
-            ProjectManager.HostProjectChanged(OtherHostProject);
+            ProjectManager.HostProjectChanged(UpdatedHostProject);
             await DocumentTracker.PendingTagHelperTask;
 
             // Assert
             var snapshot = Assert.IsType<DefaultProjectSnapshot>(DocumentTracker.ProjectSnapshot);
 
-            Assert.Same(OtherHostProject, snapshot.HostProject);
+            Assert.Same(UpdatedHostProject, snapshot.HostProject);
 
             Assert.Collection(
                 args,

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
@@ -26,8 +26,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             RazorCoreContentType = Mock.Of<IContentType>(c => c.IsOfType(RazorLanguage.ContentType) == true);
             TextBuffer = Mock.Of<ITextBuffer>(b => b.ContentType == RazorCoreContentType);
 
-            FilePath = "C:/Some/Path/TestDocumentTracker.cshtml";
-            ProjectPath = "C:/Some/Path/TestProject.csproj";
+            FilePath = TestProjectData.SomeProjectFile1.FilePath;
+            ProjectPath = TestProjectData.SomeProject.FilePath;
 
             ImportDocumentManager = Mock.Of<ImportDocumentManager>();
             WorkspaceEditorSettings = new DefaultWorkspaceEditorSettings(Mock.Of<ForegroundDispatcher>(), Mock.Of<EditorSettingsManager>());
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
 
             HostProject = new HostProject(ProjectPath, FallbackRazorConfiguration.MVC_2_1);
             UpdatedHostProject = new HostProject(ProjectPath, FallbackRazorConfiguration.MVC_2_0);
-            OtherHostProject = new HostProject("C:/Some/Other/Path/TestProject.csproj", FallbackRazorConfiguration.MVC_2_0);
+            OtherHostProject = new HostProject(TestProjectData.AnotherProject.FilePath, FallbackRazorConfiguration.MVC_2_0);
 
             DocumentTracker = new DefaultVisualStudioDocumentTracker(
                 Dispatcher,

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.Editor.Razor
             var engine = RazorProjectEngine.Create(RazorConfiguration.Default, RazorProjectFileSystem.Empty);
             ProjectEngineFactory = Mock.Of<ProjectSnapshotProjectEngineFactory>(
                 f => f.Create(
-                    It.IsAny<ProjectSnapshot>(),
+                    It.IsAny<RazorConfiguration>(),
                     It.IsAny<RazorProjectFileSystem>(),
                     It.IsAny<Action<RazorProjectEngineBuilder>>()) == engine);
         }

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerBaseTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerBaseTest.cs
@@ -21,13 +21,13 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
 
         private TestEditorDocumentManager Manager { get; }
 
-        public string Project1 => "c:\\Project1";
+        public string Project1 => TestProjectData.SomeProject.FilePath;
 
-        public string Project2 => "c:\\Project2";
+        public string Project2 => TestProjectData.AnotherProject.FilePath;
 
-        public string File1 => "c:\\Project1\\File1.cshtml";
+        public string File1 => TestProjectData.SomeProjectFile1.FilePath;
 
-        public string File2 => "c:\\Project2\\File2.cshtml";
+        public string File2 => TestProjectData.AnotherProjectFile2.FilePath;
 
         public TestTextBuffer TextBuffer => new TestTextBuffer(new StringTextSnapshot("HI"));
 
@@ -113,8 +113,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             // Assert
             Assert.Collection(
                 documents.OrderBy(d => d.ProjectFilePath),
-                d => Assert.Same(document1, d),
-                d => Assert.Same(document2, d));
+                d => Assert.Same(document2, d),
+                d => Assert.Same(document1, d));
         }
 
         [ForegroundFact]
@@ -147,8 +147,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             // Assert
             Assert.Collection(
                 Manager.Opened.OrderBy(d => d.ProjectFilePath),
-                d => Assert.Same(document1, d),
-                d => Assert.Same(document2, d));
+                d => Assert.Same(document2, d),
+                d => Assert.Same(document1, d));
         }
 
         [ForegroundFact]
@@ -165,8 +165,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             // Assert
             Assert.Collection(
                 Manager.Closed.OrderBy(d => d.ProjectFilePath),
-                d => Assert.Same(document1, d),
-                d => Assert.Same(document2, d));
+                d => Assert.Same(document2, d),
+                d => Assert.Same(document1, d));
         }
 
         private class TestEditorDocumentManager : EditorDocumentManagerBase

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerListenerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerListenerTest.cs
@@ -58,8 +58,10 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
 
             var listener = new EditorDocumentManagerListener(editorDocumentManger.Object, changedOnDisk, changedInEditor, opened, closed);
 
+            var project = Mock.Of<ProjectSnapshot>(p => p.FilePath == "/Path/to/project.csproj");
+
             // Act & Assert
-            listener.ProjectManager_Changed(null, new ProjectChangeEventArgs("/Path/to/project.csproj", ProjectChangeKind.DocumentAdded));
+            listener.ProjectManager_Changed(null, new ProjectChangeEventArgs(project, project, ProjectChangeKind.DocumentAdded));
         }
 
         [Fact]
@@ -76,8 +78,10 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
 
             var listener = new EditorDocumentManagerListener(editorDocumentManger.Object, onChangedOnDisk: null, onChangedInEditor: null, onOpened: opened, onClosed: null);
 
+            var project = Mock.Of<ProjectSnapshot>(p => p.FilePath == "/Path/to/project.csproj");
+
             // Act
-            listener.ProjectManager_Changed(null, new ProjectChangeEventArgs("/Path/to/project.csproj", ProjectChangeKind.DocumentAdded));
+            listener.ProjectManager_Changed(null, new ProjectChangeEventArgs(project, project, ProjectChangeKind.DocumentAdded));
 
             // Assert
             Assert.True(called);

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerListenerTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerListenerTest.cs
@@ -17,8 +17,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
     {
         public EditorDocumentManagerListenerTest()
         {
-            ProjectFilePath = "C:\\project1\\project.csproj";
-            DocumentFilePath = "c:\\project1\\file1.cshtml";
+            ProjectFilePath = TestProjectData.SomeProject.FilePath;
+            DocumentFilePath = TestProjectData.SomeProjectFile1.FilePath;
             TextLoader = TextLoader.From(TextAndVersion.Create(SourceText.From("FILE"), VersionStamp.Default));
             FileChangeTracker = new DefaultFileChangeTracker(DocumentFilePath);
 

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentTest.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
@@ -16,8 +17,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
         public EditorDocumentTest()
         {
             DocumentManager = Mock.Of<EditorDocumentManager>();
-            ProjectFilePath = "C:\\project1\\project.csproj";
-            DocumentFilePath = "c:\\project1\\file1.cshtml";
+            ProjectFilePath = TestProjectData.SomeProject.FilePath;
+            DocumentFilePath = TestProjectData.SomeProjectFile1.FilePath;
             TextLoader = TextLoader.From(TextAndVersion.Create(SourceText.From("FILE"), VersionStamp.Default));
             FileChangeTracker = new DefaultFileChangeTracker(DocumentFilePath);
 

--- a/test/Microsoft.VisualStudio.Editor.Razor.Test/Shared/ForegroundDispatcherWorkspaceTestBase.cs
+++ b/test/Microsoft.VisualStudio.Editor.Razor.Test/Shared/ForegroundDispatcherWorkspaceTestBase.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Razor;
 
 namespace Xunit
 {
-    public abstract class ForegroundDispatcherTestBase
+    public abstract class ForegroundDispatcherWorkspaceTestBase : WorkspaceTestBase
     {
         internal ForegroundDispatcher Dispatcher { get; } = new SingleThreadedForegroundDispatcher();
     }

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -20,12 +20,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         {
             Documents = new HostDocument[]
             {
-                new HostDocument("c:\\Test1\\Index.cshtml", "Index.cshtml"),
-                new HostDocument("c:\\Test1\\Components\\Counter.cshtml", "Components\\Counter.cshtml"),
+                TestProjectData.SomeProjectFile1,
+                TestProjectData.AnotherProjectFile1,
             };
 
-            HostProject1 = new HostProject("c:\\Test1\\Test1.csproj", FallbackRazorConfiguration.MVC_1_0);
-            HostProject2 = new HostProject("c:\\Test2\\Test2.csproj", FallbackRazorConfiguration.MVC_1_0);
+            HostProject1 = new HostProject(TestProjectData.SomeProject.FilePath, FallbackRazorConfiguration.MVC_1_0);
+            HostProject2 = new HostProject(TestProjectData.AnotherProject.FilePath, FallbackRazorConfiguration.MVC_1_0);
 
             var projectId1 = ProjectId.CreateNewId("Test1");
             var projectId2 = ProjectId.CreateNewId("Test2");
@@ -37,14 +37,14 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                     "Test1",
                     "Test1",
                     LanguageNames.CSharp,
-                    "c:\\Test1\\Test1.csproj"))
+                    TestProjectData.SomeProject.FilePath))
                 .AddProject(ProjectInfo.Create(
                     projectId2,
                     VersionStamp.Default,
                     "Test2",
                     "Test2",
                     LanguageNames.CSharp,
-                    "c:\\Test2\\Test2.csproj")); ;
+                    TestProjectData.AnotherProject.FilePath)); ;
 
             WorkspaceProject1 = solution.GetProject(projectId1);
             WorkspaceProject2 = solution.GetProject(projectId2);

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Host;
 using Moq;
 using Xunit;
 
@@ -12,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     // These tests are really integration tests. There isn't a good way to unit test this functionality since
     // the only thing in here is threading.
-    public class BackgroundDocumentGeneratorTest : ForegroundDispatcherTestBase
+    public class BackgroundDocumentGeneratorTest : ForegroundDispatcherWorkspaceTestBase
     {
         public BackgroundDocumentGeneratorTest()
         {
@@ -24,8 +26,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             HostProject1 = new HostProject("c:\\Test1\\Test1.csproj", FallbackRazorConfiguration.MVC_1_0);
             HostProject2 = new HostProject("c:\\Test2\\Test2.csproj", FallbackRazorConfiguration.MVC_1_0);
-
-            Workspace = TestWorkspace.Create();
 
             var projectId1 = ProjectId.CreateNewId("Test1");
             var projectId2 = ProjectId.CreateNewId("Test2");
@@ -60,7 +60,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private Project WorkspaceProject2 { get; }
 
-        private Workspace Workspace { get; }
+        protected override void ConfigureProjectEngine(RazorProjectEngineBuilder builder)
+        {
+            builder.Features.Remove(builder.Features.OfType<IImportProjectFeature>().Single());
+            builder.Features.Add(new TestImportProjectFeature());
+        }
 
         [ForegroundFact]
         public async Task Queue_ProcessesNotifications_AndGoesBackToSleep()

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Documents/VisualStudioFileChangeTrackerTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Documents/VisualStudioFileChangeTrackerTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 .Setup(f => f.AdviseFileChange(It.IsAny<string>(), It.IsAny<uint>(), It.IsAny<IVsFileChangeEvents>(), out cookie))
                 .Returns(VSConstants.S_OK)
                 .Verifiable();
-            var tracker = new VisualStudioFileChangeTracker("C:/_ViewImports.cshtml", Dispatcher, ErrorReporter, fileChangeService.Object);
+            var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object);
 
             // Act
             tracker.StartListening();
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 .Setup(f => f.AdviseFileChange(It.IsAny<string>(), It.IsAny<uint>(), It.IsAny<IVsFileChangeEvents>(), out cookie))
                 .Returns(VSConstants.S_OK)
                 .Callback(() => callCount++);
-            var tracker = new VisualStudioFileChangeTracker("C:/_ViewImports.cshtml", Dispatcher, ErrorReporter, fileChangeService.Object);
+            var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object);
             tracker.StartListening();
 
             // Act
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
                 .Setup(f => f.UnadviseFileChange(cookie))
                 .Returns(VSConstants.S_OK)
                 .Verifiable();
-            var tracker = new VisualStudioFileChangeTracker("C:/_ViewImports.cshtml", Dispatcher, ErrorReporter, fileChangeService.Object);
+            var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object);
             tracker.StartListening(); // Start listening for changes.
 
             // Act
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
             fileChangeService
                 .Setup(f => f.UnadviseFileChange(cookie))
                 .Throws(new InvalidOperationException());
-            var tracker = new VisualStudioFileChangeTracker("C:/_ViewImports.cshtml", Dispatcher, ErrorReporter, fileChangeService.Object);
+            var tracker = new VisualStudioFileChangeTracker(TestProjectData.SomeProjectImportFile.FilePath, Dispatcher, ErrorReporter, fileChangeService.Object);
 
             // Act & Assert
             tracker.StopListening();
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents
         public void FilesChanged_WithSpecificFlags_InvokesChangedHandler_WithExpectedArguments(uint fileChangeFlag, int expectedKind)
         {
             // Arrange
-            var filePath = "C:\\path\\to\\project\\_ViewImports.cshtml";
+            var filePath = TestProjectData.SomeProjectImportFile.FilePath;
             uint cookie;
             var fileChangeService = new Mock<IVsFileChangeEx>();
             fileChangeService

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -14,6 +14,9 @@
     <Compile Include="..\Microsoft.CodeAnalysis.Razor.Workspaces.Test\Shared\**\*.cs">
       <Link>Shared\%(RecursiveDir)%(FileName)%(Extension)</Link>
     </Compile>
+    <Compile Include="..\Microsoft.VisualStudio.Editor.Razor.Test\Shared\**\*.cs">
+      <Link>Shared\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -21,15 +21,15 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             Documents = new HostDocument[]
             {
-                new HostDocument("c:\\MyProject\\File.cshtml", "File.cshtml"),
-                new HostDocument("c:\\MyProject\\Index.cshtml", "Index.cshtml"),
+                TestProjectData.SomeProjectFile1,
+                TestProjectData.SomeProjectFile2,
 
                 // linked file
-                new HostDocument("c:\\SomeOtherProject\\Index.cshtml", "Pages\\Index.cshtml"),
+                TestProjectData.AnotherProjectNestedFile3,
             };
 
-            HostProject = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_2_0);
-            HostProjectWithConfigurationChange = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_1_0);
+            HostProject = new HostProject(TestProjectData.SomeProject.FilePath, FallbackRazorConfiguration.MVC_2_0);
+            HostProjectWithConfigurationChange = new HostProject(TestProjectData.SomeProject.FilePath, FallbackRazorConfiguration.MVC_1_0);
             
             ProjectManager = new TestProjectSnapshotManager(Dispatcher, Enumerable.Empty<ProjectSnapshotChangeTrigger>(), Workspace);
 
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 "Test",
                 "Test",
                 LanguageNames.CSharp,
-                "c:\\MyProject\\Test.csproj"));
+                TestProjectData.SomeProject.FilePath));
             WorkspaceProject = solution.GetProject(projectId);
 
             var vbProjectId = ProjectId.CreateNewId("VB");
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 "Test (Different TFM)",
                 "Test",
                 LanguageNames.CSharp,
-                "c:\\MyProject\\Test.csproj"));
+                TestProjectData.SomeProject.FilePath));
             WorkspaceProjectWithDifferentTfm = solution.GetProject(projectIdWithDifferentTfm);
 
             SomeTagHelpers = TagHelperResolver.TagHelpers;
@@ -253,8 +253,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             var snapshot = ProjectManager.GetSnapshot(HostProject);
             Assert.Collection(
                 snapshot.DocumentFilePaths.OrderBy(f => f), 
-                d => Assert.Equal(Documents[0].FilePath, d),
-                d => Assert.Equal(Documents[2].FilePath, d));
+                d => Assert.Equal(Documents[2].FilePath, d),
+                d => Assert.Equal(Documents[0].FilePath, d));
 
             Assert.Equal(ProjectChangeKind.DocumentRemoved, ProjectManager.ListenersNotifiedOf);
         }

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert
             var snapshot = ProjectManager.GetSnapshot(HostProject);
-            Assert.Collection(snapshot.DocumentFilePaths, d => Assert.Equal(Documents[0].FilePath, d));
+            Assert.Collection(snapshot.DocumentFilePaths.OrderBy(f => f), d => Assert.Equal(Documents[0].FilePath, d));
 
             Assert.Equal(ProjectChangeKind.DocumentAdded, ProjectManager.ListenersNotifiedOf);
         }
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert
             var snapshot = ProjectManager.GetSnapshot(HostProject);
-            Assert.Collection(snapshot.DocumentFilePaths, d => Assert.Equal(Documents[0].FilePath, d));
+            Assert.Collection(snapshot.DocumentFilePaths.OrderBy(f => f), d => Assert.Equal(Documents[0].FilePath, d));
 
             Assert.Null(ProjectManager.ListenersNotifiedOf);
         }
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             // Assert
             var snapshot = ProjectManager.GetSnapshot(HostProject);
             Assert.Collection(
-                snapshot.DocumentFilePaths, 
+                snapshot.DocumentFilePaths.OrderBy(f => f), 
                 d => Assert.Equal(Documents[0].FilePath, d),
                 d => Assert.Equal(Documents[2].FilePath, d));
 

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -13,21 +13,11 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
-    public class DefaultProjectSnapshotManagerTest : ForegroundDispatcherTestBase
+    public class DefaultProjectSnapshotManagerTest : ForegroundDispatcherWorkspaceTestBase
     {
         public DefaultProjectSnapshotManagerTest()
         {
             TagHelperResolver = new TestTagHelperResolver();
-
-            HostServices = TestServices.Create(
-                new IWorkspaceService[]
-                {
-                    new TestProjectSnapshotProjectEngineFactory(),
-                },
-                new ILanguageService[]
-                {
-                    TagHelperResolver,
-                });
 
             Documents = new HostDocument[]
             {
@@ -40,8 +30,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             HostProject = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_2_0);
             HostProjectWithConfigurationChange = new HostProject("c:\\MyProject\\Test.csproj", FallbackRazorConfiguration.MVC_1_0);
-
-            Workspace = TestWorkspace.Create(HostServices);
+            
             ProjectManager = new TestProjectSnapshotManager(Dispatcher, Enumerable.Empty<ProjectSnapshotChangeTrigger>(), Workspace);
 
             var projectId = ProjectId.CreateNewId("Test");
@@ -108,13 +97,14 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
         private TestProjectSnapshotManager ProjectManager { get; }
 
-        private HostServices HostServices { get; }
-
-        private Workspace Workspace { get; }
-
         private SourceText SourceText { get; }
 
         private IList<TagHelperDescriptor> SomeTagHelpers { get; }
+
+        protected override void ConfigureLanguageServices(List<ILanguageService> services)
+        {
+            services.Add(TagHelperResolver);
+        }
 
         [ForegroundFact]
         public void DocumentAdded_AddsDocument()

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -609,7 +610,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public async Task DefaultRazorProjectHost_ForegroundThread_CreateAndDispose_Succeeds()
         {
             // Arrange
-            var services = new TestProjectSystemServices("c:\\MyProject\\Test.csproj");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
             var host = new DefaultRazorProjectHost(services, Workspace, ProjectManager);
 
             // Act & Assert
@@ -624,7 +625,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         public async Task DefaultRazorProjectHost_BackgroundThread_CreateAndDispose_Succeeds()
         {
             // Arrange
-            var services = new TestProjectSystemServices("c:\\MyProject\\Test.csproj");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
             var host = new DefaultRazorProjectHost(services, Workspace, ProjectManager);
 
             // Act & Assert
@@ -643,7 +644,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             {
             };
 
-            var services = new TestProjectSystemServices("Test.csproj");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
             var host = new DefaultRazorProjectHost(services, Workspace, ProjectManager);
 
             // Act & Assert
@@ -667,8 +668,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             ExtensionItems.Item("MVC-2.1");
             ExtensionItems.Item("Another-Thing");
 
-            DocumentItems.Item("File.cshtml");
-            DocumentItems.Property("File.cshtml", Rules.RazorGenerateWithTargetPath.TargetPathProperty, "File.cshtml");
+            DocumentItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+            DocumentItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
 
             var changes = new TestProjectChangeDescription[]
             {
@@ -678,7 +679,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 DocumentItems.ToChange(),
             };
 
-            var services = new TestProjectSystemServices("c:\\MyProject\\Test.csproj");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
             var host = new DefaultRazorProjectHost(services, Workspace, ProjectManager);
 
@@ -690,7 +691,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert
             var snapshot = Assert.Single(ProjectManager.Projects);
-            Assert.Equal("c:\\MyProject\\Test.csproj", snapshot.FilePath);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
             Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
@@ -704,8 +705,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 d =>
                 {
                     var document = snapshot.GetDocument(d);
-                    Assert.Equal("c:\\MyProject\\File.cshtml", document.FilePath);
-                    Assert.Equal("File.cshtml", document.TargetPath);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                 });
 
             await Task.Run(async () => await host.DisposeAsync());
@@ -723,7 +724,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             ExtensionItems.Item("TestExtension");
 
-            DocumentItems.Item("File.cshtml");
+            DocumentItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
 
             var changes = new TestProjectChangeDescription[]
             {
@@ -733,7 +734,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 DocumentItems.ToChange(),
             };
 
-            var services = new TestProjectSystemServices("c:\\MyProject\\Test.csproj");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
             var host = new DefaultRazorProjectHost(services, Workspace, ProjectManager);
 
@@ -763,8 +764,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             ExtensionItems.Item("MVC-2.1");
             ExtensionItems.Item("Another-Thing");
 
-            DocumentItems.Item("File.cshtml");
-            DocumentItems.Property("File.cshtml", Rules.RazorGenerateWithTargetPath.TargetPathProperty, "File.cshtml");
+            DocumentItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+            DocumentItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
 
             var changes = new TestProjectChangeDescription[]
             {
@@ -774,7 +775,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 DocumentItems.ToChange(),
             };
 
-            var services = new TestProjectSystemServices("c:\\MyProject\\Test.csproj");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
             var host = new DefaultRazorProjectHost(services, Workspace, ProjectManager);
 
@@ -786,7 +787,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert - 1
             var snapshot = Assert.Single(ProjectManager.Projects);
-            Assert.Equal("c:\\MyProject\\Test.csproj", snapshot.FilePath);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
             Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
@@ -800,8 +801,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 d => 
                 {
                     var document = snapshot.GetDocument(d);
-                    Assert.Equal("c:\\MyProject\\File.cshtml", document.FilePath);
-                    Assert.Equal("File.cshtml", document.TargetPath);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                 });
 
             // Act - 2
@@ -810,9 +811,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             ConfigurationItems.RemoveItem("MVC-2.1");
             ConfigurationItems.Item("MVC-2.0", new Dictionary<string, string>() { { "Extensions", "MVC-2.0;Another-Thing" }, });
             ExtensionItems.Item("MVC-2.0");
-            DocumentItems.Item("c:\\AnotherProject\\AnotherFile.cshtml", new Dictionary<string, string>()
+            DocumentItems.Item(TestProjectData.AnotherProjectNestedFile3.FilePath, new Dictionary<string, string>()
             {
-                { Rules.RazorGenerateWithTargetPath.TargetPathProperty, "Pages\\AnotherFile.cshtml" },
+                { Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.AnotherProjectNestedFile3.TargetPath },
             });
 
             changes = new TestProjectChangeDescription[]
@@ -827,7 +828,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert - 2
             snapshot = Assert.Single(ProjectManager.Projects);
-            Assert.Equal("c:\\MyProject\\Test.csproj", snapshot.FilePath);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
             Assert.Equal(RazorLanguageVersion.Version_2_0, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.0", snapshot.Configuration.ConfigurationName);
@@ -841,14 +842,14 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 d =>
                 {
                     var document = snapshot.GetDocument(d);
-                    Assert.Equal("c:\\AnotherProject\\AnotherFile.cshtml", document.FilePath);
-                    Assert.Equal("Pages\\AnotherFile.cshtml", document.TargetPath);
+                    Assert.Equal(TestProjectData.AnotherProjectNestedFile3.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.AnotherProjectNestedFile3.TargetPath, document.TargetPath);
                 },
                 d =>
                 {
                     var document = snapshot.GetDocument(d);
-                    Assert.Equal("c:\\MyProject\\File.cshtml", document.FilePath);
-                    Assert.Equal("File.cshtml", document.TargetPath);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+                    Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                 });
 
             await Task.Run(async () => await host.DisposeAsync());
@@ -868,8 +869,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             ExtensionItems.Item("MVC-2.1");
             ExtensionItems.Item("Another-Thing");
 
-            DocumentItems.Item("File.cshtml");
-            DocumentItems.Property("File.cshtml", Rules.RazorGenerateWithTargetPath.TargetPathProperty, "File.cshtml");
+            DocumentItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+            DocumentItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
 
             var changes = new TestProjectChangeDescription[]
             {
@@ -879,7 +880,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 DocumentItems.ToChange(),
             };
 
-            var services = new TestProjectSystemServices("c:\\MyProject\\Test.csproj");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
             var host = new DefaultRazorProjectHost(services, Workspace, ProjectManager);
 
@@ -891,7 +892,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert - 1
             var snapshot = Assert.Single(ProjectManager.Projects);
-            Assert.Equal("c:\\MyProject\\Test.csproj", snapshot.FilePath);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
             Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
@@ -934,8 +935,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             ExtensionItems.Item("MVC-2.1");
             ExtensionItems.Item("Another-Thing");
 
-            DocumentItems.Item("File.cshtml");
-            DocumentItems.Property("File.cshtml", Rules.RazorGenerateWithTargetPath.TargetPathProperty, "File.cshtml");
+            DocumentItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+            DocumentItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
 
             var changes = new TestProjectChangeDescription[]
             {
@@ -945,7 +946,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 DocumentItems.ToChange(),
             };
 
-            var services = new TestProjectSystemServices("c:\\MyProject\\Test.csproj");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
             var host = new DefaultRazorProjectHost(services, Workspace, ProjectManager);
 
@@ -957,7 +958,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert - 1
             var snapshot = Assert.Single(ProjectManager.Projects);
-            Assert.Equal("c:\\MyProject\\Test.csproj", snapshot.FilePath);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
             Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
             Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
@@ -1004,8 +1005,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
             ExtensionItems.Item("MVC-2.1");
             ExtensionItems.Item("Another-Thing");
 
-            DocumentItems.Item("File.cshtml");
-            DocumentItems.Property("File.cshtml", Rules.RazorGenerateWithTargetPath.TargetPathProperty, "File.cshtml");
+            DocumentItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+            DocumentItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
 
             var changes = new TestProjectChangeDescription[]
             {
@@ -1015,7 +1016,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
                 DocumentItems.ToChange(),
             };
 
-            var services = new TestProjectSystemServices("c:\\MyProject\\Test.csproj");
+            var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
             var host = new DefaultRazorProjectHost(services, Workspace, ProjectManager);
 
@@ -1027,16 +1028,16 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 
             // Assert - 1
             var snapshot = Assert.Single(ProjectManager.Projects);
-            Assert.Equal("c:\\MyProject\\Test.csproj", snapshot.FilePath);
+            Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
             Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
 
             // Act - 2
-            services.UnconfiguredProject.FullPath = "c:\\AnotherProject\\Test2.csproj";
+            services.UnconfiguredProject.FullPath = TestProjectData.AnotherProject.FilePath;
             await Task.Run(async () => await host.OnProjectRenamingAsync());
 
             // Assert - 1
             snapshot = Assert.Single(ProjectManager.Projects);
-            Assert.Equal("c:\\AnotherProject\\Test2.csproj", snapshot.FilePath);
+            Assert.Equal(TestProjectData.AnotherProject.FilePath, snapshot.FilePath);
             Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
 
             await Task.Run(async () => await host.DisposeAsync());

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorProjectHostTest.cs
@@ -15,11 +15,10 @@ using ItemCollection = Microsoft.VisualStudio.ProjectSystem.ItemCollection;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
-    public class DefaultRazorProjectHostTest : ForegroundDispatcherTestBase
+    public class DefaultRazorProjectHostTest : ForegroundDispatcherWorkspaceTestBase
     {
         public DefaultRazorProjectHostTest()
         {
-            Workspace = new AdhocWorkspace();
             ProjectManager = new TestProjectSnapshotManager(Dispatcher, Workspace);
 
             ConfigurationItems = new ItemCollection(Rules.RazorConfiguration.SchemaName);
@@ -37,8 +36,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         private PropertyCollection RazorGeneralProperties { get; }
 
         private TestProjectSnapshotManager ProjectManager { get; }
-
-        private Workspace Workspace { get; }
 
         [Fact]
         public void TryGetDefaultConfiguration_FailsIfNoRule()

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackRazorProjectHostTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackRazorProjectHostTest.cs
@@ -12,11 +12,10 @@ using ItemReference = Microsoft.CodeAnalysis.Razor.ProjectSystem.ManagedProjectS
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
-    public class FallbackRazorProjectHostTest : ForegroundDispatcherTestBase
+    public class FallbackRazorProjectHostTest : ForegroundDispatcherWorkspaceTestBase
     {
         public FallbackRazorProjectHostTest()
         {
-            Workspace = new AdhocWorkspace();
             ProjectManager = new TestProjectSnapshotManager(Dispatcher, Workspace);
 
             ReferenceItems = new ItemCollection(ManagedProjectSystemSchema.ResolvedCompilationReference.SchemaName);
@@ -31,8 +30,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         private ItemCollection ContentItems { get; }
 
         private ItemCollection NoneItems { get; }
-
-        private Workspace Workspace { get; }
 
         [Fact]
         public void GetChangedAndRemovedDocuments_ReturnsChangedContentAndNoneItems()

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectSnapshotChangeTriggerTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectSnapshotChangeTriggerTest.cs
@@ -9,11 +9,10 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
-    public class WorkspaceProjectSnapshotChangeTriggerTest : ForegroundDispatcherTestBase
+    public class WorkspaceProjectSnapshotChangeTriggerTest : ForegroundDispatcherWorkspaceTestBase
     {
         public WorkspaceProjectSnapshotChangeTriggerTest()
         {
-            Workspace = TestWorkspace.Create();
             EmptySolution = Workspace.CurrentSolution.GetIsolatedSolution();
 
             var projectId1 = ProjectId.CreateNewId("One");
@@ -71,8 +70,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
         private Project ProjectNumberTwo { get; }
 
         private Project ProjectNumberThree { get; }
-
-        private Workspace Workspace { get; }
 
         [ForegroundTheory]
         [InlineData(WorkspaceChangeKind.SolutionAdded)]

--- a/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
+++ b/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
     {
         public VsSolutionUpdatesProjectSnapshotChangeTriggerTest()
         {
-            SomeProject = new HostProject("c:\\SomeProject\\SomeProject.csproj", FallbackRazorConfiguration.MVC_1_0);
-            SomeOtherProject = new HostProject("c:\\SomeOtherProject\\SomeOtherProject.csproj", FallbackRazorConfiguration.MVC_2_0);
+            SomeProject = new HostProject(TestProjectData.SomeProject.FilePath, FallbackRazorConfiguration.MVC_1_0);
+            SomeOtherProject = new HostProject(TestProjectData.AnotherProject.FilePath, FallbackRazorConfiguration.MVC_2_0);
 
             Workspace = TestWorkspace.Create(w =>
             {

--- a/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test.csproj
+++ b/test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test/Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test.csproj
@@ -8,6 +8,9 @@
     <Compile Include="..\Microsoft.CodeAnalysis.Razor.Workspaces.Test\Shared\**\*.cs">
       <Link>Shared\%(RecursiveDir)%(FileName)%(Extension)</Link>
     </Compile>
+    <Compile Include="..\Microsoft.VisualStudio.Editor.Razor.Test\Shared\**\*.cs">
+      <Link>Shared\%(RecursiveDir)%(FileName)%(Extension)</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add and process notifications for Imports

This builds support for tracking the effect of changes to imports on
other documents, and completes our model for being able to keep
generated code up to date.