### PR TITLE
Use 3PartySHA2 instead of 3PartyDual for code-signing Newtonsoft.Json.dll

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Design/Microsoft.AspNetCore.Razor.Design.csproj
+++ b/src/Microsoft.AspNetCore.Razor.Design/Microsoft.AspNetCore.Razor.Design.csproj
@@ -33,7 +33,7 @@
     <SignedPackageFile Include="$(MSBuildProjectDirectory)\$(OutputPath)\tools/rzc.dll" Certificate="$(AssemblySigningCertName)" />
 
     <!-- Third-party assemblies -->
-    <SignedPackageFile Include="$(MSBuildProjectDirectory)\$(OutputPath)\tools/Newtonsoft.Json.dll" Certificate="3PartyDual" />
+    <SignedPackageFile Include="$(MSBuildProjectDirectory)\$(OutputPath)\tools/Newtonsoft.Json.dll" Certificate="$(AssemblySigning3rdPartyCertName)" />
 
     <!-- Binaries that should be signed by corefx/roslyn -->
     <ExcludePackageFileFromSigning Include="$(MSBuildProjectDirectory)\$(OutputPath)\tools/Microsoft.CodeAnalysis.CSharp.dll" />


### PR DESCRIPTION
Use the right 3rd party cert.