### PR TITLE
Add Razor.Workspaces to non-shipping in NPV

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -6,6 +6,7 @@
     "packages": {
       "Microsoft.AspNetCore.Razor.TagHelpers.Testing.Sources": {},
       "RazorPageGenerator": {},
+      "Microsoft.CodeAnalysis.Razor.Workspaces": {},
       "Microsoft.CodeAnalysis.Remote.Razor": {},
       "Microsoft.VisualStudio.Editor.Razor": {},
       "Microsoft.VisualStudio.LanguageServices.Razor": {},


### PR DESCRIPTION
Putting this package where it belongs in the NPV list. This package only
ships with our other tooling-only packages.


Fixes: https://github.com/aspnet/AspNetCore-Internal/issues/1219