### PR TITLE
Add back legacy constructors used by live-share

### DIFF
--- a/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
+++ b/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectChangeEventArgs.cs
@@ -7,6 +7,31 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem
 {
     internal class ProjectChangeEventArgs : EventArgs
     {
+        [Obsolete("Adding this as a workaround to unblock live share")]
+        public ProjectChangeEventArgs(string projectFilePath, ProjectChangeKind kind)
+        {
+            if (projectFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(projectFilePath));
+            }
+
+            ProjectFilePath = projectFilePath;
+            Kind = kind;
+        }
+
+        [Obsolete("Adding this as a workaround to unblock live share")]
+        public ProjectChangeEventArgs(string projectFilePath, string documentFilePath, ProjectChangeKind kind)
+        {
+            if (projectFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(projectFilePath));
+            }
+
+            ProjectFilePath = projectFilePath;
+            DocumentFilePath = documentFilePath;
+            Kind = kind;
+        }
+
         public ProjectChangeEventArgs(ProjectSnapshot older, ProjectSnapshot newer, ProjectChangeKind kind)
         {
             if (older == null && newer == null)


### PR DESCRIPTION
Only the FAR code uses Older and Newer, most of our features still just
rely on file paths, so this is fine because it won't be running in a
live-share scenario.

Our live-share code constructs this eventargs type.