### PR TITLE
[Port] Increase timeout for msbuild processes and added better logging

### DIFF
--- a/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildProcessManager.cs
+++ b/test/Microsoft.AspNetCore.Razor.Design.Test/IntegrationTests/MSBuildProcessManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             TimeSpan? timeout = null,
             MSBuildProcessKind msBuildProcessKind = MSBuildProcessKind.Dotnet)
         {
-            timeout = timeout ?? TimeSpan.FromSeconds(60);
+            timeout = timeout ?? TimeSpan.FromSeconds(120);
 
             var processStartInfo = new ProcessStartInfo()
             {
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
                 // This is a timeout.
                 process.Kill();
-                throw new TimeoutException($"command '${process.StartInfo.FileName} {process.StartInfo.Arguments}' timed out after {timeout}.");
+                throw new TimeoutException($"command '${process.StartInfo.FileName} {process.StartInfo.Arguments}' timed out after {timeout}. Output: {output.ToString()}");
             });
 
             var waitTask = Task.Run(() =>


### PR DESCRIPTION
https://github.com/aspnet/Razor/issues/2645

In some rare cases when there is some network flakiness, msbuild restore takes a little longer than 60 seconds and it was failing a bunch of tests.
We already fixed this in 2.2 https://github.com/aspnet/Razor/pull/2576. This is just a port of the exact fix.