### PR TITLE
Show Razor build errors in non build server scenarios

### DIFF
--- a/src/Microsoft.AspNetCore.Razor.Tools/Program.cs
+++ b/src/Microsoft.AspNetCore.Razor.Tools/Program.cs
@@ -40,6 +40,9 @@ namespace Microsoft.AspNetCore.Razor.Tools
             outputWriter.Dispose();
             errorWriter.Dispose();
 
+            Console.Write(output);
+            Console.Error.Write(error);
+
             // This will no-op if server logging is not enabled.
             ServerLogger.Log(output);
             ServerLogger.Log(error);


### PR DESCRIPTION
Without this, errors are not displayed in the console when build server isn't used.

Fixes https://github.com/aspnet/Razor/issues/2733