### PR TITLE
Port new vs completion changes from rel/vs16.0 branch

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -23,10 +23,10 @@
     <MicrosoftNETCoreApp30PackageVersion>3.0.0-preview1-26907-05</MicrosoftNETCoreApp30PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftVisualStudioComponentModelHostPackageVersion>15.8.525</MicrosoftVisualStudioComponentModelHostPackageVersion>
-    <MicrosoftVisualStudioEditorPackageVersion>16.0.142-g25b7188c54</MicrosoftVisualStudioEditorPackageVersion>
     <MicrosoftVisualStudioImageCatalogPackageVersion>15.8.28010</MicrosoftVisualStudioImageCatalogPackageVersion>
-    <MicrosoftVisualStudioLanguageIntellisensePackageVersion>16.0.142-g25b7188c54</MicrosoftVisualStudioLanguageIntellisensePackageVersion>
+    <MicrosoftVisualStudioEditorPackageVersion>16.0.142-g25b7188c54</MicrosoftVisualStudioEditorPackageVersion>
     <MicrosoftVisualStudioLanguagePackageVersion>16.0.142-g25b7188c54</MicrosoftVisualStudioLanguagePackageVersion>
+    <MicrosoftVisualStudioLanguageIntellisensePackageVersion>16.0.142-g25b7188c54</MicrosoftVisualStudioLanguageIntellisensePackageVersion>
     <MicrosoftVisualStudioOLEInteropPackageVersion>7.10.6071</MicrosoftVisualStudioOLEInteropPackageVersion>
     <MicrosoftVisualStudioProjectSystemAnalyzersPackageVersion>16.0.201-pre-g7d366164d0</MicrosoftVisualStudioProjectSystemAnalyzersPackageVersion>
     <MicrosoftVisualStudioProjectSystemManagedVSPackageVersion>2.0.6142705</MicrosoftVisualStudioProjectSystemManagedVSPackageVersion>

--- a/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionProvider.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionProvider.cs
@@ -115,9 +115,9 @@ namespace Microsoft.VisualStudio.Editor.Razor
         private Task AddCompletionItems(CompletionContext context)
         {
             if (!_textBufferProvider.TryGetFromDocument(context.Document, out var textBuffer) ||
-                !_dependencies.Value.AsyncCompletionBroker.IsCompletionSupported(textBuffer.ContentType))
+                _dependencies.Value.AsyncCompletionBroker.IsCompletionSupported(textBuffer.ContentType))
             {
-                // Completion is not supported.
+                // Async completion is supported that code path will handle completion.
                 return Task.CompletedTask;
             }
 

--- a/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionSourceProvider.cs
+++ b/src/Microsoft.VisualStudio.Editor.Razor/RazorDirectiveCompletionSourceProvider.cs
@@ -48,7 +48,8 @@ namespace Microsoft.VisualStudio.Editor.Razor
             }
 
             var razorBuffer = textView.BufferGraph.GetRazorBuffers().FirstOrDefault();
-            if (!razorBuffer.Properties.TryGetProperty(typeof(RazorDirectiveCompletionSource), out IAsyncCompletionSource completionSource))
+            if (!razorBuffer.Properties.TryGetProperty(typeof(RazorDirectiveCompletionSource), out IAsyncCompletionSource completionSource) ||
+                completionSource == null)
             {
                 completionSource = CreateCompletionSource(razorBuffer);
                 razorBuffer.Properties.AddProperty(typeof(RazorDirectiveCompletionSource), completionSource);


### PR DESCRIPTION
Without this, directive completion is broken when we F5 master on VS.